### PR TITLE
docs: retire unsupported specialist and historical guidance

### DIFF
--- a/docs/HPC.md
+++ b/docs/HPC.md
@@ -1,399 +1,57 @@
-下面是一份可直接落地的《YCRC（Grace & Bouchet）GPU 项目最佳实践：从代码到提交》手册。结构涵盖：目录组织→环境→调试→提交→队列与优先级→数组作业（dSQ）→参数传递→依赖编排→监控优化→常见故障→“什么时候提交更容易上机”。
-1) 项目目录基线（可直接套用）
-your-project/
-├─ src/                     # 源码（Python/R/CUDA等）
-│  └─ train.py
-├─ configs/                 # 训练/推理超参、数据路径（YAML/JSON）
-│  └─ default.yaml
-├─ envs/                    # 环境锁定文件（conda .yaml / requirements.txt）
-│  ├─ env.yaml
-│  └─ requirements.txt
-├─ slurm/                   # 提交脚本与模板
-│  ├─ grace_gpu_a100.sbatch
-│  ├─ bouchet_gpu_h200.sbatch
-│  └─ dsq_jobs.txt          # dSQ 作业清单（每行一条命令）
-├─ scripts/                 # 数据预处理、评测脚本
-│  ├─ preprocess.sh
-│  └─ eval.sh
-├─ logs/                    # 统一收集 slurm 日志（建议 slurm-%A_%a.out）
-├─ notebooks/               # OOD/Jupyter 调试用
-└─ README.md                # 用法、依赖、分区说明与常见问题
-Slurm 输出名可使用 %j/%A/%a 模式变量，便于按 jobid/数组下标归档，例如 #SBATCH -o logs/slurm-%A_%a.out。此用法见 YCRC “Run Jobs with Slurm” → Common Job Request Options（包含输出命名、--time/--mem/--cpus-per-task/--gpus 等常用选项）。
-2) 环境管理（Conda / 模块 / 容器）
-Conda（推荐）：通过 miniconda 模块创建/激活环境；不要把 Python/R 模块与 Conda 环境混用；创建/安装包必须在计算节点上进行（salloc 申请交互节点再 module load miniconda）。示例与注意事项详见官方 Conda 指南。
-Jupyter(OOD)：首次选择 ycrc_default 会自动构建；自建环境需包含 jupyter，并在构建后执行 ycrc_conda_env.sh update 让环境出现在 OOD 下拉列表。
-模块（modules）：系统已预装常用软件；避免与 Conda 同时加载 Python/R 模块，以免冲突。
-容器（Apptainer）：用于封装依赖/复现环境，支持在计算节点运行，官方提供容器开发指南。
-3) 开发→调试→提交：最短闭环
-交互调试（短时）
-申请交互会话（默认进 devel 分区），例如：
- salloc -t 2:00:00 --mem=8G。
-进入后 module load miniconda && conda activate <env>，小规模跑通核心流程。
-锁定参数
-将路径/超参写入 configs/default.yaml；避免在脚本里硬编码。
-准备批处理脚本（sbatch）
-参考下文模板，根据目标集群/分区/卡型调整 --partition 与 --gpus。
-常用选项（--time/--mem/--cpus-per-task/--gpus/--output）详见 “Run Jobs with Slurm”。
-4) GPU 分区与模板
-4.1 Grace（公共 gpu 分区；需显式申请 GPU）
-必须用 --gpus 申请 GPU，例如 --gpus=a5000:2；未申请到 GPU 不要占用 GPU 节点。
-Grace · A100 单卡示例
-#!/bin/bash
-#SBATCH -J exp_grace_a100
-#SBATCH -p gpu
-#SBATCH --gpus=a100:1
-#SBATCH -t 08:00:00
-#SBATCH -c 4
-#SBATCH --mem=30G
-#SBATCH -o logs/slurm-%j.out
+# High-Performance Computing (HPC) Usage
 
-module reset
-module load miniconda
-conda activate YOUR_ENV
+PHM-Vibench does not currently maintain a cluster-specific High-Performance
+Computing (HPC) deployment guide.
 
-python -u src/train.py --config configs/default.yaml
-说明：--gpus 为 YCRC 官方推荐申请方式；其它通用选项见“Common Job Request Options”。
-4.2 Bouchet（H200/RTX 5000 Ada）
-Bouchet 配有 80× NVIDIA H200 与 48× RTX 5000 Ada；面向 AI 工作负载。
-Bouchet · H200 单卡示例
-#!/bin/bash
-#SBATCH -J exp_bch_h200
-#SBATCH -p gpu_h200
-#SBATCH --gpus=h200:1
-#SBATCH -t 08:00:00
-#SBATCH -c 8
-#SBATCH --mem=64G
-#SBATCH -o logs/slurm-%j.out
+The former content at this path was a YCRC/Slurm note containing changing
+site-specific partition names, hardware counts, queue advice, generic
+`src/train.py` commands, and local environment assumptions. It was not validated
+against the maintained PHM-Vibench entrypoint and should not be used as current
+cluster policy.
 
-module reset
-module load miniconda
-conda activate YOUR_ENV
+## Stable PHM-Vibench contract
 
-python -u src/train.py --config configs/default.yaml
-Bouchet · RTX 5000 Ada 单卡示例
-#!/bin/bash
-#SBATCH -J exp_bch_rtxada
-#SBATCH -p gpu
-#SBATCH --gpus=rtx_5000_ada:1
-#SBATCH -t 08:00:00
-#SBATCH -c 4
-#SBATCH --mem=32G
-#SBATCH -o logs/slurm-%j.out
-
-module reset && module load miniconda
-conda activate YOUR_ENV
-python -u src/train.py
-提示：具体分区/默认上限以集群页为准；YCRC 也提供 PyTorch 模块与 GPU 指南（若选模块路径）。
-4.3 可选：Priority & Scavenge
-Priority Tier：快车道分区（如 priority_gpu），在队列中优先于标准层；适合必须尽快启动的作业。
-Scavenge / scavenge_gpu：可被抢占的“捡漏”分区；Grace 亦有 scavenge_gpu。
-5) dSQ 作业数组（高效批量提交）
-当你有大量相似小任务，用 dSQ(Job Arrays) 比循环 sbatch 更好（回填/限速均更友好）。
-步骤
-写一个作业清单 slurm/dsq_jobs.txt：每行一条命令，例如
-python -u src/train.py --config configs/default.yaml --seed 1
-python -u src/train.py --config configs/default.yaml --seed 2
-...
-用 dSQ 生成并提交（常见 Slurm 选项可直接传入并转给 sbatch）：
-dsq --job-file slurm/dsq_jobs.txt \
-    -p gpu --gpus=a100:1 -t 4:00:00 -c 4 --mem=24G \
-    --submit --batch-file slurm/dsq-%j.sbatch
-YCRC 文档解释了 dSQ 的优势、写法与与 Slurm 集成方式；数组作业在“回填”与“Top-N 限制”统计上按一个作业计数，利于整体推进。
-也可与 Nextflow/COMSOL 等结合使用。
-6) 向作业传参（两种方式）
-命令行参数 或 环境变量 注入，YCRC 给出 Python/R 示例与推荐做法；避免修改源码即可更换输入/超参。
-7) 依赖编排（把多步流程串起来）
-使用 Slurm 依赖机制：--dependency=afterok:<jobid> 等，将预处理→训练→评测串成流水线；官方给了依赖类型与示例。
-8) 监控与优化（CPU/内存/GPU）
-运行后用 seff <jobid> / sacct -j <jobid> 看效率；“Run Jobs with Slurm”明确给出命令与上下文。
-Monitor CPU and Memory：文档教你 SSH 到作业所在节点查看瞬时占用；最大内存需等作业结束由记账生成。
-jobstats（门户/命令行）：查看 CPU/Memory/GPU/GPU 内存的利用曲线与报告；还有“总体 Slurm 使用量（getusage）”。
-资源申请策略：根据历史利用率下调到“刚好够”，尤其是 --time/--mem/--gpus/--cpus-per-task；更短墙时更利于回填启动。YCRC 在“Priority & Wait Time”中强调了数组作业与回填的交互。
-9) 常见故障与限速
-内存不足被 OOM：slurmstepd: error: Detected 1 oom-kill event(s) → 提高 --mem 或优化程序；详见“Common Job Failures”。
-提交限速（避免刷队列）：集群对提交速率有限制（如文档提到200 jobs/hour 阈值）；使用 dSQ/依赖作业/Nextflow 的混合执行模式可避免超限。
-10) 什么时候提交更容易上机（实践建议）
-晚间（22:00–08:00 ET）与周末：公共 GPU 分区普遍更空；9 月学期中 Bouchet 课程使用多，白天更拥挤，夜晚/周末更友好（YCRC 明确课程用户可用公共分区；“更拥挤”的结论基于此政策与典型 HPC 负载规律的合理推断，具体以你实际 squeue/监控为准）。
-必须马上跑：若你组开通 Priority Tier，优先投 priority_gpu。
-实时判断：
- squeue --me 查看队列；sprio -j <jobid> 看优先级；配合门户状态与 getusage 评估组内 fairshare。关键命令与页面见 YCRC 的调度与监控文档。
-附录 A：通用 CPU 作业模板
-#!/bin/bash
-#SBATCH -J exp_cpu
-#SBATCH -p general
-#SBATCH -t 04:00:00
-#SBATCH -c 8
-#SBATCH --mem=32G
-#SBATCH -o logs/slurm-%j.out
-
-module reset
-module load miniconda
-conda activate YOUR_ENV
-
-python -u src/train.py --config configs/default.yaml --device cpu
-常用参数详见“Run Jobs with Slurm”→Common Job Request Options。
-附录 B：从 0 到 1 的最小提交流程（Checklist）
-创建/激活环境（交互节点）：module load miniconda && conda create -n proj ... && conda activate proj；OOD 场景执行 ycrc_conda_env.sh update。
-小规模调通（salloc）→ 保存超参到 configs/。
-编写 sbatch（Grace/Bouchet 各一份）并设置日志命名。
-批量任务 用 dSQ（数组作业）而不是循环 sbatch。
-提交后监控：seff/sacct + jobstats + getusage；下一波作业据此缩短墙时/降低资源请求。
-紧急任务：用 priority_gpu；能容忍中断的长作业考虑 scavenge/scavenge_gpu。根据您提供的节点配置信息，我整理了GPU性能排行表格：
-
-## GPU性能排行（从高到低）
-
-| 排名 | GPU型号 | 显存 | 性能特点 | 节点数量 | CPU/节点 | 内存/节点 | 适用场景 |
-|------|---------|------|----------|----------|----------|-----------|----------|
-| 1 | **A100-80G** | 80GB | 双精度，HBM2e高带宽内存 | 26+16=42节点 | 32-48核 | 984-2096GB | 大模型训练、科学计算 |
-| 2 | **A100-40G** | 40GB | 双精度，HBM2内存 | 26节点 | 36核 | 361GB | 中等规模AI训练 |
-| 3 | **A5000** | 24GB | 双精度，RTX架构 | 116节点 | 32核 | 206GB | 图形渲染、AI推理 |
-| 4 | **V100** | 16GB | 双精度，Volta架构 | 46+26=72节点 | 24-36核 | 181-370GB | 传统深度学习 |
-| 5 | **RTX 5000** | 16GB | 双精度，Turing架构 | 25节点 | 22核 | 181GB | 图形工作站任务 |
-| 6 | **RTX 2080 Ti** | 11GB | 单精度，游戏卡 | 36节点 | 24核 | 181GB | 入门级AI训练 |
-
-## 性能对比详细说明
-
-### 顶级性能（A100系列）
-- **A100-80G**: 最强算力，312 TFLOPS (FP16)，适合LLM训练
-- **A100-40G**: 性价比之选，相同架构但显存减半
-
-### 中高端（A5000/V100）
-- **A5000**: 新一代专业卡，27.8 TFLOPS (FP32)，适合多任务
-- **V100**: 经典选择，15.7 TFLOPS (FP32)，成熟稳定
-
-### 入门级（RTX系列）
-- **RTX 5000**: 专业图形卡，11.2 TFLOPS (FP32)
-- **RTX 2080 Ti**: 消费级改装，13.4 TFLOPS (FP32)，仅单精度
-
-## 选择建议
-
-| 任务类型 | 推荐GPU | 理由 |
-|---------|---------|------|
-| **LLM/Transformer训练** | A100-80G > A100-40G | 大显存+高带宽必需 |
-| **科学计算（双精度）** | A100 > V100 > A5000 | 需要FP64性能 |
-| **CNN/传统DL** | A100-40G > V100 > A5000 | 性价比平衡 |
-| **推理/部署** | A5000 > RTX 5000 | 功耗效率高 |
-| **预算受限/原型验证** | RTX 2080 Ti | 最便宜，但限制多 |
-| **混合精度训练** | A100系列 | Tensor Core性能最佳 |
-
-## 特别提示
-1. **A100-80G** 节点通常更难申请（资源稀缺）
-2. **RTX 2080 Ti** 仅支持单精度，不适合科学计算
-3. **V100** 虽然较老但节点数多，等待时间可能更短
-4. 根据`Node Features`选择：需要大内存选`bigtmp`节点
-
-建议根据实际需求（显存需求、精度要求、等待时间）选择合适的GPU，而非一味追求最高性能。
-
-
-
-
-
-## ✅ **正确的提交方式**
-
-### 方法1：使用 sbatch 命令提交（正确方式）
-```bash
-sbatch /vast/palmer/home.grace/ql334/LQ/PHM-Vibench/script/Vibench_paper/foundation_model/run.sbatch
-sbatch /vast/palmer/home.grace/ql334/LQ/PHM-Vibench/script/Vibench_paper/foundation_model/run.sbatch
-```
-
-### 方法2：先查看文件内容
-```bash
-# 查看脚本内容，确认配置
-cat /vast/palmer/home.grace/ql334/LQ/PHM-Vibench/script/Vibench_paper/foundation_model/run.sbatch
-
-# 或用 less 查看长文件
-less /vast/palmer/home.grace/ql334/LQ/PHM-Vibench/script/Vibench_paper/foundation_model/run.sbatch
-```
-
-### 方法3：检查并修复权限（如果需要）
-```bash
-# 查看当前权限
-ls -la /vast/palmer/home.grace/ql334/LQ/PHM-Vibench/script/Vibench_paper/foundation_model/run.sbatch
-
-# 如果需要添加执行权限（通常不需要）
-chmod +x /vast/palmer/home.grace/ql334/LQ/PHM-Vibench/script/Vibench_paper/foundation_model/run.sbatch
-
-# 但仍然要用 sbatch 提交
-sbatch /vast/palmer/home.grace/ql334/LQ/PHM-Vibench/script/Vibench_paper/foundation_model/run.sbatch
-```
-
-## 📋 **完整工作流程**
+A cluster job should invoke the same public command used locally:
 
 ```bash
-# 1. 进入项目目录
-cd /vast/palmer/home.grace/ql334/LQ/PHM-Vibench
-
-# 2. 查看脚本内容（可选）
-cat script/Vibench_paper/foundation_model/run.sbatch
-
-# 3. 提交作业
-sbatch script/Vibench_paper/foundation_model/run.sbatch
-
-# 4. 查看作业状态
-squeue --me
-
-# 5. 如果需要取消作业
-# scancel <jobid>
+python main.py --config <yaml> [--override key=value ...]
 ```
 
