### PR TITLE
docs: establish canonical user documentation architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # PHM-Vibench
 
 <div align="center">
-  <img src="pic/PHM-Vibench.png" alt="PHM-Vibench logo" width="300"/>
+  <img src="pic/PHM-Vibench.png" alt="PHM-Vibench logo" width="280"/>
 
   <p>
     <a href="README.md"><strong>English</strong></a> |
@@ -13,233 +13,163 @@
   <p>
     <img src="https://img.shields.io/badge/status-alpha-orange" alt="Status: alpha"/>
     <img src="https://img.shields.io/badge/maintained%20demos-7-blue" alt="Seven maintained demos"/>
+    <a href="https://github.com/PHMbench/PHM-Vibench/actions/workflows/core-quality-gates.yml"><img src="https://github.com/PHMbench/PHM-Vibench/actions/workflows/core-quality-gates.yml/badge.svg" alt="Core quality gates"/></a>
     <img src="https://img.shields.io/badge/license-Apache%202.0-green" alt="Apache 2.0 license"/>
   </p>
 </div>
 
-PHM-Vibench organizes data loading, model construction, task wiring, training, and
-experiment configuration behind one maintained entrypoint:
+PHM-Vibench connects data loading, model construction, task logic, training, and
+experiment configuration through one public entrypoint:
 
 ```bash
 python main.py --config <yaml> [--override key=value ...]
 ```
 
-The project is in alpha. Its release-supported surface is deliberately narrower
-than the full set of files and registry entries in the repository. Start with the
-maintained demos and treat historical, reference, and research material as
-unverified until it has its own runtime evidence.
+The project is in alpha. Release support is intentionally limited to the
+maintained configurations documented in
+[SUPPORTED_COMBINATIONS.md](SUPPORTED_COMBINATIONS.md). Files, registry entries,
+research notes, and historical configs outside that surface are not automatically
+supported.
 
-## Start here
+## Run the offline example
 
-Run the repository-shipped offline smoke demo:
-
-```bash
-python main.py --config configs/demo/00_smoke/dummy_dg.yaml \
-  --override trainer.num_epochs=1 \
-  --override data.num_workers=0
-```
-
-Inspect the resolved configuration without editing a maintained YAML file:
-
-```bash
-python -m scripts.config_inspect \
-  --config configs/demo/00_smoke/dummy_dg.yaml \
-  --override trainer.num_epochs=1
-```
-
-Canonical entrypoints:
-
-- [Configuration guide](configs/README.md)
-- [Generated configuration atlas](docs/CONFIG_ATLAS.md)
-- [Supported components](SUPPORTED_COMPONENTS.md)
-- [Supported combinations](SUPPORTED_COMBINATIONS.md)
-- [Known limitations](KNOWN_LIMITATIONS.md)
-- [Data-directory policy](data/README.md)
-- [Contributor guide](CONTRIBUTING.md)
-
-## Maintained demo surface
-
-The configuration registry currently marks seven demos as `sanity_ok`. That
-status means the configuration has smoke evidence; it does **not** establish
-benchmark accuracy, state-of-the-art performance, or universal compatibility.
-
-| Area | Config | Data requirement |
-| --- | --- | --- |
-| Offline smoke / DG | `configs/demo/00_smoke/dummy_dg.yaml` | Repository-shipped dummy data |
-| Cross-domain DG | `configs/demo/01_cross_domain/cwru_dg.yaml` | Local PHM-Vibench metadata/raw data |
-| Cross-system CDDG | `configs/demo/02_cross_system/multi_system_cddg.yaml` | Local PHM-Vibench metadata/raw data |
-| Few-shot FS | `configs/demo/03_fewshot/cwru_protonet.yaml` | Local PHM-Vibench metadata/raw data |
-| Cross-system few-shot GFS | `configs/demo/04_cross_system_fewshot/cross_system_tspn.yaml` | Local PHM-Vibench metadata/raw data |
-| HSE pretraining view | `configs/demo/05_pretrain_fewshot/pretrain_hse_then_fewshot.yaml` | Local PHM-Vibench metadata/raw data |
-| HSE pretraining for CDDG | `configs/demo/06_pretrain_cddg/pretrain_hse_cddg.yaml` | Local PHM-Vibench metadata/raw data |
-
-The current v0.2.0 support documents bound the maintained model path to
-`ISFM/M_01_ISFM` with `E_01_HSE`, `B_04_Dlinear`, and
-`H_01_Linear_cla`, plus the task combinations listed in
-[SUPPORTED_COMPONENTS.md](SUPPORTED_COMPONENTS.md). Registry discovery alone is
-not a support claim.
-
-## Installation
-
-A minimal environment setup is:
+Install the environment, then execute the repository-shipped dummy configuration:
 
 ```bash
 git clone https://github.com/PHMbench/PHM-Vibench.git
 cd PHM-Vibench
-
 conda create -n phm-vibench python=3.10
 conda activate phm-vibench
-pip install -r requirements.txt
-```
+python -m pip install -r requirements.txt
 
