### PR TITLE
Improve modular Streamlit helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,7 +193,25 @@ python main.py --config configs/demo/Multiple_DG/CWRU_THU_using_ISFM.yaml
 
 # 所有数据集
 python main.py --config configs/demo/Multiple_DG/all.yaml
+### Streamlit 图形界面
+
+使用 Streamlit 提供的图形界面运行实验：
+
+```bash
+streamlit run streamlit_app.py
 ```
+
+该界面会加载 configs 目录中的 YAML 文件，并允许在侧边栏调整常见参数。
+加载后，页面会以折叠面板的形式列出 `data`、`model`、`task` 和 `trainer`
+等配置项，可直接修改任意键值后启动实验。
+
+在侧边栏中也可以选择不同的流水线模块（例如 `Pipeline_01_default`
+或 `Pipeline_02_pretrain_fewshot`），针对 few-shot 预训练流程时需额外
+指定 second-stage 的配置文件。
+
+编辑完参数后，可在 "保存配置文件" 栏输入文件名并点击“保存配置”，
+配置文件将写入 `configs/` 目录并自动刷新界面。
+
 
 ### 📊 性能基准示例
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,3 +18,5 @@ xlrd > 2.0.0
 argparse
 openpyxl
 tensorboard
+
+streamlit

--- a/src/utils/__init__.py
+++ b/src/utils/__init__.py
@@ -1,4 +1,20 @@
-# Utils 包初始化文件
-from .config_utils import load_config, makedir, path_name, transfer_namespace
+"""Utility module exports."""
+from .config_utils import (
+    load_config,
+    makedir,
+    path_name,
+    transfer_namespace,
+    save_config,
+)
+from .env_builders import build_env_traditional, build_env_phmbench
 
-__all__ = ['load_config', 'makedir', 'path_name', 'transfer_namespace']
+__all__ = [
+    'load_config',
+    'makedir',
+    'path_name',
+    'transfer_namespace',
+    'save_config',
+    'build_env_traditional',
+    'build_env_phmbench',
+]
+

--- a/src/utils/config_utils.py
+++ b/src/utils/config_utils.py
@@ -2,6 +2,7 @@ import os
 import yaml
 import types
 from datetime import datetime