-## 🔍 **常用 SLURM 命令**
+Keep site-specific values outside maintained demo configurations. Typical local
+or scheduler-provided overrides include:
 
-| 命令 | 用途 |
-|------|------|
-| `sbatch script.sbatch` | 提交批处理作业 |
-| `squeue --me` | 查看自己的作业队列 |
-| `squeue -p gpu` | 查看GPU分区队列 |
-| `scancel <jobid>` | 取消作业 |
-| `sinfo -p gpu` | 查看GPU分区节点状态 |
-| `sacct -j <jobid>` | 查看作业历史 |
-
-## ⚠️ **注意事项**
-
-1. **永远不要**直接执行 `.sbatch` 文件（`./run.sbatch`）
-2. **永远使用** `sbatch` 命令提交
-3. **确保在login节点**提交作业（您现在的位置是正确的）
-
-## 🎯 **快速开始**
-
-立即运行：
-```bash
-sbatch script/Vibench_paper/foundation_model/run.sbatch
+```text
+data.data_dir
+trainer.device
+trainer.gpus
+data.num_workers
+environment.output_dir
 ```
 
-提交后会返回类似：
-```
-Submitted batch job 12345678
-```
-
-然后查看状态：
-```bash
-squeue --me
-```
-
-如果脚本有问题或需要修改，请先用 `cat` 查看内容，我可以帮您调整参数。
-
-
-
-
-## ✅ **salloc sbatch参数基本相同，只是用法不同**
-
-### 📊 **三种提交方式的对比**
-
-| 命令 | 用途 | 语法示例 | 使用场景 |
-|------|------|----------|----------|
-| **salloc** | 交互式分配 | `salloc -p gpu --gpus=a100:1 -t 2:00:00` | 调试、交互开发 |
-| **sbatch** | 批处理提交 | `#SBATCH -p gpu`<br>`#SBATCH --gpus=a100:1` | 生产运行 |
-| **srun** | 直接运行 | `srun -p gpu --gpus=a100:1 python train.py` | 快速单命令 |
-
-### 🔄 **参数对应关系**
+Start by validating the configuration and running a small CPU or single-device
+job:
 
 ```bash
-# salloc（命令行）
-salloc -p gpu --gpus=a100:1 -t 4:00:00 --mem=32G -c 4
+python -m scripts.config_inspect \
+  --config configs/demo/00_smoke/dummy_dg.yaml \
+  --override trainer.num_epochs=1
 
-# sbatch（脚本内）
-#!/bin/bash
-#SBATCH -p gpu
-#SBATCH --gpus=a100:1  
-#SBATCH -t 4:00:00
-#SBATCH --mem=32G
-#SBATCH -c 4
+python main.py --config configs/demo/00_smoke/dummy_dg.yaml \
+  --override trainer.device=cpu \
+  --override trainer.num_epochs=1 \
+  --override data.num_workers=0
 ```
 
-**完全相同的参数！** 只是格式不同：
-- `salloc`: 一行命令，空格分隔
-- `#SBATCH`: 每行一个参数，更清晰
+## Site documentation is authoritative
 
-### 💡 **实用技巧：参数通用性**
+For modules, partitions, GPU types, wall-time limits, storage, job arrays,
+containers, and queue policy, follow the current documentation of the cluster
+operator. Do not copy another institution's Slurm directives or filesystem paths
+without review.
 
-#### 1. **从salloc测试到sbatch生产**
-```bash
-# 第一步：交互测试找到合适参数
-salloc -p day -t 1:00:00 --mem=8G -c 2
+A future PHM-Vibench HPC guide should be site-neutral and tested. Cluster-specific
+examples should identify their site, verification date, external source, expected
+environment, and maintenance owner.
 
-# 第二步：确认参数后写入sbatch
-cat > job.sbatch << 'EOF'
-#!/bin/bash
-#SBATCH -p day
-#SBATCH -t 1:00:00  
-#SBATCH --mem=8G
-#SBATCH -c 2
-
-# 你的代码
-EOF
-```
-
-#### 2. **常用参数速查**
-
-| 短格式 | 长格式 | 用途 | 示例 |
-|--------|--------|------|------|
-| `-p` | `--partition` | 分区 | `-p gpu` |
-| `-t` | `--time` | 时间限制 | `-t 4:00:00` |
-| `-c` | `--cpus-per-task` | CPU核数 | `-c 8` |
-| `-n` | `--ntasks` | 任务数 | `-n 4` |
-| `-N` | `--nodes` | 节点数 | `-N 2` |
-| `-J` | `--job-name` | 作业名 | `-J exp1` |
-| `-o` | `--output` | 输出文件 | `-o log_%j.out` |
-| `-e` | `--error` | 错误文件 | `-e log_%j.err` |
-| | `--mem` | 内存 | `--mem=32G` |
-| | `--gpus` | GPU | `--gpus=a100:1` |
-
-### 🎯 **针对您的问题**
-
-既然参数相同，您之前看到的错误：
-```bash
-salloc: error: invalid partition specified: general
-```
-
-意味着在 `#SBATCH` 中也不能用 `general` 分区。
-
-**快速查看可用分区：**
-```bash
-# 查看所有分区
-sinfo -o "%P" | sort -u
-
-# 或者查看哪些分区有空闲节点
-sinfo -t idle -o "%P"
-```
-
-### 📝 **实际应用示例**
-
-假设您找到分区名是 `day`：
-
-**交互式（用于测试下载）：**
-```bash
-salloc -p day -t 2:00:00 --mem=16G -c 4
-# 进入节点后
-module load miniconda
-conda activate P
-python download.py
-```
-
-**批处理（用于长时间下载）：**
-```bash
-#!/bin/bash
-#SBATCH -p day
-#SBATCH -t 2:00:00
-#SBATCH --mem=16G  
-#SBATCH -c 4
-#SBATCH -o download_%j.out
-
-module load miniconda
-conda activate P
-python download.py
-```
-
-### 🔍 **调试提示**
-
-如果不确定参数是否正确：
-```bash
-# 1. 先用 salloc 测试（立即看到错误）
-salloc -p test_partition -t 10:00
-
-# 2. 用 --test-only 检查sbatch
-sbatch --test-only job.sbatch
-
-# 3. 查看预估开始时间
-sbatch --test-only job.sbatch 2>&1 | grep "Estimated"
-```
-
+The previous detailed YCRC note remains recoverable from Git history; it is not
+part of the maintained documentation surface.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,17 +1,18 @@
-# docs/
+# PHM-Vibench Documentation
 