-Maintained runtime evidence was collected in the project-specific `LQ_signal`
-conda environment. A generic environment may still need dependency or platform
-adjustments; see [KNOWN_LIMITATIONS.md](KNOWN_LIMITATIONS.md).
-
-Only the dummy smoke demo is fully offline. For other demos, point the config to
-a local data root rather than editing the maintained YAML:
-
-```bash
-python main.py --config configs/demo/01_cross_domain/cwru_dg.yaml \
-  --override data.data_dir=/absolute/path/to/PHM-Vibench-data \
-  --override data.metadata_file=metadata.xlsx \
-  --override trainer.num_epochs=1 \
-  --override data.num_workers=0
-```
-
-Processed or raw datasets may also be available from:
-
-- [ModelScope processed files](https://www.modelscope.cn/datasets/PHMbench/PHM-Vibench/files)
-- [PHMbench raw-data group](https://www.modelscope.cn/datasets/PHMbench/PHMbench-raw_data)
-- [Hugging Face mirror](https://huggingface.co/datasets/PHMbench/PHM-Vibench/tree/main)
-
-Check the source license and availability before using or redistributing data.
-
-## Configuration-first workflow
-
-Maintained configs use five logical blocks:
-
-```yaml
-environment: {}
-data: {}
-model: {}
-task: {}
-trainer: {}
-```
-
-Demo files compose shared blocks through `base_configs` and then apply local YAML
-and CLI overrides. For an experiment variant:
-
-1. copy the nearest file from `configs/demo/` into `configs/experiments/`;
-2. change only the fields required by the experiment;
-3. inspect the resolved configuration and source trace;
-4. run the smallest applicable smoke command;
-5. keep the registry and generated atlas synchronized when promoting a maintained config.
-
-Useful commands:
-
-```bash
-python -m scripts.validate_configs
-python -m scripts.config_inspect --config <yaml> --override key=value
-python -m scripts.gen_config_atlas
-git diff --exit-code docs/CONFIG_ATLAS.md
-```
-
-## Validation gate
-
-Use the narrowest relevant test during development, then run the maintained gate
-before merging a runtime or configuration change:
-
-```bash
 python main.py --config configs/demo/00_smoke/dummy_dg.yaml \
   --override trainer.num_epochs=1 \
   --override data.num_workers=0
-python -m scripts.validate_configs
+```
+
+A successful run exits cleanly, prints the completion message, and writes output
+below `results/demo/dummy_dg_smoke/`. This verifies the software path; it is not a
+benchmark-performance result.
+
+Detailed setup, expected behavior, and troubleshooting:
+
+- [Installation](docs/installation.md)
+- [Quickstart](docs/quickstart.md)
+- [Known limitations](KNOWN_LIMITATIONS.md)
+
+## What is maintained
+
+The current maintained demo surface covers:
+
+- offline dummy domain-generalization smoke;
+- cross-domain and cross-system classification examples;
+- few-shot and generalized few-shot examples;
+- bounded HSE pretraining examples.
+
+Only the dummy example is fully offline. Other demos require local PHM-Vibench
+metadata and raw data supplied through configuration overrides. The exact model,
+task, data, and trainer combinations are listed in:
+
+- [Supported components](SUPPORTED_COMPONENTS.md)
+- [Supported combinations](SUPPORTED_COMBINATIONS.md)
+- [Configuration registry](configs/config_registry.csv)
+- [Generated configuration atlas](docs/CONFIG_ATLAS.md)
+
+`sanity_ok` means smoke evidence exists. It does not mean state-of-the-art
+performance, universal component compatibility, or permission to redistribute an
+external dataset.
+
+## Configuration-first workflow
+
+Maintained configurations use five logical blocks:
+
+```text
+environment / data / model / task / trainer
+```
+
+Start from the nearest file under `configs/demo/`, place local variants under
+`configs/experiments/`, and use CLI overrides for machine-specific values:
+
+```bash
 python -m scripts.config_inspect \
   --config configs/demo/00_smoke/dummy_dg.yaml \
   --override trainer.num_epochs=1
-python -m scripts.gen_config_atlas
-git diff --exit-code docs/CONFIG_ATLAS.md
-python -m scripts.validate_docs
-python -m pytest test/ -q
 ```
 
-Local validation evidence should not be described as GitHub Actions evidence.
-The repository currently needs an active required CI workflow to enforce these
-gates automatically.
-
-## Optional Streamlit workspace
-
-The Streamlit workspace is an optional interface around the same config-first
-contract. It does not replace the CLI release gate and should not import pipeline
-internals directly.
-
-```bash
-streamlit run streamlit_app.py
-```
-
-See the [maintained Streamlit guide](apps/streamlit/README.md) for configuration,
-execution, result inspection, and focused tests.
+The authoritative composition and precedence rules are in the
+[configuration guide](configs/README.md). Data layout and external-source
+boundaries are in the [data guide](data/README.md).
 
 ## Architecture
 
 ```text
 main.py
-  └── pipeline selected by YAML
+  └── configured pipeline
       ├── data factory
       ├── model factory
       ├── task factory
       └── trainer factory
 ```
 
-Primary directories:
+Primary paths:
 
-- `configs/`: base blocks, maintained demos, experiments, and registry
-- `src/data_factory/`: metadata, readers, datasets, samplers, and data construction
-- `src/model_factory/`: model families, component registries, and model construction
-- `src/task_factory/`: task implementations and task registry
-- `src/trainer_factory/`: trainer implementations
-- `apps/streamlit/`: optional experiment workspace
-- `test/`: maintained pytest gate
-- `docs/`: release, configuration, migration, and engineering documentation
-- `results/`: runtime output, not configuration source of truth
+- `configs/` — base blocks, maintained demos, experiments, and config registry;
+- `src/data_factory/` — metadata, readers, datasets, samplers, and data wiring;
+- `src/model_factory/` — model families, components, and model construction;
+- `src/task_factory/` — tasks, losses, metrics, and task registry;
+- `src/trainer_factory/` — trainer construction and extensions;
+- `apps/streamlit/` — optional browser workspace around the same CLI;
+- `test/` — maintained pytest suite;
+- `docs/` — user, development, release, and historical documentation.
 
-## Extending PHM-Vibench
+Do not add dataset- or model-specific branches to `main.py`; extend the existing
+factory boundary.
 
-Keep extensions within factory boundaries; do not add model- or dataset-specific
-branches to `main.py`.
+## Validate a change
 
-- [Add a dataset or reader](src/data_factory/contributing.md)
-- [Add a model](src/model_factory/contributing.md)
-- [Add a task](src/task_factory/contributing.md)
-- [Add a trainer](src/trainer_factory/contributing.md)
+```bash
+python -m scripts.validate_docs
+python -m scripts.validate_configs
+python -m scripts.gen_config_atlas
+git diff --exit-code docs/CONFIG_ATLAS.md
+python -m pytest test/ -q
+```
 
-A public component change should include its implementation, registry/config
-entry, focused test, documentation, and an applicable smoke path. Research-only
-ideas should remain in clearly marked project or experiment areas until their
-protocol and validation evidence are defined.
+Runtime or configuration changes should also run the offline smoke command above.
+GitHub Actions currently enforce documentation/configuration consistency and the
+focused UXFD assembly contract. See the [testing guide](docs/testing.md) for
+evidence terminology and narrower commands.
 
-## Evidence boundaries
+## Documentation
 
-PHM-Vibench currently provides functional smoke and contract evidence for a
-bounded configuration matrix. It does not, by itself, prove:
+Use the [documentation index](docs/index.md) to find installation, configuration,
+data, development, testing, Streamlit, release, and historical material.
 
-- state-of-the-art performance;
-- fair comparison across arbitrary external experiments;
-- support for every registry-discovered component pair;
-- availability or redistribution rights for every referenced dataset;
-- reproducibility outside the recorded environment and data setup.
+For the optional web interface:
 
-Record the exact repository commit, config, overrides, data source, seed, and
-environment when reporting an experiment.
+```bash
+python -m pip install -r apps/streamlit/requirements.txt
+streamlit run apps/streamlit/app.py
+```
 
-## Contributing, license, and citation
+See [apps/streamlit/README.md](apps/streamlit/README.md) for its local
+single-worker boundary.
 
-Read [CONTRIBUTING.md](CONTRIBUTING.md) before opening a pull request. Keep each
-change small, explicit, reviewable, and backed by copy-paste validation commands.
+## Contributing and support
+
+Read [CONTRIBUTING.md](CONTRIBUTING.md) before opening an issue or pull request.
+Keep changes small, update the authoritative document rather than copying it, and
+report the exact commit, config, overrides, environment, and logs.
+
+- Bugs and feature requests: [GitHub Issues](https://github.com/PHMbench/PHM-Vibench/issues)
+- Security reports: [SECURITY.md](SECURITY.md)
+- Development workflow: [docs/developer_guide.md](docs/developer_guide.md)
+
+## Citation and license
 
 PHM-Vibench is licensed under the [Apache License 2.0](LICENSE). Dataset and model
-artifacts may have separate licenses at their original sources.
+artifacts can have separate source licenses.
 
-The project remains in alpha. Until a stable publication citation is released,
-reference the exact Git commit or release tag used for an experiment.
+Until a stable publication citation is provided, cite the exact Git commit or
+release tag used for an experiment and record the configuration, overrides, data
+source, seed, and environment.

--- a/README_CN.md
+++ b/README_CN.md
@@ -1,7 +1,7 @@
 # PHM-Vibench
 
 <div align="center">
-  <img src="pic/PHM-Vibench.png" alt="PHM-Vibench 标志" width="300"/>
+  <img src="pic/PHM-Vibench.png" alt="PHM-Vibench 标志" width="280"/>
 
   <p>
     <a href="README.md">English</a> |
@@ -13,168 +13,91 @@
   <p>
     <img src="https://img.shields.io/badge/状态-alpha-orange" alt="状态：alpha"/>
     <img src="https://img.shields.io/badge/维护中%20demo-7-blue" alt="7 个维护中 demo"/>
+    <a href="https://github.com/PHMbench/PHM-Vibench/actions/workflows/core-quality-gates.yml"><img src="https://github.com/PHMbench/PHM-Vibench/actions/workflows/core-quality-gates.yml/badge.svg" alt="核心质量门禁"/></a>
     <img src="https://img.shields.io/badge/许可-Apache%202.0-green" alt="Apache 2.0 许可"/>
   </p>
 </div>
 
-PHM-Vibench 将数据加载、模型构建、任务装配、训练和实验配置统一到一个维护入口：
+PHM-Vibench 通过一个公开入口连接数据加载、模型构建、任务逻辑、训练和实验配置：
 
 ```bash
 python main.py --config <yaml> [--override key=value ...]
 ```
 
-项目仍处于 alpha 阶段。当前 release-supported surface 明显小于仓库中全部文件和注册表条目。
-请从维护中的 demo 开始；历史、参考和研究材料在没有独立运行证据前，不应视为已验证能力。
+项目仍处于 alpha 阶段。发布支持范围仅限
+[SUPPORTED_COMBINATIONS.md](SUPPORTED_COMBINATIONS.md) 中列出的维护配置。
+仓库中的其他文件、注册表条目、研究笔记和历史配置不应自动视为受支持能力。
 
-## 从这里开始
+## 运行离线示例
 
-运行仓库自带的离线冒烟 demo：
-
-```bash
-python main.py --config configs/demo/00_smoke/dummy_dg.yaml \
-  --override trainer.num_epochs=1 \
-  --override data.num_workers=0
-```
-
-在不修改维护 YAML 的情况下检查最终配置：
-
-```bash
-python -m scripts.config_inspect \
-  --config configs/demo/00_smoke/dummy_dg.yaml \
-  --override trainer.num_epochs=1
-```
-
-权威入口：
-
-- [配置系统指南](configs/README.md)
-- [生成的配置图谱](docs/CONFIG_ATLAS.md)
-- [支持组件](SUPPORTED_COMPONENTS.md)
-- [支持组合](SUPPORTED_COMBINATIONS.md)
-- [已知限制](KNOWN_LIMITATIONS.md)
-- [数据目录边界](data/README.md)
-- [贡献指南](CONTRIBUTING_CN.md)
-
-## 维护中的 demo 面
-
-配置注册表当前将 7 个 demo 标记为 `sanity_ok`。该状态只代表配置具有功能冒烟证据，
-不代表基准精度、SOTA 性能或任意组件之间都兼容。
-
-| 场景 | 配置 | 数据要求 |
-| --- | --- | --- |
-| 离线冒烟 / DG | `configs/demo/00_smoke/dummy_dg.yaml` | 仓库自带 Dummy 数据 |
-| 跨域 DG | `configs/demo/01_cross_domain/cwru_dg.yaml` | 本地 PHM-Vibench metadata/raw 数据 |
-| 跨系统 CDDG | `configs/demo/02_cross_system/multi_system_cddg.yaml` | 本地 PHM-Vibench metadata/raw 数据 |
-| 小样本 FS | `configs/demo/03_fewshot/cwru_protonet.yaml` | 本地 PHM-Vibench metadata/raw 数据 |
-| 跨系统小样本 GFS | `configs/demo/04_cross_system_fewshot/cross_system_tspn.yaml` | 本地 PHM-Vibench metadata/raw 数据 |
-| HSE 预训练视角 | `configs/demo/05_pretrain_fewshot/pretrain_hse_then_fewshot.yaml` | 本地 PHM-Vibench metadata/raw 数据 |
-| 面向 CDDG 的 HSE 预训练 | `configs/demo/06_pretrain_cddg/pretrain_hse_cddg.yaml` | 本地 PHM-Vibench metadata/raw 数据 |
-
-当前 v0.2.0 支持文档将维护模型路径限定为 `ISFM/M_01_ISFM`、`E_01_HSE`、
-`B_04_Dlinear`、`H_01_Linear_cla`，以及
-[SUPPORTED_COMPONENTS.md](SUPPORTED_COMPONENTS.md) 中列出的任务组合。
-注册表中存在条目本身并不构成支持声明。
-
-## 安装
-
-最小环境示例：
+安装环境后，运行仓库自带的 Dummy 配置：
 
 ```bash
 git clone https://github.com/PHMbench/PHM-Vibench.git
 cd PHM-Vibench
-
 conda create -n phm-vibench python=3.10
 conda activate phm-vibench
-pip install -r requirements.txt
-```
+python -m pip install -r requirements.txt
 
-维护中的运行证据来自项目专用的 `LQ_signal` conda 环境。通用环境仍可能需要依赖或平台调整，
-详见 [KNOWN_LIMITATIONS.md](KNOWN_LIMITATIONS.md)。
-
-只有 Dummy 冒烟 demo 完全离线。其他 demo 应通过 override 指向本地数据根目录，
-不要直接修改维护配置：
-
-```bash
-python main.py --config configs/demo/01_cross_domain/cwru_dg.yaml \
-  --override data.data_dir=/absolute/path/to/PHM-Vibench-data \
-  --override data.metadata_file=metadata.xlsx \
-  --override trainer.num_epochs=1 \
-  --override data.num_workers=0
-```
-
-处理后或原始数据也可能位于：
-
-- [ModelScope 处理后文件](https://www.modelscope.cn/datasets/PHMbench/PHM-Vibench/files)
-- [PHMbench 原始数据组](https://www.modelscope.cn/datasets/PHMbench/PHMbench-raw_data)
-- [Hugging Face 镜像](https://huggingface.co/datasets/PHMbench/PHM-Vibench/tree/main)
-
-使用或再分发前必须核验来源许可和可用性。
-
-## 配置优先工作流
-
-维护配置由五个逻辑块组成：
-
-```yaml
-environment: {}
-data: {}
-model: {}
-task: {}
-trainer: {}
-```
-
-Demo 通过 `base_configs` 组合共享 block，再应用 YAML 和 CLI override。建立实验变体时：
-
-1. 从 `configs/demo/` 复制最接近的模板到 `configs/experiments/`；
-2. 只修改实验真正需要的字段；
-3. 检查最终配置和字段来源；
-4. 运行最小适用冒烟命令；
-5. 若要提升为维护配置，同步更新注册表和生成的 atlas。
-
-常用命令：
-
-```bash
-python -m scripts.validate_configs
-python -m scripts.config_inspect --config <yaml> --override key=value
-python -m scripts.gen_config_atlas
-git diff --exit-code docs/CONFIG_ATLAS.md
-```
-
-## 合并前验证门禁
-
-开发时先运行最聚焦的测试；运行时或配置改动在合并前应执行维护门禁：
-
-```bash
 python main.py --config configs/demo/00_smoke/dummy_dg.yaml \
   --override trainer.num_epochs=1 \
   --override data.num_workers=0
-python -m scripts.validate_configs
+```
+
+成功运行应正常退出、打印完成信息，并在 `results/demo/dummy_dg_smoke/`
+下写入输出。该命令验证软件链路，不代表基准性能。
+
+详细安装、预期行为和故障排查：
+
+- [安装指南](docs/installation.md)
+- [快速开始](docs/quickstart.md)
+- [已知限制](KNOWN_LIMITATIONS.md)
+
+## 当前维护范围
+
+当前维护中的 demo 覆盖：
+
+- 离线 Dummy 域泛化冒烟；
+- 跨域和跨系统分类示例；
+- 小样本和广义小样本示例；
+- 边界明确的 HSE 预训练示例。
+
+只有 Dummy 示例完全离线。其他 demo 需要通过配置覆盖传入本地
+PHM-Vibench metadata 和原始数据。准确的模型、任务、数据和训练器组合见：
+
+- [支持组件](SUPPORTED_COMPONENTS.md)
+- [支持组合](SUPPORTED_COMBINATIONS.md)
+- [配置注册表](configs/config_registry.csv)
+- [生成的配置图谱](docs/CONFIG_ATLAS.md)
+
+`sanity_ok` 表示已有功能冒烟证据，不表示达到 SOTA、任意组件均兼容，
+也不表示外部数据集可以自由再分发。
+
+## 配置优先工作流
+
+维护配置使用五个逻辑块：
+
+```text
+environment / data / model / task / trainer
+```
+
+从 `configs/demo/` 中最接近的配置开始，将本地实验变体放在
+`configs/experiments/`，机器相关值使用 CLI override：
+
+```bash
 python -m scripts.config_inspect \
   --config configs/demo/00_smoke/dummy_dg.yaml \
   --override trainer.num_epochs=1
-python -m scripts.gen_config_atlas
-git diff --exit-code docs/CONFIG_ATLAS.md
-python -m scripts.validate_docs
-python -m pytest test/ -q
 ```
 
-本地验证证据不能表述为 GitHub Actions 证据。仓库仍需要启用并设为 required 的 CI workflow，
-才能自动执行这些门禁。
-
-## 可选 Streamlit 工作区
-
-Streamlit 工作区是同一配置优先契约的可选界面。它不替代 CLI release gate，
-也不应直接导入 pipeline 内部实现。
-
-```bash
-streamlit run streamlit_app.py
-```
-
-配置、运行、结果查看和聚焦测试见[维护中的 Streamlit 指南](apps/streamlit/README.md)。
+配置组合和优先级的权威说明位于[配置指南](configs/README.md)，数据布局和
+外部数据边界位于[数据指南](data/README.md)。
 
 ## 架构
 
 ```text
 main.py
-  └── 由 YAML 选择 pipeline
+  └── 配置选择的 pipeline
       ├── data factory
       ├── model factory
       ├── task factory
@@ -183,45 +106,59 @@ main.py
 
 主要目录：
 
-- `configs/`：base block、维护 demo、实验配置和注册表
-- `src/data_factory/`：metadata、reader、dataset、sampler 与数据构建
-- `src/model_factory/`：模型家族、组件注册表与模型构建
-- `src/task_factory/`：任务实现和任务注册表
-- `src/trainer_factory/`：训练器实现
-- `apps/streamlit/`：可选实验工作区
-- `test/`：维护中的 pytest 门禁
-- `docs/`：release、配置、迁移和工程文档
-- `results/`：运行输出，不是配置事实来源
+- `configs/`：base block、维护 demo、实验配置和配置注册表；
+- `src/data_factory/`：metadata、reader、dataset、sampler 与数据装配；
+- `src/model_factory/`：模型家族、组件与模型构建；
+- `src/task_factory/`：任务、loss、metric 与任务注册表；
+- `src/trainer_factory/`：训练器构建和扩展；
+- `apps/streamlit/`：围绕同一 CLI 的可选浏览器工作区；
+- `test/`：维护中的 pytest 测试；
+- `docs/`：用户、开发、发布和历史文档。
 
-## 扩展 PHM-Vibench
+添加数据集或模型时，应扩展现有 factory，不要在 `main.py` 中加入专用分支。
 
-扩展应留在 factory 边界内，不要在 `main.py` 中加入模型或数据集专用分支。
+## 验证改动
 
-- [添加数据集或 reader](src/data_factory/contributing.md)
-- [添加模型](src/model_factory/contributing.md)
-- [添加任务](src/task_factory/contributing.md)
-- [添加训练器](src/trainer_factory/contributing.md)
+```bash
+python -m scripts.validate_docs
+python -m scripts.validate_configs
+python -m scripts.gen_config_atlas
+git diff --exit-code docs/CONFIG_ATLAS.md
+python -m pytest test/ -q
+```
 
-公开组件改动应同时包含实现、注册表或配置入口、聚焦测试、文档和适用的冒烟路径。
-研究想法在协议与验证证据明确前，应留在清楚标注的 project 或 experiment 区域。
+运行时或配置改动还应执行前面的离线冒烟命令。GitHub Actions 当前执行
+文档/配置一致性和聚焦的 UXFD 装配测试。证据术语和更聚焦的命令见
+[测试指南](docs/testing.md)。
 
-## 证据边界
+## 文档
 
-PHM-Vibench 当前为有限配置矩阵提供功能冒烟和契约证据。它本身不能证明：
+通过[文档索引](docs/index.md)查找安装、配置、数据、开发、测试、Streamlit、
+发布和历史材料。
 
-- 达到 SOTA 性能；
-- 任意外部实验之间都能公平比较；
-- 所有注册表组件组合均受支持；
-- 所有引用数据集都可获得或允许再分发；
-- 在未记录的数据与环境设置下仍可复现。
+可选 Web 界面：
 
-报告实验时，应记录准确的仓库 commit、配置、override、数据来源、随机种子和运行环境。
+```bash
+python -m pip install -r apps/streamlit/requirements.txt
+streamlit run apps/streamlit/app.py
+```
 
-## 贡献、许可与引用
+其本地单 worker 边界见 [apps/streamlit/README.md](apps/streamlit/README.md)。
 
-提交 PR 前请阅读 [CONTRIBUTING_CN.md](CONTRIBUTING_CN.md)。每个改动应保持小、明确、可审查，
-并给出可复制的验证命令。
+## 贡献与支持
 
-PHM-Vibench 使用 [Apache License 2.0](LICENSE)。数据集和模型产物可能适用其原始来源的独立许可。
+提交 Issue 或 Pull Request 前请阅读 [CONTRIBUTING_CN.md](CONTRIBUTING_CN.md)。
+保持改动小而可审查，修改权威文档而不是复制内容，并提供准确的 commit、
+配置、override、环境和日志。
 
-项目仍处于 alpha 阶段。在稳定论文引用发布前，请引用实验所使用的准确 Git commit 或 release tag。
+- Bug 与功能建议：[GitHub Issues](https://github.com/PHMbench/PHM-Vibench/issues)
+- 安全问题：[SECURITY.md](SECURITY.md)
+- 开发流程：[docs/developer_guide.md](docs/developer_guide.md)
+
+## 引用与许可
+
+PHM-Vibench 使用 [Apache License 2.0](LICENSE)。数据集和模型产物可能适用
+原始来源的独立许可。
+
+在稳定论文引用发布前，请引用实验所使用的准确 Git commit 或 release tag，
+并记录配置、override、数据来源、随机种子和运行环境。

--- a/configs/README.md
+++ b/configs/README.md
@@ -1,93 +1,149 @@
-# Config System (v0.1.0)
+# Configuration System
 
-This folder defines experiments via a 5-block configuration model:
-`environment` / `data` / `model` / `task` / `trainer`.
+This page is the maintained authority for PHM-Vibench configuration composition,
+precedence, inspection, and registry maintenance.
 
-The **single recommended entrypoint** is:
+The public runtime entrypoint is:
 
 ```bash
 python main.py --config <yaml> [--override key=value ...]
 ```
 
-## 30-Second Smoke Run (No External Data)
+For environment setup and the first successful run, use the
+[installation guide](../docs/installation.md) and
+[quickstart](../docs/quickstart.md) instead of duplicating those procedures here.
 
-1) Run the repo-shipped dummy demo:
-```bash
-python main.py --config configs/demo/00_smoke/dummy_dg.yaml
+## Five-block model
+
+Maintained configurations use:
+
+```yaml
+environment: {}
+data: {}
+model: {}
+task: {}
+trainer: {}
 ```
 
-2) Find outputs:
+A top-level `pipeline` selects the pipeline module. New datasets, models, tasks,
+and trainers should normally extend their factory rather than require a new
+pipeline.
+
+## Composition and precedence
+
+Configuration values are applied from lower to higher precedence:
+
+1. YAML files referenced by `base_configs`;
+2. blocks in the selected experiment YAML;
+3. optional machine-local values from `configs/local/local.yaml`;
+4. repeatable CLI `--override key=value` arguments.
+
+Machine paths, credentials, and workstation-specific settings belong in local
+configuration or CLI overrides, not maintained demo files.
+
+## Maintained directories
+
+- `configs/base/` — reusable environment, data, model, task, and trainer blocks;
+- `configs/demo/` — maintained user-facing examples;
+- `configs/experiments/` — local or research variants that are not automatically
+  release-supported;
+- `configs/local/` — untracked machine-local values, with tracked examples and
+  documentation;
+- `configs/reference/` and versioned historical directories — reference material,
+  not the maintained quickstart surface.
+
+Start a local experiment by copying the nearest maintained demo into
+`configs/experiments/` and changing only required behavior-affecting values.
+
+## Inspect a resolved configuration
+
 ```bash
-ls -la results/demo/dummy_dg_smoke
+python -m scripts.config_inspect \
+  --config configs/demo/00_smoke/dummy_dg.yaml \
+  --override trainer.num_epochs=1
 ```
 
-If you want a fast sanity run for any config:
+Useful views:
+
 ```bash
-python main.py --config configs/demo/01_cross_domain/cwru_dg.yaml \
-  --override trainer.num_epochs=1 --override data.num_workers=0
+python -m scripts.config_inspect --config <yaml> --dump resolved --format yaml
+python -m scripts.config_inspect --config <yaml> --dump sources --format md
+python -m scripts.config_inspect --config <yaml> --dump targets --format json
 ```
 
-## How Config Composition Works
+The inspector returns non-zero when any sanity check fails. A missing import or
+invalid target is not a successful inspection.
 
-**Precedence (low → high):**
-1) `base_configs.*` YAML files
-2) The demo YAML’s own block overrides (e.g. `data: {...}`)
-3) Optional machine-local override `configs/local/local.yaml` (or `--local_config ...`)
-4) CLI `--override key=value` (repeatable)
+## Registry and generated atlas
 
-## Single Source of Truth (Registry + Atlas)
+The authoritative maintained-config inventory is:
 
-- Registry (authoritative index): `configs/config_registry.csv`
-- Schema for registry fields: `docs/config_registry_schema.md`
-- Human-readable atlas (generated): `docs/CONFIG_ATLAS.md`
-
-Regenerate atlas:
-```bash
-python -m scripts.gen_config_atlas --registry configs/config_registry.csv
+```text
+configs/config_registry.csv
 ```
 
-## Config Inspect (Explain Resolved Values + Sources + Targets)
+Related files:
 
-Inspect a config and overrides (default output is Markdown):
+- registry field reference: `docs/config_registry_schema.md`;
+- generated human-readable view: `docs/CONFIG_ATLAS.md`.
+
+After an intentional registry change:
+
 ```bash
-python -m scripts.config_inspect --config configs/demo/01_cross_domain/cwru_dg.yaml \
-  --override trainer.num_epochs=1 --override data.num_workers=0
-```
-
-Dump only field sources:
-```bash
-python -m scripts.config_inspect --config configs/demo/01_cross_domain/cwru_dg.yaml \
-  --dump sources --format md
-```
-
-## Schema Validation (Pydantic)
-
-Validate all `configs/demo/**/*.yaml` (and registry rows with `status != "/"`):
-```bash
+python -m scripts.gen_config_atlas
 python -m scripts.validate_configs
+git diff --exit-code docs/CONFIG_ATLAS.md
 ```
 
-## Common Edits (Copy-Paste)
+Do not hand-edit `docs/CONFIG_ATLAS.md`. A registry row records inventory and
+status; it does not by itself prove release support. The public support boundary is
+maintained in `SUPPORTED_COMPONENTS.md` and `SUPPORTED_COMBINATIONS.md`.
 
-### “Run 1 epoch for smoke test”
+## Common overrides
+
+Run one epoch:
+
 ```bash
 python main.py --config <yaml> --override trainer.num_epochs=1
 ```
 
-### “Change dataset without changing model/task”
-- Edit the config (recommended) or use a local override:
-```yaml
-data:
-  data_dir: "/path/to/PHM-Vibench"
-  metadata_file: "metadata.xlsx"
+Use local data without editing a demo:
+
+```bash
+python main.py --config <yaml> \
+  --override data.data_dir=/absolute/path/to/data \
+  --override data.metadata_file=metadata.xlsx
 ```
 
-### “Change task but reuse the same data/model”
-- Keep `base_configs.data` + `base_configs.model`, switch `base_configs.task` to another base task.
+Select CPU and avoid worker-process complexity during a smoke test:
 
-## Where to Read Next
+```bash
+python main.py --config <yaml> \
+  --override trainer.device=cpu \
+  --override trainer.num_epochs=1 \
+  --override data.num_workers=0
+```
 
-- Base blocks overview: `configs/base/README.md`
-- Demo overview: `configs/demo/README.md`
-- Local research configs: `configs/experiments/README.md`
-- Deep dive: `docs/CONFIG_ATLAS.md`
+## Promoting a configuration
+
+A config should enter the maintained registry only when its PR includes:
+
+- a clear purpose and supported audience;
+- valid five-block composition;
+- no personal absolute paths;
+- successful schema validation and inspection;
+- the smallest applicable runtime evidence;
+- synchronized registry and generated atlas;
+- updated support or limitation documentation when the public surface changes.
+
+Use `needs_smoke` or another explicit non-supported status until runtime evidence
+exists. Do not label a configuration `sanity_ok` based only on YAML parsing.
+
+## Read next
+
+- Base blocks: `configs/base/README.md`
+- Maintained demos: `configs/demo/README.md`
+- Experiment variants: `configs/experiments/README.md`
+- Local overrides: `configs/local/README.md`
+- Documentation index: `docs/index.md`
+- Testing and evidence: `docs/testing.md`

--- a/docs/app_usage.md
+++ b/docs/app_usage.md
@@ -1,107 +1,17 @@
-# Streamlit Experiment Workspace
+# Streamlit Workspace
 
-PHM-Vibench provides an optional browser-based workspace for users who prefer a
-guided experiment flow over editing YAML and invoking the CLI manually.
+This path is retained for compatibility with existing links.
 
-The workspace does not replace the maintained command:
+The maintained installation, usage, architecture, process-lifecycle, result,
+testing, and troubleshooting documentation is:
+
+- [PHM-Vibench Streamlit Experiment Workspace](../apps/streamlit/README.md)
+
+The Streamlit application is an optional adapter around the public command:
 
 ```bash
 python main.py --config <yaml> [--override key=value ...]
 ```
 
-It selects a validated template, creates a portable YAML snapshot, launches that
-command, and reads the resulting logs and artifacts.
-
-## Install
-
-```bash
-pip install -r requirements.txt
-pip install -r apps/streamlit/requirements.txt
-```
-
-## Start
-
-Run from the repository root:
-
-```bash
-streamlit run apps/streamlit/app.py
-```
-
-The historical command remains compatible and routes to the same workspace:
-
-```bash
-streamlit run streamlit_app.py
-```
-
-For the first experiment, use:
-
-```text
-Template: demo_00_smoke_dummy_dg
-Device: cpu
-Epochs: 1
-```
-
-This template uses repository-shipped dummy data and requires no dataset download.
-
-## Workflow
-
-### 1. Select a template
-
-Templates come from `configs/config_registry.csv`. The UI shows only entries
-selected by the declarative groups in `apps/streamlit/field_catalog.yaml`.
-
-### 2. Configure
-
-Quick Start exposes a minimal safe parameter surface. Advanced mode adds the
-portable YAML editor and typed CLI overrides.
-
-### 3. Validate and run
-
-The UI delegates validation to:
-
-```bash
-python -m scripts.config_inspect --config <yaml> --dump all --format json
-```
-
-The Run button is enabled only for the exact configuration signature that passed
-validation. Execution uses an argv list and `shell=False`.
-
-### 4. Inspect evidence
-
-The live run area contains:
-
-- process status, PID, elapsed time, and exit code;
-- cancel and immutable restart controls;
-- actual reproduction command;
-- headline metrics and CSV/JSON tables;
-- image and file artifacts;
-- live log tail and full log download.
-
-Every run writes:
-
-```text
-outputs/streamlit/<run_id>/execution.yaml
-outputs/streamlit/<run_id>/run.json
-outputs/streamlit/<run_id>/run.log
-```
-
-## Configuration precedence
-
-```text
-portable YAML
-< configs/local/local.yaml
-< safe UI overrides
-< raw Advanced overrides
-```
-
-Machine-specific paths should remain in `configs/local/local.yaml` or Advanced
-overrides, not in maintained demo configurations.
-
-## Operational limits
-
-The optional UI is intentionally a local single-worker experiment console, not a
-multi-user scheduler. It manages one active process at a time, does not implement
-pause/resume, and applies bounded artifact scanning.
-
-See `apps/streamlit/README.md` for architecture, compatibility, testing, and
-troubleshooting details.
+Do not add a second copy of the Streamlit guide here. Update
+`apps/streamlit/README.md` and keep this page as a redirect.

--- a/docs/archive/README.md
+++ b/docs/archive/README.md
@@ -1,0 +1,41 @@
+# Documentation Archive
+
+This directory stores historical documentation that remains useful for provenance,
+release reconstruction, design review, or research context but is not current user
+guidance.
+
+Archived documents may contain obsolete commands, paths, component names, status
+claims, or environment assumptions. Do not follow them unless a maintained page
+explicitly links to a specific archived procedure.
+
+## Archive rules
+
+Archive a document instead of deleting it when it records at least one of:
+
+- a released migration or compatibility decision;
+- an architecture decision that still explains current constraints;
+- an experiment protocol or failure with reproducibility value;
+- a branch, release, or governance audit needed to reconstruct history;
+- an externally cited path that should remain recoverable.
+
+Delete a document only when it is wholly duplicated, empty, unrelated to the
+repository, or a template with no historical or operational value, and only after
+checking references.
+
+## Current historical locations
+
+The repository already contains historical material outside this directory:
+
+- `docs/v0.1.0/`
+- `docs/past/`
+- `configs/v0.0.9/`
+- selected material under `dev/`
+
+Those paths are preserved to avoid unnecessary link breakage. New historical audit
+snapshots should be placed under `docs/archive/` rather than added to the maintained
+documentation root.
+
+## Maintained documentation
+
+Return to the [documentation index](../index.md) for current installation, usage,
+configuration, development, support, and release guidance.

--- a/docs/archive/audits/documentation-audit-20260714.md
+++ b/docs/archive/audits/documentation-audit-20260714.md
@@ -1,0 +1,148 @@
+# Documentation Audit — 2026-07-14
+
+Status: **historical audit snapshot**
+
+Baseline: `main` at `9554eee5cae2dd2d9aa178008cb7056096d0e44d`
+
+This audit covers the root documentation surface, `docs/`, contribution and
+security files, configuration/data/application guides, repository templates, and
+representative module-level documentation discoverable in the tracked repository.
+Historical research and release subtrees were classified rather than rewritten
+line by line. The audit does not treat a document's existence as proof that its
+claims are implemented.
+
+## Executive findings
+
+1. The root README had become the de facto source for installation, quickstart,
+   configuration, testing, architecture, support boundaries, and contribution.
+   That made it accurate but too broad and encouraged downstream duplication.
+2. There was no maintained `docs/index.md`, installation page, or quickstart page.
+3. English and Chinese contribution guides still described Python 3.8, broad
+   component support, obsolete test filenames, and generic CI behavior that no
+   longer matched the repository.
+4. The lowercase `contributing.md` mixed a legacy redirect with a copied Code of
+   Conduct containing `[INSERT CONTACT METHOD]`.
+5. `SECURITY.md` was an uncustomized template: it claimed `1.0.x` support and
+   contained an email placeholder.
+6. English and Chinese issue templates contained `<YOUR_REPO_URL>` placeholders
+   and an invalid historical command (`python src/main.py --config-name=...`).
+7. `docs/app_usage.md` duplicated the maintained `apps/streamlit/README.md`.
+8. `configs/README.md` was still titled `v0.1.0` and duplicated first-run guidance.
+9. `docs/testing.md` did not describe focused tests, generated-doc checks, smoke
+   evidence, CI evidence, or environment limitations.
+10. `docs/HPC.md` is a long YCRC-specific note with generic `src/train.py`
+    commands, cluster-specific assertions, and externally changing operational
+    details. It is not a maintained PHM-Vibench user guide.
+11. Historical material under `docs/v0.1.0/`, `docs/past/`, `configs/v0.0.9/`, and
+    `dev/` was not clearly separated by a central navigation policy.
+12. Several lowercase README files are intentional compatibility redirects and
+    should not be removed solely for stylistic consistency.
+
+## Document disposition matrix
+
+| Path or group | Audience | Finding | Action |
+| --- | --- | --- | --- |
+| `README.md` | users | Accurate but overextended; stale statement that active CI is still needed | Rewrite as concise project/front-door page |
+| `README_CN.md` | users | Mirrors README structure and same stale CI statement | Rewrite in parallel with English README |
+| `docs/index.md` | all | Missing | Add canonical navigation and source-of-truth map |
+| `docs/installation.md` | users | Missing | Add authoritative installation page |
+| `docs/quickstart.md` | users | Missing | Add authoritative offline smoke walkthrough |
+| `configs/README.md` | users/developers | Useful config authority, but version title and first-run duplication are stale | Retain; update title and link to quickstart |
+| `data/README.md` | users/contributors | Recently rewritten; clearly separates dummy data, local data, and references | Retain as data authority |
+| `docs/developer_guide.md` | developers | Current, focused, and factory-aligned | Retain; link from documentation index |
+| `docs/testing.md` | developers | Too small to serve as test authority | Rewrite as test/evidence authority |
+| `apps/streamlit/README.md` | users/developers | Detailed maintained UI authority | Retain |
+| `docs/app_usage.md` | users | Duplicates Streamlit guide | Replace with compatibility redirect |
+| `docs/custom_dataset.md` | users/contributors | Useful short bridge; overlaps factory guide | Retain for now; link to data and contribution authorities |
+| `CONTRIBUTING.md` | contributors | Outdated environment, tests, support assumptions, and component instructions | Rewrite in contributor-governance PR |
+| `CONTRIBUTING_CN.md` | contributors | Same problems as English guide | Rewrite together with English guide |
+| `contributing.md` | contributors | Duplicate plus embedded Code of Conduct placeholder | Replace with compatibility redirect |
+| `CODE_OF_CONDUCT.md` | community | Missing | Add customized conduct policy |
+| `SECURITY.md` | security reporters | Incorrect supported versions and placeholder contact | Rewrite without unverifiable response-time promises |
+| `CITATION.cff` | researchers | Missing | Add minimal software citation metadata after maintainer identity check |
+| `.github/ISSUE_TEMPLATE/*` | users/contributors | Duplicate bilingual templates with placeholders and invalid commands | Rewrite with real repository links and evidence fields |
+| `.github/PULL_REQUEST_TEMPLATE.md` | contributors | Missing | Add scope, evidence, compatibility, docs, and rollback checklist |
+| `CHANGELOG.md` | users/release managers | Current release-candidate record | Retain |
+| `RELEASE_NOTES_v0.2.0.md` | users/release managers | Release-specific authority | Retain; do not duplicate in general docs |
+| `MIGRATION_v0.1_to_v0.2.md` | users | Migration authority | Retain |
+| `SUPPORTED_COMPONENTS.md` | users/developers | Support boundary authority | Retain |
+| `SUPPORTED_COMBINATIONS.md` | users/developers | Maintained combination authority | Retain |
+| `KNOWN_LIMITATIONS.md` | users/developers | Limitation authority | Retain |
+| `docs/CONFIG_ATLAS.md` | users/developers | Generated view of registry | Retain; never hand-edit |
+| `docs/branch_governance_20260709.md` | maintainers | Important governance decision record | Retain |
+| `docs/REPOSITORY_OPTIMIZATION_SOP.md` | maintainers | Stable change-management SOP | Retain |
+| `docs/PIPELINE_06_GENERATIVE_MIGRATION.md` | developers/researchers | Explicit future migration contract | Retain, clearly outside release support |
+| `docs/HPC.md` | specific HPC users | Unverified, cluster-specific, and not aligned to current entrypoint | Archive or replace with a warning page in a separate PR |
+| `docs/v0.1.0/**` | maintainers/researchers | Historical release and planning evidence | Preserve; classify as historical |
+| `docs/past/**` | maintainers/researchers | Historical guides that may contain obsolete commands | Preserve; classify as historical |
+| `src/**/README.md` | developers | Local component documentation; mixed depth but useful near code | Retain; prefer links to central policies |
+| lowercase redirect READMEs | compatibility | Short redirects already prevent case/link breakage | Retain unless a reference audit proves deletion safe |
+| `AGENTS.md`, `CLAUDE.md`, `GEMINI.md` | maintainers/agents | Engineering runbook and constraints, not user documentation | Retain; link only from developer navigation |
+
+## Single-source-of-truth decisions
+
+| Information | Authority |
+| --- | --- |
+| Project positioning and shortest entry | `README.md` |
+| Installation | `docs/installation.md` |
+| First successful run | `docs/quickstart.md` |
+| Documentation navigation | `docs/index.md` |
+| Configuration behavior | `configs/README.md` |
+| Config inventory | `configs/config_registry.csv` |
+| Rendered config inventory | generated `docs/CONFIG_ATLAS.md` |
+| Data layout and external-data boundary | `data/README.md` |
+| Supported release components | `SUPPORTED_COMPONENTS.md` |
+| Supported release combinations | `SUPPORTED_COMBINATIONS.md` |
+| Known constraints | `KNOWN_LIMITATIONS.md` |
+| Tests and evidence terminology | `docs/testing.md` |
+| General contribution process | `CONTRIBUTING.md` |
+| Factory-specific extension steps | each `src/*_factory/contributing.md` |
+| Streamlit behavior | `apps/streamlit/README.md` |
+| Security reporting | `SECURITY.md` |
+| Release history | `CHANGELOG.md` plus versioned release notes |
+
+## Planned PR sequence
+
+### PR A — user documentation architecture
+
+- add documentation index, installation guide, quickstart, archive policy, and
+  this audit snapshot;
+- shorten English and Chinese root READMEs;
+- make testing guidance authoritative;
+- turn duplicate Streamlit usage content into a redirect;
+- remove the stale version label from the config guide.
+
+### PR B — contribution and repository templates
+
+- rewrite bilingual contribution guides;
+- separate the lowercase compatibility page from the Code of Conduct;
+- replace the security template;
+- add a pull-request template;
+- repair bilingual bug and feature templates;
+- add minimal citation metadata after maintainer review.
+
+### PR C — historical and specialist cleanup
+
+- audit references to `docs/HPC.md` and either archive it with a warning or remove
+  it if no provenance value remains;
+- add explicit archive landing pages for existing historical subtrees without
+  mass-renaming paths;
+- review large code comments or AI workflow documents that act as unofficial
+  user documentation.
+
+## Validation requirements
+
+Each documentation PR must run:
+
+```bash
+python -m scripts.validate_docs
+python -m scripts.validate_configs
+python -m scripts.gen_config_atlas
+git diff --exit-code docs/CONFIG_ATLAS.md
+git diff --check
+```
+
+A quickstart or command change additionally requires the repository-shipped smoke
+command in an environment with the maintained runtime dependencies. Missing local
+runtime dependencies must be reported as `NOT_EXECUTED` or `FAILED`, never as a
+pass.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,86 @@
+# PHM-Vibench Documentation
+
+This page is the navigation entrypoint for maintained PHM-Vibench documentation.
+The public runtime contract is configuration-first:
+
+```bash
+python main.py --config <yaml> [--override key=value ...]
+```
+
+Documentation uses four status labels:
+
+- **Maintained** — expected to match current `main` and covered by repository checks.
+- **Experimental** — implemented or under active development, but outside the release-supported surface.
+- **Historical** — retained as evidence of earlier decisions or releases; not current instructions.
+- **Generated** — produced from another source of truth and should not be edited manually.
+
+## Start here
+
+| Need | Maintained entrypoint |
+| --- | --- |
+| Install PHM-Vibench | [Installation](installation.md) |
+| Run the offline example | [Quickstart](quickstart.md) |
+| Understand YAML composition and overrides | [Configuration guide](../configs/README.md) |
+| Find maintained configurations | [Configuration atlas](CONFIG_ATLAS.md) |
+| Prepare local datasets | [Data directory guide](../data/README.md) |
+| See the supported release surface | [Supported components](../SUPPORTED_COMPONENTS.md) and [supported combinations](../SUPPORTED_COMBINATIONS.md) |
+| Check known constraints | [Known limitations](../KNOWN_LIMITATIONS.md) |
+| Use the optional web interface | [Streamlit workspace](../apps/streamlit/README.md) |
+| Troubleshoot a first run | [Quickstart troubleshooting](quickstart.md#troubleshooting) |
+
+## Develop and contribute
+
+| Task | Maintained entrypoint |
+| --- | --- |
+| Development workflow and architecture | [Developer guide](developer_guide.md) |
+| Tests and validation gates | [Testing guide](testing.md) |
+| General contribution process | [CONTRIBUTING.md](../CONTRIBUTING.md) |
+| Add a dataset or reader | [Data factory contribution guide](../src/data_factory/contributing.md) |
+| Add a model | [Model factory contribution guide](../src/model_factory/contributing.md) |
+| Add a task | [Task factory contribution guide](../src/task_factory/contributing.md) |
+| Add or change a trainer | [Trainer factory contribution guide](../src/trainer_factory/contributing.md) |
+| Repository change constraints | [CLAUDE.md](../CLAUDE.md) |
+| Copy-paste maintainer commands | [AGENTS.md](../AGENTS.md) |
+
+## Releases and governance
+
+- [Changelog](../CHANGELOG.md)
+- [v0.2.0 release notes](../RELEASE_NOTES_v0.2.0.md)
+- [v0.1 to v0.2 migration guide](../MIGRATION_v0.1_to_v0.2.md)
+- [Security policy](../SECURITY.md)
+- [Apache License 2.0](../LICENSE)
+- [Branch governance record](branch_governance_20260709.md)
+- [Repository optimization SOP](REPOSITORY_OPTIMIZATION_SOP.md)
+- [Pipeline 06 migration contract](PIPELINE_06_GENERATIVE_MIGRATION.md)
+
+## Generated and historical material
+
+`docs/CONFIG_ATLAS.md` is generated from `configs/config_registry.csv`; update the
+registry, run `python -m scripts.gen_config_atlas`, and commit both changes.
+
+Earlier release and planning material remains under:
+
+- `docs/v0.1.0/`
+- `docs/past/`
+- `configs/v0.0.9/`
+- `dev/`
+
+Those paths are retained for provenance and research context. They are not current
+installation, usage, compatibility, or support instructions unless a maintained
+page links to a specific document and says otherwise.
+
+## Single-source-of-truth map
+
+| Information | Authority | Other documents should do |
+| --- | --- | --- |
+| Project positioning and shortest successful path | `README.md` | Link to the README or the detailed page below |
+| Installation | `docs/installation.md` | Keep only a minimal command and link |
+| First successful run | `docs/quickstart.md` | Avoid copying the complete walkthrough |
+| Configuration semantics | `configs/README.md` | Link rather than redefine precedence |
+| Maintained config inventory | `configs/config_registry.csv` | Regenerate `docs/CONFIG_ATLAS.md` |
+| Supported components and combinations | `SUPPORTED_COMPONENTS.md`, `SUPPORTED_COMBINATIONS.md` | Do not infer support from registry presence |
+| Data layout and external-data boundary | `data/README.md` | Link from reader and dataset pages |
+| Contribution process | `CONTRIBUTING.md` | Factory guides describe only factory-specific steps |
+| Test commands and evidence terms | `docs/testing.md` | Link to the relevant gate |
+| Optional Streamlit behavior | `apps/streamlit/README.md` | Keep compatibility pages as short redirects |
+| Release changes | `CHANGELOG.md` and release notes | Historical plans must not override release documents |

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,0 +1,111 @@
+# Installation
+
+This page is the maintained installation reference for PHM-Vibench. The project
+currently runs from a repository checkout; it is not documented as an installed
+Python package.
+
+## Supported installation baseline
+
+The active repository checks use:
+
+- Python 3.10;
+- Ubuntu runners;
+- PyTorch 2.6.0 for focused CPU tests.
+
+Other Python versions and operating systems may work, but they are not part of
+the documented validation baseline. See [known limitations](../KNOWN_LIMITATIONS.md)
+before reporting a platform-specific problem.
+
+## Clone the repository
+
+```bash
+git clone https://github.com/PHMbench/PHM-Vibench.git
+cd PHM-Vibench
+```
+
+Run commands from the repository root unless a page explicitly says otherwise.
+
+## Create an isolated environment
+
+Conda example:
+
+```bash
+conda create -n phm-vibench python=3.10
+conda activate phm-vibench
+python -m pip install --upgrade pip
+```
+
+Standard-library `venv` is also acceptable:
+
+```bash
+python3.10 -m venv .venv
+source .venv/bin/activate
+python -m pip install --upgrade pip
+```
+
+On Windows, activate a `venv` with `.venv\Scripts\activate`.
+
+## Install dependencies
+
+The repository dependency file includes the core runtime plus optional research
+libraries used by model families that are not all release-supported:
+
+```bash
+python -m pip install -r requirements.txt
+```
+
+For a CPU-only PyTorch installation, install the pinned CPU wheels first:
+
+```bash
+python -m pip install --index-url https://download.pytorch.org/whl/cpu \
+  torch==2.6.0 torchvision==0.21.0 torchaudio==2.6.0
+python -m pip install -r requirements.txt
+```
+
+For CUDA, choose the PyTorch wheel compatible with the local driver and hardware.
+Do not copy a CUDA command from an unrelated machine. Keep the repository's
+pinned PyTorch family versions aligned unless a dedicated compatibility PR changes
+them.
+
+## Optional Streamlit interface
+
+The command-line interface is the maintained runtime entrypoint. Install the web
+workspace only when needed:
+
+```bash
+python -m pip install -r apps/streamlit/requirements.txt
+streamlit run apps/streamlit/app.py
+```
+
+See the [Streamlit guide](../apps/streamlit/README.md) for its local single-worker
+scope and validation commands.
+
+## Verify the installation
+
+Check lightweight documentation and configuration contracts:
+
+```bash
+python -m scripts.validate_docs
+python -m scripts.validate_configs
+python -m scripts.config_inspect \
+  --config configs/demo/00_smoke/dummy_dg.yaml \
+  --override trainer.num_epochs=1
+```
+
+Then run the repository-shipped offline example:
+
+```bash
+python main.py --config configs/demo/00_smoke/dummy_dg.yaml \
+  --override trainer.num_epochs=1 \
+  --override data.num_workers=0
+```
+
+Continue with the [quickstart](quickstart.md) for expected behavior, outputs, and
+troubleshooting.
+
+## External data
+
+Only the dummy example is fully contained in the repository. Other maintained
+demos require local PHM-Vibench metadata and raw data. Do not hard-code a personal
+path into a maintained YAML file; use CLI overrides or `configs/local/local.yaml`.
+See the [data directory guide](../data/README.md).

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,0 +1,131 @@
+# Quickstart
+
+This walkthrough verifies the maintained configuration-first path with repository-
+shipped dummy data. It is a software smoke test, not a benchmark-performance run.
+
+## 1. Install the environment
+
+Complete the [installation guide](installation.md), activate the environment, and
+run all commands from the repository root.
+
+## 2. Inspect the configuration
+
+```bash
+python -m scripts.config_inspect \
+  --config configs/demo/00_smoke/dummy_dg.yaml \
+  --override trainer.num_epochs=1
+```
+
+The inspector resolves the composed configuration, reports field sources and
+runtime targets, and returns a non-zero exit code when a sanity check fails.
+Resolve inspector errors before starting training.
+
+The maintained configuration contains the five public blocks:
+
+```text
+environment / data / model / task / trainer
+```
+
+It selects `Pipeline_01_default`, uses `data/metadata_dummy.csv`, runs on CPU, and
+writes below `results/demo/dummy_dg_smoke/`.
+
+## 3. Run one offline epoch
+
+```bash
+python main.py --config configs/demo/00_smoke/dummy_dg.yaml \
+  --override trainer.num_epochs=1 \
+  --override data.num_workers=0
+```
+
+A successful smoke run should:
+
+- exit with status code `0`;
+- complete the config → data → model → task → trainer path;
+- print the repository completion message;
+- create run output beneath `results/demo/dummy_dg_smoke/`;
+- require no external dataset download.
+
+Inspect the output tree without assuming a fixed experiment subdirectory name:
+
+```bash
+find results/demo/dummy_dg_smoke -maxdepth 4 -type f | sort
+```
+
+Runtime outputs are evidence for the exact commit, configuration, overrides, data,
+and environment used. They are not a configuration source of truth and should not
+be committed unless a specific review requires a small fixture.
+
+## 4. Run repository checks
+
+```bash
+python -m scripts.validate_docs
+python -m scripts.validate_configs
+python -m scripts.gen_config_atlas
+git diff --exit-code docs/CONFIG_ATLAS.md
+python -m pytest test/ -q
+```
+
+Use the focused test closest to a change during development; use the broader gate
+before requesting review for runtime or configuration changes. See the
+[testing guide](testing.md).
+
+## 5. Run a maintained demo with local data
+
+Only the dummy demo is fully offline. For another maintained configuration, pass
+local data paths as overrides instead of editing the tracked YAML:
+
+```bash
+python main.py --config configs/demo/01_cross_domain/cwru_dg.yaml \
+  --override data.data_dir=/absolute/path/to/PHM-Vibench-data \
+  --override data.metadata_file=metadata.xlsx \
+  --override trainer.num_epochs=1 \
+  --override data.num_workers=0
+```
+
+Read the [data directory guide](../data/README.md), then check the exact maintained
+surface in [supported combinations](../SUPPORTED_COMBINATIONS.md).
+
+## Configuration variants
+
+For a local experiment:
+
+1. copy the nearest YAML from `configs/demo/` to `configs/experiments/`;
+2. change only behavior-affecting fields required by the experiment;
+3. inspect the resolved configuration;
+4. run the smallest applicable test;
+5. record the commit, config, overrides, seed, data source, and environment.
+
+Do not add a local variant to `configs/config_registry.csv` unless it is being
+reviewed for promotion to the maintained surface. The complete composition and
+precedence rules live in the [configuration guide](../configs/README.md).
+
+## Troubleshooting
+
+### The inspector reports a missing module
+
+Install the core dependencies from `requirements.txt`. A model family may import
+an optional research dependency even when it is outside the maintained release
+surface; report unconditional optional imports as dependency-boundary bugs.
+
+### A data or metadata path does not exist
+
+Return to the offline dummy config to verify the software environment. For local
+data, use `data.data_dir` and `data.metadata_file` overrides or
+`configs/local/local.yaml`.
+
+### CUDA initialization fails
+
+Run the CPU dummy config first. Verify the local PyTorch build, driver, and device
+independently before changing PHM-Vibench configuration.
+
+### The generated atlas changes
+
+`docs/CONFIG_ATLAS.md` is generated from `configs/config_registry.csv`. If the
+registry change is intentional, regenerate and commit the atlas. Otherwise revert
+the unintended registry change.
+
+### The run succeeds but metrics differ
+
+The quickstart verifies execution, not fixed scientific metrics. Reproducibility
+claims require the same commit, environment, data, split, seed, and configuration.
+See [known limitations](../KNOWN_LIMITATIONS.md).

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,16 +1,169 @@
-# Testing Guide
+# Testing and Validation
 
-## Pytest
+This page is the maintained source for PHM-Vibench test commands and evidence
+terminology. Run the narrowest test that exercises a change, then apply the
+relevant merge gate.
+
+## Evidence terms
+
+Use precise language in issues and pull requests:
+
+- **Local pass** — the command ran successfully in a named local environment.
+- **CI pass** — a GitHub Actions job attached to the commit completed successfully.
+- **Not executed** — the command was not run; do not infer a result.
+- **Expected failure** — an intentionally invalid case failed with the documented
+  error boundary.
+- **Smoke evidence** — a bounded path executed; this is not benchmark-performance
+  evidence.
+- **Contract evidence** — inputs, outputs, shapes, devices, errors, or artifacts
+  satisfied explicit assertions.
+
+Never describe local output as CI output, an import as an end-to-end run, or
+synthetic data as evidence of scientific performance.
+
+## Maintained test directory
+
+The maintained pytest gate is:
 
 ```bash
-python -m pytest test/
+python -m pytest test/ -q
 ```
 
-## Legacy runner (optional; historical matrix)
+Files under `dev/test_history/`, `test/todo_test/`, historical release folders, or
+research workspaces are diagnostic unless a maintained page explicitly promotes a
+specific command.
 
-`dev/test_history/` contains a historical test runner used during earlier refactors. It may require additional
-dependencies and is not part of the maintained workflow.
+## Lightweight documentation and configuration gate
+
+Use this gate for documentation, registry, and YAML changes:
 
 ```bash
-python dev/test_history/run_tests.py --unit
+python -m scripts.validate_docs
+python -m scripts.validate_configs
+python -m scripts.gen_config_atlas
+git diff --exit-code docs/CONFIG_ATLAS.md
+git diff --check
 ```
+
+`docs/CONFIG_ATLAS.md` is generated from `configs/config_registry.csv`. Do not
+hand-edit the atlas to make the diff disappear.
+
+A documentation-only pull request may stop at this gate when it does not change a
+command, configuration, runtime claim, or executable example. The pull-request
+description must explain why runtime tests are not applicable.
+
+## Configuration inspection
+
+Inspect the resolved values, sources, runtime targets, and sanity checks:
+
+```bash
+python -m scripts.config_inspect \
+  --config configs/demo/00_smoke/dummy_dg.yaml \
+  --override trainer.num_epochs=1
+```
+
+The command must return non-zero when a sanity check fails. Missing dependencies,
+unknown imports, or invalid targets are failures, not warnings to ignore.
+
+## Offline end-to-end smoke
+
+The repository-shipped dummy configuration is the default runtime gate:
+
+```bash
+python main.py --config configs/demo/00_smoke/dummy_dg.yaml \
+  --override trainer.num_epochs=1 \
+  --override data.num_workers=0
+```
+
+A pass requires a clean exit through config loading, data construction, model and
+task assembly, trainer execution, and output creation. See the
+[quickstart](quickstart.md) for expected behavior.
+
+This smoke uses synthetic repository data and does not validate accuracy on an
+industrial dataset.
+
+## Focused tests
+
+Examples of focused gates already present in the repository:
+
+```bash
+# Configuration tooling
+python -m pytest test/test_config_tools.py -q
+
+# Streamlit configuration and process boundaries
+python -m pytest \
+  test/test_streamlit_config_service.py \
+  test/test_streamlit_runtime_policy.py \
+  test/test_streamlit_run_service.py \
+  test/test_streamlit_result_service.py -q
+
+# TSPN_UXFD assembly contract
+python -m pytest test/test_tspn_uxfd_assembly.py -q
+
+# Generative/pretraining contract tests
+python -m pytest test/generative/ -q
+```
+
+Verify that a referenced test file exists on the branch before copying a command
+into documentation or a pull request.
+
+## Active GitHub Actions gate
+
+`.github/workflows/core-quality-gates.yml` currently runs on pull requests and
+pushes to `main`.
+
+The active workflow checks:
+
+1. documentation and maintained configuration consistency;
+2. generated atlas cleanliness and whitespace;
+3. focused CPU compilation and tests for the UXFD U1 assembly contract.
+
+The workflow is intentionally narrower than the entire optional research stack.
+A green focused workflow does not mean every model family, dataset, or external-
+data demo has been executed.
+
+## Test selection by change type
+
+| Change | Minimum focused gate | Additional merge gate |
+| --- | --- | --- |
+| Documentation wording or links | `validate_docs` | `validate_configs`, atlas clean diff, `git diff --check` |
+| Maintained YAML or registry | `validate_configs`, `config_inspect` | atlas clean diff and applicable smoke |
+| Data reader or sampler | focused contract test | dummy smoke plus affected real-data test when assets exist |
+| Model implementation | import/assembly/shape test | affected task integration and dummy smoke |
+| Task, loss, or metric | focused behavior and negative tests | affected maintained demo smoke |
+| Trainer or checkpoint behavior | focused lifecycle test | dummy train/test loop and checkpoint round trip |
+| Streamlit | focused service tests | core config checks; CLI smoke remains authoritative |
+| Release support claim | linked runtime evidence | independent review of supported components/combinations |
+
+## Environment reporting
+
+Include at least:
+
+```text
+operating system
+Python version
+PyTorch and PyTorch Lightning versions
+CPU/GPU and CUDA version when relevant
+repository commit
+configuration path and overrides
+data source
+full command
+exit code
+```
+
+For dependency diagnostics:
+
+```bash
+python --version
+python -m pip freeze
+```
+
+Do not commit a complete environment dump unless it is a deliberate, reviewed
+release artifact; attach it to an issue or CI artifact instead.
+
+## Reproducibility
+
+For a reproducibility claim, record the commit, configuration, overrides, data
+version, split, seed, environment, and output artifact. A repeated run can be
+considered reproducible only against an explicit tolerance appropriate to the
+metric and hardware path; GPU bitwise identity is not assumed.


### PR DESCRIPTION
## Objective

Establish a maintainable user-facing documentation architecture before performing any broad historical cleanup.

This PR is the first of three documentation-governance slices:

1. user documentation architecture and single sources of truth — this PR;
2. contribution, security, conduct, issue, and PR templates — follow-up;
3. specialist/historical cleanup after reference and provenance checks — follow-up.

## Audit findings

The dated audit snapshot is stored at:

```text
docs/archive/audits/documentation-audit-20260714.md
```

Major findings addressed here:

- no maintained documentation index, installation guide, or quickstart;
- root READMEs duplicated installation, configuration, testing, architecture, and support material;
- root READMEs still said an active CI workflow was needed after core quality gates had been enabled;
- `docs/testing.md` was not sufficient as a test/evidence authority;
- `docs/app_usage.md` duplicated `apps/streamlit/README.md`;
- `configs/README.md` retained a `v0.1.0` title and duplicated onboarding steps;
- historical documentation lacked a central archive policy.

## Changes

### Added

- `docs/index.md` — maintained documentation navigation and source-of-truth map;
- `docs/installation.md` — installation authority;
- `docs/quickstart.md` — offline smoke walkthrough, expected behavior, and troubleshooting;
- `docs/archive/README.md` — archive criteria and historical-material policy;
- `docs/archive/audits/documentation-audit-20260714.md` — reviewable audit evidence.

### Rewritten or consolidated

- `README.md` and `README_CN.md` are concise user entrypoints;
- `docs/testing.md` is now the authority for local/CI/smoke/contract evidence and test selection;
- `configs/README.md` is the authority for five-block composition, precedence, registry, and promotion;
- `docs/app_usage.md` is reduced to a compatibility redirect to `apps/streamlit/README.md`.

## Single-source-of-truth boundaries

| Information | Authority |
| --- | --- |
| Project positioning and shortest path | `README.md` |
| Installation | `docs/installation.md` |
| First successful run | `docs/quickstart.md` |
| Documentation navigation | `docs/index.md` |
| Configuration semantics | `configs/README.md` |
| Config inventory | `configs/config_registry.csv` |
| Generated config view | `docs/CONFIG_ATLAS.md` |
| Data layout | `data/README.md` |
| Testing and evidence terms | `docs/testing.md` |
| Streamlit behavior | `apps/streamlit/README.md` |

## Scope controls

- no runtime, factory, configuration, registry, dependency, test, or workflow changes;
- no historical document deletion or mass movement;
- no change to the seven-demo release-supported surface;
- no performance or compatibility claims added;
- contributor/security/template problems are recorded but intentionally deferred to the next PR.

## Validation

Required CI/static gates:

```bash
python -m scripts.validate_docs
python -m scripts.validate_configs
python -m scripts.gen_config_atlas
git diff --exit-code docs/CONFIG_ATLAS.md
git diff --check
```

The README and quickstart preserve the existing repository-shipped smoke command:

```bash
python main.py --config configs/demo/00_smoke/dummy_dg.yaml \
  --override trainer.num_epochs=1 \
  --override data.num_workers=0
```

No new runtime command is introduced. This connector session did not execute the runtime smoke; the PR relies on the already maintained command and requests repository CI/local verification rather than claiming a new pass.

## Review focus

- relative links and documented paths exist;
- detailed information lives in only one authority;
- English and Chinese README boundaries match;
- historical material remains recoverable;
- the audit snapshot is clearly non-authoritative after its date.

## Rollback

Revert the eventual squash merge. The PR changes documentation only.