### PR TITLE
fix: make the offline config-first smoke dependency-bounded

### DIFF
--- a/.github/workflows/core-quality-gates.yml
+++ b/.github/workflows/core-quality-gates.yml
@@ -140,6 +140,7 @@ jobs:
             "h5py" \
             "einops" \
             "sympy" \
+            "reformer-pytorch" \
             "pytorch-lightning>=1.5" \
             "torchmetrics>=1.0" \
             "PyYAML>=6.0" \

--- a/.github/workflows/core-quality-gates.yml
+++ b/.github/workflows/core-quality-gates.yml
@@ -140,7 +140,6 @@ jobs:
             "h5py" \
             "einops" \
             "sympy" \
-            "reformer-pytorch" \
             "pytorch-lightning>=1.5" \
             "torchmetrics>=1.0" \
             "PyYAML>=6.0" \

--- a/.github/workflows/core-quality-gates.yml
+++ b/.github/workflows/core-quality-gates.yml
@@ -107,3 +107,66 @@ jobs:
             uxfd-focused-environment.txt
           if-no-files-found: warn
           retention-days: 7
+
+  offline-smoke:
+    name: Offline config-first smoke
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    env:
+      MPLBACKEND: Agg
+      WANDB_MODE: disabled
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+
+      - name: Install CPU Torch
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install --index-url https://download.pytorch.org/whl/cpu "torch==2.6.0"
+
+      - name: Install maintained smoke dependencies
+        run: |
+          python -m pip install \
+            "numpy>=1.20" \
+            "pandas>=1.3" \
+            "scipy" \
+            "scikit-learn>=1.0" \
+            "h5py" \
+            "einops" \
+            "sympy" \
+            "pytorch-lightning>=1.5" \
+            "torchmetrics>=1.0" \
+            "PyYAML>=6.0" \
+            "matplotlib" \
+            "tensorboard" \
+            "openpyxl"
+
+      - name: Record smoke environment
+        run: python -m pip freeze > offline-smoke-environment.txt
+
+      - name: Run repository-shipped dummy smoke
+        shell: bash
+        run: |
+          set -o pipefail
+          python main.py \
+            --config configs/demo/00_smoke/dummy_dg.yaml \
+            --override trainer.num_epochs=1 \
+            --override data.num_workers=0 \
+            2>&1 | tee offline-smoke.log
+
+      - name: Upload smoke diagnostics
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: offline-smoke-diagnostics
+          path: |
+            offline-smoke.log
+            offline-smoke-environment.txt
+          if-no-files-found: warn
+          retention-days: 7

--- a/src/model_factory/ISFM/M_01_ISFM.py
+++ b/src/model_factory/ISFM/M_01_ISFM.py
@@ -1,134 +1,155 @@
-from src.model_factory.ISFM.embedding import *
-from src.model_factory.ISFM.embedding import E_03_Patch
-from src.model_factory.ISFM.backbone import *
-from src.model_factory.ISFM.task_head import *
-from src.model_factory.ISFM.system_utils import resolve_batch_metadata
-import torch.nn as nn
-import numpy as np
-import os
+from __future__ import annotations
+
+from importlib import import_module
+from typing import Any
+
 import torch
-import pandas as pd
+import torch.nn as nn
+
+from src.model_factory.ISFM.system_utils import resolve_batch_metadata
 from src.utils.utils import get_num_classes
 
+
+# Component IDs remain config-facing. Values are module and symbol names so the
+# selected implementation is imported only when the model is instantiated.
 Embedding_dict = {
-    'E_01_HSE': E_01_HSE,
-    # 'E_01_HSE_Prompt': E_01_HSE_Prompt,  # Prompt-guided HSE for contrastive learning
-    'E_02_HSE_v2': E_02_HSE_v2,  # Updated to use the new HSE class
-    # Patch-based embedding as basic baseline (P1)
-    'E_03_Patch': E_03_Patch,
+    "E_01_HSE": ("src.model_factory.ISFM.embedding.E_01_HSE", "E_01_HSE"),
+    "E_02_HSE_v2": ("src.model_factory.ISFM.embedding.E_02_HSE_rec", "E_02_HSE_v2"),
+    "E_03_Patch": ("src.model_factory.ISFM.embedding.E_03_Patch", "E_03_Patch"),
 }