-Maintained documentation for PHM-Vibench.
+The maintained documentation entrypoint is [docs/index.md](index.md).
 
-## Key docs
+Use it to find installation, quickstart, configuration, data, testing,
+development, contribution, Streamlit, release, and historical documentation.
 
-- Config atlas (generated): `docs/CONFIG_ATLAS.md`
-- Config registry schema: `docs/config_registry_schema.md`
-- Developer guide: `docs/developer_guide.md`
-- Custom dataset guide: `docs/custom_dataset.md`
+Key maintenance commands:
 
-## Generation / validation
+```bash
+python -m scripts.validate_docs
+python -m scripts.validate_configs
+python -m scripts.gen_config_atlas
+git diff --exit-code docs/CONFIG_ATLAS.md
+```
 
-See `AGENTS.md` for the copy-paste commands:
-
-- `python -m scripts.gen_config_atlas`
-- `python -m scripts.validate_configs`
+`docs/CONFIG_ATLAS.md` is generated from `configs/config_registry.csv`; do not
+edit the atlas manually.

--- a/docs/archive/audits/documentation-audit-20260714.md
+++ b/docs/archive/audits/documentation-audit-20260714.md
@@ -30,38 +30,51 @@ claims are implemented.
 8. `configs/README.md` was still titled `v0.1.0` and duplicated first-run guidance.
 9. `docs/testing.md` did not describe focused tests, generated-doc checks, smoke
    evidence, CI evidence, or environment limitations.
-10. `docs/HPC.md` is a long YCRC-specific note with generic `src/train.py`
+10. `docs/HPC.md` was a long YCRC-specific note with generic `src/train.py`
     commands, cluster-specific assertions, and externally changing operational
-    details. It is not a maintained PHM-Vibench user guide.
-11. Historical material under `docs/v0.1.0/`, `docs/past/`, `configs/v0.0.9/`, and
+    details. It was not a maintained PHM-Vibench user guide.
+11. `docs/grace.md` and `docs/past/grace.md` exposed contributor-specific `/gpfs`
+    and `/vast` paths, a local Conda environment name, and editor commands.
+12. `docs/multi_task_phm_foundation_model.md` mixed an existing model component
+    with a missing task module/config and presented unverified capabilities as a
+    complete system.
+13. `docs/multitask_pretrain_finetune_guide.md` bypassed the public entrypoint,
+    referenced an unmaintained config, and contained unsupported accuracy,
+    convergence, RUL, anomaly, and statistical-significance numbers.
+14. Factory-specific contribution guides described incorrect runtime contracts:
+    BaseReader/in-`__init__` registration, `__main__` tests, stale task paths, and
+    a custom Trainer subclass rather than the actual builder function.
+15. Historical material under `docs/v0.1.0/`, `docs/past/`, `configs/v0.0.9/`, and
     `dev/` was not clearly separated by a central navigation policy.
-12. Several lowercase README files are intentional compatibility redirects and
+16. Several lowercase README files are intentional compatibility redirects and
     should not be removed solely for stylistic consistency.
 
 ## Document disposition matrix
 
 | Path or group | Audience | Finding | Action |
 | --- | --- | --- | --- |
-| `README.md` | users | Accurate but overextended; stale statement that active CI is still needed | Rewrite as concise project/front-door page |
+| `README.md` | users | Accurate but overextended; stale statement that active CI was still needed | Rewrite as concise project/front-door page |
 | `README_CN.md` | users | Mirrors README structure and same stale CI statement | Rewrite in parallel with English README |
+| `docs/README.md` | all | Sparse parallel index | Redirect to canonical `docs/index.md` |
 | `docs/index.md` | all | Missing | Add canonical navigation and source-of-truth map |
 | `docs/installation.md` | users | Missing | Add authoritative installation page |
 | `docs/quickstart.md` | users | Missing | Add authoritative offline smoke walkthrough |
-| `configs/README.md` | users/developers | Useful config authority, but version title and first-run duplication are stale | Retain; update title and link to quickstart |
+| `configs/README.md` | users/developers | Useful config authority, but version title and first-run duplication were stale | Retain; update title and link to quickstart |
 | `data/README.md` | users/contributors | Recently rewritten; clearly separates dummy data, local data, and references | Retain as data authority |
 | `docs/developer_guide.md` | developers | Current, focused, and factory-aligned | Retain; link from documentation index |
 | `docs/testing.md` | developers | Too small to serve as test authority | Rewrite as test/evidence authority |
 | `apps/streamlit/README.md` | users/developers | Detailed maintained UI authority | Retain |
 | `docs/app_usage.md` | users | Duplicates Streamlit guide | Replace with compatibility redirect |
-| `docs/custom_dataset.md` | users/contributors | Useful short bridge; overlaps factory guide | Retain for now; link to data and contribution authorities |
+| `docs/custom_dataset.md` | users/contributors | Short bridge used stale reader instructions | Rewrite as bridge to data and contribution authorities |
 | `CONTRIBUTING.md` | contributors | Outdated environment, tests, support assumptions, and component instructions | Rewrite in contributor-governance PR |
 | `CONTRIBUTING_CN.md` | contributors | Same problems as English guide | Rewrite together with English guide |
 | `contributing.md` | contributors | Duplicate plus embedded Code of Conduct placeholder | Replace with compatibility redirect |
 | `CODE_OF_CONDUCT.md` | community | Missing | Add customized conduct policy |
 | `SECURITY.md` | security reporters | Incorrect supported versions and placeholder contact | Rewrite without unverifiable response-time promises |
-| `CITATION.cff` | researchers | Missing | Add minimal software citation metadata after maintainer identity check |
+| `CITATION.cff` | researchers | Missing | Add minimal software citation metadata; require identity confirmation |
 | `.github/ISSUE_TEMPLATE/*` | users/contributors | Duplicate bilingual templates with placeholders and invalid commands | Rewrite with real repository links and evidence fields |
 | `.github/PULL_REQUEST_TEMPLATE.md` | contributors | Missing | Add scope, evidence, compatibility, docs, and rollback checklist |
+| `src/*_factory/contributing.md` | developers | Factory contracts and tests did not match code | Rewrite against actual imports and constructors |
 | `CHANGELOG.md` | users/release managers | Current release-candidate record | Retain |
 | `RELEASE_NOTES_v0.2.0.md` | users/release managers | Release-specific authority | Retain; do not duplicate in general docs |
 | `MIGRATION_v0.1_to_v0.2.md` | users | Migration authority | Retain |
@@ -72,9 +85,12 @@ claims are implemented.
 | `docs/branch_governance_20260709.md` | maintainers | Important governance decision record | Retain |
 | `docs/REPOSITORY_OPTIMIZATION_SOP.md` | maintainers | Stable change-management SOP | Retain |
 | `docs/PIPELINE_06_GENERATIVE_MIGRATION.md` | developers/researchers | Explicit future migration contract | Retain, clearly outside release support |
-| `docs/HPC.md` | specific HPC users | Unverified, cluster-specific, and not aligned to current entrypoint | Archive or replace with a warning page in a separate PR |
-| `docs/v0.1.0/**` | maintainers/researchers | Historical release and planning evidence | Preserve; classify as historical |
-| `docs/past/**` | maintainers/researchers | Historical guides that may contain obsolete commands | Preserve; classify as historical |
+| `docs/HPC.md` | specific HPC users | Unverified, site-specific, and not aligned to current entrypoint | Replace with site-neutral boundary page; retain old content in Git history |
+| `docs/grace.md`, `docs/past/grace.md` | one contributor | Personal cluster paths and environment commands | Remove personal values; keep compatibility status pages |
+| `docs/multi_task_phm_foundation_model.md` | researchers | Implemented/proposed/missing pieces mixed together | Replace with experimental status and promotion requirements |
+| `docs/multitask_pretrain_finetune_guide.md` | researchers | Unsupported commands and numerical claims | Replace with historical status and evidence requirements |
+| `docs/v0.1.0/**` | maintainers/researchers | Historical release and planning evidence | Preserve; add historical landing page |
+| `docs/past/**` | maintainers/researchers | Historical guides that may contain obsolete commands | Preserve; add historical landing page |
 | `src/**/README.md` | developers | Local component documentation; mixed depth but useful near code | Retain; prefer links to central policies |
 | lowercase redirect READMEs | compatibility | Short redirects already prevent case/link breakage | Retain unless a reference audit proves deletion safe |
 | `AGENTS.md`, `CLAUDE.md`, `GEMINI.md` | maintainers/agents | Engineering runbook and constraints, not user documentation | Retain; link only from developer navigation |
@@ -97,11 +113,13 @@ claims are implemented.
 | Tests and evidence terminology | `docs/testing.md` |
 | General contribution process | `CONTRIBUTING.md` |
 | Factory-specific extension steps | each `src/*_factory/contributing.md` |
-| Streamlit behavior | `apps/streamlit/README.md` |
+| Community behavior | `CODE_OF_CONDUCT.md` |
 | Security reporting | `SECURITY.md` |
+| Citation metadata | `CITATION.cff` |
+| Streamlit behavior | `apps/streamlit/README.md` |
 | Release history | `CHANGELOG.md` plus versioned release notes |
 
-## Planned PR sequence
+## Implemented PR sequence
 
 ### PR A — user documentation architecture
 
@@ -114,21 +132,22 @@ claims are implemented.
 
 ### PR B — contribution and repository templates
 
-- rewrite bilingual contribution guides;
+- rewrite bilingual general and factory-specific contribution guides;
 - separate the lowercase compatibility page from the Code of Conduct;
 - replace the security template;
 - add a pull-request template;
 - repair bilingual bug and feature templates;
-- add minimal citation metadata after maintainer review.
+- add minimal citation metadata subject to maintainer identity review.
 
 ### PR C — historical and specialist cleanup
 
