### PR TITLE
feat: add TSPN_UXFD core contract

### DIFF
--- a/configs/base/model/tspn_uxfd.yaml
+++ b/configs/base/model/tspn_uxfd.yaml
@@ -1,0 +1,43 @@
+# Base model: TSPN_UXFD (UXFD-aligned TSPN wrapper)
+#
+# Notes:
+# - This base is intentionally "dummy-data friendly" (CPU, small dims).
+# - It is a *base*, so downstream demos/experiments should override as needed
+#   (e.g., `in_dim`, `in_channels`, `signal_processing_configs`, `uxfd.*`).
+
+model:
+  type: "X_model"
+  name: "TSPN_UXFD"
+  device: "cpu"
+
+  # Dummy_Data windows are (B, L=window_size, C=2) by default.
+  in_dim: 128
+  out_dim: 128
+  in_channels: 2
+
+  # Minimal TSPN settings.
+  out_channels: 4
+  scale: 1
+  skip_connection: true
+
+  signal_processing_configs:
+    layer1: ["I"]
+  feature_extractor_configs: ["Mean", "Std"]
+
+  # UXFD assembly toggles (disabled by default in base).
+  uxfd:
+    enable_sp2d: false
+    fusion:
+      type: "concat"
+    fuzzy:
+      enable: false
+      logit_scale: 1.0
+    operator_attention:
+      enable: false
+      operators: ["I", "HT", "FFT"]
+      hidden_dim: 128
+      temperature: 1.0
+    logic:
+      enable: false
+      hidden_dim: 128
+      logit_scale: 1.0

--- a/src/model_factory/X_model/TSPN_UXFD.py
+++ b/src/model_factory/X_model/TSPN_UXFD.py
@@ -66,6 +66,11 @@ class Model(_TSPNModel):
 
         if self._uxfd_enable_sp2d:
             cfg = _build_stft_cfg(args)
