### PR TITLE
Fix __all__ exports in factory modules

### DIFF
--- a/src/data_factory/__init__.py
+++ b/src/data_factory/__init__.py
@@ -25,4 +25,7 @@ def build_data(args_data,args_task) -> Any:
 
 
 # 导出公共API
-__all__ = ["register_dataset", "build_dataset", "_dataset_registry"]
+# 当前模块仅暴露 `build_data` 方法。原先的 `register_dataset` 等接口
+# 在早期版本中已被移除，继续暴露这些不存在的名称会导致 `import *`
+# 时出现 `ImportError`。因此将 `__all__` 更新为实际可用的函数列表。
+__all__ = ["build_data"]

--- a/src/trainer_factory/__init__.py
+++ b/src/trainer_factory/__init__.py
@@ -30,4 +30,5 @@ def build_trainer(
 
 
 # 导出公共API
-__all__ = ["register_trainer", "build_trainer"]
+# 仅导出 `build_trainer`，原来的 `register_trainer` 接口已移除。
+__all__ = ["build_trainer"]


### PR DESCRIPTION
## Summary
- update `__all__` in `data_factory` and `trainer_factory`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_68405a47d86883238587803cc018c5d8