### PR TITLE
fix(streamlit): preserve cancelled run status

### DIFF
--- a/apps/streamlit/run_service.py
+++ b/apps/streamlit/run_service.py
@@ -456,7 +456,12 @@ def get_run(repo_root: Path, run_id: str) -> RunRecord:
                     payload = _read_payload(run_dir)
             else:
                 pid = payload.get("pid")
-                new_status = "detached" if isinstance(pid, int) and _pid_exists(pid) else "orphaned"
+                cancel_requested = bool(payload.get("cancel_requested"))
+                new_status = (
+                    "cancelled"
+                    if cancel_requested
+                    else "detached" if isinstance(pid, int) and _pid_exists(pid) else "orphaned"
+                )
                 payload.update(
                     status=new_status,
                     ended_at="" if new_status == "detached" else _utc_now(),
@@ -464,6 +469,8 @@ def get_run(repo_root: Path, run_id: str) -> RunRecord:
                         "The Streamlit worker restarted while the process is still alive; "
                         "automatic cancellation is disabled for safety."
                         if new_status == "detached"
+                        else ""
+                        if new_status == "cancelled"
                         else "The managed process is no longer available."
                     ),
                 )


### PR DESCRIPTION
## Summary

- Preserve `cancelled` status when `get_run()` refreshes a run whose cancellation was requested but whose managed process is no longer present.
- Keeps the current release gate from reporting a successfully cancelled Streamlit run as `orphaned`.

## Why

Phase 0 of the PR convergence plan failed on current `main` at `test_cancel_terminates_process_group`: expected `cancelled`, got `orphaned`. This is one of the plan's stop conditions, so this hotfix needs to land before continuing PR #41/#40/#43 convergence.

## Validation

- `conda run -n LQ_signal python -m pytest test/test_streamlit_run_service.py::test_cancel_terminates_process_group -q` -> passed
- `conda run -n LQ_signal python -m pytest test/ -q` -> 69 passed
- `python -m scripts.validate_docs` -> passed
- `python -m scripts.validate_configs` -> passed
- `python -m scripts.gen_config_atlas` -> no diff
- `git diff --check` -> passed
- `conda run -n LQ_signal python main.py --config configs/demo/00_smoke/dummy_dg.yaml --override trainer.num_epochs=1 --override data.num_workers=0` -> passed