+
 Backbone_dict = {
-    'B_01_basic_transformer': B_01_basic_transformer,
-    'B_03_FITS': B_03_FITS,
-    'B_04_Dlinear': B_04_Dlinear,
-    'B_05_Mamba': B_05_Mamba,   
-    'B_06_TimesNet': B_06_TimesNet,
-    'B_07_TSMixer': B_07_TSMixer,
-    'B_08_PatchTST': B_08_PatchTST,
-    'B_09_FNO': B_09_FNO,
-    
+    "B_01_basic_transformer": (
+        "src.model_factory.ISFM.backbone.B_01_basic_transformer",
+        "B_01_basic_transformer",
+    ),
+    "B_03_FITS": ("src.model_factory.ISFM.backbone.B_03_FITS", "B_03_FITS"),
+    "B_04_Dlinear": ("src.model_factory.ISFM.backbone.B_04_Dlinear", "B_04_Dlinear"),
+    "B_05_Mamba": ("src.model_factory.ISFM.backbone.B_05_Mamba", "B_05_Mamba"),
+    "B_06_TimesNet": ("src.model_factory.ISFM.backbone.B_06_TimesNet", "B_06_TimesNet"),
+    "B_07_TSMixer": ("src.model_factory.ISFM.backbone.B_07_TSMixer", "B_07_TSMixer"),
+    "B_08_PatchTST": ("src.model_factory.ISFM.backbone.B_08_PatchTST", "B_08_PatchTST"),
+    "B_09_FNO": ("src.model_factory.ISFM.backbone.B_09_FNO", "B_09_FNO"),
 }
+
 TaskHead_dict = {
-    'H_01_Linear_cla': H_01_Linear_cla,
-    'H_02_distance_cla': H_02_distance_cla,
-    'H_03_Linear_pred': H_03_Linear_pred,
-    'H_09_multiple_task': H_09_multiple_task, # Add the new multiple task head
-    'MultiTaskHead': MultiTaskHead, # Add the enhanced multi-task head
+    "H_01_Linear_cla": (
+        "src.model_factory.ISFM.task_head.H_01_Linear_cla",
+        "H_01_Linear_cla",
+    ),
+    "H_02_distance_cla": (
+        "src.model_factory.ISFM.task_head.H_02_distance_cla",
+        "H_02_distance_cla",
+    ),
+    "H_03_Linear_pred": (
+        "src.model_factory.ISFM.task_head.H_03_Linear_pred",
+        "H_03_Linear_pred",
+    ),
+    "H_09_multiple_task": (
+        "src.model_factory.ISFM.task_head.H_09_multiple_task",
+        "H_09_multiple_task",
+    ),
+    "MultiTaskHead": (
+        "src.model_factory.ISFM.task_head.multi_task_head",
+        "MultiTaskHead",
+    ),
 }
+
+
+def _load_component(registry: dict[str, tuple[str, str]], component_id: str, kind: str) -> Any:
+    """Load one configured component with a component-specific failure message."""
+    try:
+        module_path, symbol = registry[component_id]
+    except KeyError as exc:
+        available = ", ".join(sorted(registry))
+        raise ValueError(
+            f"Unknown ISFM {kind} {component_id!r}. Available values: {available}"
+        ) from exc
+
+    try:
+        module = import_module(module_path)
+    except ModuleNotFoundError as exc:
+        missing = exc.name or "unknown dependency"
+        raise RuntimeError(
+            f"Unable to load ISFM {kind} {component_id!r}: missing dependency {missing!r}."
+        ) from exc
+
+    try:
+        return getattr(module, symbol)
+    except AttributeError as exc:
+        raise RuntimeError(
+            f"ISFM {kind} {component_id!r} expects symbol {symbol!r} in {module_path!r}."
+        ) from exc
 
 
 class Model(nn.Module):
-    """ISFM architecture with flexible embedding/backbone/head.
+    """ISFM architecture with configurable embedding, backbone, and task head.
 
