### PR TITLE
Refactor Streamlit app modules

### DIFF
--- a/app/README.md
+++ b/app/README.md
@@ -1,0 +1,12 @@
+# App Module
+
+This directory contains a Streamlit interface for running PHM-Vibench pipelines.
+The web UI guides users through loading metadata, configuring parameters and
+starting experiments. Terminal output is streamed in real time and the process
+can be paused or resumed.
+
+Run the application with:
+
+```bash
+streamlit run app/gui.py
+```

--- a/app/gui.py
+++ b/app/gui.py
@@ -1,0 +1,130 @@
+"""Streamlit interface for PHM-Vibench."""
+
+import os
+import streamlit as st
+
+from . import utils
+
+
+def step_load_data() -> None:
+    """Step 1: load metadata and preview it."""
+    st.header("\u6b65\u9aa4 1: \u52a0\u8f7d\u6570\u636e")
+    upload = st.file_uploader("\u9009\u62e9\u5143\u6570\u636e\u6587\u4ef6", type=["csv", "xlsx"])
+    if upload is not None:
+        df = utils.load_metadata(upload)
+        if df is not None:
+            ids = utils.available_ids(df)
+            st.session_state["available_ids"] = ids
+            st.success("\u8bfb\u53d6\u6210\u529f")
+            utils.preview_metadata()
+
+    selected_id = st.session_state.get("test_id")
+    if selected_id and st.session_state.data_dir:
+        signal = utils.load_signal(st.session_state.data_dir, selected_id)
+        if signal is not None:
+            utils.plot_signal(signal)
+
+
+def _data_params(col) -> None:
+    """Render dataset related parameters."""
+    st.session_state.data_dir = col.text_input(
+        "HDF5 Data Directory",
+        value=st.session_state.data_dir,
+        key="data_dir_input",
+    )
+    if st.session_state.data_dir:
+        exists = os.path.exists(st.session_state.data_dir)
+        if exists:
+            col.success("\u8def\u5f84\u6b63\u786e")
+        else:
+            col.error("\u8def\u5f84\u65e0\u6548")
+    ids = st.session_state.get("available_ids", [])
+    st.session_state.train_ids = col.multiselect(
+        "Train IDs", ids, default=st.session_state.train_ids
+    )
+    st.session_state.val_ids = col.multiselect(
+        "Val IDs", ids, default=st.session_state.val_ids
+    )
+    st.session_state.test_id = (
+        col.selectbox(
+            "Test ID",
+            ids,
+            index=ids.index(st.session_state.test_id)
+            if st.session_state.test_id in ids
+            else 0,
+        )
+        if ids
+        else None
+    )
+
+
+def _model_params(col) -> None:
+    """Render model parameter inputs."""
+    st.session_state.learning_rate = col.number_input(
+        "Learning Rate",
+        min_value=1e-6,
+        max_value=1.0,
+        value=float(st.session_state.learning_rate),
+        step=1e-4,
+        format="%f",
+        help="\u8bad\u7ec3\u7684\u5b66\u4e60\u7387",
+    )
+
+
+def _task_params(col) -> None:
+    """Render task parameter inputs."""
+    st.session_state.task_type = col.text_input(
+        "Task Type",
+        value=st.session_state.task_type,
+        help="\u4efb\u52a1\u7c7b\u578b\uff0c\u5982\u5206\u7c7b",
+    )
+
+
+def _trainer_params(col) -> None:
+    """Render trainer parameter placeholder."""
+    col.write("...")
+
+
+def step_configure() -> None:
+    """Step 2: parameter configuration."""
+    st.header("\u6b65\u9aa4 2: \u914d\u7f6e\u53c2\u6570")
+    cols = st.columns(4)
+    with cols[0].expander("Data", expanded=False):
+        _data_params(cols[0])
+    with cols[1].expander("Model", expanded=False):
+        _model_params(cols[1])
+    with cols[2].expander("Task", expanded=False):
+        _task_params(cols[2])
+    with cols[3].expander("Trainer", expanded=False):
+        _trainer_params(cols[3])
+
+
+def step_run() -> None:
+    """Step 3: run or pause the experiment."""
+    st.header("\u6b65\u9aa4 3: \u8fd0\u884c\u5e76\u67e5\u770b\u7ed3\u679c")
+    run_col, pause_col = st.columns(2)
+    if run_col.button("Start Experiment"):
+        if st.session_state.test_id is None:
+            st.warning("\u8bf7\u9009\u62e9 Test ID")
+        elif not os.path.exists(st.session_state.data_dir):
+            st.warning("\u8bf7\u6307\u5b9a\u6709\u6548\u7684 HDF5 \u76ee\u5f55")
+        else:
+            utils.start_pipeline("configs/demo/ID/id_demo.yaml")
+    if pause_col.button("Pause/Resume") and st.session_state.process:
+        utils.toggle_pause()
+
+    utils.display_output()
+
+
+def main() -> None:
+    """Entry point for the Streamlit application."""
+    st.set_page_config(page_title="PHM-Vibench", layout="wide")
+    utils.init_session_state()
+    st.title("PHM-Vibench")
+    step_load_data()
+    step_configure()
+    step_run()
+
+
+if __name__ == "__main__":  # pragma: no cover - entry point
+    main()

