### PR TITLE
ci: add core documentation, config, and UXFD gates

### DIFF
--- a/.github/workflows/core-quality-gates.yml
+++ b/.github/workflows/core-quality-gates.yml
@@ -87,5 +87,22 @@ jobs:
             src/model_factory/X_model/UXFD/neurosymbolic/logic_reasoner.py \
             test/test_tspn_uxfd_assembly.py
 
+      - name: Record focused environment
+        run: python -m pip freeze > uxfd-focused-environment.txt
+
       - name: Run UXFD assembly tests
-        run: python -m pytest test/test_tspn_uxfd_assembly.py -q
+        shell: bash
+        run: |
+          set -o pipefail
+          python -m pytest test/test_tspn_uxfd_assembly.py -vv --tb=long 2>&1 | tee uxfd-pytest.log
+
+      - name: Upload focused diagnostics
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: uxfd-focused-diagnostics
+          path: |
+            uxfd-pytest.log
+            uxfd-focused-environment.txt
+          if-no-files-found: warn
+          retention-days: 7

--- a/.github/workflows/core-quality-gates.yml
+++ b/.github/workflows/core-quality-gates.yml
@@ -71,6 +71,7 @@ jobs:
         run: |
           python -m pip install \
             "numpy>=1.20" \
+            "pandas>=1.3" \
             "scipy" \
             "einops" \
             "sympy" \

--- a/.github/workflows/core-quality-gates.yml
+++ b/.github/workflows/core-quality-gates.yml
@@ -1,0 +1,91 @@
+name: Core quality gates
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: core-quality-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  docs-and-configs:
+    name: Docs and config contracts
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+
+      - name: Install config-tooling dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install "PyYAML>=6.0" "pydantic>=2.0"
+
+      - name: Validate documentation
+        run: python -m scripts.validate_docs
+
+      - name: Validate maintained configurations
+        run: python -m scripts.validate_configs
+
+      - name: Verify generated configuration atlas
+        run: |
+          python -m scripts.gen_config_atlas
+          git diff --exit-code docs/CONFIG_ATLAS.md
+
+      - name: Check whitespace errors
+        run: git diff --check
+
+  uxfd-focused:
+    name: UXFD focused contract
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+
+      - name: Install CPU Torch
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install --index-url https://download.pytorch.org/whl/cpu "torch==2.6.0"
+
+      - name: Install focused test dependencies
+        run: |
+          python -m pip install \
+            "numpy>=1.20" \
+            "scipy" \
+            "einops" \
+            "sympy" \
+            "pytorch-lightning>=1.5" \
+            "pytest>=7"
+
+      - name: Compile UXFD modules
+        run: |
+          python -m py_compile \
+            src/model_factory/X_model/TSPN_UXFD.py \
+            src/model_factory/X_model/UXFD/fusion/simple_fusion.py \
+            src/model_factory/X_model/UXFD/fuzzy/fuzzy_reasoner.py \
+            src/model_factory/X_model/UXFD/operator_attention/operator_attention_1d.py \
+            src/model_factory/X_model/UXFD/neurosymbolic/logic_reasoner.py \
+            test/test_tspn_uxfd_assembly.py
+
+      - name: Run UXFD assembly tests
+        run: python -m pytest test/test_tspn_uxfd_assembly.py -q


### PR DESCRIPTION
## Summary

Add the first active GitHub Actions workflow for the current maintained repository surface.

The workflow contains two isolated jobs:

1. **Docs and config contracts**
   - installs only PyYAML and Pydantic;
   - runs `scripts.validate_docs`;
   - runs `scripts.validate_configs`;
   - regenerates `docs/CONFIG_ATLAS.md` and requires a clean diff;
   - checks whitespace errors.
2. **UXFD focused contract**
   - installs CPU-only Torch and the focused import/test dependencies;
   - compiles the UXFD U1 modules and test;
   - runs `test/test_tspn_uxfd_assembly.py`;
   - retains a seven-day diagnostic artifact containing the focused environment and pytest log.

## Why

Until now, pull requests have relied on local validation descriptions without an active workflow attached to their heads. The UXFD U2 demo must not be promoted from `needs_smoke` without independently visible validation. This workflow establishes a narrow, reproducible baseline without installing the repository's full optional research stack in every job.

## Scope

Exactly one new file:

```text
.github/workflows/core-quality-gates.yml
```

No runtime, config, registry, docs, tests, or dependency-file changes.

## Design constraints

- Preserves `python main.py --config ...` and all factory boundaries.
- Uses Python 3.10, matching the documented setup.
- Uses CPU-only Torch for the focused model contract.
- Separates lightweight docs/config validation from model-test dependencies.
- Uses read-only repository permissions.
- Cancels superseded runs for the same workflow/ref.
- Does not claim to be the final release matrix or a performance benchmark.

## CI evidence

Workflow run `29269387587` completed successfully on head `d574cca9569f346e14c6f80412154e964c49cdde`.

### Docs and config contracts — passed

- documentation validation
- maintained config schema validation
- generated config atlas clean-diff check
- whitespace check

### UXFD focused contract — passed

- CPU Torch installation
- focused dependency installation
- UXFD module/test compilation
- focused environment capture
- `test/test_tspn_uxfd_assembly.py`
- diagnostic artifact upload

An earlier run exposed a real dependency-closure issue: importing `src.model_factory` loads `src.utils.env_builders`, which imports pandas. The workflow was corrected by adding pandas to the focused dependency set; no check was disabled or waived.

## Acceptance criteria

- Both jobs are created by GitHub for pull requests and pushes to `main`.
- Both jobs pass on the final head.
- No generated atlas diff remains.
- Failed focused runs preserve their environment and pytest output for diagnosis.
