### PR TITLE
docs: establish canonical user onboarding pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,71 +17,41 @@
   </p>
 </div>
 
-PHM-Vibench organizes data loading, model construction, task wiring, training, and
-experiment configuration behind one maintained entrypoint:
+PHM-Vibench connects data loading, model construction, task logic, training, and
+experiment configuration through one maintained entrypoint:
 
 ```bash
 python main.py --config <yaml> [--override key=value ...]
 ```
 
-The project is in alpha. Its release-supported surface is deliberately narrower
-than the full set of files and registry entries in the repository. Start with the
-maintained demos and treat historical, reference, and research material as
-unverified until it has its own runtime evidence.
+The project is in alpha. The release-supported surface is deliberately smaller
+than the set of files and registry entries in the repository. A component is not
+supported merely because it can be discovered or imported; support requires a
+maintained configuration and runtime evidence.
 
-## Start here
+## What is currently maintained
 
-Run the repository-shipped offline smoke demo:
+The maintained public surface covers seven demo configurations for:
 
-```bash
-python main.py --config configs/demo/00_smoke/dummy_dg.yaml \
-  --override trainer.num_epochs=1 \
-  --override data.num_workers=0
-```
+- offline Dummy-data domain generalization (DG);
+- cross-domain DG;
+- cross-system/cross-dataset domain generalization (CDDG);
+- few-shot (FS) and generalized few-shot (GFS) classification;
+- two bounded HSE pretraining views.
 
-Inspect the resolved configuration without editing a maintained YAML file:
+The exact model, task, pipeline, data, and trainer combinations are listed in:
 
-```bash
-python -m scripts.config_inspect \
-  --config configs/demo/00_smoke/dummy_dg.yaml \
-  --override trainer.num_epochs=1
-```
-
-Canonical entrypoints:
-
-- [Configuration guide](configs/README.md)
-- [Generated configuration atlas](docs/CONFIG_ATLAS.md)
 - [Supported components](SUPPORTED_COMPONENTS.md)
 - [Supported combinations](SUPPORTED_COMBINATIONS.md)
 - [Known limitations](KNOWN_LIMITATIONS.md)
-- [Data-directory policy](data/README.md)
-- [Contributor guide](CONTRIBUTING.md)
 
-## Maintained demo surface
+Smoke evidence establishes that a software path runs; it does not establish
+benchmark accuracy, state-of-the-art performance, universal compatibility, or
+data redistribution rights.
 
-The configuration registry currently marks seven demos as `sanity_ok`. That
-status means the configuration has smoke evidence; it does **not** establish
-benchmark accuracy, state-of-the-art performance, or universal compatibility.
+## Install
 
-| Area | Config | Data requirement |
-| --- | --- | --- |
-| Offline smoke / DG | `configs/demo/00_smoke/dummy_dg.yaml` | Repository-shipped dummy data |
-| Cross-domain DG | `configs/demo/01_cross_domain/cwru_dg.yaml` | Local PHM-Vibench metadata/raw data |
-| Cross-system CDDG | `configs/demo/02_cross_system/multi_system_cddg.yaml` | Local PHM-Vibench metadata/raw data |
-| Few-shot FS | `configs/demo/03_fewshot/cwru_protonet.yaml` | Local PHM-Vibench metadata/raw data |
-| Cross-system few-shot GFS | `configs/demo/04_cross_system_fewshot/cross_system_tspn.yaml` | Local PHM-Vibench metadata/raw data |
-| HSE pretraining view | `configs/demo/05_pretrain_fewshot/pretrain_hse_then_fewshot.yaml` | Local PHM-Vibench metadata/raw data |
-| HSE pretraining for CDDG | `configs/demo/06_pretrain_cddg/pretrain_hse_cddg.yaml` | Local PHM-Vibench metadata/raw data |
-
-The current v0.2.0 support documents bound the maintained model path to
-`ISFM/M_01_ISFM` with `E_01_HSE`, `B_04_Dlinear`, and
-`H_01_Linear_cla`, plus the task combinations listed in
-[SUPPORTED_COMPONENTS.md](SUPPORTED_COMPONENTS.md). Registry discovery alone is
-not a support claim.
-
-## Installation
-
-A minimal environment setup is:
+Python 3.10 is the maintained documentation and CI baseline.
 
 ```bash
 git clone https://github.com/PHMbench/PHM-Vibench.git
@@ -89,35 +59,53 @@ cd PHM-Vibench
 
 conda create -n phm-vibench python=3.10
 conda activate phm-vibench
-pip install -r requirements.txt
+python -m pip install -r requirements.txt
 ```
 
-Maintained runtime evidence was collected in the project-specific `LQ_signal`
-conda environment. A generic environment may still need dependency or platform
-adjustments; see [KNOWN_LIMITATIONS.md](KNOWN_LIMITATIONS.md).
+CPU-only PyTorch, CUDA selection, platform boundaries, and environment checks are
+covered in the [installation guide](docs/installation.md).
 
-Only the dummy smoke demo is fully offline. For other demos, point the config to
-a local data root rather than editing the maintained YAML:
+## Run the offline smoke experiment
+
+This command uses repository-shipped Dummy data and CPU execution:
 
 ```bash
-python main.py --config configs/demo/01_cross_domain/cwru_dg.yaml \
-  --override data.data_dir=/absolute/path/to/PHM-Vibench-data \
-  --override data.metadata_file=metadata.xlsx \
+python main.py \
+  --config configs/demo/00_smoke/dummy_dg.yaml \
   --override trainer.num_epochs=1 \
   --override data.num_workers=0
 ```
 
-Processed or raw datasets may also be available from:
+A successful run exits with code `0`, prints the completion message, and creates
+artifacts below:
 