-- audit references to `docs/HPC.md` and either archive it with a warning or remove
-  it if no provenance value remains;
-- add explicit archive landing pages for existing historical subtrees without
-  mass-renaming paths;
-- review large code comments or AI workflow documents that act as unofficial
-  user documentation.
+- route `docs/README.md` to the canonical index;
+- replace the unmaintained HPC/YCRC page and personal Grace notes with bounded
+  status pages while preserving path compatibility and Git history;
+- replace unsupported multi-task pages with explicit experimental/historical
+  status and promotion gates;
+- add landing pages for `docs/past/` and `docs/v0.1.0/`;
+- correct the custom-dataset bridge without creating another full data guide.
 
 ## Validation requirements
 

--- a/docs/archive/audits/documentation-inventory-20260714.csv
+++ b/docs/archive/audits/documentation-inventory-20260714.csv
@@ -1,0 +1,65 @@
+path_or_group,purpose,audience,current_status,duplicate,outdated,factual_issue,disposition,authority,verification
+README.md,Project positioning and shortest successful path,users,MAINTAINED,no,no,no,REWRITE,README.md,PR65_CI_PASS
+README_CN.md,Chinese project positioning and shortest path,users,MAINTAINED,translation_peer,no,no,REWRITE,README.md,PR65_CI_PASS
+docs/index.md,Documentation navigation and SSOT map,all,MAINTAINED,no,no,no,ADD,docs/index.md,PR65_CI_PASS
+docs/installation.md,Installation baseline and dependency setup,users,MAINTAINED,no,no,no,ADD,docs/installation.md,PR65_CI_PASS
+docs/quickstart.md,First offline run and troubleshooting,users,MAINTAINED,no,no,no,ADD,docs/quickstart.md,PR65_CI_PASS
+docs/testing.md,Test commands and evidence terminology,developers,MAINTAINED,no,no,no,REWRITE,docs/testing.md,PR65_CI_PASS
+docs/README.md,Compatibility entry for docs directory,all,COMPAT_REDIRECT,yes,no,no,REDIRECT,docs/index.md,PR69_CI_PENDING
+docs/developer_guide.md,Current development workflow and factory boundaries,developers,MAINTAINED,no,no,no,RETAIN,docs/developer_guide.md,STATIC_REVIEW
+docs/app_usage.md,Legacy Streamlit usage entry,users,COMPAT_REDIRECT,yes,no,no,REDIRECT,apps/streamlit/README.md,PR65_CI_PASS
+apps/streamlit/README.md,Optional Streamlit workspace usage and boundaries,users|developers,MAINTAINED,no,no,no,RETAIN,apps/streamlit/README.md,STATIC_REVIEW
+apps/streamlit/REVIEW.md,Streamlit review decisions and extension boundaries,maintainers,DECISION_RECORD,no,no,no,RETAIN,apps/streamlit/REVIEW.md,STATIC_REVIEW
+docs/custom_dataset.md,Short bridge for custom dataset onboarding,users|contributors,MAINTAINED,partial,yes,stale reader contract,REWRITE,data/README.md|src/data_factory/contributing.md,PR69_CI_PENDING
+data/README.md,Data layout external sources and licensing boundary,users|contributors,MAINTAINED,no,no,no,RETAIN,data/README.md,STATIC_REVIEW
+configs/README.md,Configuration composition precedence registry and promotion,users|developers,MAINTAINED,no,no,no,REWRITE,configs/README.md,PR65_CI_PASS
+configs/base/README.md and subtree READMEs,Reusable five-block configuration documentation,developers,MAINTAINED_GROUP,partial,unknown,not fully line-reviewed,RETAIN,configs/README.md,GROUP_CLASSIFIED
+configs/demo/README.md and demo READMEs,Maintained runnable examples,users,MAINTAINED_GROUP,partial,unknown,must track registry status,RETAIN,configs/config_registry.csv,GROUP_CLASSIFIED
+configs/experiments/README.md,Boundary for local and research variants,developers,MAINTAINED,no,no,no,RETAIN,configs/experiments/README.md,STATIC_REVIEW
+configs/local/README.md,Machine-local override policy,developers,MAINTAINED,no,no,no,RETAIN,configs/local/README.md,STATIC_REVIEW
+configs/config_registry.csv,Authoritative maintained configuration inventory,developers,AUTHORITATIVE_DATA,no,no,no,RETAIN,configs/config_registry.csv,CI_VALIDATED
+docs/config_registry_schema.md,Config registry field reference,developers,MAINTAINED,no,no,no,RETAIN,configs/config_registry.csv,CI_VALIDATED
+docs/CONFIG_ATLAS.md,Generated human-readable config inventory,users|developers,GENERATED,no,no,no,RETAIN_GENERATED,configs/config_registry.csv,CI_CLEAN_DIFF
+CONTRIBUTING.md,General contribution process,contributors,MAINTAINED,no,no,no,REWRITE,CONTRIBUTING.md,PR67_CI_PASS
+CONTRIBUTING_CN.md,Chinese contribution process,contributors,MAINTAINED,translation_peer,no,no,REWRITE,CONTRIBUTING.md,PR67_CI_PASS
+contributing.md,Legacy lowercase contribution path,contributors,COMPAT_REDIRECT,yes,no,no,REDIRECT,CONTRIBUTING.md,PR67_CI_PASS
+src/data_factory/contributing.md,Data reader and adapter contribution contract,developers,MAINTAINED,no,no,no,REWRITE,CONTRIBUTING.md|runtime factory,PR67_CI_PASS
+src/model_factory/contributing.md,Model contribution contract,developers,MAINTAINED,no,no,no,REWRITE,CONTRIBUTING.md|runtime factory,PR67_CI_PASS
+src/task_factory/contributing.md,Task loss metric and sampler contribution contract,developers,MAINTAINED,no,no,no,REWRITE,CONTRIBUTING.md|runtime factory,PR67_CI_PASS
+src/trainer_factory/contributing.md,Trainer builder and extension contribution contract,developers,MAINTAINED,no,no,no,REWRITE,CONTRIBUTING.md|runtime factory,PR67_CI_PASS
+src/*_factory/README.md and component READMEs,Near-code architecture and component documentation,developers,MAINTAINED_GROUP,partial,unknown,mixed depth and not fully line-reviewed,RETAIN,local README plus central guides,GROUP_CLASSIFIED
+src/**/CLAUDE.md,Agent-facing architecture constraints,maintainers|agents,ENGINEERING_POLICY,partial,unknown,not user documentation,RETAIN,root CLAUDE.md,GROUP_CLASSIFIED
+AGENTS.md and AGENTS_CN.md,Maintainer runbook and quality gates,maintainers|agents,ENGINEERING_POLICY,partial,no,no,RETAIN,AGENTS.md,STATIC_REVIEW
+CLAUDE.md and CLAUDE_CN.md,Change strategy and architecture invariants,maintainers|agents,ENGINEERING_POLICY,partial,no,no,RETAIN,CLAUDE.md,STATIC_REVIEW
+GEMINI.md,Minimal AI assistant pointers,maintainers|agents,ENGINEERING_POLICY,no,no,no,RETAIN,GEMINI.md,STATIC_REVIEW
+CODE_OF_CONDUCT.md,Community behavior and enforcement,community,MAINTAINED,no,no,no,ADD,CODE_OF_CONDUCT.md,PR67_CI_PASS
+SECURITY.md,Private vulnerability reporting and support boundary,security_reporters,MAINTAINED,no,no,no,REWRITE,SECURITY.md,PR67_CI_PASS
+CITATION.cff,Machine-readable software citation,researchers,MAINTAINED,no,no,no,ADD,CITATION.cff,PR67_CI_PASS
+LICENSE,Repository software license,all,LEGAL_AUTHORITY,no,no,no,RETAIN,LICENSE,STATIC_REVIEW
+CHANGELOG.md,Release change history,users|release_managers,MAINTAINED,no,no,no,RETAIN,CHANGELOG.md,STATIC_REVIEW
+RELEASE_NOTES_v0.2.0.md,Version-specific release narrative,users|release_managers,RELEASE_RECORD,no,no,no,RETAIN,RELEASE_NOTES_v0.2.0.md,STATIC_REVIEW
+MIGRATION_v0.1_to_v0.2.md,Version migration guidance,users,MAINTAINED,no,no,no,RETAIN,MIGRATION_v0.1_to_v0.2.md,STATIC_REVIEW
+SUPPORTED_COMPONENTS.md,Release-supported component boundary,users|developers,AUTHORITATIVE_SUPPORT,no,no,no,RETAIN,SUPPORTED_COMPONENTS.md,STATIC_REVIEW
+SUPPORTED_COMBINATIONS.md,Release-supported combination boundary,users|developers,AUTHORITATIVE_SUPPORT,no,no,no,RETAIN,SUPPORTED_COMBINATIONS.md,STATIC_REVIEW
+KNOWN_LIMITATIONS.md,Explicit release limitations,users|developers,AUTHORITATIVE_SUPPORT,no,no,no,RETAIN,KNOWN_LIMITATIONS.md,STATIC_REVIEW
+.github/ISSUE_TEMPLATE/bug_report.md,English bug intake,users|contributors,MAINTAINED,language_peer,no,no,REWRITE,CONTRIBUTING.md|SECURITY.md,PR67_CI_PASS
+.github/ISSUE_TEMPLATE/bug-report--错误报告-cn-.md,Chinese bug intake,users|contributors,MAINTAINED,language_peer,no,no,REWRITE,CONTRIBUTING_CN.md|SECURITY.md,PR67_CI_PASS
+.github/ISSUE_TEMPLATE/feature_request.md,English feature intake,users|contributors,MAINTAINED,language_peer,no,no,REWRITE,CONTRIBUTING.md,PR67_CI_PASS
+.github/ISSUE_TEMPLATE/功能建议--feature-request-.md,Chinese feature intake,users|contributors,MAINTAINED,language_peer,no,no,REWRITE,CONTRIBUTING_CN.md,PR67_CI_PASS
+.github/PULL_REQUEST_TEMPLATE.md,PR scope evidence and rollback checklist,contributors|reviewers,MAINTAINED,no,no,no,ADD,CONTRIBUTING.md,PR67_CI_PASS
+docs/branch_governance_20260709.md,Branch governance decision record,maintainers,DECISION_RECORD,no,no,no,RETAIN,document itself,STATIC_REVIEW
+docs/REPOSITORY_OPTIMIZATION_SOP.md,Repository optimization process,maintainers,MAINTAINED_SOP,no,no,no,RETAIN,document itself,STATIC_REVIEW
+docs/PIPELINE_06_GENERATIVE_MIGRATION.md,Future generative migration contract,developers|researchers,EXPERIMENTAL_CONTRACT,no,no,no,RETAIN,document itself,STATIC_REVIEW
+docs/HPC.md,Site-specific HPC guidance,cluster_users,STATUS_PAGE,no,yes,YCRC-specific claims and wrong entrypoint,REWRITE_STATUS,official site docs plus current CLI,PR69_CI_PENDING
+docs/grace.md,Contributor-specific cluster scratch note,one_contributor,COMPAT_STATUS,no,yes,personal paths and environment,REWRITE_STATUS,docs/HPC.md,PR69_CI_PENDING
+docs/past/grace.md,Historical contributor cluster scratch note,one_contributor,HISTORICAL_STATUS,no,yes,personal paths and environment,REWRITE_STATUS,docs/HPC.md,PR69_CI_PENDING
+docs/multi_task_phm_foundation_model.md,Proposed multi-task model guide,researchers,EXPERIMENTAL_STATUS,no,yes,missing paths and unsupported support claims,REWRITE_STATUS,SUPPORTED_COMPONENTS.md|SUPPORTED_COMBINATIONS.md,PR69_CI_PENDING
+docs/multitask_pretrain_finetune_guide.md,Proposed Pipeline03 training guide,researchers,HISTORICAL_STATUS,no,yes,invalid direct commands and unsupported metrics,REWRITE_STATUS,KNOWN_LIMITATIONS.md|docs/testing.md,PR69_CI_PENDING
+docs/v0.1.0/**,v0.1.0 plans reports and decision evidence,maintainers|researchers,HISTORICAL_GROUP,partial,yes,commands and facts may be obsolete,PRESERVE_GROUP,docs/v0.1.0/README.md,GROUP_CLASSIFIED
+docs/past/**,Older guides and migration notes,maintainers|researchers,HISTORICAL_GROUP,partial,yes,commands and facts may be obsolete,PRESERVE_GROUP,docs/past/README.md,GROUP_CLASSIFIED
+configs/v0.0.9/**,Older configuration records,maintainers|researchers,HISTORICAL_GROUP,partial,yes,not maintained config surface,PRESERVE_GROUP,docs/archive policy,GROUP_CLASSIFIED
+dev/** and dev/**/README*,Development experiments logs and scratch documentation,developers|researchers,DEVELOPMENT_GROUP,unknown,unknown,not fully inventoried as maintained docs,PRESERVE_REVIEW_REQUIRED,dev/README.md,GROUP_CLASSIFIED
+paper/**,Paper sources notes and experiment records,researchers,RESEARCH_GROUP,unknown,unknown,requires claim provenance and publication context,PRESERVE_REVIEW_REQUIRED,each paper README,GROUP_CLASSIFIED
+examples/README.md,Examples directory boundary,users|developers,MAINTAINED,no,no,no,RETAIN,examples/README.md,STATIC_REVIEW
+scripts/README.md,Utility script index,developers,MAINTAINED,no,no,no,RETAIN,scripts/README.md,STATIC_REVIEW
+source-code module docstrings and long comments,API and implementation explanation,developers,MIXED_GROUP,unknown,unknown,some act as unofficial docs,AUDIT_WHEN_TOUCHED,near-code README plus tests,GROUP_CLASSIFIED

--- a/docs/custom_dataset.md
+++ b/docs/custom_dataset.md
@@ -1,19 +1,61 @@
-# Custom Dataset Tutorial
+# Add a Custom Dataset
 
-This project expects datasets to be integrated through the `src/data_factory/` registry/factory layer rather
-than by hard-coding paths in pipelines.
+This page is a short user bridge. The authoritative data layout is
+[data/README.md](../data/README.md), and the complete contribution requirements
+are in the [data factory contribution guide](../src/data_factory/contributing.md).
 
-## Quick Checklist
+PHM-Vibench integrates data through configuration, metadata, readers, task
+adapters, and samplers. Do not hard-code a local path or dataset-specific branch
+in a pipeline.
 
-- Put raw inputs under `data/raw/<dataset_name>/` (keep directory casing consistent).
-- Prepare a metadata spreadsheet (typically `metadata_*.xlsx`) and/or processed H5 files as needed.
-- Implement a reader by inheriting `BaseReader` (see examples in `src/data_factory/reader/` such as
-  `RM_*.py`).
-- Register the reader/factory entry in `src/data_factory/__init__.py`.
-- Validate with a small config under `configs/demo/` (start from
-  `configs/demo/01_cross_domain/cwru_dg.yaml`, or use `configs/demo/00_smoke/dummy_dg.yaml` for an offline smoke run).
+## Reader path
 
-## References
+A metadata row's `Name` selects:
 
-- `src/data_factory/README.md`
-- `src/data_factory/contributing.md`
+```text
+src.data_factory.reader.<Name>
+```
+
+The reader module exposes:
+
+```python
+def read(file_path, args_data):
+    ...
+```
+
+The default raw path is:
+
+```text
+<data.data_dir>/raw/<Name>/<File>
+```
+
+where `Name` and `File` come from metadata.
+
+## Minimal workflow
+
+1. Verify the original data source, license, citation, and redistribution terms.
+2. Define metadata fields including `Id`, `Name`, and `File`, plus task-specific
+   labels, domains, or system identifiers.
+3. Implement `src/data_factory/reader/<Name>.py` and document units, sampling
+   frequency, channels, input shape, returned shape, dtype, and preprocessing.
+4. Add or reuse the appropriate adapter under
+   `src/data_factory/dataset_task/<task.type>/`.
+5. Add a legal small fixture or synthetic contract test under `test/`.
+6. Create an initial configuration under `configs/experiments/`.
+7. Inspect and run the smallest applicable path.
+
+```bash
+python -m scripts.validate_configs
+python -m scripts.config_inspect --config <yaml> --override trainer.num_epochs=1
+python -m pytest <focused-data-test> -q
+python main.py --config <yaml> \
+  --override trainer.num_epochs=1 \
+  --override data.num_workers=0
+```
+
+Only promote a configuration to `configs/demo/` after source/license review and
+runtime evidence. Update the config registry, generated atlas, and support
+boundaries only when the maintained public surface intentionally changes.
+
+Large or restricted dataset payloads normally remain outside Git. Metadata and
+reference notes do not imply redistribution rights or release support.

--- a/docs/grace.md
+++ b/docs/grace.md
@@ -1,9 +1,16 @@
-data_dir /gpfs/gibbs/project/lu_lu/ql334/PHM-Vibench/data
+# Grace Cluster Notes — Retired
 
-# Load modules and environment
-module reset
-module load miniconda
-conda activate P  # 使用您的环境名称
+This compatibility path previously contained a contributor-specific filesystem
+path, local Conda environment name, and editor launch commands. Those values are
+not portable PHM-Vibench documentation and have been removed.
 
-module load VSCode
-vscode
+Use:
+
+- [Installation](installation.md) for the supported environment baseline;
+- [Quickstart](quickstart.md) for the maintained runtime command;
+- [HPC usage](HPC.md) for the site-neutral scheduler boundary;
+- `configs/local/local.yaml` or CLI overrides for machine-specific data paths.
+
+Never commit a personal cluster path into a maintained configuration or user
+guide. The prior note remains recoverable from Git history if needed for private
+provenance.

--- a/docs/multi_task_phm_foundation_model.md
+++ b/docs/multi_task_phm_foundation_model.md
@@ -1,391 +1,58 @@
-# Multi-Task PHM Foundation Model Documentation
+# Multi-Task PHM Model — Experimental Status Note
 
-## Overview
+This path is retained because it previously described a proposed multi-task
+Prognostics and Health Management (PHM) model. It is **not** a maintained usage
+guide and is outside the current release-supported surface.
 
-This document provides comprehensive documentation for the multi-task Prognostics and Health Management (PHM) foundation model implementation within the PHM-Vibench framework. The model simultaneously performs three distinct tasks using the ISFM (Intelligent Signal Foundation Model) architecture.
+## Why the former guide was retired
 
-## Table of Contents
+The previous page mixed implemented modules, missing paths, proposed
+configurations, and example metrics without reproducible evidence. In particular,
+it referenced:
 
-1. [Architecture Overview](#architecture-overview)
-2. [Components](#components)
-3. [Configuration](#configuration)
-4. [Usage Guide](#usage-guide)
-5. [Training](#training)
-6. [Evaluation](#evaluation)
-7. [Troubleshooting](#troubleshooting)
-8. [API Reference](#api-reference)
-
-## Architecture Overview
-
-The multi-task PHM foundation model is designed to simultaneously handle three critical PHM tasks:
-
-1. **Fault Classification**: Multi-class classification to identify different types of faults
-2. **Remaining Useful Life (RUL) Prediction**: Regression task to predict remaining operational time before failure
-3. **Anomaly Detection**: Binary classification to detect abnormal operating conditions
-
-### Model Architecture
-
-```
-Input Signal (B, L, C)
-        ↓
-    Embedding Layer
-        ↓
-    Backbone Network (ISFM)
-        ↓
-    Shared Features (B, hidden_dim)
-        ↓
-    ┌─────────────────┬─────────────────┬─────────────────┐
-    │                 │                 │                 │
-    │  Classification │  RUL Prediction │ Anomaly Detection│
-    │     Head        │      Head       │      Head       │
-    │                 │                 │                 │
-    └─────────────────┴─────────────────┴─────────────────┘
+```text
+src/task_factory/multi_task_lightning.py
+configs/multi_task_config.yaml
 ```
 
-## Components
-
-### 1. MultiTaskHead (`src/model_factory/ISFM/task_head/multi_task_head.py`)
-
-The core multi-task head module that takes shared feature representations and outputs predictions for all three tasks.
-
-**Key Features:**
-- Separate output layers for each task with appropriate dimensions
-- Configurable activation functions and hidden dimensions
-- Proper weight initialization using Xavier/Glorot method
-- Support for both 2D and 3D input tensors
-- Comprehensive error handling and input validation
-
-**Parameters:**
-- `output_dim`: Dimension of input features from backbone
-- `hidden_dim`: Dimension of hidden layers (default: 256)
-- `dropout`: Dropout probability (default: 0.1)
-- `num_classes`: Dictionary mapping system IDs to number of classes
-- `rul_max_value`: Maximum RUL value for output scaling (default: 1000.0)
-- `use_batch_norm`: Whether to use batch normalization (default: True)
-- `activation`: Activation function name (default: 'relu')
-
-### 2. MultiTaskLightningModule (`src/task_factory/multi_task_lightning.py`)
-
-PyTorch Lightning module that handles multi-task training with combined loss functions and separate metrics tracking.
-
-**Key Features:**
-- Configurable loss weights for each task
-- Separate metrics tracking (accuracy, F1-score, MSE, MAE, R2, AUROC)
-- Support for different optimizers and learning rate schedulers
-- Regularization support (L1, L2)
-- Comprehensive logging and monitoring
-
-**Supported Loss Functions:**
-- Classification: CrossEntropyLoss
-- RUL Prediction: MSELoss or L1Loss (MAE)
-- Anomaly Detection: BCEWithLogitsLoss
-
-### 3. Configuration File (`configs/multi_task_config.yaml`)
-
-Comprehensive YAML configuration file that defines all model, training, and evaluation parameters.
-
-**Key Sections:**
-- Environment configuration
-- Data preprocessing parameters
-- Model architecture settings
-- Task-specific configurations
-- Training hyperparameters
-- Logging and monitoring settings
-
-## Configuration
-
-### Basic Configuration
-
-```yaml
-# Model Configuration
-model:
-  name: "M_01_ISFM"
-  task_head: MultiTaskHead
-  hidden_dim: 512
-  activation: "gelu"
-  rul_max_value: 2000.0
-
-# Task Configuration
-task:
-  enabled_tasks: ['classification', 'rul_prediction', 'anomaly_detection']
-  task_weights:
-    classification: 1.0
-    rul_prediction: 0.8
-    anomaly_detection: 0.6
-```
-
-### Advanced Configuration
-
-```yaml
-# Multi-task specific settings
-task:
-  # Loss function configuration
-  classification_loss: "CE"
-  rul_loss: "MSE"
-  anomaly_loss: "BCE"
-  
-  # Task-specific parameters
-  rul_prediction:
-    max_rul_value: 2000.0
-    normalize_targets: true
-    loss_weight: 0.8
-  
-  anomaly_detection:
-    threshold: 0.5
-    class_weights: [1.0, 2.0]
-    loss_weight: 0.6
-```
-
-## Usage Guide
-
-### 1. Basic Usage
-
-```python
-from src.model_factory.ISFM.task_head.multi_task_head import MultiTaskHead
-from argparse import Namespace
-
-# Configure model
-args = Namespace(
-    output_dim=512,
-    hidden_dim=256,
-    num_classes={'system1': 5, 'system2': 3},
-    rul_max_value=1000.0
-)
-
-# Create model
-model = MultiTaskHead(args)
-
-# Forward pass for all tasks
-x = torch.randn(16, 128, 512)  # (batch, sequence, features)
-outputs = model(x, system_id='system1', task_id='all')
-
-# Individual task outputs
-classification_output = outputs['classification']  # (16, 5)
-rul_output = outputs['rul_prediction']            # (16, 1)
-anomaly_output = outputs['anomaly_detection']     # (16, 1)
-```
-
-### 2. Training with Lightning
-
-```python
-from src.task_factory.multi_task_lightning import MultiTaskLightningModule
-import pytorch_lightning as pl
-
-# Create Lightning module
-lightning_module = MultiTaskLightningModule(
-    network=model,
-    args_data=data_args,
-    args_model=model_args,
-    args_task=task_args,
-    args_trainer=trainer_args,
-    args_environment=env_args,
-    metadata=metadata
-)
-
-# Create trainer
-trainer = pl.Trainer(
-    max_epochs=100,
-    gpus=1,
-    precision=16
-)
-
-# Train model
-trainer.fit(lightning_module, train_dataloader, val_dataloader)
-```
-
-### 3. Configuration-based Training
-
-```bash
-# Using the provided configuration file
-python main.py --config configs/multi_task_config.yaml
-```
-
-## Training
-
-### Loss Function
-
-The total loss is computed as a weighted combination of individual task losses:
-
-```
-L_total = w_cls * L_classification + w_rul * L_rul + w_anom * L_anomaly + L_reg
-```
-
-Where:
-- `w_cls`, `w_rul`, `w_anom` are configurable task weights
-- `L_reg` is the regularization loss (L1 + L2)
-
-### Metrics Tracking
-
-The model tracks the following metrics for each task:
-
-**Classification:**
-- Accuracy
-- F1-Score
-- Precision
-- Recall
-
-**RUL Prediction:**
-- Mean Squared Error (MSE)
-- Mean Absolute Error (MAE)
-- R² Score
-
-**Anomaly Detection:**
-- Accuracy
-- F1-Score
-- Area Under ROC Curve (AUROC)
-
-### Learning Rate Scheduling
-
-Supported schedulers:
-- ReduceLROnPlateau
-- CosineAnnealingLR
-- StepLR
-
-## Evaluation
-
-### Model Evaluation
-
-```python
-# Evaluate on test set
-trainer.test(lightning_module, test_dataloader)
-
-# Get predictions
-model.eval()
-with torch.no_grad():
-    predictions = model(test_batch, system_id='system1', task_id='all')
-```
-
-### Metrics Computation
-
-```python
-from sklearn.metrics import accuracy_score, f1_score, mean_squared_error
-
-# Classification metrics
-y_pred_cls = torch.argmax(predictions['classification'], dim=1)
-accuracy = accuracy_score(y_true_cls, y_pred_cls)
-f1 = f1_score(y_true_cls, y_pred_cls, average='weighted')
-
-# RUL prediction metrics
-mse = mean_squared_error(y_true_rul, predictions['rul_prediction'])
-
-# Anomaly detection metrics
-y_pred_anom = torch.sigmoid(predictions['anomaly_detection']) > 0.5
-anom_accuracy = accuracy_score(y_true_anom, y_pred_anom)
-```
-
-## Troubleshooting
-
-### Common Issues
-
-1. **CUDA Out of Memory**
-   - Reduce batch size in configuration
-   - Enable gradient accumulation
-   - Use mixed precision training (precision=16)
-
-2. **Convergence Issues**
-   - Adjust learning rate
-   - Modify task weights
-   - Check data normalization
-
-3. **Imbalanced Tasks**
-   - Adjust task weights in configuration
-   - Use class weights for classification
-   - Apply different loss functions
-
-### Debug Mode
-
-Enable debug logging:
-
-```yaml
-logging:
-  level: DEBUG
-  
-trainer:
-  log_every_n_steps: 10
-```
-
-## API Reference
-
-### MultiTaskHead
-
-```python
-class MultiTaskHead(nn.Module):
-    def __init__(self, args_m):
-        """Initialize multi-task head.
-        
-        Args:
-            args_m: Configuration namespace with model parameters
-        """
-    
-    def forward(self, x, system_id=None, task_id=None, return_feature=False):
-        """Forward pass through multi-task head.
-        
-        Args:
-            x: Input tensor (B, L, C) or (B, C)
-            system_id: System identifier for classification
-            task_id: Task to execute ('classification', 'rul_prediction', 
-                    'anomaly_detection', 'all')
-            return_feature: Return intermediate features if True
-            
-        Returns:
-            Task predictions or feature representations
-        """
-```
-
-### MultiTaskLightningModule
-
-```python
-class MultiTaskLightningModule(pl.LightningModule):
-    def __init__(self, network, args_data, args_model, args_task, 
-                 args_trainer, args_environment, metadata):
-        """Initialize Lightning module for multi-task training.
-        
-        Args:
-            network: Backbone network (ISFM model)
-            args_data: Data configuration
-            args_model: Model configuration
-            args_task: Task configuration
-            args_trainer: Trainer configuration
-            args_environment: Environment configuration
-            metadata: Dataset metadata
-        """
-```
-
-## Best Practices
-
-1. **Data Preparation**
-   - Ensure balanced datasets across tasks
-   - Normalize RUL targets appropriately
-   - Handle missing labels gracefully
-
-2. **Training Strategy**
-   - Start with equal task weights, then adjust based on performance
-   - Use learning rate scheduling for better convergence
-   - Monitor individual task losses during training
-
-3. **Model Selection**
-   - Validate on held-out data from each task
-   - Consider task-specific early stopping criteria
-   - Save models based on combined validation performance
-
-4. **Deployment**
-   - Test inference speed for real-time applications
-   - Validate model outputs across different systems
-   - Implement proper error handling for production use
-
-## Future Enhancements
-
-1. **Additional Tasks**
-   - Severity estimation
-   - Failure mode classification
-   - Maintenance scheduling
-
-2. **Architecture Improvements**
-   - Attention mechanisms for task weighting
-   - Dynamic task balancing
-   - Meta-learning for few-shot adaptation
-
-3. **Training Enhancements**
-   - Curriculum learning
-   - Multi-task uncertainty estimation
-   - Domain adaptation techniques
+which are not current maintained entrypoints. It also described classification,
+Remaining Useful Life (RUL), anomaly-detection, optimizer, scheduler, and metric
+behavior as a complete supported system without a maintained config-first smoke
+path.
+
+The repository contains research-oriented multi-task components, including an
+ISFM multi-task head, but component presence does not prove end-to-end task,
+dataset, loss, metric, checkpoint, or benchmark support.
+
+## Current authority
+
+Use these maintained pages instead:
+
+- [Supported components](../SUPPORTED_COMPONENTS.md)
+- [Supported combinations](../SUPPORTED_COMBINATIONS.md)
+- [Known limitations](../KNOWN_LIMITATIONS.md)
+- [Developer guide](developer_guide.md)
+- [Task contribution guide](../src/task_factory/contributing.md)
+- [Model contribution guide](../src/model_factory/contributing.md)
+
+## Promotion requirements
+
+A future multi-task capability should be documented as maintained only after a
+focused PR provides:
+
+- a valid five-block config selected through `main.py --config`;
+- an explicit batch and model-output contract for every task;
+- loss weighting and metric semantics;
+- data split and leakage controls;
+- compatible sampler, model, task, and trainer rules;
+- focused positive and negative tests;
+- checkpoint and artifact behavior;
+- a minimum end-to-end smoke run;
+- reproducible experiment evidence for any numerical claim.
+
+Until those gates exist, treat multi-task files as experimental research code and
+refer to the exact commit when discussing them.
+
+The former detailed page remains recoverable from Git history before this status
+note; it is not copied into the maintained documentation because its commands and
+metrics were not validated.

--- a/docs/multitask_pretrain_finetune_guide.md
+++ b/docs/multitask_pretrain_finetune_guide.md
@@ -1,448 +1,61 @@
-# Two-Stage Multi-Task PHM Foundation Model Training Guide
+# Multi-Task Pretrain/Fine-Tune Pipeline — Historical Status
 
-## Overview
+This path is retained as a compatibility and provenance marker. The former guide
+described an unverified two-stage Pipeline 03 workflow and is **not** current
+PHM-Vibench operating guidance.
 
-This guide provides comprehensive documentation for the two-stage multi-task Prognostics and Health Management (PHM) foundation model training pipeline. The pipeline implements a systematic pretraining-to-fine-tuning approach with backbone architecture comparison.
+## Current status
 
-## Table of Contents
-
-1. [Architecture Overview](#architecture-overview)
-2. [Pipeline Stages](#pipeline-stages)
-3. [Configuration Guide](#configuration-guide)
-4. [Usage Examples](#usage-examples)
-5. [Performance Analysis](#performance-analysis)
-6. [Troubleshooting](#troubleshooting)
-7. [Extending the Pipeline](#extending-the-pipeline)
-
-## Architecture Overview
-
-### Two-Stage Training Approach
-
-```
-STAGE 1: UNSUPERVISED PRETRAINING
-Input: Unlabeled time-series data from systems [1,5,6,13,19]
-Task: Masked signal reconstruction (self-supervised learning)
-Output: Pretrained backbone weights for each architecture
-
-        ↓
-
-STAGE 2: SUPERVISED FINE-TUNING
-Input: Labeled data + pretrained backbone weights
-Tasks: 
-- Single-task: Fault classification, Anomaly detection (systems 1,5,6,13,19)
-- Multi-task: Classification + RUL + Anomaly detection (system 2)
-Output: Task-specific fine-tuned models
-```
-
-### Backbone Architecture Comparison
-
-The pipeline systematically compares four backbone architectures:
-
-1. **B_09_FNO** (Fourier Neural Operator)
-   - Frequency domain processing
-   - Global receptive field
-   - Efficient for periodic signals
-
-2. **B_04_Dlinear** (Direct Linear)
-   - Simple linear transformations
-   - Fast training and inference
-   - Baseline comparison
-
-3. **B_06_TimesNet** (Time Series Network)
-   - Multi-scale temporal modeling
-   - Adaptive period detection
-   - Strong for complex patterns
-
-4. **B_08_PatchTST** (Patch Time Series Transformer)
-   - Patch-based attention
-   - Efficient transformer variant
-   - Good for long sequences
-
-## Pipeline Stages
-
-### Stage 1: Unsupervised Pretraining
-
-**Objective**: Learn robust feature representations through self-supervised reconstruction
-
-**Key Components**:
-- **Masking Strategy**: 15% random masking + 10% forecasting
-- **Loss Function**: MSE reconstruction loss on masked regions
-- **Metrics**: Reconstruction MSE, signal correlation, spectral similarity
-- **Duration**: 100 epochs per backbone
-
-**Implementation Details**:
-```python
-# Masking process
-x_masked, total_mask = add_mask(signal, forecast_part=0.1, mask_ratio=0.15)
-
-# Reconstruction loss
-loss = MSE(model(x_masked)[total_mask], signal[total_mask])
-
-# Metrics
-correlation = corrcoef(predicted_masked, true_masked)
-```
-
-### Stage 2: Supervised Fine-Tuning
-
-**Objective**: Adapt pretrained models to specific PHM tasks
-
-**Single-Task Fine-Tuning** (Systems 1, 5, 6, 13, 19):
-- **Fault Classification**: Multi-class classification using fault labels
-- **Anomaly Detection**: Binary classification (normal=0, fault=1)
-
-**Multi-Task Fine-Tuning** (System 2):
-- **Fault Classification**: Multi-class fault type identification
-- **RUL Prediction**: Regression for remaining useful life
-- **Anomaly Detection**: Binary anomaly detection
-- **Loss Weighting**: Classification (1.0), RUL (0.8), Anomaly (0.6)
-
-## Configuration Guide
-
-### Basic Configuration
-
-```yaml
-# Enable both stages
-training:
-  stage_1_pretraining:
-    enabled: true
-    target_systems: [1, 5, 6, 13, 19]
-    backbones_to_compare: ["B_09_FNO", "B_04_Dlinear", "B_06_TimesNet", "B_08_PatchTST"]
-    epochs: 100
-    masking_ratio: 0.15
-    
-  stage_2_finetuning:
-    enabled: true
-    individual_systems: [1, 5, 6, 13, 19]
-    multitask_system: 2
-    epochs: 50
-    task_weights:
-      classification: 1.0
-      rul_prediction: 0.8
-      anomaly_detection: 0.6
-```
-
-### Advanced Configuration
-
-```yaml
-# Memory optimization
-advanced:
-  memory_efficient: true
-  compile_model: false  # Set true for PyTorch 2.0+
-
-# Progressive unfreezing
-training:
-  stage_2_finetuning:
-    progressive_unfreezing:
-      enabled: true
-      freeze_backbone_epochs: 10
-      freeze_embedding_epochs: 5
-```
-
-## Usage Examples
-
-### 1. Complete Pipeline Execution
+`Pipeline_03_multitask_pretrain_finetune.py` exists as research-oriented code, but
+Pipeline 03 is outside the current release-supported surface. The maintained
+public entrypoint remains:
 
 ```bash
-# Run both pretraining and fine-tuning
-python src/Pipeline_03_multitask_pretrain_finetune.py \
-    --config_path configs/multitask_pretrain_finetune_config.yaml \
-    --stage complete
+python main.py --config <yaml> [--override key=value ...]
 ```
 
-### 2. Stage-Specific Execution
+The previous page used direct script commands, proposed configuration keys, and
+paths such as:
 
-```bash
-# Run only pretraining
-python src/Pipeline_03_multitask_pretrain_finetune.py \
-    --config_path configs/multitask_pretrain_finetune_config.yaml \
-    --stage pretraining
-
-# Run only fine-tuning (requires existing checkpoints)
-python src/Pipeline_03_multitask_pretrain_finetune.py \
-    --config_path configs/multitask_pretrain_finetune_config.yaml \
-    --stage finetuning \
-    --checkpoint_dir results/multitask_pretrain_finetune/checkpoints
+```text
+configs/multitask_pretrain_finetune_config.yaml
 ```
 
-### 3. Programmatic Usage
+without a maintained registry entry and release-gate evidence. It also included
+example accuracy, RUL, anomaly, convergence, statistical-significance, and
+performance-improvement numbers that were not linked to reproducible repository
+artifacts. Those values must not be treated as benchmark results.
 
-```python
-from src.Pipeline_03_multitask_pretrain_finetune import MultiTaskPretrainFinetunePipeline
+## Use maintained documentation
 
-# Initialize pipeline
-pipeline = MultiTaskPretrainFinetunePipeline('configs/multitask_pretrain_finetune_config.yaml')
+- [Quickstart](quickstart.md)
+- [Configuration system](../configs/README.md)
+- [Supported components](../SUPPORTED_COMPONENTS.md)
+- [Supported combinations](../SUPPORTED_COMBINATIONS.md)
+- [Known limitations](../KNOWN_LIMITATIONS.md)
+- [Testing and evidence](testing.md)
 
-# Run complete pipeline
-results = pipeline.run_complete_pipeline()
+The current maintained pretraining surface is limited to the configurations and
+single-stage behavior explicitly listed in the support documents.
 
-# Access results
-pretraining_checkpoints = results['pretraining']['checkpoint_paths']
-finetuning_results = results['finetuning']
-summary = results['summary']
-```
+## Requirements for a future maintained Pipeline 03 workflow
 
-## Performance Analysis
+A promotion PR must provide:
 
-### Expected Performance Improvements
+- a valid config-first `main.py --config` entry;
+- explicit stage configuration and state transitions;
+- checkpoint production, selection, loading, and resume rules;
+- model/task/data compatibility constraints;
+- train-only normalization and split/leakage controls;
+- focused tests for each stage and stage handoff;
+- a minimum pretrain → fine-tune → evaluate closure;
+- artifact provenance and exact reproduction commands;
+- multi-seed evidence before numerical performance claims;
+- updated registry, atlas, support, migration, and limitation documents.
 
-**Pretraining Benefits**:
-- **Convergence Speed**: 2-3x faster convergence during fine-tuning
-- **Performance Gain**: 10-15% improvement over random initialization
-- **Data Efficiency**: Better performance with limited labeled data
+Until then, Pipeline 03 work should remain under an explicitly experimental
+configuration and must not be represented as a released benchmark capability.
 
-**Backbone Comparison Insights**:
-- **FNO**: Best for periodic/frequency-rich signals
-- **PatchTST**: Balanced performance across tasks
-- **TimesNet**: Strong for complex temporal patterns
-- **Dlinear**: Fast baseline with reasonable performance
-
-### Evaluation Metrics
-
-**Pretraining Metrics**:
-```python
-metrics = {
-    'reconstruction_mse': 0.025,      # Lower is better
-    'signal_correlation': 0.85,       # Higher is better (0-1)
-    'spectral_similarity': 0.78,      # Higher is better (0-1)
-    'convergence_rate': 0.92          # Training stability
-}
-```
-
-**Fine-tuning Metrics**:
-```python
-# Classification metrics
-classification_metrics = {
-    'accuracy': 0.94,
-    'f1_weighted': 0.93,
-    'precision': 0.95,
-    'recall': 0.92
-}
-
-# RUL prediction metrics
-rul_metrics = {
-    'mse': 125.3,
-    'mae': 8.7,
-    'r2_score': 0.89,
-    'correlation': 0.94
-}
-
-# Anomaly detection metrics
-anomaly_metrics = {
-    'auroc': 0.96,
-    'auprc': 0.94,
-    'f1_score': 0.91,
-    'optimal_threshold': 0.52
-}
-```
-
-### Statistical Significance Testing
-
-The pipeline automatically performs statistical significance testing:
-
-```python
-# Backbone comparison results
-comparison_results = {
-    'best_backbone': 'B_08_PatchTST',
-    'performance_ranking': ['B_08_PatchTST', 'B_06_TimesNet', 'B_09_FNO', 'B_04_Dlinear'],
-    'statistical_significance': {
-        'p_value': 0.023,  # p < 0.05 indicates significant difference
-        'effect_size': 0.34,  # Cohen's d
-        'confidence_interval': [0.12, 0.18]
-    }
-}
-```
-
-## Troubleshooting
-
-### Common Issues and Solutions
-
-#### 1. CUDA Out of Memory
-
-**Problem**: GPU memory exhaustion during training
-
-**Solutions**:
-```yaml
-# Reduce batch size
-training:
-  stage_1_pretraining:
-    batch_size: 32  # Reduce from 64
-  stage_2_finetuning:
-    batch_size: 16  # Reduce from 32
-
-# Enable gradient accumulation
-trainer:
-  accumulate_grad_batches: 2
-  precision: 16  # Use mixed precision
-```
-
-#### 2. Pretraining Convergence Issues
-
-**Problem**: Reconstruction loss not decreasing
-
-**Solutions**:
-```yaml
-# Adjust masking strategy
-training:
-  stage_1_pretraining:
-    masking_ratio: 0.10  # Reduce masking
-    forecast_part: 0.05  # Reduce forecasting
-
-# Modify learning rate
-training:
-  stage_1_pretraining:
-    learning_rate: 0.0005  # Reduce learning rate
-    weight_decay: 0.005    # Reduce regularization
-```
-
-#### 3. Fine-tuning Performance Degradation
-
-**Problem**: Fine-tuned model performs worse than random initialization
-
-**Solutions**:
-```yaml
-# Enable progressive unfreezing
-training:
-  stage_2_finetuning:
-    progressive_unfreezing:
-      enabled: true
-      freeze_backbone_epochs: 15
-
-# Adjust learning rate
-training:
-  stage_2_finetuning:
-    learning_rate: 0.00005  # Lower learning rate for fine-tuning
-```
-
-#### 4. Multi-Task Imbalance
-
-**Problem**: One task dominates training
-
-**Solutions**:
-```yaml
-# Adjust task weights
-training:
-  stage_2_finetuning:
-    task_weights:
-      classification: 0.8    # Reduce dominant task weight
-      rul_prediction: 1.2    # Increase weak task weight
-      anomaly_detection: 1.0
-```
-
-### Debug Mode
-
-Enable detailed logging for debugging:
-
-```yaml
-logging:
-  level: DEBUG
-  
-trainer:
-  log_every_n_steps: 10
-  
-advanced:
-  profiler: "simple"  # Enable profiling
-```
-
-### Performance Monitoring
-
-Monitor training progress:
-
-```python
-# Check pretraining progress
-def monitor_pretraining(checkpoint_path):
-    checkpoint = torch.load(checkpoint_path)
-    metrics = checkpoint.get('metrics', {})
-    
-    print(f"Reconstruction MSE: {metrics.get('val_reconstruction_loss', 'N/A')}")
-    print(f"Signal Correlation: {metrics.get('val_signal_correlation', 'N/A')}")
-    print(f"Training Epoch: {checkpoint.get('epoch', 'N/A')}")
-
-# Check fine-tuning progress
-def monitor_finetuning(results_file):
-    import pandas as pd
-    df = pd.read_csv(results_file)
-    
-    print("Fine-tuning Results:")
-    for col in df.columns:
-        if 'test_' in col:
-            print(f"{col}: {df[col].iloc[0]:.4f}")
-```
-
-## Extending the Pipeline
-
-### Adding New Backbone Architectures
-
-1. **Implement the backbone** in `src/model_factory/ISFM/backbone/`
-2. **Register in model factory**:
-```python
-# In src/model_factory/ISFM/M_01_ISFM.py
-Backbone_dict = {
-    'B_01_basic_transformer': B_01_basic_transformer,
-    'B_NEW_CustomBackbone': B_NEW_CustomBackbone,  # Add new backbone
-    # ... existing backbones
-}
-```
-
-3. **Update configuration**:
-```yaml
-training:
-  stage_1_pretraining:
-    backbones_to_compare: ["B_08_PatchTST", "B_NEW_CustomBackbone"]
-```
-
-### Adding New Tasks
-
-1. **Extend MultiTaskHead** to support new task outputs
-2. **Update MultiTaskLightningModule** for new loss functions
-3. **Modify configuration**:
-```yaml
-task:
-  finetuning:
-    multitask:
-      enabled_tasks: ['classification', 'rul_prediction', 'anomaly_detection', 'new_task']
-      loss_weights:
-        new_task: 1.0
-```
-
-### Custom Evaluation Metrics
-
-```python
-# Add custom metrics to evaluation
-def custom_metric(y_true, y_pred):
-    # Implement custom evaluation logic
-    return metric_value
-
-# Register in pipeline
-pipeline.register_custom_metric('custom_metric', custom_metric)
-```
-
-## Best Practices
-
-### 1. Data Preparation
-- Ensure balanced datasets across systems
-- Validate data quality before training
-- Use appropriate normalization strategies
-
-### 2. Hyperparameter Tuning
-- Start with provided defaults
-- Adjust learning rates based on convergence
-- Monitor validation metrics closely
-
-### 3. Resource Management
-- Use mixed precision training for memory efficiency
-- Implement gradient accumulation for large effective batch sizes
-- Monitor GPU utilization and memory usage
-
-### 4. Experiment Tracking
-- Use meaningful experiment names
-- Tag experiments with relevant metadata
-- Save intermediate checkpoints for analysis
-
-### 5. Model Validation
-- Always validate on held-out test data
-- Compare against appropriate baselines
-- Perform statistical significance testing
-
-## Conclusion
-
-The two-stage multi-task PHM foundation model training pipeline provides a systematic approach to developing robust PHM models through pretraining and fine-tuning. By following this guide and leveraging the provided configuration options, you can achieve state-of-the-art performance on PHM tasks while gaining insights into backbone architecture effectiveness.
+The former detailed guide remains available in Git history for research
+provenance, but its commands and numerical examples are intentionally removed from
+the maintained documentation surface.

--- a/docs/past/README.md
+++ b/docs/past/README.md
@@ -1,0 +1,19 @@
+# Historical Guides
+
+Documents in this directory are retained for provenance and compatibility with
+older links. They are not current installation, usage, configuration, API, model,
+or benchmark instructions.
+
+Historical pages may contain:
+
+- commands that bypass the current `main.py --config` entrypoint;
+- old file and module names;
+- removed or experimental configuration keys;
+- compatibility assumptions from earlier releases;
+- unverified benchmark or maturity claims.
+
+Use the [maintained documentation index](../index.md) for current guidance.
+
+When a historical document is still valuable, cite the repository commit or tag
+that it describes. Do not silently update historical evidence to look current; add
+a maintained replacement page and link to the old record when necessary.

--- a/docs/past/grace.md
+++ b/docs/past/grace.md
@@ -1,9 +1,14 @@
-data_dir /vast/palmer/scratch/lu_lu/ql334/PHM-Vibench/data
+# Historical Grace Cluster Note
 
-# Load modules and environment
-module reset
-module load miniconda
-conda activate P  # 使用您的环境名称
+The original file contained only a contributor-specific scratch path, Conda
+environment name, and editor launch command. Those private machine details have
+been removed from the tracked documentation surface.
 
-module load VSCode
-vscode
+This page remains only to preserve the historical path. Current guidance is:
+
+- [HPC usage boundary](../HPC.md)
+- [Installation](../installation.md)
+- [Quickstart](../quickstart.md)
+
+Use local configuration or CLI overrides for site-specific paths. The previous
+content remains available in Git history.

--- a/docs/v0.1.0/README.md
+++ b/docs/v0.1.0/README.md
@@ -1,0 +1,22 @@
+# PHM-Vibench v0.1.0 Documentation Archive
+
+This directory preserves v0.1.0 release notes, plans, validation reports, conflict
+records, and implementation decisions. It is historical evidence, not the current
+user or contributor guide.
+
+Use the [maintained documentation index](../index.md) for current installation,
+quickstart, configuration, testing, development, support, and release guidance.
+
+## How to read this archive
+
+- `done/` records completed work as understood during the v0.1.0 cycle.
+- planning and Codex files record proposed or intermediate work and may not match
+  the final implementation.
+- commands, paths, module names, configuration keys, and support claims can be
+  obsolete.
+- a historical validation result applies only to the commit, environment, data,
+  and command recorded by that document.
+
+Do not edit an old report to represent current behavior. Add a new maintained
+page, migration note, or dated audit instead. When citing this archive, include the
+exact repository commit or tag.


### PR DESCRIPTION
## Objective

Remove misleading current-use signals from specialist and historical documentation while preserving paths and Git provenance.

This PR targets current `main` after PRs #65 and #67 established the user and contributor documentation authorities. Its branch was rebuilt as one commit on top of those squash merges before the final inventory addition; specialist file contents are unchanged from the reviewed stacked diff.

## Findings addressed

- `docs/HPC.md` was an unmaintained YCRC-specific manual with changing cluster assertions and non-repository `src/train.py` commands.
- `docs/grace.md` and `docs/past/grace.md` exposed contributor-specific `/gpfs` and `/vast` paths, a local environment name, and editor commands.
- `docs/multi_task_phm_foundation_model.md` mixed an existing component with missing task/config paths and described unverified multi-task support.
- `docs/multitask_pretrain_finetune_guide.md` bypassed the public entrypoint and included unsupported numerical performance and significance examples.
- `docs/custom_dataset.md` used stale reader/registration instructions.
- `docs/README.md` was a second incomplete documentation index.
- `docs/past/` and `docs/v0.1.0/` lacked landing pages that clearly marked their material as historical.
- The audit lacked a machine-readable disposition inventory.

## Changes

- route `docs/README.md` to the canonical `docs/index.md`;
- make `docs/custom_dataset.md` a concise bridge to the authoritative data layout and factory contribution guides;
- replace the YCRC/HPC manual with a site-neutral boundary page using the maintained `main.py --config` contract;
- remove personal cluster paths from both Grace note paths while keeping compatibility pages;
- replace the two multi-task pages with explicit experimental/historical status notes and concrete promotion gates;
- add `docs/past/README.md` and `docs/v0.1.0/README.md`;
- complete the dated documentation audit with the additional specialist findings and dispositions;
- add `docs/archive/audits/documentation-inventory-20260714.csv`, covering maintained entrypoints and governance files individually while marking large historical/research trees as `GROUP_CLASSIFIED` where a line-by-line review was not performed.

## Preservation policy

No architecture decision, release report, paper, experiment record, or historical subtree is deleted or mass-moved. Replaced detailed pages remain recoverable through Git history. Existing paths are retained where external or historical links may exist.

## Scope controls

- documentation only;
- no runtime, config, registry, dependency, workflow, test, or supported-surface changes;
- no claim that Pipeline 03, multi-task PHM, or site-specific HPC deployment is maintained;
- no external cluster policy is copied or invented;
- group-classified inventory rows explicitly disclose that they are not per-page validation results.

## Validation

```bash
python -m scripts.validate_docs
python -m scripts.validate_configs
python -m scripts.gen_config_atlas
git diff --exit-code docs/CONFIG_ATLAS.md
git diff --check
```

Runtime tests are not applicable to the specialist cleanup diff. The replacement pages refer only to existing maintained commands and explicitly avoid claiming new runtime evidence.

## Review focus

- unsupported numerical and maturity claims no longer appear as current guidance;
- personal filesystem paths are removed;
- replacement pages preserve enough context to explain why the old guide was retired;
- historical landing pages warn readers without rewriting historical evidence;
- all current-use links resolve to authoritative maintained pages;
- the inventory distinguishes individual review from group classification.

## Rollback

Revert the eventual squash merge. Prior detailed content also remains available in Git history.