+from typing import Any, Dict
 
 def load_config(config_path):
     """加载YAML配置文件
@@ -74,3 +75,11 @@ def transfer_namespace(raw_arg_dict):
     for k, v in raw_arg_dict.items():
         setattr(namespace, k, v)
     return namespace
+
+
+def save_config(config: Dict[str, Any], path: str) -> str:
+    """Save config dictionary to a YAML file."""
+    makedir(os.path.dirname(path))
+    with open(path, "w") as f:
+        yaml.safe_dump(config, f)
+    return path

--- a/src/utils/env_builders.py
+++ b/src/utils/env_builders.py
@@ -1,0 +1,69 @@
+import pandas as pd
+from typing import List, Union
+
+def build_env_traditional(train_files: List[str], val_files: List[str], test_files: List[str]):
+    """Stub for traditional file upload environment builder.
+
+    Parameters
+    ----------
+    train_files : list of str
+        Uploaded training file paths.
+    val_files : list of str
+        Uploaded validation file paths.
+    test_files : list of str
+        Uploaded test file paths.
+
+    Returns
+    -------
+    dict
+        A dictionary describing the dataset environment.
+    """
+    return {
+        "train_files": [f.name if hasattr(f, "name") else f for f in train_files],
+        "val_files": [f.name if hasattr(f, "name") else f for f in val_files],
+        "test_files": [f.name if hasattr(f, "name") else f for f in test_files],
+    }
+
+
+def build_env_phmbench(
+    metadata: Union[str, pd.DataFrame],
+    data_dir: str,
+    train_ids: List[str],
+    val_ids: List[str],
+    test_ids: List[str],
+):
+    """Stub for PHMbench metadata environment builder.
+
+    Parameters
+    ----------
+    metadata : str or pandas.DataFrame
+        Metadata table or path to file.
+    data_dir : str
+        Directory that stores h5 files.
+    train_ids : list[str]
+        Selected training ids.
+    val_ids : list[str]
+        Selected validation ids.
+    test_ids : list[str]
+        Selected testing ids.
+
+    Returns
+    -------
+    dict
+        A dictionary describing the dataset environment.
+    """
+    if isinstance(metadata, str):
+        if metadata.endswith(".csv"):
+            meta_df = pd.read_csv(metadata)
+        else:
+            meta_df = pd.read_excel(metadata)
+    else:
+        meta_df = metadata
+    return {
+        "metadata": meta_df,
+        "data_dir": data_dir,
+        "train_ids": train_ids,
+        "val_ids": val_ids,
+        "test_ids": test_ids,
+    }
+

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -1,0 +1,278 @@
+import argparse
+import importlib
+import os
+import tempfile
+from typing import Any, Dict, List, Optional
+
+
+from src.utils import (
+    build_env_phmbench,
+    build_env_traditional,
+    load_config,
+    save_config,
+)
+
+try:
+    import streamlit as st  # type: ignore
+except Exception:  # pragma: no cover - optional dependency
+    st = None
+
+
+def list_config_files() -> List[str]:
+    """Recursively list yaml config files under the configs directory."""
+    cfg_files: List[str] = []
+    for root, _, files in os.walk("configs"):
+        for name in files:
+            if name.endswith(".yaml"):
+                cfg_files.append(os.path.join(root, name))
+    return sorted(cfg_files)
+
+
+def list_pipeline_modules() -> List[str]:
+    """Return available pipeline modules under src directory."""
+    pipelines: List[str] = []
+    for name in os.listdir("src"):
+        if name.startswith("Pipeline") and name.endswith(".py"):
+            pipelines.append(name[:-3])
+    return sorted(pipelines)
+
+
+def run_pipeline(
+    config: Dict[str, Any],
+    pipeline_name: str = "Pipeline_01_default",
+    fs_config_path: Optional[str] = None,
+) -> Any:
+    """Run a pipeline using a temporary config file."""
+    module = importlib.import_module(f"src.{pipeline_name}")
+    import yaml  # local import
+    with tempfile.NamedTemporaryFile("w", suffix=".yaml", delete=False) as f:
+        yaml.safe_dump(config, f)
+        temp_path = f.name
+    args = argparse.Namespace(
+        config_path=temp_path,
+        fs_config_path=fs_config_path,
+        notes="",
+    )
+    results = module.pipeline(args)
+    os.remove(temp_path)
+    return results
+
+
+def parse_metadata_file(uploaded_file: Any):
+    """Parse uploaded metadata file into a pandas DataFrame."""
+    if uploaded_file is None:
+        return None
+    try:
+        import pandas as pd  # local import
+        if uploaded_file.name.endswith(".csv"):
+            return pd.read_csv(uploaded_file)
+        return pd.read_excel(uploaded_file)
+    except Exception:  # pragma: no cover - UI error
+        if st:
+            st.sidebar.error("读取元数据失败")
+        return None
+
+
+def choose_ids_ui(ids: List[str]) -> List[List[str]]:
+    """Let the user select train/val/test ids from list."""
+    if st is None:
+        return [[], [], []]
+    train = st.sidebar.multiselect("选择 train ids", ids)
+    val = st.sidebar.multiselect("选择 val ids", ids)
+    test = st.sidebar.multiselect("选择 test ids", ids)
+    return [train, val, test]
+
+
+def build_traditional_ui() -> Optional[Dict[str, Any]]:
+    """Upload train/val/test files via sidebar."""
+    if st is None:
+        return None
+    train_files = st.sidebar.file_uploader(
+        "上传训练文件", accept_multiple_files=True
+    )
+    val_files = st.sidebar.file_uploader(
+        "上传验证文件", accept_multiple_files=True
+    )
+    test_files = st.sidebar.file_uploader(
+        "上传测试文件", accept_multiple_files=True
+    )
+    if train_files and val_files and test_files:
+        return build_env_traditional(train_files, val_files, test_files)
+    return None
+
+
+def build_phmbench_ui() -> Optional[Dict[str, Any]]:
+    """Upload metadata and choose ids via sidebar."""
+    if st is None:
+        return None
+    metadata_file = st.sidebar.file_uploader(
+        "上传 metadata.csv/xlsx", type=["csv", "xlsx"]
+    )
+    data_dir = st.sidebar.text_input("h5 文件目录")
+    meta_df = parse_metadata_file(metadata_file)
+    if meta_df is not None:
+        ids = meta_df.iloc[:, 0].astype(str).tolist()
+        train_ids, val_ids, test_ids = choose_ids_ui(ids)
+        if train_ids and val_ids and test_ids:
+            return build_env_phmbench(
+                meta_df, data_dir, train_ids, val_ids, test_ids
+            )
+    return None
+
+
+def cast_value(original: Any, new_val: Any) -> Any:
+    """Cast a UI value back to the original type."""
+    if isinstance(original, bool):
+        return bool(new_val)
+    if isinstance(original, int) and not isinstance(original, bool):
+        return int(new_val)
+    if isinstance(original, float):
+        return float(new_val)
+    if isinstance(original, (list, dict)):
+        try:
+            import yaml  # local import
+            return yaml.safe_load(new_val)
+        except Exception:
+            return original
+    return type(original)(new_val)
+
+
+def render_field(key: str, value: Any) -> Any:
+    """Render a single config field based on value type."""
+    if st is None:
+        return value
+    if isinstance(value, bool):
+        return st.checkbox(key, value=value)
+    if isinstance(value, int) and not isinstance(value, bool):
+        return st.number_input(key, value=value, step=1)
+    if isinstance(value, float):
+        return st.number_input(key, value=value, format="%f")
+    if isinstance(value, (list, dict)):
+        import yaml  # local import
+        return st.text_input(key, value=yaml.safe_dump(value))
+    return st.text_input(key, value=str(value))
+
+
+def edit_section(name: str, cfg: Dict[str, Any]) -> Dict[str, Any]:
+    """Create UI inputs for a config section and return updated values."""
+    if st is None:
+        return cfg
+    updated: Dict[str, Any] = {}
+    with st.expander(f"{name} Parameters"):
+        for k, v in cfg.items():
+            new_v = render_field(k, v)
+            updated[k] = cast_value(v, new_v)
+    return updated
+
+
+def select_environment() -> Optional[Dict[str, Any]]:
+    """Sidebar widgets for uploading data and building environment dict."""
+    if st is None:
+        return None
+    st.sidebar.header("数据加载方式")
+    load_mode = st.sidebar.radio(
+        "选择模式",
+        ["传统文件上传模式", "PHMbench元数据模式"],
+        index=0,
+    )
+
+    if load_mode == "传统文件上传模式":
+        return build_traditional_ui()
+    return build_phmbench_ui()
+    return None
+
+
+def select_pipeline() -> (str, Optional[str]):
+    """Sidebar widgets to choose pipeline and optional FS config."""
+    if st is None:
+        return "Pipeline_01_default", None
+    st.sidebar.header("实验流水线")
+    pipelines = list_pipeline_modules()
+    selected = st.sidebar.selectbox("选择 pipeline", pipelines)
+    fs_path = None
+    if selected == "Pipeline_02_pretrain_fewshot":
+        fs_path = st.sidebar.selectbox("Few-shot 配置", list_config_files())
+    return selected, fs_path
+
+
+def load_base_config() -> Dict[str, Any]:
+    """Load a base YAML config selected from sidebar."""
+    if st is None:
+        return load_config(list_config_files()[0])
+    st.sidebar.header("实验配置")
+    config_files = list_config_files()
+    selected_cfg_path = st.sidebar.selectbox("选择配置文件", config_files)
+    return load_config(selected_cfg_path)
+
+
+def update_config(
+    base_cfg: Dict[str, Any],
+    sections: Dict[str, Dict[str, Any]],
+    env: Optional[Dict[str, Any]],
+) -> Dict[str, Any]:
+    """Merge edited sections and environment into base config."""
+    cfg = dict(base_cfg)
+    for sec, val in sections.items():
+        cfg[sec] = val
+    if env is not None:
+        cfg.setdefault("environment", {}).update(env)
+    return cfg
+
+
+def save_config_ui(config: Dict[str, Any]) -> None:
+    """Sidebar UI to save edited config to file."""
+    if st is None:
+        return
+    with st.sidebar.expander("保存配置文件"):
+        filename = st.text_input("文件名", "edited_config.yaml")
+        if st.button("保存配置"):
+            path = os.path.join("configs", filename)
+            save_config(config, path)
+            st.sidebar.success(f"已保存到 {path}")
+            st.experimental_rerun()
+
+
+def display_results(result: Any) -> None:
+    """Render experiment results in tabs."""
+    if st is None:
+        return
+    tab1, _, _, tab4 = st.tabs(["指标总结", "训练曲线", "预测详情", "原始日志"])
+    with tab1:
+        if isinstance(result, list) and result:
+            df = pd.DataFrame(result)
+            st.dataframe(df)
+        else:
+            st.write("无结果")
+    with tab4:
+        st.code(str(result))
+
+
+def run_app() -> None:
+    if st is None:
+        raise RuntimeError("streamlit is required to run the app")
+    st.set_page_config(page_title="PHMbench UI", layout="wide")
+    st.title("PHMbench 实验管理器")
+
+    uploaded_env = select_environment()
+    pipeline, fs_path = select_pipeline()
+    base_cfg = load_base_config()
+
+    updated_sections = {}
+    for sec in ["data", "model", "task", "trainer"]:
+        if sec in base_cfg:
+            updated_sections[sec] = edit_section(sec, base_cfg[sec])
+
+    temp_cfg = update_config(base_cfg, updated_sections, uploaded_env)
+    save_config_ui(temp_cfg)
+
+    run_button = st.button("🚀 开始实验 | Run Experiment")
+    if run_button:
+        final_cfg = temp_cfg
+        with st.spinner("实验进行中..."):
+            result = run_pipeline(final_cfg, pipeline, fs_path)
+        st.success("实验完成")
+        display_results(result)
+
+
+if __name__ == "__main__":
+    run_app()

--- a/test/test_streamlit_app.py
+++ b/test/test_streamlit_app.py
@@ -1,0 +1,47 @@
+try:
+    from streamlit_app import (
+        list_config_files,
+        list_pipeline_modules,
+        cast_value,
+        update_config,
+        save_config,
+    )
+    import yaml
+except Exception:  # pragma: no cover - optional dependencies
+    import pytest
+    pytest.skip("streamlit or pandas not installed", allow_module_level=True)
+
+
+def test_list_config_files():
+    files = list_config_files()
+    assert any(f.endswith('CWRU.yaml') for f in files)
+
+
+def test_list_pipeline_modules():
+    modules = list_pipeline_modules()
+    assert 'Pipeline_01_default' in modules
+
+
+def test_cast_value():
+    assert cast_value(1, '2') == 2
+    assert cast_value(True, False) is False
+    assert cast_value([1, 2], '[3, 4]') == [3, 4]
+
+
+def test_update_config():
+    base = {"data": {"a": 1}}
+    sections = {"data": {"a": 2}}
+    cfg = update_config(base, sections, {"foo": "bar"})
+    assert cfg["data"]["a"] == 2
+    assert cfg["environment"]["foo"] == "bar"
+
+
+def test_save_config(tmp_path):
+    cfg = {"a": 1}
+    out = tmp_path / "cfg.yaml"
+    save_config(cfg, str(out))
+    with open(out, "r") as f:
+        data = yaml.safe_load(f)
+    assert data == cfg
+
+


### PR DESCRIPTION
## Summary
- refactor Streamlit app to break UI logic into small helper functions
- lazily import optional dependencies to allow importing without Streamlit
- add utility tests for config merging
- allow saving edited configuration from the Streamlit sidebar

## Testing
- `pytest -q test/test_streamlit_app.py` *(tests skipped: optional dependency)*

------
https://chatgpt.com/codex/tasks/task_e_687411d4f43483239fca4b02e28cc5fa