-    Parameters
-    ----------
-    args_m : Namespace
-        Defines ``embedding``, ``backbone`` and ``task_head`` as well as
-        ``num_classes``.
-    metadata : Any
-        Metadata accessor providing dataset information.
-
-    Notes
-    -----
-    Input tensors are expected with shape ``(B, L, C)`` and outputs depend on
-    the selected task head.
+    Only the selected components are imported. This keeps the maintained
+    ``M_01_ISFM + B_04_Dlinear`` path independent of optional dependencies used
+    by non-selected research backbones.
     """
 
     def __init__(self, args_m, metadata):
-        super(Model, self).__init__()
+        super().__init__()
         self.metadata = metadata
         self.args_m = args_m
-        self.embedding = Embedding_dict[args_m.embedding](args_m)
-        self.backbone = Backbone_dict[args_m.backbone](args_m)
-        self.num_classes = self.get_num_classes()  # TODO prediction 任务不需要label？ @liq22
-        args_m.num_classes = self.num_classes  # Ensure num_classes is set in args_m
-        self.task_head = TaskHead_dict[args_m.task_head](args_m)
+
+        embedding_cls = _load_component(Embedding_dict, args_m.embedding, "embedding")
+        backbone_cls = _load_component(Backbone_dict, args_m.backbone, "backbone")
+        self.embedding = embedding_cls(args_m)
+        self.backbone = backbone_cls(args_m)
+
+        self.num_classes = self.get_num_classes()
+        args_m.num_classes = self.num_classes
+        task_head_cls = _load_component(TaskHead_dict, args_m.task_head, "task head")
+        self.task_head = task_head_cls(args_m)
 
     def get_num_classes(self):
-        """获取数据集类别数映射"""
+        """Return the metadata-derived dataset-to-class-count mapping."""
         return get_num_classes(self.metadata)
-    
-
 
     def _embed(self, x, file_id):
-        """1 Embedding"""
-        if self.args_m.embedding in ('E_01_HSE', 'E_02_HSE_v2'):
+        """Apply the configured embedding."""
+        if self.args_m.embedding in ("E_01_HSE", "E_02_HSE_v2"):
             _, fs_tensor = resolve_batch_metadata(self.metadata, file_id, device=x.device)
-            x = self.embedding(x, fs_tensor)
-        else:
-            x = self.embedding(x)
-        return x
+            return self.embedding(x, fs_tensor)
+        return self.embedding(x)
 
     def _encode(self, x):
-        """2 Backbone"""
+        """Apply the configured backbone."""
         return self.backbone(x)
 
-    def _head(self, x, file_id = False, task_id = False, return_feature=False):
-        """3 Task Head"""
-        B = x.size(0)
-
+    def _head(self, x, file_id=False, task_id=False, return_feature=False):
+        """Apply the configured task head."""
         system_ids_tensor, _ = resolve_batch_metadata(self.metadata, file_id, device=x.device)
-        system_ids = [int(v) for v in system_ids_tensor.view(-1).tolist()]
+        system_ids = [int(value) for value in system_ids_tensor.view(-1).tolist()]
 
-        if task_id in ['classification']:
-            # 对于分类任务，将 per-sample system_ids 传递给多头线性分类器
-            return self.task_head(x, system_id=system_ids, return_feature=return_feature, task_id=task_id)
-        elif task_id in ['prediction']:
+        if task_id == "classification":
+            return self.task_head(
+                x,
+                system_id=system_ids,
+                return_feature=return_feature,
+                task_id=task_id,
+            )
+        if task_id == "prediction":
             shape = (self.shape[1], self.shape[2]) if len(self.shape) > 2 else (self.shape[1],)
-            return self.task_head(x, return_feature=return_feature, task_id=task_id, shape=shape)
-        # if task_id in ['classification', 'prediction']:
-        #     # For classification or prediction tasks, we need to pass system_id
-        #     return self.task_head(x, system_id=system_id, return_feature=return_feature)
-        # elif task_id in ['multitask']:
-        # return self.task_head(x, system_id=system_id, return_feature=return_feature, task_id=task_id)
+            return self.task_head(
+                x,
+                return_feature=return_feature,
+                task_id=task_id,
+                shape=shape,
+            )
+        return None
 
-    def forward(self, x, file_id=False, task_id=False, return_feature=False):
-        """Forward pass through embedding, backbone and head.
-
-        Parameters
-        ----------
-        x : torch.Tensor
-            Input tensor ``(B, L, C)``.
-        file_id : Any, optional
-            Key used to fetch metadata for the sample.
-        task_id : str, optional
-            Task type such as ``"classification"`` or ``"prediction"``.
-        return_feature : bool, optional
-            If ``True`` return features instead of logits.
-
-        Returns
-        -------
-        torch.Tensor
-            Model output defined by the task head.
-        """
+    def forward(self, x: torch.Tensor, file_id=False, task_id=False, return_feature=False):
+        """Forward pass through embedding, backbone, and task head."""
         self.shape = x.shape
         x = self._embed(x, file_id)
         if return_feature:
             feature = self._encode(x)
-            x = self._head(feature, file_id, task_id)
-            return x, feature
-        else:
-            x = self._encode(x)
-            x = self._head(x, file_id, task_id)
-        return x
-    
+            output = self._head(feature, file_id, task_id)
+            return output, feature
+
+        x = self._encode(x)
+        return self._head(x, file_id, task_id)

--- a/src/model_factory/ISFM/__init__.py
+++ b/src/model_factory/ISFM/__init__.py
@@ -1,20 +1,23 @@
-"""
-ISFM package exports.
+"""Lazy public exports for the ISFM model family.
 
-仅导出当前仓库中实际存在且被 Vbench 使用的组件：
-- embedding 子模块
-- backbone 子模块
-- task_head 子模块
-- M_01_ISFM / M_02_ISFM / M_03_ISFM 模型实现
+Importing one concrete ISFM model must not import every embedding, backbone,
+task head, or model implementation. Some non-selected components have optional
+third-party dependencies, so eager package imports make the maintained model
+path depend on unrelated research modules.
 """
 