-- [ModelScope processed files](https://www.modelscope.cn/datasets/PHMbench/PHM-Vibench/files)
-- [PHMbench raw-data group](https://www.modelscope.cn/datasets/PHMbench/PHMbench-raw_data)
-- [Hugging Face mirror](https://huggingface.co/datasets/PHMbench/PHM-Vibench/tree/main)
+```text
+results/demo/dummy_dg_smoke/
+```
 
-Check the source license and availability before using or redistributing data.
+See [Quickstart](docs/quickstart.md) for configuration inspection, expected
+evidence, external-data overrides, and the next experiment steps.
+
+## Documentation
+
+- [Documentation index](docs/index.md)
+- [Installation](docs/installation.md)
+- [Quickstart](docs/quickstart.md)
+- [Configuration system](configs/README.md)
+- [Generated configuration atlas](docs/CONFIG_ATLAS.md)
+- [Data directory and licensing boundary](data/README.md)
+- [Testing and evidence](docs/testing.md)
+- [Troubleshooting](docs/troubleshooting.md)
+- [Developer guide](docs/developer_guide.md)
+- [Contributor guide](CONTRIBUTING.md)
+
+Historical, paper, development-log, and agent-workflow material is not part of
+the current user path. The [documentation audit](docs/DOCUMENTATION_AUDIT.md)
+records its status and retention rules.
 
 ## Configuration-first workflow
 
-Maintained configs use five logical blocks:
+Maintained configs use five logical sections:
 
 ```yaml
 environment: {}
@@ -127,119 +115,90 @@ task: {}
 trainer: {}
 ```
 
-Demo files compose shared blocks through `base_configs` and then apply local YAML
-and CLI overrides. For an experiment variant:
-
-1. copy the nearest file from `configs/demo/` into `configs/experiments/`;
-2. change only the fields required by the experiment;
-3. inspect the resolved configuration and source trace;
-4. run the smallest applicable smoke command;
-5. keep the registry and generated atlas synchronized when promoting a maintained config.
-
-Useful commands:
+Create local variants under `configs/experiments/`, not by editing a maintained
+demo. Inspect the resolved values and sources before running:
 
 ```bash
-python -m scripts.validate_configs
-python -m scripts.config_inspect --config <yaml> --override key=value
-python -m scripts.gen_config_atlas
-git diff --exit-code docs/CONFIG_ATLAS.md
-```
-
-## Validation gate
-
-Use the narrowest relevant test during development, then run the maintained gate
-before merging a runtime or configuration change:
-
-```bash
-python main.py --config configs/demo/00_smoke/dummy_dg.yaml \
-  --override trainer.num_epochs=1 \
-  --override data.num_workers=0
-python -m scripts.validate_configs
 python -m scripts.config_inspect \
   --config configs/demo/00_smoke/dummy_dg.yaml \
   --override trainer.num_epochs=1
-python -m scripts.gen_config_atlas
-git diff --exit-code docs/CONFIG_ATLAS.md
-python -m scripts.validate_docs
-python -m pytest test/ -q
 ```
 
-Local validation evidence should not be described as GitHub Actions evidence.
-The repository currently needs an active required CI workflow to enforce these
-gates automatically.
+`configs/config_registry.csv` is the configuration inventory source of truth.
+`docs/CONFIG_ATLAS.md` is generated from it and should not be edited manually.
+
+## Repository structure
+
+```text
+configs/             base blocks, maintained demos, experiments, registry
+src/data_factory/    metadata, readers, datasets, samplers, data construction
+src/model_factory/   model families, components, model construction
+src/task_factory/    task implementations, losses, metrics, task registry
+src/trainer_factory/ trainer construction and extensions
+apps/streamlit/      optional browser workspace around the public CLI
+docs/                user, developer, release, migration, and design docs
+test/                maintained pytest suite
+```
+
+Extensions should stay inside the existing factory boundaries. Do not add a
+model- or dataset-specific branch to `main.py`.
+
+## Validate a change
+
+Start with the narrow test for the affected contract. Before merging a runtime or
+configuration change, run the applicable maintained gates:
+
+```bash
+python -m scripts.validate_docs
+python -m scripts.validate_configs
+python -m scripts.gen_config_atlas
+git diff --exit-code docs/CONFIG_ATLAS.md
+python -m pytest test/ -q
+python main.py \
+  --config configs/demo/00_smoke/dummy_dg.yaml \
+  --override trainer.num_epochs=1 \
+  --override data.num_workers=0
+```
+
+The exact automated jobs for the current branch are defined in
+`.github/workflows/core-quality-gates.yml`. Local output must not be presented as
+GitHub Actions evidence. See [Testing and evidence](docs/testing.md).
 
 ## Optional Streamlit workspace
 
-The Streamlit workspace is an optional interface around the same config-first
-contract. It does not replace the CLI release gate and should not import pipeline
-internals directly.
+The Streamlit workspace is an optional adapter around the same config-first CLI;
+it is not a second training framework.
 
 ```bash
-streamlit run streamlit_app.py
+python -m pip install -r apps/streamlit/requirements.txt
+streamlit run apps/streamlit/app.py
 ```
 
-See the [maintained Streamlit guide](apps/streamlit/README.md) for configuration,
-execution, result inspection, and focused tests.
+See [Streamlit usage](docs/app_usage.md).
 
-## Architecture
+## Contribute
 
-```text
-main.py
-  └── pipeline selected by YAML
-      ├── data factory
-      ├── model factory
-      ├── task factory
-      └── trainer factory
-```
+Read [CONTRIBUTING.md](CONTRIBUTING.md) before opening an issue or pull request.
+A public component contribution should include implementation, registry/config
+traceability, a focused test, documentation, an applicable smoke path, and
+explicit compatibility limits.
 
-Primary directories:
+For factory-specific details:
 
-- `configs/`: base blocks, maintained demos, experiments, and registry
-- `src/data_factory/`: metadata, readers, datasets, samplers, and data construction
-- `src/model_factory/`: model families, component registries, and model construction
-- `src/task_factory/`: task implementations and task registry
-- `src/trainer_factory/`: trainer implementations
-- `apps/streamlit/`: optional experiment workspace
-- `test/`: maintained pytest gate
-- `docs/`: release, configuration, migration, and engineering documentation
-- `results/`: runtime output, not configuration source of truth
+- [Data and readers](src/data_factory/contributing.md)
+- [Models](src/model_factory/contributing.md)
+- [Tasks](src/task_factory/contributing.md)
+- [Trainers](src/trainer_factory/contributing.md)
 
-## Extending PHM-Vibench
+## Citation, license, and support
 
-Keep extensions within factory boundaries; do not add model- or dataset-specific
-branches to `main.py`.
+Until a stable publication or DOI is released, record and cite the exact Git tag
+or commit used for an experiment. Do not infer scientific claims from the Dummy
+smoke run or registry inventory.
 
-- [Add a dataset or reader](src/data_factory/contributing.md)
-- [Add a model](src/model_factory/contributing.md)
-- [Add a task](src/task_factory/contributing.md)
-- [Add a trainer](src/trainer_factory/contributing.md)
+PHM-Vibench source code is licensed under the [Apache License 2.0](LICENSE).
+Datasets, pretrained weights, and third-party models may have separate licenses at
+their original sources.
 
-A public component change should include its implementation, registry/config
-entry, focused test, documentation, and an applicable smoke path. Research-only
-ideas should remain in clearly marked project or experiment areas until their
-protocol and validation evidence are defined.
-
-## Evidence boundaries
-
-PHM-Vibench currently provides functional smoke and contract evidence for a
-bounded configuration matrix. It does not, by itself, prove:
-
-- state-of-the-art performance;
-- fair comparison across arbitrary external experiments;
-- support for every registry-discovered component pair;
-- availability or redistribution rights for every referenced dataset;
-- reproducibility outside the recorded environment and data setup.
-
-Record the exact repository commit, config, overrides, data source, seed, and
-environment when reporting an experiment.
-
-## Contributing, license, and citation
-
-Read [CONTRIBUTING.md](CONTRIBUTING.md) before opening a pull request. Keep each
-change small, explicit, reviewable, and backed by copy-paste validation commands.
-
-PHM-Vibench is licensed under the [Apache License 2.0](LICENSE). Dataset and model
-artifacts may have separate licenses at their original sources.
-
-The project remains in alpha. Until a stable publication citation is released,
-reference the exact Git commit or release tag used for an experiment.
+Use GitHub Issues for reproducible bugs and feature proposals. Do not post
+security vulnerabilities publicly; follow [SECURITY.md](SECURITY.md).

--- a/README_CN.md
+++ b/README_CN.md
@@ -17,66 +17,36 @@
   </p>
 </div>
 
-PHM-Vibench 将数据加载、模型构建、任务装配、训练和实验配置统一到一个维护入口：
+PHM-Vibench 通过一个维护中的入口连接数据加载、模型构建、任务逻辑、训练和实验配置：
 
 ```bash
 python main.py --config <yaml> [--override key=value ...]
 ```
 
-项目仍处于 alpha 阶段。当前 release-supported surface 明显小于仓库中全部文件和注册表条目。
-请从维护中的 demo 开始；历史、参考和研究材料在没有独立运行证据前，不应视为已验证能力。
+项目仍处于 alpha 阶段。仓库中的文件或注册表条目数量大于当前 release-supported surface。
+组件可被发现或导入，并不等于其已受支持；支持声明需要维护配置和运行证据。
 
-## 从这里开始
+## 当前维护范围
 
-运行仓库自带的离线冒烟 demo：
+当前公开维护面包含 7 个 demo，覆盖：
 
-```bash
-python main.py --config configs/demo/00_smoke/dummy_dg.yaml \
-  --override trainer.num_epochs=1 \
-  --override data.num_workers=0
-```
+- 使用 Dummy 数据的离线域泛化（DG）冒烟路径；
+- 跨域 DG；
+- 跨系统/跨数据集域泛化（CDDG）；
+- 小样本（FS）和广义小样本（GFS）分类；
+- 两个边界明确的 HSE 预训练视角。
 
-在不修改维护 YAML 的情况下检查最终配置：
+准确的模型、任务、pipeline、数据和 trainer 组合见：
 
-```bash
-python -m scripts.config_inspect \
-  --config configs/demo/00_smoke/dummy_dg.yaml \
-  --override trainer.num_epochs=1
-```
-
-权威入口：
-
-- [配置系统指南](configs/README.md)
-- [生成的配置图谱](docs/CONFIG_ATLAS.md)
 - [支持组件](SUPPORTED_COMPONENTS.md)
 - [支持组合](SUPPORTED_COMBINATIONS.md)
 - [已知限制](KNOWN_LIMITATIONS.md)
-- [数据目录边界](data/README.md)
-- [贡献指南](CONTRIBUTING_CN.md)
 
-## 维护中的 demo 面
-
-配置注册表当前将 7 个 demo 标记为 `sanity_ok`。该状态只代表配置具有功能冒烟证据，
-不代表基准精度、SOTA 性能或任意组件之间都兼容。
-
-| 场景 | 配置 | 数据要求 |
-| --- | --- | --- |
-| 离线冒烟 / DG | `configs/demo/00_smoke/dummy_dg.yaml` | 仓库自带 Dummy 数据 |
-| 跨域 DG | `configs/demo/01_cross_domain/cwru_dg.yaml` | 本地 PHM-Vibench metadata/raw 数据 |
-| 跨系统 CDDG | `configs/demo/02_cross_system/multi_system_cddg.yaml` | 本地 PHM-Vibench metadata/raw 数据 |
-| 小样本 FS | `configs/demo/03_fewshot/cwru_protonet.yaml` | 本地 PHM-Vibench metadata/raw 数据 |
-| 跨系统小样本 GFS | `configs/demo/04_cross_system_fewshot/cross_system_tspn.yaml` | 本地 PHM-Vibench metadata/raw 数据 |
-| HSE 预训练视角 | `configs/demo/05_pretrain_fewshot/pretrain_hse_then_fewshot.yaml` | 本地 PHM-Vibench metadata/raw 数据 |
-| 面向 CDDG 的 HSE 预训练 | `configs/demo/06_pretrain_cddg/pretrain_hse_cddg.yaml` | 本地 PHM-Vibench metadata/raw 数据 |
-
-当前 v0.2.0 支持文档将维护模型路径限定为 `ISFM/M_01_ISFM`、`E_01_HSE`、
-`B_04_Dlinear`、`H_01_Linear_cla`，以及
-[SUPPORTED_COMPONENTS.md](SUPPORTED_COMPONENTS.md) 中列出的任务组合。
-注册表中存在条目本身并不构成支持声明。
+冒烟证据只说明软件路径能够运行，不代表基准精度、SOTA 性能、任意兼容性或数据再分发权利。
 
 ## 安装
 
-最小环境示例：
+Python 3.10 是当前文档和 CI 基线。
 
 ```bash
 git clone https://github.com/PHMbench/PHM-Vibench.git
@@ -84,34 +54,49 @@ cd PHM-Vibench
 
 conda create -n phm-vibench python=3.10
 conda activate phm-vibench
-pip install -r requirements.txt
+python -m pip install -r requirements.txt
 ```
 
-维护中的运行证据来自项目专用的 `LQ_signal` conda 环境。通用环境仍可能需要依赖或平台调整，
-详见 [KNOWN_LIMITATIONS.md](KNOWN_LIMITATIONS.md)。
+CPU-only PyTorch、CUDA 选择、平台边界和环境检查见[安装指南](docs/installation.md)。
 
-只有 Dummy 冒烟 demo 完全离线。其他 demo 应通过 override 指向本地数据根目录，
-不要直接修改维护配置：
+## 运行离线冒烟实验
+
+以下命令使用仓库自带的 Dummy 数据和 CPU：
 
 ```bash
-python main.py --config configs/demo/01_cross_domain/cwru_dg.yaml \
-  --override data.data_dir=/absolute/path/to/PHM-Vibench-data \
-  --override data.metadata_file=metadata.xlsx \
+python main.py \
+  --config configs/demo/00_smoke/dummy_dg.yaml \
   --override trainer.num_epochs=1 \
   --override data.num_workers=0
 ```
 
-处理后或原始数据也可能位于：
+成功运行应以退出码 `0` 结束，打印完成信息，并在以下目录下生成产物：
 
-- [ModelScope 处理后文件](https://www.modelscope.cn/datasets/PHMbench/PHM-Vibench/files)
-- [PHMbench 原始数据组](https://www.modelscope.cn/datasets/PHMbench/PHMbench-raw_data)
-- [Hugging Face 镜像](https://huggingface.co/datasets/PHMbench/PHM-Vibench/tree/main)
+```text
+results/demo/dummy_dg_smoke/
+```
 
-使用或再分发前必须核验来源许可和可用性。
+配置检查、预期证据、外部数据 override 和后续实验步骤见[快速开始](docs/quickstart.md)。
+
+## 文档导航
+
+- [文档索引](docs/index.md)
+- [安装](docs/installation.md)
+- [快速开始](docs/quickstart.md)
+- [配置系统](configs/README.md)
+- [生成的配置图谱](docs/CONFIG_ATLAS.md)
+- [数据目录与许可边界](data/README.md)
+- [测试与证据](docs/testing.md)
+- [故障排查](docs/troubleshooting.md)
+- [开发者指南](docs/developer_guide.md)
+- [中文贡献指南](CONTRIBUTING_CN.md)
+
+历史、论文、开发日志和 Agent 工作流材料不属于当前用户路径。
+其状态和保留规则记录在[文档审计](docs/DOCUMENTATION_AUDIT.md)中。
 
 ## 配置优先工作流
 
-维护配置由五个逻辑块组成：
+维护配置使用五个逻辑段：
 
 ```yaml
 environment: {}
@@ -121,107 +106,80 @@ task: {}
 trainer: {}
 ```
 
-Demo 通过 `base_configs` 组合共享 block，再应用 YAML 和 CLI override。建立实验变体时：
-
-1. 从 `configs/demo/` 复制最接近的模板到 `configs/experiments/`；
-2. 只修改实验真正需要的字段；
-3. 检查最终配置和字段来源；
-4. 运行最小适用冒烟命令；
-5. 若要提升为维护配置，同步更新注册表和生成的 atlas。
-
-常用命令：
+个人实验变体应放在 `configs/experiments/`，不要直接修改维护 demo。运行前先检查解析后的值和来源：
 
 ```bash
-python -m scripts.validate_configs
-python -m scripts.config_inspect --config <yaml> --override key=value
-python -m scripts.gen_config_atlas
-git diff --exit-code docs/CONFIG_ATLAS.md
-```
-
-## 合并前验证门禁
-
-开发时先运行最聚焦的测试；运行时或配置改动在合并前应执行维护门禁：
-
-```bash
-python main.py --config configs/demo/00_smoke/dummy_dg.yaml \
-  --override trainer.num_epochs=1 \
-  --override data.num_workers=0
-python -m scripts.validate_configs
 python -m scripts.config_inspect \
   --config configs/demo/00_smoke/dummy_dg.yaml \
   --override trainer.num_epochs=1
-python -m scripts.gen_config_atlas
-git diff --exit-code docs/CONFIG_ATLAS.md
-python -m scripts.validate_docs
-python -m pytest test/ -q
 ```
 
-本地验证证据不能表述为 GitHub Actions 证据。仓库仍需要启用并设为 required 的 CI workflow，
-才能自动执行这些门禁。
+`configs/config_registry.csv` 是配置清单的事实源；`docs/CONFIG_ATLAS.md` 由它生成，
+不应手工编辑。
+
+## 仓库结构
+
+```text
+configs/             base block、维护 demo、实验配置与注册表
+src/data_factory/    metadata、reader、dataset、sampler 与数据构建
+src/model_factory/   模型家族、组件与模型构建
+src/task_factory/    任务实现、loss、metric 与任务注册表
+src/trainer_factory/ trainer 构建与扩展
+apps/streamlit/      围绕公开 CLI 的可选浏览器工作区
+docs/                用户、开发、release、迁移与设计文档
+test/                维护中的 pytest 测试集
+```
+
+扩展应留在现有 factory 边界内，不要在 `main.py` 中增加模型或数据集专用分支。
+
+## 验证改动
+
+开发时先运行最聚焦的测试。运行时或配置改动合并前，应执行适用的维护门禁：
+
+```bash
+python -m scripts.validate_docs
+python -m scripts.validate_configs
+python -m scripts.gen_config_atlas
+git diff --exit-code docs/CONFIG_ATLAS.md
+python -m pytest test/ -q
+python main.py \
+  --config configs/demo/00_smoke/dummy_dg.yaml \
+  --override trainer.num_epochs=1 \
+  --override data.num_workers=0
+```
+
+当前分支实际自动执行的任务以 `.github/workflows/core-quality-gates.yml` 为准。
+本地输出不能表述为 GitHub Actions 证据。详见[测试与证据](docs/testing.md)。
 
 ## 可选 Streamlit 工作区
 
-Streamlit 工作区是同一配置优先契约的可选界面。它不替代 CLI release gate，
-也不应直接导入 pipeline 内部实现。
+Streamlit 工作区是围绕同一配置优先 CLI 的可选适配层，不是第二套训练框架。
 
 ```bash
-streamlit run streamlit_app.py
+python -m pip install -r apps/streamlit/requirements.txt
+streamlit run apps/streamlit/app.py
 ```
 
-配置、运行、结果查看和聚焦测试见[维护中的 Streamlit 指南](apps/streamlit/README.md)。
+使用说明见 [Streamlit 指南](docs/app_usage.md)。
 
-## 架构
+## 参与贡献
 
-```text
-main.py
-  └── 由 YAML 选择 pipeline
-      ├── data factory
-      ├── model factory
-      ├── task factory
-      └── trainer factory
-```
+提交 Issue 或 PR 前请阅读 [CONTRIBUTING_CN.md](CONTRIBUTING_CN.md)。
+公开组件贡献应包含实现、注册表/配置可追踪性、聚焦测试、文档、适用的冒烟路径和明确兼容边界。
 
-主要目录：
+Factory 专项说明：
 
-- `configs/`：base block、维护 demo、实验配置和注册表
-- `src/data_factory/`：metadata、reader、dataset、sampler 与数据构建
-- `src/model_factory/`：模型家族、组件注册表与模型构建
-- `src/task_factory/`：任务实现和任务注册表
-- `src/trainer_factory/`：训练器实现
-- `apps/streamlit/`：可选实验工作区
-- `test/`：维护中的 pytest 门禁
-- `docs/`：release、配置、迁移和工程文档
-- `results/`：运行输出，不是配置事实来源
+- [数据与 reader](src/data_factory/contributing.md)
+- [模型](src/model_factory/contributing.md)
+- [任务](src/task_factory/contributing.md)
+- [Trainer](src/trainer_factory/contributing.md)
 
-## 扩展 PHM-Vibench
+## 引用、许可与支持
 
-扩展应留在 factory 边界内，不要在 `main.py` 中加入模型或数据集专用分支。
+在稳定论文或 DOI 发布前，请记录并引用实验使用的准确 Git tag 或 commit。
+不要从 Dummy 冒烟结果或注册表清单推导科学结论。
 
-- [添加数据集或 reader](src/data_factory/contributing.md)
-- [添加模型](src/model_factory/contributing.md)
-- [添加任务](src/task_factory/contributing.md)
-- [添加训练器](src/trainer_factory/contributing.md)
+PHM-Vibench 源代码使用 [Apache License 2.0](LICENSE)。数据集、预训练权重和第三方模型
+可能适用其原始来源的独立许可。
 
-公开组件改动应同时包含实现、注册表或配置入口、聚焦测试、文档和适用的冒烟路径。
-研究想法在协议与验证证据明确前，应留在清楚标注的 project 或 experiment 区域。
-
-## 证据边界
-
-PHM-Vibench 当前为有限配置矩阵提供功能冒烟和契约证据。它本身不能证明：
-
-- 达到 SOTA 性能；
-- 任意外部实验之间都能公平比较；
-- 所有注册表组件组合均受支持；
-- 所有引用数据集都可获得或允许再分发；
-- 在未记录的数据与环境设置下仍可复现。
-
-报告实验时，应记录准确的仓库 commit、配置、override、数据来源、随机种子和运行环境。
-
-## 贡献、许可与引用
-
-提交 PR 前请阅读 [CONTRIBUTING_CN.md](CONTRIBUTING_CN.md)。每个改动应保持小、明确、可审查，
-并给出可复制的验证命令。
-
-PHM-Vibench 使用 [Apache License 2.0](LICENSE)。数据集和模型产物可能适用其原始来源的独立许可。
-
-项目仍处于 alpha 阶段。在稳定论文引用发布前，请引用实验所使用的准确 Git commit 或 release tag。
+可复现 Bug 和功能建议请使用 GitHub Issues。不要公开提交安全漏洞；请遵循 [SECURITY.md](SECURITY.md)。

--- a/configs/README.md
+++ b/configs/README.md
@@ -1,93 +1,136 @@
-# Config System (v0.1.0)
+# PHM-Vibench Configuration System
 
-This folder defines experiments via a 5-block configuration model:
-`environment` / `data` / `model` / `task` / `trainer`.
+This directory is the canonical guide to configuration composition, inspection,
+validation, and promotion. Installation and the first successful run are covered
+in [`docs/installation.md`](../docs/installation.md) and
+[`docs/quickstart.md`](../docs/quickstart.md).
 
-The **single recommended entrypoint** is:
+The public runtime entrypoint is:
 
 ```bash
 python main.py --config <yaml> [--override key=value ...]
 ```
 
-## 30-Second Smoke Run (No External Data)
+## Five configuration sections
 
-1) Run the repo-shipped dummy demo:
-```bash
-python main.py --config configs/demo/00_smoke/dummy_dg.yaml
+Maintained experiments use five logical sections:
+
+```yaml
+environment: {}
+data: {}
+model: {}
+task: {}
+trainer: {}
 ```
 
-2) Find outputs:
+A top-level `pipeline` selects the pipeline module. Component-specific fields
+remain inside the five sections; do not add model- or dataset-specific arguments
+to `main.py`.
+
+## Directory roles
+
+| Location | Purpose | Promotion status |
+|---|---|---|
+| `configs/base/` | Reusable environment, data, model, task, and trainer blocks | Maintained building blocks |
+| `configs/demo/` | Public runnable examples listed in the config registry | Maintained only after evidence |
+| `configs/experiments/` | Local/research variants | Not release-supported by default |
+| `configs/reference/` | Reference or historical configurations | Unverified unless stated otherwise |
+| `configs/local/` | Machine-specific overrides | Never commit `local.yaml` |
+| `configs/config_registry.csv` | Authoritative shipped-config inventory | Source of truth |
+
+Start a new experiment by copying the nearest maintained demo into
+`configs/experiments/`. Do not place an unverified config directly under
+`configs/demo/`.
+
+## Composition and precedence
+
+Configuration values are applied from lower to higher precedence:
+
+1. YAML files referenced by `base_configs`;
+2. the selected YAML file's own sections;
+3. optional machine-local `configs/local/local.yaml`;
+4. repeatable CLI `--override key=value` arguments.
+
+Example:
+
 ```bash
-ls -la results/demo/dummy_dg_smoke
+python main.py --config configs/demo/00_smoke/dummy_dg.yaml \
+  --override trainer.num_epochs=1 \
+  --override data.num_workers=0
 ```
 
-If you want a fast sanity run for any config:
+Keep personal paths in `configs/local/local.yaml` or CLI overrides. Do not commit
+absolute workstation paths in maintained configs.
+
+## Inspect resolved values and sources
+
 ```bash
-python main.py --config configs/demo/01_cross_domain/cwru_dg.yaml \
-  --override trainer.num_epochs=1 --override data.num_workers=0
+python -m scripts.config_inspect \
+  --config configs/demo/00_smoke/dummy_dg.yaml \
+  --override trainer.num_epochs=1
 ```
 
-## How Config Composition Works
+Useful focused views:
 
-**Precedence (low → high):**
-1) `base_configs.*` YAML files
-2) The demo YAML’s own block overrides (e.g. `data: {...}`)
-3) Optional machine-local override `configs/local/local.yaml` (or `--local_config ...`)
-4) CLI `--override key=value` (repeatable)
-
-## Single Source of Truth (Registry + Atlas)
-
-- Registry (authoritative index): `configs/config_registry.csv`
-- Schema for registry fields: `docs/config_registry_schema.md`
-- Human-readable atlas (generated): `docs/CONFIG_ATLAS.md`
-
-Regenerate atlas:
 ```bash
-python -m scripts.gen_config_atlas --registry configs/config_registry.csv
+python -m scripts.config_inspect --config <yaml> --dump resolved
+python -m scripts.config_inspect --config <yaml> --dump sources
+python -m scripts.config_inspect --config <yaml> --dump targets
+python -m scripts.config_inspect --config <yaml> --dump all --format json
 ```
 
-## Config Inspect (Explain Resolved Values + Sources + Targets)
+The inspector returns non-zero when any sanity check fails. A successful inspect
+proves configuration and import resolution, not end-to-end execution.
 
-Inspect a config and overrides (default output is Markdown):
-```bash
-python -m scripts.config_inspect --config configs/demo/01_cross_domain/cwru_dg.yaml \
-  --override trainer.num_epochs=1 --override data.num_workers=0
-```
+## Validate maintained configs
 
-Dump only field sources:
-```bash
-python -m scripts.config_inspect --config configs/demo/01_cross_domain/cwru_dg.yaml \
-  --dump sources --format md
-```
-
-## Schema Validation (Pydantic)
-
-Validate all `configs/demo/**/*.yaml` (and registry rows with `status != "/"`):
 ```bash
 python -m scripts.validate_configs
 ```
 
-## Common Edits (Copy-Paste)
+The validator covers `configs/demo/**/*.yaml` and active registry paths. Schema
+validation does not replace a smoke run.
 
-### “Run 1 epoch for smoke test”
+## Registry and generated atlas
+
+- Authoritative inventory: `configs/config_registry.csv`
+- Column contract: [`docs/config_registry_schema.md`](../docs/config_registry_schema.md)
+- Generated human-readable view: [`docs/CONFIG_ATLAS.md`](../docs/CONFIG_ATLAS.md)
+
+After an intentional registry change:
+
 ```bash
-python main.py --config <yaml> --override trainer.num_epochs=1
+python -m scripts.gen_config_atlas
+git diff -- docs/CONFIG_ATLAS.md
+git diff --exit-code docs/CONFIG_ATLAS.md
 ```
 
-### “Change dataset without changing model/task”
-- Edit the config (recommended) or use a local override:
-```yaml
-data:
-  data_dir: "/path/to/PHM-Vibench"
-  metadata_file: "metadata.xlsx"
-```
+Commit the registry and generated atlas together. Do not hand-edit the atlas.
 
-### “Change task but reuse the same data/model”
-- Keep `base_configs.data` + `base_configs.model`, switch `base_configs.task` to another base task.
+## Promote an experiment to a maintained demo
 
-## Where to Read Next
+Promotion requires all of the following:
 
-- Base blocks overview: `configs/base/README.md`
-- Demo overview: `configs/demo/README.md`
-- Local research configs: `configs/experiments/README.md`
-- Deep dive: `docs/CONFIG_ATLAS.md`
+1. a clear public use case and owner;
+2. a portable YAML file without personal paths;
+3. valid base composition and schema;
+4. resolved pipeline/factory targets;
+5. the smallest applicable end-to-end smoke command;
+6. focused tests for new behavior;
+7. a registry row with accurate status and documentation links;
+8. regenerated `docs/CONFIG_ATLAS.md`;
+9. support/limitation documentation when the public surface changes.
+
+Use `needs_smoke` or an equivalent non-supported status until the smoke command
+has actually passed. `sanity_ok` means functional smoke evidence; it is not a
+benchmark-performance claim.
+
+## Read next
+
+- [Base blocks](base/README.md)
+- [Maintained demos](demo/README.md)
+- [Local experiments](experiments/README.md)
+- [Reference configs](reference/README.md)
+- [Quickstart](../docs/quickstart.md)
+- [Testing and evidence](../docs/testing.md)
+- [Supported combinations](../SUPPORTED_COMBINATIONS.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,14 +8,17 @@ agent-workflow material is intentionally separated from the current user path.
 
 1. Read the [project overview](../README.md) or
    [Chinese overview](../README_CN.md).
-2. Run the repository-shipped offline smoke command from the overview.
-3. Learn how configuration composition and overrides work in the
+2. [Install PHM-Vibench](installation.md) in a Python 3.10 environment.
+3. [Run the repository-shipped offline experiment](quickstart.md).
+4. Learn configuration composition and overrides in the
    [configuration guide](../configs/README.md).
-4. Confirm the current support boundary in
+5. Confirm the current support boundary in
    [supported components](../SUPPORTED_COMPONENTS.md),
    [supported combinations](../SUPPORTED_COMBINATIONS.md), and
    [known limitations](../KNOWN_LIMITATIONS.md).
-5. For external data, read the [data directory policy](../data/README.md).
+6. For external data, read the [data directory policy](../data/README.md).
+
+Common failures are covered in [Troubleshooting](troubleshooting.md).
 
 ## Configuration reference
 
@@ -43,7 +46,7 @@ The Streamlit workspace is an optional adapter around the same
 - [Contributor guide](../CONTRIBUTING.md)
 - [Chinese contributor guide](../CONTRIBUTING_CN.md)
 - [Developer guide](developer_guide.md)
-- [Testing guide](testing.md)
+- [Testing and evidence guide](testing.md)
 - [Custom dataset tutorial](custom_dataset.md)
 - [Data factory contribution guide](../src/data_factory/contributing.md)
 - [Model factory contribution guide](../src/model_factory/contributing.md)

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,0 +1,156 @@
+# Install PHM-Vibench
+
+This page is the canonical installation and environment guide. The shortest
+successful run is documented in [Quickstart](quickstart.md).
+
+## Supported evidence boundary
+
+The maintained GitHub Actions jobs use:
+
+- Ubuntu 24.04 runners;
+- Python 3.10;
+- CPU PyTorch 2.6.0 for focused model-contract tests.
+
+Local release-candidate evidence was collected in a project-specific conda
+environment named `LQ_signal`. Windows, macOS, other Python versions, and other
+CUDA/PyTorch combinations may work, but they are not currently covered by the
+same repository-level evidence. See [Known limitations](../KNOWN_LIMITATIONS.md).
+
+## Clone the repository
+
+```bash
+git clone https://github.com/PHMbench/PHM-Vibench.git
+cd PHM-Vibench
+```
+
+## Create a Python 3.10 environment
+
+Conda:
+
+```bash
+conda create -n phm-vibench python=3.10
+conda activate phm-vibench
+```
+
+Standard library `venv`:
+
+```bash
+python3.10 -m venv .venv
+source .venv/bin/activate
+```
+
+On Windows PowerShell, activate a `venv` with:
+
+```powershell
+.\.venv\Scripts\Activate.ps1
+```
+
+Confirm the interpreter before installing packages:
+
+```bash
+python --version
+python -m pip --version
+```
+
+## Install dependencies
+
+### Default repository environment
+
+The current repository-wide dependency list is:
+
+```bash
+python -m pip install --upgrade pip
+python -m pip install -r requirements.txt
+```
+
+`requirements.txt` includes core training dependencies and optional research or
+UI packages. It is the simplest installation path, but not a minimal dependency
+set.
+
+### CPU-only PyTorch
+
+For a CPU-only environment, install the pinned CPU wheels first, then install the
+remaining requirements:
+
+```bash
+python -m pip install --upgrade pip
+python -m pip install \
+  --index-url https://download.pytorch.org/whl/cpu \
+  torch==2.6.0 torchvision==0.21.0 torchaudio==2.6.0
+python -m pip install -r requirements.txt
+```
+
+### CUDA
+
+Choose PyTorch wheels that match the installed driver and intended CUDA runtime.
+The comment in `requirements.txt` documents the currently pinned Torch family,
+but it is not a universal CUDA compatibility guarantee. Verify the selected
+installation independently:
+
+```bash
+python - <<'PY'
+import torch
+print("torch:", torch.__version__)
+print("cuda runtime:", torch.version.cuda)
+print("cuda available:", torch.cuda.is_available())
+PY
+```
+
+Start with the CPU smoke configuration even when a GPU is available. Move to a
+GPU configuration only after the config-first path works on CPU.
+
+## Optional Streamlit workspace
+
+Install the core environment first. The optional web workspace has an additional
+requirements file:
+
+```bash
+python -m pip install -r apps/streamlit/requirements.txt
+```
+
+See [Streamlit usage](app_usage.md).
+
+## Verify the environment
+
+Run lightweight checks first:
+
+```bash
+python main.py --help
+python -m scripts.validate_configs
+python -m scripts.validate_docs
+python -m pip check
+```
+
+Inspect the offline smoke configuration:
+
+```bash
+python -m scripts.config_inspect \
+  --config configs/demo/00_smoke/dummy_dg.yaml \
+  --override trainer.num_epochs=1
+```
+
+Then follow [Quickstart](quickstart.md) for the end-to-end command.
+
+## External datasets
+
+Only `configs/demo/00_smoke/dummy_dg.yaml` uses repository-shipped data. Other
+maintained demos require a local PHM-Vibench data root. Do not commit a personal
+absolute path into a maintained YAML file. Use a CLI override or
+`configs/local/local.yaml`:
+
+```bash
+python main.py --config configs/demo/01_cross_domain/cwru_dg.yaml \
+  --override data.data_dir=/absolute/path/to/PHM-Vibench-data \
+  --override data.metadata_file=metadata.xlsx \
+  --override trainer.num_epochs=1 \
+  --override data.num_workers=0
+```
+
+Data sources, expected layout, and licensing boundaries are documented in
+[`data/README.md`](../data/README.md).
+
+## Installation problems
+
+Do not solve an import error by installing unrelated packages blindly. Record the
+failing import and determine whether it belongs to the selected component or is
+an unconditional optional import. See [Troubleshooting](troubleshooting.md).

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,0 +1,133 @@
+# Run the First PHM-Vibench Experiment
+
+This page is the canonical first-run guide. It uses the repository-shipped dummy
+data and does not require an external dataset or GPU.
+
+## Prerequisites
+
+- repository root is the current working directory;
+- Python 3.10 environment is active;
+- dependencies are installed as described in [Installation](installation.md).
+
+## 1. Confirm the public entrypoint
+
+```bash
+python main.py --help
+```
+
+The maintained runtime contract is:
+
+```bash
+python main.py --config <yaml> [--override key=value ...]
+```
+
+## 2. Validate and inspect the configuration
+
+Validate maintained configuration schemas:
+
+```bash
+python -m scripts.validate_configs
+```
+
+Inspect the resolved smoke configuration, field sources, import targets, and
+sanity checks:
+
+```bash
+python -m scripts.config_inspect \
+  --config configs/demo/00_smoke/dummy_dg.yaml \
+  --override trainer.num_epochs=1
+```
+
+A non-zero inspector exit code means at least one sanity check failed. Fix that
+failure before starting the run.
+
+## 3. Run one offline epoch
+
+```bash
+python main.py \
+  --config configs/demo/00_smoke/dummy_dg.yaml \
+  --override trainer.num_epochs=1 \
+  --override data.num_workers=0
+```
+
+The maintained smoke config already selects CPU execution and repository-shipped
+Dummy data. The explicit overrides keep the command suitable for quick local
+verification.
+
+## 4. Confirm the result
+
+A successful command should exit with code `0`, print the final completion
+message, and create output below:
+
+```text
+results/demo/dummy_dg_smoke/
+```
+
+The exact nested run directory and artifacts are controlled by the environment,
+trainer, and logger configuration. Treat command success, logs, checkpoints, and
+metrics as functional evidence only; the Dummy run is not algorithm-performance
+evidence.
+
+Useful checks:
+
+```bash
+find results/demo/dummy_dg_smoke -maxdepth 4 -type f | sort
+```
+
+Record the repository commit and exact command when sharing the result:
+
+```bash
+git rev-parse HEAD
+```
+
+## 5. Try a local experiment variant
+
+Do not edit a maintained demo for personal paths or hyperparameters. Copy the
+nearest template into `configs/experiments/`:
+
+```bash
+cp configs/demo/00_smoke/dummy_dg.yaml \
+  configs/experiments/my_dummy_experiment.yaml
+```
+
+Inspect and run the copied config:
+
+```bash
+python -m scripts.config_inspect \
+  --config configs/experiments/my_dummy_experiment.yaml \
+  --override trainer.num_epochs=1
+
+python main.py \
+  --config configs/experiments/my_dummy_experiment.yaml \
+  --override trainer.num_epochs=1 \
+  --override data.num_workers=0
+```
+
+A config belongs under `configs/demo/` only after it has a maintained purpose,
+registry entry, documentation, and runtime evidence.
+
+## 6. Use an external dataset
+
+Read the [data directory policy](../data/README.md), then point an existing demo
+to a local data root with overrides:
+
+```bash
+python main.py --config configs/demo/01_cross_domain/cwru_dg.yaml \
+  --override data.data_dir=/absolute/path/to/PHM-Vibench-data \
+  --override data.metadata_file=metadata.xlsx \
+  --override trainer.num_epochs=1 \
+  --override data.num_workers=0
+```
+
+External-data demos are not offline tests. Record the data source, license,
+metadata version, split, preprocessing, seed, and overrides.
+
+## Next steps
+
+- [Configuration system](../configs/README.md)
+- [Supported components](../SUPPORTED_COMPONENTS.md)
+- [Supported combinations](../SUPPORTED_COMBINATIONS.md)
+- [Known limitations](../KNOWN_LIMITATIONS.md)
+- [Troubleshooting](troubleshooting.md)
+- [Testing and evidence](testing.md)
+- [Optional Streamlit workspace](app_usage.md)

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,16 +1,169 @@
-# Testing Guide
+# Test and Validate PHM-Vibench
 
-## Pytest
+This page is the canonical testing and validation guide. Use the narrowest test
+that proves the changed contract, then run the broader maintained gate before
+merging.
+
+## Evidence levels
+
+Do not describe every successful command as the same kind of evidence.
+
+| Level | What it proves | What it does not prove |
+|---|---|---|
+| Import | A module can be imported in one environment | Factory construction or runtime behavior |
+| Unit | A focused function/class contract holds | Pipeline integration |
+| Component contract | Shape, dtype, device, error, or registry contract holds | Full training/evaluation path |
+| Config inspection | YAML composition, sources, targets, and sanity checks resolve | A batch can run |
+| Smoke | The selected path runs a minimal batch/epoch/sample and exits cleanly | Scientific performance or broad compatibility |
+| Mini end-to-end | Load, build, train/evaluate, and artifact path complete | Full-scale convergence or benchmark validity |
+| Reproducibility | Repeated documented runs satisfy a stated tolerance | Universal determinism across hardware |
+
+A skipped, not-executed, missing-data, or missing-dependency case is not a pass.
+
+## Fast documentation and configuration checks
 
 ```bash
-python -m pytest test/
+python -m scripts.validate_docs
+python -m scripts.validate_configs
+python -m scripts.gen_config_atlas
+git diff --exit-code docs/CONFIG_ATLAS.md
+git diff --check
 ```
 
-## Legacy runner (optional; historical matrix)
+`docs/CONFIG_ATLAS.md` is generated from `configs/config_registry.csv`. An
+intentional registry change should update both files in the same pull request.
 
-`dev/test_history/` contains a historical test runner used during earlier refactors. It may require additional
-dependencies and is not part of the maintained workflow.
+## Inspect one configuration
 
 ```bash
-python dev/test_history/run_tests.py --unit
+python -m scripts.config_inspect \
+  --config configs/demo/00_smoke/dummy_dg.yaml \
+  --override trainer.num_epochs=1
 ```
+
+The inspector returns non-zero when a sanity check fails. A zero exit code is a
+configuration/import contract, not an end-to-end result.
+
+## Run focused tests
+
+Examples:
+
+```bash
+python -m pytest test/test_config_tools.py -q
+python -m pytest test/test_tspn_uxfd_assembly.py -q
+python -m pytest test/test_streamlit_config_service.py -q
+```
+
+For a failure, preserve full context:
+
+```bash
+python -m pytest path/to/test_file.py::test_name -vv --tb=long
+```
+
+A useful regression test should assert behavior, output, error semantics, or
+observable state. Merely asserting that code does not raise is usually
+insufficient.
+
+## Run the maintained pytest suite
+
+```bash
+python -m pytest test/ -q
+```
+
+The `test/` directory is the maintained gate. Historical or experimental tests
+outside that directory are diagnostic unless explicitly promoted.
+
+## Run the offline config-first smoke
+
+```bash
+python main.py \
+  --config configs/demo/00_smoke/dummy_dg.yaml \
+  --override trainer.num_epochs=1 \
+  --override data.num_workers=0
+```
+
+Expected behavior is documented in [Quickstart](quickstart.md). The run uses
+repository-shipped dummy data and provides functional evidence only.
+
+## Validate a changed maintained config
+
+For each affected config:
+
+```bash
+python -m scripts.config_inspect \
+  --config <yaml> \
+  --override trainer.num_epochs=1
+
+python main.py \
+  --config <yaml> \
+  --override trainer.num_epochs=1 \
+  --override data.num_workers=0
+```
+
+External-data runs require the correct local data root and metadata. Record the
+source, split, preprocessing, seed, environment, and overrides.
+
+## Test a component contribution
+
+A model, task, sampler, trainer, reader, or configuration contribution should
+normally include:
+
+- import or registry lookup coverage;
+- constructor validation;
+- input/output or batch contract assertions;
+- invalid-input behavior;
+- CPU coverage where feasible;
+- GPU coverage only when the component requires it and suitable hardware exists;
+- checkpoint/artifact coverage when the change affects persistence;
+- the smallest applicable config-first smoke.
+
+## Randomness and reproducibility
+
+Record the configured seed and test at least the seeds needed for the claim being
+made. Fixed-seed reproducibility should use explicit tolerances and account for
+hardware/library differences; do not require cross-GPU bitwise identity unless
+that is an explicit supported contract.
+
+Always check for:
+
+```python
+assert torch.isfinite(loss)
+assert torch.isfinite(output).all()
+```
+
+where numerical stability is part of the contract.
+
+## GitHub Actions and local evidence
+
+The active workflow is `.github/workflows/core-quality-gates.yml`. Read that file
+for the exact jobs and dependency sets enforced on the current branch.
+
+Use these labels accurately in pull requests:
+
+- **GitHub Actions evidence**: a named workflow run attached to the PR head;
+- **local evidence**: commands executed in a described local environment;
+- **not executed**: a required gate that could not be run;
+- **expected failure**: a negative test whose non-zero exit is the assertion.
+
+Never describe local output as CI evidence. Never hide a failed check with
+`continue-on-error`, a broad skip, or an unrelated dependency installation.
+
+## Documentation-only changes
+
+A documentation-only pull request may omit runtime tests when it explains why
+they are not applicable. It should still run:
+
+```bash
+python -m scripts.validate_docs
+python -m scripts.validate_configs
+python -m scripts.gen_config_atlas
+git diff --exit-code docs/CONFIG_ATLAS.md
+git diff --check
+```
+
+## Legacy test material
+
+`dev/test_history/` contains historical validation material from earlier
+refactors. It may require obsolete dependencies and is not part of the maintained
+gate. Preserve it as evidence, but do not cite it as current pass status without
+re-running and reviewing it on the current commit.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,159 @@
+# Troubleshoot PHM-Vibench
+
+Start with the repository-shipped CPU smoke configuration. Do not debug an
+external dataset, GPU stack, and new model at the same time.
+
+## Capture a reproducible failure
+
+Before changing code, record:
+
+```bash
+git rev-parse HEAD
+python --version
+python -m pip freeze
+python main.py --help
+```
+
+Also preserve:
+
+- the exact config path;
+- every `--override` argument;
+- the full command and exit code;
+- the complete traceback or log;
+- operating system and hardware;
+- external data source, metadata version, and relevant paths.
+
+## The config inspector exits non-zero
+
+Run:
+
+```bash
+python -m scripts.config_inspect \
+  --config <yaml> \
+  --override trainer.num_epochs=1 \
+  --dump all
+```
+
+The inspector returns non-zero when any sanity check fails. Typical causes are:
+
+- missing configuration file or base config;
+- invalid schema value;
+- unresolved pipeline, model, task, or trainer import;
+- missing Python dependency;
+- target path inconsistent with the selected registry/factory entry.
+
+Do not ignore the exit code and start a long training job.
+
+## `ModuleNotFoundError`
+
+Confirm that the intended environment is active:
+
+```bash
+which python
+python --version
+python -m pip --version
+python -m pip check
+```
+
+Install the repository environment from [Installation](installation.md).
+
+If the missing package belongs to a component that was **not** selected, report
+it as a possible unconditional optional-import problem. Include the selected
+config and the full import traceback; do not hide the architecture issue by
+adding every optional research dependency to a minimal environment.
+
+## Data or metadata path does not exist
+
+Only `configs/demo/00_smoke/dummy_dg.yaml` is fully offline. For other demos,
+use a local override rather than editing and committing a maintained YAML file:
+
+```bash
+python main.py --config <yaml> \
+  --override data.data_dir=/absolute/path/to/data \
+  --override data.metadata_file=metadata.xlsx
+```
+
+Check the expected layout in [`data/README.md`](../data/README.md) and the selected
+base data config under `configs/base/data/`.
+
+## The generated configuration atlas changes
+
+`docs/CONFIG_ATLAS.md` is generated from `configs/config_registry.csv`.
+Regenerate it after an intentional registry change:
+
+```bash
+python -m scripts.gen_config_atlas
+git diff -- docs/CONFIG_ATLAS.md
+```
+
+Commit the registry and generated atlas together. If the registry did not change,
+an atlas diff indicates generation drift or an unintended edit.
+
+## CUDA is unavailable or a GPU run fails
+
+Verify PyTorch independently:
+
+```bash
+python - <<'PY'
+import torch
+print(torch.__version__)
+print(torch.version.cuda)
+print(torch.cuda.is_available())
+print(torch.cuda.device_count())
+PY
+```
+
+Then return to the CPU smoke configuration. A successful CPU path does not prove
+that the selected CUDA, driver, precision, distributed strategy, or third-party
+kernel combination is supported.
+
+## A maintained test fails only in the full suite
+
+Run the specific failing test first, then the maintained suite:
+
+```bash
+python -m pytest path/to/test_file.py::test_name -vv --tb=long
+python -m pytest test/ -q
+```
+
+Check for:
+
+- test-order dependence;
+- reused output directories;
+- mutable global state;
+- environment variables;
+- existing checkpoints or cache files;
+- tests that depend on external data or GPUs.
+
+Do not change a test merely to suppress a real failure. Record missing data or
+optional dependencies explicitly.
+
+## Streamlit cannot validate or start a run
+
+The optional UI does not replace the core environment. First run the same config
+through the CLI inspector:
+
+```bash
+python -m scripts.config_inspect --config <yaml> --dump all --format json
+```
+
+Then see the [Streamlit user guide](app_usage.md) and
+[Streamlit architecture guide](../apps/streamlit/README.md).
+
+## The documentation check fails
+
+Run:
+
+```bash
+python -m scripts.validate_docs
+```
+
+Fix the reported path rather than adding a broad validation exclusion. Historical,
+paper, and agent-workflow trees have deliberate boundaries; maintained user,
+contributor, configuration, release, and policy documents should remain checked.
+
+## Reporting an issue
+
+Use the repository bug-report template and include a minimal config whenever
+possible. Security vulnerabilities must follow [`SECURITY.md`](../SECURITY.md)
+and must not be posted as public issues.

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,5 +1,8 @@
-# examples/
+# Examples
 
-Example assets and lightweight usage snippets.
+This directory contains lightweight example assets and snippets. It is not the
+source of truth for maintained runnable experiments.
 
-For maintained runnable experiments, use `configs/demo/` (documented in `configs/README.md`).
+Start with the [offline quickstart](../docs/quickstart.md). Maintained experiment
+configurations live under [`configs/demo/`](../configs/demo/README.md), and local
+variants belong under [`configs/experiments/`](../configs/experiments/README.md).


### PR DESCRIPTION
## Purpose

Implement the user-facing portion of the documentation audit as a stacked PR on top of #64.

## Added canonical sources

- `docs/installation.md` — Python/PyTorch environment, CPU/CUDA boundaries, optional Streamlit setup, external-data policy;
- `docs/quickstart.md` — config inspection, one-epoch offline command, expected output location, experiment-copy workflow;
- `docs/troubleshooting.md` — reproducible failure capture, import/data/CUDA/config/Streamlit failure handling.

## Rewritten or narrowed

- `docs/testing.md` is now the testing/evidence SSOT instead of a two-command placeholder.
- `README.md` and `README_CN.md` now focus on project purpose, bounded capability, minimal install/run, output, navigation, structure, validation, contribution, license, citation, and support.
- `configs/README.md` now documents configuration composition, registry/Atlas ownership, inspection, validation, and promotion only; installation/quickstart are links.
- `docs/index.md` links the new progressive onboarding path.
- `examples/README.md` points users to the maintained quickstart and config locations.

## Single-source rules implemented

- installation → `docs/installation.md`;
- first successful run → `docs/quickstart.md`;
- tests/evidence → `docs/testing.md`;
- configuration → `configs/README.md`;
- config inventory → `configs/config_registry.csv`;
- rendered config reference → generated `docs/CONFIG_ATLAS.md`.

## Scope

Documentation only. No runtime, config YAML, registry CSV, generated Atlas, dependency, test, CI, model, task, data, trainer, or release-support change.

## Required validation

```bash
python -m scripts.validate_docs
python -m scripts.validate_configs
python -m scripts.gen_config_atlas
git diff --exit-code docs/CONFIG_ATLAS.md
git diff --check
```

The following command is required because the README and Quickstart present it as the first successful path:

```bash
python main.py \
  --config configs/demo/00_smoke/dummy_dg.yaml \
  --override trainer.num_epochs=1 \
  --override data.num_workers=0
```

The GitHub connector has not executed these commands. CI and local maintainer evidence must be recorded before ready-for-review.

## Merge order

1. merge #64;
2. retarget this PR to `main`;
3. verify the diff contains only the onboarding changes;
4. run the required gates;
5. review and squash merge.