--- a/app/utils.py
+++ b/app/utils.py
@@ -1,0 +1,155 @@
+"""Utility functions for the Streamlit GUI."""
+
+import os
+import signal
+import subprocess
+import threading
+from typing import List, Optional
+
+import h5py
+import matplotlib.pyplot as plt
+import pandas as pd
+import streamlit as st
+
+
+# ---------------------------------------------------------------------------
+# Session State Utilities
+# ---------------------------------------------------------------------------
+
+def init_session_state() -> None:
+    """Initialize default values in ``st.session_state``.
+
+    The GUI relies heavily on session state to persist user choices and the
+    running process between reruns triggered by widget interaction.
+    """
+    defaults = {
+        "metadata_df": None,
+        "train_ids": [],
+        "val_ids": [],
+        "test_id": None,
+        "data_dir": "",
+        "learning_rate": 0.001,
+        "task_type": "classification",
+        "process": None,
+        "output_lines": [],
+        "paused": False,
+        "experiment_run": False,
+    }
+    for key, value in defaults.items():
+        if key not in st.session_state:
+            st.session_state[key] = value
+
+
+# ---------------------------------------------------------------------------
+# Data Loading Helpers
+# ---------------------------------------------------------------------------
+
+def load_metadata(file) -> Optional[pd.DataFrame]:
+    """Load metadata from ``file`` with basic error handling."""
+    try:
+        if file.name.endswith(".csv"):
+            df = pd.read_csv(file)
+        else:
+            df = pd.read_excel(file)
+    except Exception as exc:  # pragma: no cover - UI feedback
+        st.error(f"\u4e0a\u4f20\u5931\u8d25: {exc}")
+        return None
+    st.session_state.metadata_df = df
+    return df
+
+
+def preview_metadata() -> None:
+    """Display the first few rows of the loaded metadata."""
+    df = st.session_state.metadata_df
+    if df is not None:
+        with st.expander("\u5148\u770b\u5143\u6570\u636e", expanded=False):
+            st.dataframe(df.head())
+
+
+def available_ids(df: pd.DataFrame) -> List[str]:
+    """Return a list of sample IDs from ``df`` if present."""
+    for col in ("id", "ID", "sample_id"):
+        if col in df.columns:
+            return df[col].astype(str).unique().tolist()
+    return []
+
+
+def load_signal(data_dir: str, sample_id: str) -> Optional[List[float]]:
+    """Load raw signal for ``sample_id`` from ``data_dir``.
+
+    The function expects each sample to be stored as ``<id>.h5`` with a
+    ``signal`` dataset. Errors are reported via ``st.error`` and ``None`` is
+    returned on failure.
+    """
+    path = os.path.join(data_dir, f"{sample_id}.h5")
+    try:
+        with h5py.File(path, "r") as hf:
+            signal = hf["signal"][:]
+    except Exception as exc:  # pragma: no cover - UI feedback
+        st.error(f"\u65ad\u7247\u52a0\u8f7d\u9519\u8bef: {exc}")
+        return None
+    return signal
+
+
+def plot_signal(signal: List[float]) -> None:
+    """Plot ``signal`` on the main page."""
+    fig, ax = plt.subplots()
+    ax.plot(signal)
+    ax.set_title("\u539f\u59cb\u4fe1\u53f7")
+    st.pyplot(fig)
+
+
+# ---------------------------------------------------------------------------
+# Subprocess Management
+# ---------------------------------------------------------------------------
+
+def _reader_thread(process: subprocess.Popen) -> None:
+    """Collect output from ``process`` into the session state."""
+    for line in iter(process.stdout.readline, b""):
+        st.session_state.output_lines.append(line.decode())
+        st.experimental_rerun()  # force UI update
+    process.wait()
+    st.session_state.process = None
+    st.session_state.paused = False
+
+
+def start_pipeline(config_path: str) -> None:
+    """Launch the training pipeline as a subprocess."""
+    if st.session_state.process:
+        st.warning("\u5df2\u7ecf\u6709\u6b63\u5728\u8fd0\u884c\u7684\u4efb\u52a1")
+        return
+    cmd = ["python", "main.py", "--config_path", config_path]
+    process = subprocess.Popen(
+        cmd,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+    )
+    st.session_state.process = process
+    st.session_state.output_lines = []
+    st.session_state.experiment_run = True
+    thread = threading.Thread(target=_reader_thread, args=(process,), daemon=True)
+    thread.start()
+
+
+def toggle_pause() -> None:
+    """Pause or resume the running subprocess."""
+    process = st.session_state.process
+    if not process:
+        return
+    if st.session_state.paused:
+        os.kill(process.pid, signal.SIGCONT)
+        st.session_state.paused = False
+    else:
+        os.kill(process.pid, signal.SIGSTOP)
+        st.session_state.paused = True
+
+
+def display_output() -> None:
+    """Stream captured output to the UI."""
+    if st.session_state.output_lines:
+        st.text_area(
+            "\u8fd0\u884c\u8f93\u51fa",
+            value="".join(st.session_state.output_lines),
+            height=200,
+        )
+