-from . import embedding
-from . import backbone
-from . import task_head
-from .M_01_ISFM import Model as M_01_ISFM
-from .M_02_ISFM import Model as M_02_ISFM
-from .M_02_ISFM_heterogeneous_batch import Model as M_02_ISFM_heterogeneous_batch
-from .M_03_ISFM import Model as M_03_ISFM
+from __future__ import annotations
+
+from importlib import import_module
+from typing import Any
+
+_SUBPACKAGE_EXPORTS = {"embedding", "backbone", "task_head"}
+_MODEL_EXPORTS = {
+    "M_01_ISFM": "M_01_ISFM",
+    "M_02_ISFM": "M_02_ISFM",
+    "M_02_ISFM_heterogeneous_batch": "M_02_ISFM_heterogeneous_batch",
+    "M_03_ISFM": "M_03_ISFM",
+}
 
 __all__ = [
     "embedding",
@@ -25,3 +28,21 @@ __all__ = [
     "M_02_ISFM_heterogeneous_batch",
     "M_03_ISFM",
 ]
+
+
+def __getattr__(name: str) -> Any:
+    """Resolve public ISFM exports only when they are requested."""
+    if name in _SUBPACKAGE_EXPORTS:
+        value = import_module(f"{__name__}.{name}")
+    elif name in _MODEL_EXPORTS:
+        module = import_module(f"{__name__}.{_MODEL_EXPORTS[name]}")
+        value = module.Model
+    else:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+    globals()[name] = value
+    return value
+
+
+def __dir__() -> list[str]:
+    return sorted(set(globals()) | set(__all__))

--- a/src/model_factory/ISFM/backbone/__init__.py
+++ b/src/model_factory/ISFM/backbone/__init__.py
@@ -1,22 +1,40 @@
-from .B_01_basic_transformer import B_01_basic_transformer# ,B_03_FITS
-from .B_03_FITS import B_03_FITS
-from .B_04_Dlinear import B_04_Dlinear
-from .B_05_Mamba import B_05_Mamba
-from .B_06_TimesNet import B_06_TimesNet
-from .B_07_TSMixer import B_07_TSMixer
-from .B_08_PatchTST import B_08_PatchTST
-from .B_09_FNO import B_09_FNO
-from .B_10_VIBT import B_10_VIBT  # Vibration Transformer Backbone
-from .B_11_MomentumEncoder import B_11_MomentumEncoder  # Momentum Encoder Backbone
+"""Lazy exports for ISFM backbone implementations.
 
-__all__ = ["B_01_basic_transformer",
-       'B_03_FITS',
-       'B_04_Dlinear',
-       'B_05_Mamba',
-       'B_06_TimesNet',
-       'B_07_TSMixer',
-       'B_08_PatchTST',
-       'B_09_FNO',
-       'B_10_VIBT',  # Vibration Transformer Backbone
-       'B_11_MomentumEncoder',  # Momentum Encoder Backbone
-       ]
+A selected backbone should not require dependencies used only by a different
+backbone. Public names remain available through module-level ``__getattr__``.
+"""
+
+from __future__ import annotations
+
+from importlib import import_module
+from typing import Any
+
+_BACKBONE_MODULES = {
+    "B_01_basic_transformer": "B_01_basic_transformer",
+    "B_03_FITS": "B_03_FITS",
+    "B_04_Dlinear": "B_04_Dlinear",
+    "B_05_Mamba": "B_05_Mamba",
+    "B_06_TimesNet": "B_06_TimesNet",
+    "B_07_TSMixer": "B_07_TSMixer",
+    "B_08_PatchTST": "B_08_PatchTST",
+    "B_09_FNO": "B_09_FNO",
+    "B_10_VIBT": "B_10_VIBT",
+    "B_11_MomentumEncoder": "B_11_MomentumEncoder",
+}
+
+__all__ = list(_BACKBONE_MODULES)
+
+
+def __getattr__(name: str) -> Any:
+    module_name = _BACKBONE_MODULES.get(name)
+    if module_name is None:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+    module = import_module(f"{__name__}.{module_name}")
+    value = getattr(module, name)
+    globals()[name] = value
+    return value
+
+
+def __dir__() -> list[str]:
+    return sorted(set(globals()) | set(__all__))

--- a/src/trainer_factory/Default_trainer.py
+++ b/src/trainer_factory/Default_trainer.py
@@ -1,30 +1,35 @@
-import pytorch_lightning as pl
-from pytorch_lightning.loggers import WandbLogger, CSVLogger
-from pytorch_lightning.callbacks import ModelCheckpoint, ModelPruning, EarlyStopping
-from torch.utils.tensorboard.writer import SummaryWriter
 import os
-import swanlab
-from swanlab.integration.pytorch_lightning import SwanLabLogger
+
+import pytorch_lightning as pl
+from pytorch_lightning.callbacks import EarlyStopping, ModelCheckpoint, ModelPruning
+from pytorch_lightning.loggers import CSVLogger, WandbLogger
+from torch.utils.tensorboard.writer import SummaryWriter
+
+try:
+    from swanlab.integration.pytorch_lightning import SwanLabLogger
+except ImportError:  # Optional experiment service; required only when enabled.
+    SwanLabLogger = None
+
 from src.trainer_factory import register_trainer
 from src.trainer_factory.extensions import ManifestWriterCallback
 
 # 获取当前进程的排名
 is_main_process = True  # 默认为主进程
-if 'LOCAL_RANK' in os.environ:
-    local_rank = int(os.environ['LOCAL_RANK'])
+if "LOCAL_RANK" in os.environ:
+    local_rank = int(os.environ["LOCAL_RANK"])
     is_main_process = local_rank == 0
-    
+
 
 @register_trainer("Default_trainer")
-def trainer(args_e,args_t, args_d, path):
+def trainer(args_e, args_t, args_d, path):
     """
     设置训练器的配置，包括日志记录、回调函数和数据加载器等。
-    
+
     参数:
     - args_t: 包含训练配置的对象
     - args_d: 包含数据配置的对象
     - path: 存储日志、检查点的路径
-    
+
     返回:
     - trainer: 训练器对象
     """
@@ -39,29 +44,30 @@ def trainer(args_e,args_t, args_d, path):
     # 获取回调列表
     callback_list = call_backs(args_t, path)
     log_list = [CSVLogger(path, name="logs")]
-    use_wandb = getattr(args_e, 'wandb', False)
-    use_swanlab = getattr(args_e, 'swanlab', False)    
-    # 根据 wandb_flag 确定日志记录器列表
+    use_wandb = getattr(args_e, "wandb", False)
+    use_swanlab = getattr(args_e, "swanlab", False)
+
     if use_wandb:
-        # 配置 WandB 日志记录
-        wandb_logger = WandbLogger(project=args_e.project,
-                                   offline= not is_main_process,
-                                  )
+        wandb_logger = WandbLogger(
+            project=args_e.project,
+            offline=not is_main_process,
+        )
         log_list.append(wandb_logger)
 
     if use_swanlab:
-        # swanlab
-        swanlab_logger = SwanLabLogger(
-                project = args_e.project,
-                # experiment_name=args_t.logger_name
+        if SwanLabLogger is None:
+            raise RuntimeError(
+                "environment.swanlab=true requires the optional 'swanlab' package. "
+                "Install it or disable SwanLab logging."
             )
+        swanlab_logger = SwanLabLogger(project=args_e.project)
         log_list.append(swanlab_logger)
-            
+
     # 设置设备类型：CPU 或自动选择
-    accelerate_type = 'cpu' if args_t.device == 'cpu' else 'auto'
+    accelerate_type = "cpu" if args_t.device == "cpu" else "auto"
 
     # 如果不存在log_every_n_steps，使用默认值50 # TODO @liq22
-    if not getattr(args_t, 'log_every_n_steps', None):
+    if not getattr(args_t, "log_every_n_steps", None):
         args_t.log_every_n_steps = 50
 
     # 初始化训练器
@@ -72,30 +78,30 @@ def trainer(args_e,args_t, args_d, path):
         devices=args_t.gpus,
         logger=log_list,
         log_every_n_steps=args_t.log_every_n_steps,
-        strategy="ddp_find_unused_parameters_true" if args_t.gpus > 1 else 'auto',
+        strategy="ddp_find_unused_parameters_true" if args_t.gpus > 1 else "auto",
     )
     return trainer
+
 
 def call_backs(args, path):
     """
     配置训练时所需的回调函数，包括检查点保存、模型修剪、早期停止等。
-    
+
     参数:
     - args: 包含训练配置的对象
     - path: 存储检查点的路径
-    
+
     返回:
-    - callback_list: 配置好的回调函数列表
+    - callback_list: 配置好的回调列表
     """
-    # 检查点回调（保存最好的模型）
     checkpoint_callback = ModelCheckpoint(
         monitor=args.monitor,
-        filename='model-{epoch:02d}-{val_loss:.4f}',
-        save_top_k=getattr(args, 'save_top_k', 1),  # 从args中读取保存的模型数量
-        mode='min',
-        dirpath=path
+        filename="model-{epoch:02d}-{val_loss:.4f}",
+        save_top_k=getattr(args, "save_top_k", 1),
+        mode="min",
+        dirpath=path,
     )
-    
+
     callback_list = [checkpoint_callback]
 
     # UXFD merge: always write an auditable manifest (safe no-op if not main process).
@@ -123,58 +129,59 @@ def call_backs(args, path):
     if getattr(args, "pruning", 0.0):
         prune_callback = Prune_callback(args)
         callback_list.append(prune_callback)
-    
+
     # 早期停止回调（若未配置 early_stopping，则默认为不启用）
     if getattr(args, "early_stopping", False):
         early_stopping = create_early_stopping_callback(args)
         callback_list.append(early_stopping)
-    
+
     return callback_list
+
 
 def Prune_callback(args):
     """
     根据训练配置，返回模型修剪回调函数。
-    
+
     参数:
     - args: 包含训练配置的对象
-    
+
     返回:
     - prune_callback: 配置好的修剪回调（如果有）
     """
+
     def compute_amount(epoch):
-        # 根据训练进度动态调整修剪比例
         if epoch == args.num_epochs // 4:
             return args.pruning[0]
-        elif epoch == args.num_epochs // 2:
+        if epoch == args.num_epochs // 2:
             return args.pruning[1]
-        elif 3 * args.num_epochs // 4 < epoch:
+        if 3 * args.num_epochs // 4 < epoch:
             return args.pruning[2]
-            
+        return None
+
     if isinstance(args.pruning, (int, float)):
-        prune_callback = ModelPruning("l1_unstructured", parameter_names=['weight'], amount=args.pruning)
+        prune_callback = ModelPruning(
+            "l1_unstructured",
+            parameter_names=["weight"],
+            amount=args.pruning,
+        )
     elif isinstance(args.pruning, list):
-        prune_callback = ModelPruning("l1_unstructured", parameter_names=['weight'], amount=compute_amount)
+        prune_callback = ModelPruning(
+            "l1_unstructured",
+            parameter_names=["weight"],
+            amount=compute_amount,
+        )
     else:
         prune_callback = None
     return prune_callback
 
+
 def create_early_stopping_callback(args):
-    """
-    创建并返回早期停止回调函数。
-    
-    参数:
-    - args: 包含训练配置的对象
-    
-    返回:
-    - early_stopping: 配置好的早期停止回调
-    """
-    # 配置早期停止回调，监控验证集的损失
-    early_stopping = EarlyStopping(
-        monitor=args.monitor, # TODO @liq22
+    """创建并返回早期停止回调。"""
+    return EarlyStopping(
+        monitor=args.monitor,
         min_delta=0.00,
-        patience=getattr(args, "patience", 10),  # 从args中读取patience值，如缺失则使用默认值
+        patience=getattr(args, "patience", 10),
         verbose=True,
-        mode='min',
-        check_finite=True,  # 防止无穷大或NaN值时停止训练
+        mode="min",
+        check_finite=True,
     )
-    return early_stopping


### PR DESCRIPTION
## Summary

Add an end-to-end CPU smoke job for the repository-shipped Dummy configuration and fix the import boundaries that prevented the maintained path from running without unrelated optional stacks:

```bash
python main.py \
  --config configs/demo/00_smoke/dummy_dg.yaml \
  --override trainer.num_epochs=1 \
  --override data.num_workers=0
```

## Root cause

The first smoke run reached model construction, then failed because importing `M_01_ISFM` eagerly imported every ISFM backbone:

- `B_08_PatchTST` required `reformer_pytorch` even though the selected backbone was `B_04_Dlinear`;
- after installing that package diagnostically, the next eager import reached `B_10_VIBT` and required `timm`;
- the default trainer also imported SwanLab unconditionally even when `environment.swanlab` was false.

Installing the entire research dependency stack would have hidden the architectural problem. The final fix keeps the maintained path dependency-bounded instead.

## Changes

### Active smoke gate

- Add `Offline config-first smoke` to `.github/workflows/core-quality-gates.yml`.
- Run one CPU epoch through `main.py` using repo-shipped Dummy data.
- Keep the dependency set bounded; do not install `timm`, `reformer-pytorch`, SwanLab, WandB, or external-data tooling.
- Always upload the smoke log and frozen environment for diagnosis.

### Import-boundary fixes

- Make `src.model_factory.ISFM` exports lazy.
- Make ISFM backbone exports lazy.
- Change `M_01_ISFM` to import only the configured embedding, backbone, and task head, with explicit errors for unknown IDs or missing selected-component dependencies.
- Make SwanLab an opt-in trainer dependency and fail clearly only when `environment.swanlab=true` without the package.

## Scope

Exactly five modified files:

```text
.github/workflows/core-quality-gates.yml
src/model_factory/ISFM/__init__.py
src/model_factory/ISFM/backbone/__init__.py
src/model_factory/ISFM/M_01_ISFM.py
src/trainer_factory/Default_trainer.py
```

No config, registry, data, task, result, documentation, or dependency-file changes.

## CI evidence

Final head: `e51efc490f52eb12ea75c7b6e73385849fd3a824`

Workflow run `29300395876` completed successfully:

- `Docs and config contracts` — passed
- `UXFD focused contract` — passed
- `Offline config-first smoke` — passed

The smoke reached successful one-epoch training and testing through the maintained `python main.py --config ...` entrypoint using CPU and repository-local Dummy data.

## Acceptance criteria

- [x] Existing docs/config and UXFD jobs remain green.
- [x] The public config-first path completes a one-epoch train/test smoke.
- [x] No external datasets or GPU are required.
- [x] Unselected research backbones no longer impose their optional dependencies on `M_01_ISFM + B_04_Dlinear`.
- [x] Disabled SwanLab logging does not require the SwanLab package.
- [x] Failures remain blocking; no `continue-on-error` or waiver is used.
