### PR TITLE
fix(config): remove personal data path from demo 05

### DIFF
--- a/configs/demo/05_pretrain_fewshot/pretrain_hse_then_fewshot.yaml
+++ b/configs/demo/05_pretrain_fewshot/pretrain_hse_then_fewshot.yaml
@@ -15,8 +15,6 @@ environment:
   output_dir: "results/demo/pretrain_hse_then_fewshot"
   notes: "Two-stage pretrain (HSE) + few-shot finetune demo."
 
-data: 
-  data_dir: "/home/xyc3090/data1/PHM-Vibench-base/data/dataset"
 # 模型配置全部由 base_configs.model (backbone_dlinear.yaml) 提供
 
 # 当前版本将此 demo 视作单阶段 HSE 对比预训练示例（后续可通过 stages 扩展为真正的两阶段：pretrain + few-shot）


### PR DESCRIPTION
## Summary

Removes a hardcoded personal machine path from the maintained `demo_05_pretrain_fewshot` config.

Before this PR, `configs/demo/05_pretrain_fewshot/pretrain_hse_then_fewshot.yaml` overrode the base data path with:

```text
/home/xyc3090/data1/PHM-Vibench-base/data/dataset
```

That path caused the v0.2.0 release gate to fail with a read-only filesystem error. The demo now inherits `data.data_dir` from `configs/base/data/base_classification.yaml`, matching the maintained config system.

## Scope

- One config file changed.
- No runtime code changes.
- No registry changes.
- No release-surface expansion.

## Validation

- `python -m scripts.validate_configs` -> passed (`7/7 configs`)
- `python -m scripts.validate_docs` -> passed (`111 files scanned`)
- `conda run -n LQ_signal python -m scripts.config_inspect --config configs/demo/05_pretrain_fewshot/pretrain_hse_then_fewshot.yaml --override trainer.num_epochs=1` -> passed; `data.data_dir` source is `base:configs/base/data/base_classification.yaml`
- `python -m scripts.gen_config_atlas` + `git diff --exit-code docs/CONFIG_ATLAS.md` -> no diff
- `conda run -n LQ_signal python main.py --config configs/demo/05_pretrain_fewshot/pretrain_hse_then_fewshot.yaml --override trainer.num_epochs=1 --override data.num_workers=0` -> passed
- `git diff --check` -> passed

## Release-gate context

This was found while running the full v0.2.0 maintained-demo smoke gate after PR #41/#48/#49 convergence. The gate is stopped until this fix lands on `main`.