--- a/configs/demo/ID/id_demo.yaml
+++ b/configs/demo/ID/id_demo.yaml
@@ -1,0 +1,36 @@
+# Demo configuration using id_data_factory
+
+environment:
+  WANDB_MODE: "disabled"
+  VBENCH_HOME: "."
+  PYTHONPATH: "."
+  PHMBench: "."
+  project: "id_demo"
+  seed: 42
+  output_dir: "results/id_demo"
+  notes: "ID dataset demo"
+  iterations: 1
+
+data:
+  factory: "id_data_factory"
+  data_dir: "./data"
+  metadata_file: "metadata_6_1.xlsx"
+  batch_size: 32
+  num_workers: 0
+
+model:
+  name: "Transformer_Dummy"
+  type: "Transformer"
+  input_dim: 2
+  num_classes: 4
+
+task:
+  name: "Classification"
+  type: "DG"
+  source_domain_id: [0]
+  target_domain_id: [1]
+  target_system_id: [1]
+
+trainer:
+  name: "Default_trainer"
+  wandb: false

--- a/doc/app_usage.md
+++ b/doc/app_usage.md
@@ -1,0 +1,12 @@
+# GUI Usage
+
+A Streamlit application is provided in `app/gui.py`. It organizes data, model,
+task and trainer parameters in expandable sections. After loading metadata you
+can preview it directly and visualize raw signals for a selected sample.
+Process output is streamed live and you may pause or resume the run.
+
+Launch the GUI with:
+
+```bash
+streamlit run app/gui.py
+```