+            if not cfg.magnitude:
+                raise ValueError(
+                    "TSPN_UXFD SP2D requires uxfd.sp2d.magnitude=true; "
+                    "complex real/imag output is not supported by the U1 pooling and fusion contract."
+                )
             self._uxfd_sp2d = STFTTimeFrequency(cfg).to(self.args.device)
             self._uxfd_2d_proj = nn.Linear(
                 int(self.args.in_channels), int(self.channel_for_classifier)

--- a/src/model_factory/X_model/TSPN_UXFD.py
+++ b/src/model_factory/X_model/TSPN_UXFD.py
@@ -6,17 +6,273 @@ This model intentionally stays close to the upstream UXFD `TSPN.py` structure:
 `SignalProcessingLayer → FeatureExtractorlayer → Classifier`.
 
 Implementation note:
-- Today this wrapper reuses the existing `src/model_factory/X_model/TSPN.py` code path.
-- Future UXFD modularization should live under `src/model_factory/X_model/UXFD/`.
+- Default behavior reuses the existing `src/model_factory/X_model/TSPN.py` code path.
+- When enabled via `model.uxfd.*` config, it assembles optional UXFD modules under
+  `src/model_factory/X_model/UXFD/` (best-effort; keeps the entrypoint stable).
 """
 
 from __future__ import annotations
 
+from dataclasses import asdict
+from numbers import Integral
+from typing import Any, Dict, Optional
+
+import torch
+import torch.nn as nn
+
 from .TSPN import Model as _TSPNModel
+from .UXFD.fusion import FusionConfig, build_fusion
+from .UXFD.fuzzy import FuzzyConfig, FuzzyReasoner
+from .UXFD.neurosymbolic import LogicConfig, LogicReasoner
+from .UXFD.operator_attention import OperatorAttention1D, OperatorAttentionConfig
+from .UXFD.signal_processing_2d import STFTTimeFrequency
+from .UXFD.signal_processing_2d.stft_tfr import STFTConfig
 
 
 class Model(_TSPNModel):
-    """Alias of the existing TSPN implementation for stable registry naming."""
+    """UXFD-aligned TSPN with optional module assembly.
 
-    pass
+    Config (optional):
+    ```yaml
+    model:
+      name: TSPN_UXFD
+      type: X_model
+      uxfd:
+        enable_sp2d: true
+        sp2d:
+          n_fft: 128
+          hop_length: 64
+    ```
+    """
 
+    def __init__(self, args: Any, metadata: Any = None):
+        _validate_num_classes(args)
+        super().__init__(args, metadata)
+        self._uxfd_enable_sp2d = bool(_get_attr(args, "uxfd.enable_sp2d", False))
+        self._uxfd_enable_fuzzy = bool(_get_attr(args, "uxfd.fuzzy.enable", False))
+        self._uxfd_enable_operator_attention = bool(
+            _get_attr(args, "uxfd.operator_attention.enable", False)
+        )
+        self._uxfd_enable_logic = bool(_get_attr(args, "uxfd.logic.enable", False))
+
+        self._uxfd_sp2d: Optional[nn.Module] = None
+        self._uxfd_2d_proj: Optional[nn.Module] = None
+        self._uxfd_fusion: Optional[nn.Module] = None
+        self._uxfd_fuzzy: Optional[nn.Module] = None
+        self._uxfd_fuzzy_scale: float = 1.0
+        self._uxfd_operator_attention: Optional[nn.Module] = None
+        self._uxfd_logic: Optional[nn.Module] = None
+        self._uxfd_logic_scale: float = 1.0
+
+        if self._uxfd_enable_sp2d:
+            cfg = _build_stft_cfg(args)
+            self._uxfd_sp2d = STFTTimeFrequency(cfg).to(self.args.device)
+            self._uxfd_2d_proj = nn.Linear(
+                int(self.args.in_channels), int(self.channel_for_classifier)
+            ).to(self.args.device)
+            fusion_cfg = _build_fusion_cfg(args)
+            self._uxfd_fusion = build_fusion(int(self.channel_for_classifier), cfg=fusion_cfg).to(
+                self.args.device
+            )
+
+        if self._uxfd_enable_fuzzy:
+            fuzzy_cfg = _build_fuzzy_cfg(args)
+            self._uxfd_fuzzy = FuzzyReasoner(
+                dim_in=int(self.channel_for_classifier),
+                num_classes=int(self.args.num_classes),
+                cfg=fuzzy_cfg,
+            ).to(self.args.device)
+            self._uxfd_fuzzy_scale = float(getattr(fuzzy_cfg, "logit_scale", 1.0))
+
+        if self._uxfd_enable_operator_attention:
+            op_cfg = _build_operator_attention_cfg(args)
+            self._uxfd_operator_attention = OperatorAttention1D(
+                in_channels=int(getattr(self.args, "in_channels", 1)),
+                cfg=op_cfg,
+            ).to(self.args.device)
+
+        if self._uxfd_enable_logic:
+            logic_cfg = _build_logic_cfg(args)
+            self._uxfd_logic = LogicReasoner(
+                dim_in=int(self.channel_for_classifier),
+                num_classes=int(self.args.num_classes),
+                cfg=logic_cfg,
+            ).to(self.args.device)
+            self._uxfd_logic_scale = float(getattr(logic_cfg, "logit_scale", 1.0))
+
+    def forward(self, x: torch.Tensor, data_id=None, task_id=None) -> torch.Tensor:
+        features_1d = self._forward_1d_features(x)  # (B, D)
+        features = features_1d
+
+        if self._uxfd_enable_sp2d:
+            assert self._uxfd_sp2d is not None
+            assert self._uxfd_2d_proj is not None
+            assert self._uxfd_fusion is not None
+
+            x2d = self._uxfd_sp2d(x)  # (B, T, F, C) magnitude
+            pooled = x2d.mean(dim=(1, 2))  # (B, C)
+            proj = self._uxfd_2d_proj(pooled)  # (B, D)
+            features = self._uxfd_fusion(features_1d, proj)  # (B, D)
+
+        base_logits = self.clf(features)
+        logits = base_logits
+        if self._uxfd_enable_fuzzy:
+            assert self._uxfd_fuzzy is not None
+            fuzzy_logits = self._uxfd_fuzzy(features)
+            logits = logits + self._uxfd_fuzzy_scale * fuzzy_logits
+        if self._uxfd_enable_logic:
+            assert self._uxfd_logic is not None
+            logic_logits = self._uxfd_logic(features)
+            logits = logits + self._uxfd_logic_scale * logic_logits
+        return logits
+
+    def _forward_1d_features(self, x: torch.Tensor) -> torch.Tensor:
+        if self._uxfd_enable_operator_attention:
+            assert self._uxfd_operator_attention is not None
+            x, _weights = self._uxfd_operator_attention(x)
+        for layer in self.signal_processing_layers:
+            x = layer(x)
+        return self.feature_extractor_layers(x)
+
+    def get_uxfd_debug_state(self) -> Dict[str, Any]:
+        state: Dict[str, Any] = {
+            "enable_sp2d": bool(self._uxfd_enable_sp2d),
+            "enable_fuzzy": bool(self._uxfd_enable_fuzzy),
+            "enable_operator_attention": bool(self._uxfd_enable_operator_attention),
+            "enable_logic": bool(self._uxfd_enable_logic),
+        }
+
+        try:
+            if self._uxfd_enable_operator_attention and self._uxfd_operator_attention is not None:
+                op_attn = self._uxfd_operator_attention
+                weights = getattr(op_attn, "last_attention_weights", None)
+                ops = getattr(op_attn, "operators", None)
+                if weights is not None and hasattr(weights, "mean"):
+                    mean_w = weights.mean(dim=0).detach().cpu().tolist()
+                else:
+                    mean_w = None
+                state["operator_attention"] = {"operators": ops, "attention_mean": mean_w}
+        except Exception:
+            pass
+
+        return state
+
+
+def _get_attr(obj: Any, dotted: str, default: Any) -> Any:
+    cur = obj
+    for part in dotted.split("."):
+        if cur is None or not hasattr(cur, part):
+            return default
+        cur = getattr(cur, part)
+    return cur
+
+
+def _validate_num_classes(args: Any) -> None:
+    num_classes = getattr(args, "num_classes", None)
+    if isinstance(num_classes, bool) or not isinstance(num_classes, Integral):
+        if isinstance(num_classes, dict):
+            detail = f"dict keys={list(num_classes.keys())}"
+        else:
+            detail = type(num_classes).__name__
+        raise ValueError(
+            "TSPN_UXFD U1 requires args.num_classes to be an integer. "
+            f"Got {detail}; dict-valued multi-dataset heads are out of scope for U1."
+        )
+    if int(num_classes) <= 0:
+        raise ValueError(f"TSPN_UXFD requires a positive num_classes, got {num_classes}.")
+
+
+def _build_stft_cfg(args: Any) -> STFTConfig:
+    # Prefer explicit config, otherwise derive a safe default from `in_dim`.
+    in_dim = int(getattr(args, "in_dim", 256) or 256)
+    default_n_fft = max(16, min(256, in_dim))
+    default_hop = max(1, default_n_fft // 2)
+
+    sp2d_cfg = _get_attr(args, "uxfd.sp2d", None)
+    if sp2d_cfg is None:
+        return STFTConfig(n_fft=default_n_fft, hop_length=default_hop)
+
+    cfg_dict = {}
+    if hasattr(sp2d_cfg, "__dict__"):
+        cfg_dict = dict(sp2d_cfg.__dict__)
+    elif isinstance(sp2d_cfg, dict):
+        cfg_dict = dict(sp2d_cfg)
+
+    merged = dict(asdict(STFTConfig(n_fft=default_n_fft, hop_length=default_hop)))
+    allowed = set(merged.keys())
+    merged.update({k: v for k, v in cfg_dict.items() if k in allowed and v is not None})
+    merged["n_fft"] = max(16, min(int(merged["n_fft"]), in_dim))
+    merged["hop_length"] = max(1, min(int(merged["hop_length"]), merged["n_fft"]))
+    if merged.get("win_length") is not None:
+        merged["win_length"] = max(1, min(int(merged["win_length"]), merged["n_fft"]))
+    return STFTConfig(**merged)
+
+
+def _build_fusion_cfg(args: Any) -> FusionConfig:
+    fusion_obj = _get_attr(args, "uxfd.fusion", None)
+    if fusion_obj is None:
+        return FusionConfig()
+
+    fusion_type = None
+    if hasattr(fusion_obj, "type"):
+        fusion_type = getattr(fusion_obj, "type")
+    elif isinstance(fusion_obj, dict):
+        fusion_type = fusion_obj.get("type")
+
+    if fusion_type is None:
+        return FusionConfig()
+
+    return FusionConfig(fusion_type=str(fusion_type))
+
+
+def _build_fuzzy_cfg(args: Any) -> FuzzyConfig:
+    fuzzy_obj = _get_attr(args, "uxfd.fuzzy", None)
+    if fuzzy_obj is None:
+        return FuzzyConfig()
+
+    cfg_dict = {}
+    if hasattr(fuzzy_obj, "__dict__"):
+        cfg_dict = dict(fuzzy_obj.__dict__)
+    elif isinstance(fuzzy_obj, dict):
+        cfg_dict = dict(fuzzy_obj)
+
+    base = FuzzyConfig()
+    allowed = set(base.__dict__.keys())
+    merged = {k: v for k, v in cfg_dict.items() if k in allowed and v is not None}
+    return FuzzyConfig(**{**base.__dict__, **merged})
+
+
+def _build_operator_attention_cfg(args: Any) -> OperatorAttentionConfig:
+    op_obj = _get_attr(args, "uxfd.operator_attention", None)
+    if op_obj is None:
+        return OperatorAttentionConfig()
+
+    cfg_dict = {}
+    if hasattr(op_obj, "__dict__"):
+        cfg_dict = dict(op_obj.__dict__)
+    elif isinstance(op_obj, dict):
+        cfg_dict = dict(op_obj)
+
+    base = OperatorAttentionConfig()
+    allowed = set(base.__dict__.keys())
+    merged = {k: v for k, v in cfg_dict.items() if k in allowed and v is not None}
+    if isinstance(merged.get("operators"), str):
+        merged["operators"] = [s.strip() for s in merged["operators"].split(",") if s.strip()]
+    return OperatorAttentionConfig(**{**base.__dict__, **merged})
+
+
+def _build_logic_cfg(args: Any) -> LogicConfig:
+    logic_obj = _get_attr(args, "uxfd.logic", None)
+    if logic_obj is None:
+        return LogicConfig()
+
+    cfg_dict = {}
+    if hasattr(logic_obj, "__dict__"):
+        cfg_dict = dict(logic_obj.__dict__)
+    elif isinstance(logic_obj, dict):
+        cfg_dict = dict(logic_obj)
+
+    base = LogicConfig()
+    allowed = set(base.__dict__.keys())
+    merged = {k: v for k, v in cfg_dict.items() if k in allowed and v is not None}
+    return LogicConfig(**{**base.__dict__, **merged})

--- a/src/model_factory/X_model/UXFD/FACT_TABLE.md
+++ b/src/model_factory/X_model/UXFD/FACT_TABLE.md
@@ -1,0 +1,62 @@
+# UXFD Fact Table (SSOT)
+
+This document is **fact-driven**: it only describes what exists in code/config today.
+
+## Core Model Contract
+
+All UXFD demos/papers should converge on:
+
+- `model.type: X_model`
+- `model.name: TSPN_UXFD`
+
+Implementation entry:
+- `src/model_factory/X_model/TSPN_UXFD.py`
+
+## Data Flow (high level)
+
+Input:
+- tensor `x` with shape `(B, L, C)` (time-series windows; `C=in_channels`)
+
+Forward (default):
+- `TSPN` path in `src/model_factory/X_model/TSPN.py`:
+  - Signal processing layers (operator graph)
+  - Feature extraction (statistical features)
+  - Classifier → logits `(B, num_classes)`
+
+Optional UXFD modules (assembled by `TSPN_UXFD`):
+- `model.uxfd.operator_attention.enable=true`: pre-processing of `x` via operator-attention
+- `model.uxfd.enable_sp2d=true`: 2D STFT branch + fusion into 1D feature vector
+- `model.uxfd.fuzzy.enable=true`: fuzzy logits residual added to base logits
+- `model.uxfd.logic.enable=true`: logic logits residual added to base logits
+
+## NSN Wrapper
+
+NSN is planned for U3 and is out of scope for the U1 runtime contract. This repository state only exposes the
+`TSPN_UXFD` entrypoint listed above.
+
+Semantic rule for future NSN work:
+- `STFT` is not an `ALL_SP` operator key. If a YAML uses an `STFT` token, it must be mapped to the SP2D branch
+  (`model.uxfd.enable_sp2d=true`) rather than treated as a 1D operator.
+
+## Configuration Surface (selected knobs)
+
+TSPN composition:
+- `model.signal_processing_configs.layer*`: operator keys (see `src/model_factory/X_model/UXFD/OPERATOR_CATALOG.md`)
+- `model.feature_extractor_configs`: feature keys (see `src/model_factory/X_model/UXFD/OPERATOR_CATALOG.md`)
+
+UXFD assembly toggles:
+- `model.uxfd.enable_sp2d` (bool)
+- `model.uxfd.sp2d.n_fft`, `model.uxfd.sp2d.hop_length`
+- `model.uxfd.fusion.type`: `concat|sum|gated`
+- `model.uxfd.fuzzy.enable`, `model.uxfd.fuzzy.logit_scale`
+- `model.uxfd.operator_attention.enable`, `model.uxfd.operator_attention.operators`
+- `model.uxfd.logic.enable`, `model.uxfd.logic.logit_scale`
+
+Run artifacts:
+- `<run_dir>/config_snapshot.yaml`
+- `<run_dir>/artifacts/manifest.json`
+- optional: `<run_dir>/artifacts/predictions.npz` when `trainer.extensions.predictions.enable=true`
+
+## Runnable Demos
+
+Maintained UXFD and NSN demos are planned for U2/U3 and are not part of this U1 contract.

--- a/src/model_factory/X_model/UXFD/OPERATOR_CATALOG.md
+++ b/src/model_factory/X_model/UXFD/OPERATOR_CATALOG.md
@@ -1,0 +1,73 @@
+# UXFD Operator Catalog (SSOT)
+
+This catalog enumerates the currently available operators/features that can be composed by `TSPN` / `TSPN_UXFD`.
+
+## Signal Processing Operators (`ALL_SP`)
+
+Defined in `src/model_factory/X_model/TSPN.py` (mapping keys → operator modules).
+
+### Unary operators
+
+- `FFT`
+- `HT`
+- `WF`
+- `I`
+- `LNO`
+- `RWF`
+- `LWF`
+- `CWF`
+- `MWF`
+- `Morlet`
+- `Laplace`
+- `Order1MAFilter`
+- `Order2MAFilter`
+- `Order1DFFilter`
+- `Order2DFFilter`
+- `Log`
+- `Squ`
+- `Sin`
+
+### Binary operators (2-arity)
+
+- `Add`
+- `Mul`
+- `Div`
+
+Configuration mapping:
+- `model.signal_processing_configs.layer1: ["I", "FFT", ...]`
+
+## Feature Extractors (`ALL_FE`)
+
+Defined in `src/model_factory/X_model/TSPN.py` (mapping keys → feature modules).
+
+- `Mean`
+- `Std`
+- `Var`
+- `Entropy`
+- `Max`
+- `Min`
+- `AbsMean`
+- `Kurtosis`
+- `RMS`
+- `CrestFactor`
+- `Skewness`
+- `ClearanceFactor`
+- `ShapeFactor`
+
+Configuration mapping:
+- `model.feature_extractor_configs: ["Mean", "Std", ...]`
+
+## UXFD-specific Modules (assembled by `TSPN_UXFD`)
+
+Implementation: `src/model_factory/X_model/TSPN_UXFD.py`
+
+- SP2D: `src/model_factory/X_model/UXFD/signal_processing_2d/`
+  - knobs: `model.uxfd.enable_sp2d`, `model.uxfd.sp2d.*`
+- Fusion: `src/model_factory/X_model/UXFD/fusion/`
+  - knobs: `model.uxfd.fusion.type` (`concat|sum|gated`)
+- Fuzzy: `src/model_factory/X_model/UXFD/fuzzy/`
+  - knobs: `model.uxfd.fuzzy.enable`, `model.uxfd.fuzzy.logit_scale`
+- Operator Attention: `src/model_factory/X_model/UXFD/operator_attention/`
+  - knobs: `model.uxfd.operator_attention.enable`, `model.uxfd.operator_attention.operators`
+- Logic (neuro-symbolic): `src/model_factory/X_model/UXFD/neurosymbolic/`
+  - knobs: `model.uxfd.logic.enable`, `model.uxfd.logic.logit_scale`

--- a/src/model_factory/X_model/UXFD/README.md
+++ b/src/model_factory/X_model/UXFD/README.md
@@ -1,12 +1,40 @@
 # UXFD (Common Modules)
 
-This package hosts **common, reusable UXFD building blocks** that are shared across the 7 UXFD paper submodules.
+This package hosts **reusable UXFD building blocks** that are shared across the UXFD paper submodules.
 
-Scope:
-- Put reusable operators/modules here (signal processing 1D/2D, fusion, fuzzy logic, operator attention, TSPN wrappers).
-- Do **not** put paper-specific experiment configs here (those live in each `paper/UXFD_paper/<paper_id>/` submodule).
+## Quick Validate
 
-Notes:
-- The current maintained runnable TSPN implementation lives in `src/model_factory/X_model/TSPN.py`.
-- This package provides an organized landing area; some modules may initially re-export from legacy files for compatibility.
+```bash
+python -m scripts.validate_configs
+python -m scripts.validate_docs
+python -m pytest test/test_tspn_uxfd_assembly.py -q
+```
 
+## Core Contract (SSOT)
+
+One core model contract for UXFD-enabled runs:
+- `model.type: X_model`
+- `model.name: TSPN_UXFD` (implementation: `src/model_factory/X_model/TSPN_UXFD.py`)
+
+The composition surface is config-driven:
+- base operator graph: `model.signal_processing_configs.layer*` (keys from `ALL_SP`)
+- base feature extraction: `model.feature_extractor_configs` (keys from `ALL_FE`)
+- UXFD assembly toggles: `model.uxfd.*` (SP2D / fusion / fuzzy / operator-attention / logic)
+
+SSOT docs:
+- `src/model_factory/X_model/UXFD/FACT_TABLE.md` (what exists today + artifact contract)
+- `src/model_factory/X_model/UXFD/OPERATOR_CATALOG.md` (operator/feature key catalog)
+
+## Package Layout
+
+- `src/model_factory/X_model/UXFD/signal_processing_1d/`: 1D signal operators used by `TSPN` (see `ALL_SP`).
+- `src/model_factory/X_model/UXFD/signal_processing_2d/`: 2D time-frequency branch (STFT) used by `TSPN_UXFD`.
+- `src/model_factory/X_model/UXFD/fusion/`: fusion modules for combining SP2D branch with 1D features.
+- `src/model_factory/X_model/UXFD/fuzzy/`: fuzzy residual logits (best-effort, config-gated).
+- `src/model_factory/X_model/UXFD/operator_attention/`: operator-attention pre-processing of raw input (config-gated).
+- `src/model_factory/X_model/UXFD/neurosymbolic/`: neurosymbolic / logic residual logits (best-effort, config-gated).
+
+## Repo Discipline
+
+- Keep paper-specific configs inside each paper submodule (`paper/UXFD_paper/<paper_id>/`).
+- Keep shared code here. Maintained runnable entrypoints under `configs/demo/uxfd/` are planned for U2.

--- a/src/model_factory/X_model/UXFD/fusion/__init__.py
+++ b/src/model_factory/X_model/UXFD/fusion/__init__.py
@@ -1,4 +1,8 @@
 """Fusion operators (UXFD)."""
 
-__all__ = []
+from .simple_fusion import FusionConfig, build_fusion
 
+__all__ = [
+    "FusionConfig",
+    "build_fusion",
+]

--- a/src/model_factory/X_model/UXFD/fusion/simple_fusion.py
+++ b/src/model_factory/X_model/UXFD/fusion/simple_fusion.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal, Optional
+
+import torch
+import torch.nn as nn
+
+
+FusionType = Literal["concat", "sum", "gated"]
+
+
+@dataclass(frozen=True)
+class FusionConfig:
+    fusion_type: FusionType = "concat"
+
+
+class ConcatProjectFusion(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        self.proj = nn.Linear(dim * 2, dim)
+
+    def forward(self, a: torch.Tensor, b: torch.Tensor) -> torch.Tensor:
+        return self.proj(torch.cat([a, b], dim=1))
+
+
+class SumFusion(nn.Module):
+    def forward(self, a: torch.Tensor, b: torch.Tensor) -> torch.Tensor:
+        return a + b
+
+
+class GatedFusion(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        self.gate = nn.Sequential(nn.Linear(dim * 2, dim), nn.Sigmoid())
+
+    def forward(self, a: torch.Tensor, b: torch.Tensor) -> torch.Tensor:
+        gate = self.gate(torch.cat([a, b], dim=1))
+        return gate * a + (1.0 - gate) * b
+
+
+def build_fusion(dim: int, cfg: Optional[FusionConfig] = None) -> nn.Module:
+    cfg = cfg or FusionConfig()
+    if cfg.fusion_type == "concat":
+        return ConcatProjectFusion(dim)
+    if cfg.fusion_type == "sum":
+        return SumFusion()
+    if cfg.fusion_type == "gated":
+        return GatedFusion(dim)
+    raise ValueError(f"Unknown fusion_type: {cfg.fusion_type}")

--- a/src/model_factory/X_model/UXFD/fuzzy/__init__.py
+++ b/src/model_factory/X_model/UXFD/fuzzy/__init__.py
@@ -1,4 +1,8 @@
 """Fuzzy logic operators (UXFD)."""
 
-__all__ = []
+from .fuzzy_reasoner import FuzzyConfig, FuzzyReasoner
 
+__all__ = [
+    "FuzzyConfig",
+    "FuzzyReasoner",
+]

--- a/src/model_factory/X_model/UXFD/fuzzy/fuzzy_reasoner.py
+++ b/src/model_factory/X_model/UXFD/fuzzy/fuzzy_reasoner.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+
+@dataclass(frozen=True)
+class FuzzyConfig:
+    num_fuzzy_features: int = 32
+    num_membership_functions: int = 3  # low/medium/high (Gaussian)
+    num_rules: int = 10
+    logit_scale: float = 1.0
+
+
+class FuzzyReasoner(nn.Module):
+    """A small fuzzy-rule head over a feature vector.
+
+    Input:  (B, D)
+    Output: (B, num_classes) logits (to be added to a base classifier).
+    """
+
+    def __init__(self, dim_in: int, num_classes: int, cfg: Optional[FuzzyConfig] = None):
+        super().__init__()
+        self.cfg = cfg or FuzzyConfig()
+
+        self.feature_reducer = nn.Sequential(
+            nn.Linear(dim_in, int(self.cfg.num_fuzzy_features)),
+            nn.ReLU(inplace=True),
+        )
+
+        f = int(self.cfg.num_fuzzy_features)
+        m = int(self.cfg.num_membership_functions)
+        r = int(self.cfg.num_rules)
+        k = int(num_classes)
+
+        self.centers = nn.Parameter(torch.randn(f, m) * 0.5)
+        self.widths = nn.Parameter(torch.ones(f, m) * 0.3)
+        self.rule_weights = nn.Parameter(torch.ones(r, f) / max(1, f))
+        self.rule_outputs = nn.Parameter(torch.randn(r, k) * 0.1)
+
+        self.classifier = nn.Sequential(
+            nn.Linear(k, 64),
+            nn.ReLU(inplace=True),
+            nn.Linear(64, k),
+        )
+
+    def forward(self, features: torch.Tensor) -> torch.Tensor:
+        reduced = self.feature_reducer(features)  # (B, F)
+        membership = self._compute_membership(reduced)  # (B, F, M)
+        fuzzy_logits = self._apply_rules(membership)  # (B, K)
+        return self.classifier(fuzzy_logits)
+
+    def _compute_membership(self, x: torch.Tensor) -> torch.Tensor:
+        x_expanded = x.unsqueeze(-1)  # (B, F, 1)
+        centers = self.centers.unsqueeze(0)  # (1, F, M)
+        widths = torch.abs(self.widths).unsqueeze(0).clamp_min(1e-6)  # (1, F, M)
+        return torch.exp(-((x_expanded - centers) ** 2) / (2.0 * widths**2))
+
+    def _apply_rules(self, membership: torch.Tensor) -> torch.Tensor:
+        aggregated = membership.mean(dim=2)  # (B, F)
+        activation = torch.sum(
+            aggregated.unsqueeze(1) * self.rule_weights.unsqueeze(0),
+            dim=2,
+        )  # (B, R)
+        activation = F.softmax(activation, dim=-1)
+        outputs = activation.unsqueeze(-1) * self.rule_outputs.unsqueeze(0)  # (B, R, K)
+        return outputs.sum(dim=1)

--- a/src/model_factory/X_model/UXFD/neurosymbolic/__init__.py
+++ b/src/model_factory/X_model/UXFD/neurosymbolic/__init__.py
@@ -1,0 +1,8 @@
+"""Neuro-symbolic / logic reasoning components (UXFD)."""
+
+from .logic_reasoner import LogicConfig, LogicReasoner
+
+__all__ = [
+    "LogicConfig",
+    "LogicReasoner",
+]

--- a/src/model_factory/X_model/UXFD/neurosymbolic/logic_reasoner.py
+++ b/src/model_factory/X_model/UXFD/neurosymbolic/logic_reasoner.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+import torch
+import torch.nn as nn
+
+
+@dataclass(frozen=True)
+class LogicConfig:
+    """Minimal neuro-symbolic reasoning config.
+
+    This is a best-effort placeholder slot for the UXFD merge. It is designed to:
+    - be device-agnostic (no import-time .cuda())
+    - never hard-crash when enabled
+    - provide a stable knob surface under `model.uxfd.logic.*`
+    """
+
+    hidden_dim: int = 128
+    logit_scale: float = 1.0
+
+
+class LogicReasoner(nn.Module):
+    """A minimal "logic residual" head over learned features.
+
+    Input:  features (B, D)
+    Output: logits_residual (B, num_classes)
+    """
+
+    def __init__(self, dim_in: int, num_classes: int, cfg: Optional[LogicConfig] = None) -> None:
+        super().__init__()
+        self.cfg = cfg or LogicConfig()
+        self.net = nn.Sequential(
+            nn.Linear(int(dim_in), int(self.cfg.hidden_dim)),
+            nn.ReLU(inplace=True),
+            nn.Linear(int(self.cfg.hidden_dim), int(num_classes)),
+        )
+
+    def forward(self, features: torch.Tensor) -> torch.Tensor:
+        if features.ndim != 2:
+            features = features.view(features.size(0), -1)
+        return self.net(features)

--- a/src/model_factory/X_model/UXFD/operator_attention/__init__.py
+++ b/src/model_factory/X_model/UXFD/operator_attention/__init__.py
@@ -1,4 +1,8 @@
 """Operator-attention components (UXFD)."""
 
-__all__ = []
+from .operator_attention_1d import OperatorAttention1D, OperatorAttentionConfig
 
+__all__ = [
+    "OperatorAttention1D",
+    "OperatorAttentionConfig",
+]

--- a/src/model_factory/X_model/UXFD/operator_attention/operator_attention_1d.py
+++ b/src/model_factory/X_model/UXFD/operator_attention/operator_attention_1d.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List, Optional, Sequence
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+
+@dataclass(frozen=True)
+class OperatorAttentionConfig:
+    operators: Sequence[str] = ("I", "HT", "FFT")
+    hidden_dim: int = 128
+    temperature: float = 1.0
+
+
+class OperatorAttention1D(nn.Module):
+    """Operator-attention over a small set of 1D signal operators.
+
+    Input:  x (B, L, C)
+    Output: y (B, L, C), attention_weights (B, K)
+    """
+
+    def __init__(self, in_channels: int, cfg: Optional[OperatorAttentionConfig] = None):
+        super().__init__()
+        self.cfg = cfg or OperatorAttentionConfig()
+        self.operators = [str(op) for op in self.cfg.operators]
+        if not self.operators:
+            raise ValueError("OperatorAttention1D requires a non-empty operators list.")
+
+        self.temperature = float(self.cfg.temperature)
+        self.gate = nn.Sequential(
+            nn.Linear(int(in_channels), int(self.cfg.hidden_dim)),
+            nn.ReLU(inplace=True),
+            nn.Linear(int(self.cfg.hidden_dim), len(self.operators)),
+        )
+        self.last_attention_weights: Optional[torch.Tensor] = None
+
+    def forward(self, x: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+        if x.ndim != 3:
+            raise ValueError(f"Expected x shape (B,L,C), got {tuple(x.shape)}")
+
+        b, l, c = x.shape
+        global_features = x.mean(dim=1)  # (B, C)
+        logits = self.gate(global_features) / max(self.temperature, 1e-6)
+        weights = F.softmax(logits, dim=1)  # (B, K)
+
+        outputs: List[torch.Tensor] = []
+        for op in self.operators:
+            outputs.append(_apply_operator(op, x))
+
+        y = torch.zeros_like(outputs[0])
+        for i, out in enumerate(outputs):
+            y = y + weights[:, i].view(b, 1, 1) * out
+
+        self.last_attention_weights = weights.detach()
+        return y, weights
+
+
+def _apply_operator(op: str, x: torch.Tensor) -> torch.Tensor:
+    op_norm = op.strip().upper()
+    if op_norm in {"I", "IDENTITY"}:
+        return x
+    if op_norm in {"HT", "HILBERT"}:
+        return _hilbert_envelope(x)
+    if op_norm in {"FFT"}:
+        return _fft_magnitude_resample(x)
+    raise ValueError(f"Unsupported operator for OperatorAttention1D: {op}")
+
+
+def _hilbert_envelope(x: torch.Tensor) -> torch.Tensor:
+    # Based on Signal_processing.HilbertTransform but device-agnostic.
+    x_bcl = x.permute(0, 2, 1)  # (B, C, L)
+    n = x_bcl.shape[-1]
+    xf = torch.fft.fft(x_bcl, dim=2)
+    if n % 2 == 0:
+        xf[..., 1 : n // 2] *= 2
+        xf[..., n // 2 + 1 :] = 0
+    else:
+        xf[..., 1 : (n + 1) // 2] *= 2
+        xf[..., (n + 1) // 2 :] = 0
+    env = torch.fft.ifft(xf, dim=2).abs()
+    return env.permute(0, 2, 1)  # (B, L, C)
+
+
+def _fft_magnitude_resample(x: torch.Tensor) -> torch.Tensor:
+    b, l, c = x.shape
+    fft = torch.fft.rfft(x, dim=1, norm="ortho")  # (B, F, C) complex
+    mag = fft.abs()  # (B, F, C)
+    mag_bcf = mag.permute(0, 2, 1)  # (B, C, F)
+    mag_up = F.interpolate(mag_bcf, size=l, mode="linear", align_corners=False)  # (B, C, L)
+    return mag_up.permute(0, 2, 1).contiguous()  # (B, L, C)

--- a/src/model_factory/model_factory.py
+++ b/src/model_factory/model_factory.py
@@ -35,7 +35,14 @@ def model_factory(args_model: Any, metadata: Any):
     nn.Module
         Instantiated model ready for training.
     """
-    args_model.num_classes = get_num_classes(metadata)
+    # Respect an explicit `num_classes` from config (common for classification models).
+    # Otherwise infer from metadata; if only one dataset_id is present, collapse to an int.
+    if not getattr(args_model, "num_classes", None):
+        inferred = get_num_classes(metadata)
+        if isinstance(inferred, dict):
+            args_model.num_classes = next(iter(inferred.values())) if len(inferred) == 1 else inferred
+        else:
+            args_model.num_classes = inferred
     # key = f"{args_model.type}.{args_model.name}"
 
 
@@ -89,4 +96,3 @@ def load_ckpt(model, ckpt_path):
         for name, model_sz in skipped:
             print(f"  {name}: checkpoint vs model {model_sz}")
     print(f"已加载匹配的权重: {ckpt_path}")
-

--- a/test/test_tspn_uxfd_assembly.py
+++ b/test/test_tspn_uxfd_assembly.py
@@ -1,0 +1,144 @@
+from __future__ import annotations
+
+import copy
+from types import SimpleNamespace
+from typing import Optional
+
+import pytest
+import torch
+
+from src.model_factory.X_model.TSPN_UXFD import Model as TSPNUXFD
+
+
+def _ns(**kwargs):  # type: ignore[no-untyped-def]
+    return SimpleNamespace(**kwargs)
+
+
+def _make_args(
+    *,
+    enable_sp2d: bool = False,
+    fusion_type: str = "concat",
+    enable_fuzzy: bool = False,
+    fuzzy_logit_scale: float = 1.0,
+    enable_operator_attention: bool = False,
+    operator_list: Optional[list[str]] = None,
+    enable_logic: bool = False,
+    logic_logit_scale: float = 1.0,
+    num_classes: object = 3,
+) -> SimpleNamespace:
+    uxfd = _ns(
+        enable_sp2d=enable_sp2d,
+        sp2d=_ns(n_fft=128, hop_length=64),
+        fusion=_ns(type=fusion_type),
+        fuzzy=_ns(enable=enable_fuzzy, logit_scale=fuzzy_logit_scale),
+        operator_attention=_ns(
+            enable=enable_operator_attention,
+            operators=operator_list or ["I", "FFT"],
+            hidden_dim=32,
+            temperature=1.0,
+        ),
+        logic=_ns(enable=enable_logic, logit_scale=logic_logit_scale, hidden_dim=32),
+    )
+
+    return _ns(
+        device="cpu",
+        num_classes=num_classes,
+        in_channels=2,
+        out_channels=4,
+        scale=1,
+        skip_connection=True,
+        signal_processing_configs={"layer1": ["I"]},
+        feature_extractor_configs=["Mean", "Std"],
+        in_dim=128,
+        out_dim=128,
+        uxfd=uxfd,
+    )
+
+
+def _forward_once(model: TSPNUXFD, x: torch.Tensor) -> torch.Tensor:
+    model.eval()
+    with torch.no_grad():
+        return model(x)
+
+
+def test_tspn_uxfd_rejects_dict_num_classes() -> None:
+    args = _make_args(num_classes={"source": 3, "target": 4})
+
+    with pytest.raises(ValueError, match="dict-valued multi-dataset heads are out of scope"):
+        TSPNUXFD(args)
+
+
+def test_tspn_uxfd_sp2d_modules_follow_configured_device() -> None:
+    args = _make_args(enable_sp2d=True, fusion_type="concat")
+    args.device = "meta"
+
+    model = TSPNUXFD(args)
+
+    assert model._uxfd_2d_proj is not None
+    assert model._uxfd_2d_proj.weight.device.type == "meta"
+    assert model._uxfd_fusion is not None
+    fusion_params = list(model._uxfd_fusion.parameters())
+    assert fusion_params
+    assert all(param.device.type == "meta" for param in fusion_params)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is not available")
+def test_tspn_uxfd_sp2d_forward_on_cuda() -> None:
+    torch.manual_seed(0)
+    args = _make_args(enable_sp2d=True, fusion_type="gated")
+    args.device = "cuda"
+    model = TSPNUXFD(args)
+    x = torch.randn(2, 128, 2, device="cuda")
+
+    logits = _forward_once(model, x)
+
+    assert logits.shape == (2, args.num_classes)
+    assert logits.device.type == "cuda"
+    assert torch.isfinite(logits).all()
+
+
+@pytest.mark.parametrize("fusion_type", ["concat", "sum", "gated"])
+def test_tspn_uxfd_sp2d_fusion_forward_shape(fusion_type: str) -> None:
+    torch.manual_seed(0)
+    args = _make_args(enable_sp2d=True, fusion_type=fusion_type)
+    model = TSPNUXFD(args)
+    x = torch.randn(2, 128, 2)
+
+    logits = _forward_once(model, x)
+    assert logits.shape == (2, args.num_classes)
+    assert torch.isfinite(logits).all()
+
+
+def test_tspn_uxfd_fuzzy_and_logic_residuals_forward_shape() -> None:
+    torch.manual_seed(0)
+    args = _make_args(enable_fuzzy=True, enable_logic=True, fuzzy_logit_scale=0.5, logic_logit_scale=0.5)
+    model = TSPNUXFD(args)
+    x = torch.randn(2, 128, 2)
+
+    logits = _forward_once(model, x)
+    assert logits.shape == (2, args.num_classes)
+    assert torch.isfinite(logits).all()
+
+
+def test_tspn_uxfd_operator_attention_debug_state() -> None:
+    torch.manual_seed(0)
+    args = _make_args(enable_operator_attention=True, operator_list=["I", "FFT"])
+    model = TSPNUXFD(args)
+    x = torch.randn(2, 128, 2)
+
+    _ = _forward_once(model, x)
+    state = model.get_uxfd_debug_state()
+    assert state["enable_operator_attention"] is True
+
+
+def test_tspn_uxfd_forward_is_repeatable_given_same_state() -> None:
+    torch.manual_seed(0)
+    args = _make_args(enable_sp2d=True, fusion_type="gated", enable_operator_attention=True)
+    model = TSPNUXFD(args)
+    x = torch.randn(2, 128, 2)
+
+    state_before = copy.deepcopy(model.state_dict())
+    out1 = _forward_once(model, x)
+    model.load_state_dict(state_before)
+    out2 = _forward_once(model, x)
+    assert torch.allclose(out1, out2, atol=0.0, rtol=0.0)

--- a/test/test_tspn_uxfd_assembly.py
+++ b/test/test_tspn_uxfd_assembly.py
@@ -68,6 +68,14 @@ def test_tspn_uxfd_rejects_dict_num_classes() -> None:
         TSPNUXFD(args)
 
 
+def test_tspn_uxfd_rejects_complex_sp2d_output() -> None:
+    args = _make_args(enable_sp2d=True)
+    args.uxfd.sp2d.magnitude = False
+
+    with pytest.raises(ValueError, match="requires uxfd.sp2d.magnitude=true"):
+        TSPNUXFD(args)
+
+
 def test_tspn_uxfd_sp2d_modules_follow_configured_device() -> None:
     args = _make_args(enable_sp2d=True, fusion_type="concat")
     args.device = "meta"


### PR DESCRIPTION
## Summary

Rebuild the reviewed UXFD U1 vertical slice on current `main` as a small, current, reviewable branch.

Included:

- `configs/base/model/tspn_uxfd.yaml`
- `src/model_factory/X_model/TSPN_UXFD.py`
- reusable UXFD modules under `src/model_factory/X_model/UXFD/`
  - fusion
  - fuzzy residual head
  - operator attention
  - neurosymbolic/logic residual head
- UXFD fact/operator documentation
- `test/test_tspn_uxfd_assembly.py`
- a focused `model_factory.py` adjustment that preserves explicit `model.num_classes` and collapses a single inferred class-count mapping to an integer

The current model registry already contains the `X_model,TSPN_UXFD` row, so this PR does not duplicate or broaden registry changes.

## Scope boundaries

Explicitly excluded:

- `configs/demo/uxfd/*`
- `configs/demo/nsn/*`
- `configs/config_registry.csv`
- `docs/CONFIG_ATLAS.md`
- NSN wrapper
- run-artifact or plot-factory code
- trainer extensions
- paper notes
- `main.py` changes

Those are separate U2+ capabilities and require their own validation gates.

## Rebuild provenance

- The prior PR #39 was 17 commits ahead and 15 commits behind current `main`, and GitHub no longer considered it mergeable.
- Changes on `main` since #39's merge base did not touch any of the 15 U1 files.
- This branch was created from current `main` and populated with the exact reviewed file blobs from the final #39 head.
- The rebuilt branch is currently three commits ahead and zero commits behind `main`:
  1. reviewed U1 source snapshot;
  2. explicit SP2D output-contract fix;
  3. focused regression test.

## Review fixes retained

- Reject dict-valued or otherwise non-integer `args.num_classes` before constructing the base classifier.
- Move SP2D projection, fusion, fuzzy, operator-attention, and logic modules to `args.device` during assembly.
- Remove or mark future-only references to absent NSN/demo entrypoints.
- Keep all optional UXFD modules disabled by default in the base config.
- Reject `uxfd.sp2d.magnitude=false` with a structured error because U1 pooling/fusion accepts only the four-dimensional magnitude contract, not real/imag-stacked complex output.

## Validation evidence

### Prior full-repository environment evidence from the reviewed #39 head

```text
python -m scripts.validate_docs
[OK] Documentation checks passed (109 files scanned).

python -m scripts.validate_configs
[OK] 7/7 configs passed schema validation.

python -m py_compile src/model_factory/X_model/TSPN_UXFD.py
passed

conda activate LQ_signal
python -m pytest test/test_tspn_uxfd_assembly.py -q
8 passed, 1 skipped
```

### Current rebuilt-head focused execution

A production-contract-compatible focused package was reconstructed from the reviewed U1 modules because the execution container could not resolve `github.com` for a full checkout.

```text
py_compile: passed for TSPN_UXFD and all focused U1 modules/tests
pytest -q test/test_tspn_uxfd_assembly.py
9 passed, 1 skipped in 4.21s
```

The skipped case is the CUDA-only forward test because the available runtime is CPU-only. This focused execution validates all CPU assembly paths and the new `magnitude=false` regression case; it is not represented as a full repository test run.

## Required local/CI gate before later demo promotion

```bash
python -m scripts.validate_docs
python -m scripts.validate_configs
python -m py_compile src/model_factory/X_model/TSPN_UXFD.py
python -m pytest test/test_tspn_uxfd_assembly.py -q
```

GitHub Actions are not configured for this head, so no CI result is claimed.

## Supersedes

Supersedes #39 without merging its stale branch history.