### PR TITLE
Refine few-shot pipeline and update demo configs

### DIFF
--- a/configs/demo/Single_DG/CWRU.yaml
+++ b/configs/demo/Single_DG/CWRU.yaml
@@ -17,7 +17,7 @@ environment:
 # 数据配置
 data:
   # data_dir: "/mnt/crucial/LQ/PHMbench_data"  # 数据目录
-  data_dir: "/mnt/crucial/LQ/PHM-Vibench"  # for dummy test
+  data_dir: "data"  # 使用仓库自带的示例数据
   metadata_file: "metadata_6_1.xlsx"  # 指定元数据文件路径
   batch_size: 32
   num_workers: 32

--- a/configs/demo/Single_DG/THU.yaml
+++ b/configs/demo/Single_DG/THU.yaml
@@ -17,7 +17,7 @@ environment:
 # 数据配置
 data:
   # data_dir: "/mnt/crucial/LQ/PHMbench_data"  # 数据目录
-  data_dir: "/mnt/crucial/LQ/PHM-Vibench"  # for test 需要
+  data_dir: "data"  # 使用仓库自带的示例数据
   # metadata_file: "metadata_5_data.csv"  # 指定元数据文件路径
   metadata_file: 'metadata_6_1.xlsx'  # 指定元数据文件路径
   batch_size: 32

--- a/configs/demo/Single_DG/THU_wuzhui.yaml
+++ b/configs/demo/Single_DG/THU_wuzhui.yaml
@@ -17,7 +17,7 @@ environment:
 # 数据配置
 data:
   # data_dir: "/mnt/crucial/LQ/PHMbench_data"  # 数据目录
-  data_dir: "/mnt/crucial/LQ/PHM-Vibench"  # for test 需要
+  data_dir: "data"  # 使用仓库自带的示例数据
   # metadata_file: "metadata_5_data.csv"  # 指定元数据文件路径
   metadata_file: 'metadata_6_1.xlsx'  # 指定元数据文件路径
   batch_size: 32


### PR DESCRIPTION
## Summary
- refactor `Pipeline_02_pretrain_fewshot.py` to expose `run_pretraining_stage` and `run_fewshot_stage`
- add generic `run_stage` helper for individual phases
- adjust demo configs to use local example data

## Testing
- `python main.py --config configs/demo/Single_DG/THU_wuzhui.yaml` *(fails: ID not found in HDF5 cache)*

------
https://chatgpt.com/codex/tasks/task_e_6845ed9e6d248323840e292e53fb876a