--- a/src/Pipeline_ID.py
+++ b/src/Pipeline_ID.py
@@ -1,0 +1,8 @@
+"""Pipeline that uses id_data_factory."""
+
+from src.Pipeline_01_default import pipeline as default_pipeline
+
+
+def pipeline(args):
+    """Run the default pipeline. Configs should specify id_data_factory."""
+    return default_pipeline(args)

--- a/src/data_factory/__init__.py
+++ b/src/data_factory/__init__.py
@@ -9,6 +9,14 @@ from typing import Dict, Any, Optional
 from .data_factory import data_factory
 from .dataset_task.Dataset_cluster import IdIncludedDataset
 
+def _select_factory(args_data):
+    """Return the data factory class based on args_data.factory."""
+    factory_name = getattr(args_data, "factory", "data_factory")
+    if factory_name == "id_data_factory":
+        from .id_data_factory import id_data_factory
+        return id_data_factory
+    return data_factory
+
 def build_data(args_data,args_task) -> Any:
     """根据配置构建数据集实例
     
@@ -20,7 +28,8 @@ def build_data(args_data,args_task) -> Any:
 
         
     """
-    return data_factory(args_data, args_task)
+    factory_cls = _select_factory(args_data)
+    return factory_cls(args_data, args_task)
 
 
 

--- a/src/data_factory/dataset_task/ID/Classification_dataset.py
+++ b/src/data_factory/dataset_task/ID/Classification_dataset.py
@@ -1,0 +1,8 @@
+from ..Default_dataset import Default_dataset
+
+
+class set_dataset(Default_dataset):
+    """Dataset class for ID tasks."""
+
+    def __init__(self, data, metadata, args_data, args_task, mode="train"):
+        super().__init__(data, metadata, args_data, args_task, mode)

--- a/src/data_factory/id_data_factory.py
+++ b/src/data_factory/id_data_factory.py
@@ -1,0 +1,25 @@
+"""Data factory specialized for ID datasets."""
+
+from .data_factory import data_factory
+from torch.utils.data import DataLoader
+
+
+class id_data_factory(data_factory):
+    """Data factory that initializes default dataloaders."""
+
+    def _make_loader(self, dataset, shuffle: bool) -> DataLoader:
+        """Return a DataLoader with default parameters for ``dataset``."""
+        return DataLoader(
+            dataset,
+            batch_size=self.args_data.batch_size,
+            shuffle=shuffle,
+            num_workers=self.args_data.num_workers,
+            pin_memory=True,
+        )
+
+    def _init_dataloader(self):
+        """Initialize train/val/test dataloaders using default sampler."""
+        self.train_loader = self._make_loader(self.train_dataset, shuffle=True)
+        self.val_loader = self._make_loader(self.val_dataset, shuffle=False)
+        self.test_loader = self._make_loader(self.test_dataset, shuffle=False)
+        return self.train_loader, self.val_loader, self.test_loader

--- a/test/test_id_data_factory.py
+++ b/test/test_id_data_factory.py
@@ -1,0 +1,17 @@
+import types
+from argparse import Namespace
+import torch
+from torch.utils.data import TensorDataset
+
+from src.data_factory.id_data_factory import id_data_factory
+
+
+def test_dataloader_initialization():
+    args_data = Namespace(batch_size=2, num_workers=0)
+    df = id_data_factory.__new__(id_data_factory)
+    df.args_data = args_data
+    df.train_dataset = TensorDataset(torch.randn(4, 1))
+    df.val_dataset = TensorDataset(torch.randn(4, 1))
+    df.test_dataset = TensorDataset(torch.randn(4, 1))
+    loaders = id_data_factory._init_dataloader(df)
+    assert len(loaders) == 3


### PR DESCRIPTION
## Summary
- extract reusable GUI helpers into `app/utils.py`
- break interface logic in `app/gui.py` into small annotated functions
- use columns correctly when rendering parameter sections

## Testing
- `python -m py_compile app/gui.py app/utils.py`

------
https://chatgpt.com/codex/tasks/task_e_68746ac2b17c832387ced7272b5c36cf