### PR TITLE
docs: define historical and research documentation boundary

### DIFF
--- a/docs/archive/README.md
+++ b/docs/archive/README.md
@@ -1,0 +1,90 @@
+# Historical and Research Documentation
+
+This page defines the boundary between current PHM-Vibench documentation and
+preserved evidence. It is an index, not a new copy of historical content.
+
+For maintained instructions, start at [`docs/index.md`](../index.md).
+
+## Why historical material remains
+
+Older plans, migration notes, failed experiments, paper workflows, and agent
+records may provide:
+
+- release and compatibility evidence;
+- architectural decision context;
+- experiment provenance;
+- references used by papers, issues, or external links;
+- explanations for code or configuration that still exists;
+- recovery information for superseded branches and workflows.
+
+Age, verbosity, or an obsolete command is not enough reason to delete evidence.
+At the same time, preserved material must not be presented as current usage or
+release support.
+
+## Preserved locations
+
+| Location | Classification | Use |
+|---|---|---|
+| `docs/v0.1.0/` | release history | v0.1 planning, migration, validation, and change records |
+| `docs/past/` | historical user/developer docs | prior guides retained for provenance or old links |
+| `src/configs/plan/` | historical design | old configuration-refactor plans |
+| `configs/v0.0.9/` | compatibility/history | prior configuration snapshots, not current demos |
+| `dev/` | research/development evidence | experiments, logs, notebooks, scripts, and prior validation material |
+| `paper/` | paper-specific research | manuscripts, experiment protocols, and publication evidence |
+| `.claude/` and `.codex/` | tooling/research | agent skills, specs, prompts, and workflow records |
+| branch-governance and migration contracts in `docs/` | maintained design evidence | current decisions about future or historical migrations |
+
+These locations are excluded from the beginner navigation and may be excluded
+from current documentation link gates. Exclusion does not validate their
+commands or claims.
+
+## How to read archived material
+
+Before using a historical command or config:
+
+1. identify the commit/release it describes;
+2. compare paths and parameters with current code;
+3. inspect the current config with `scripts.config_inspect`;
+4. check current registries and support documents;
+5. run the narrowest applicable test or smoke path;
+6. label any result as historical, reproduced, modified, or not reproduced.
+
+Do not copy old claims or procedures into current docs without new evidence.
+
+## Promote useful content back to current docs
+
+When a historical page contains still-valid information:
+
+- move only the verified concept or procedure into its current single source of
+  truth;
+- link to the historical record for provenance instead of copying the whole page;
+- update commands, paths, terminology, and support boundaries;
+- add tests or runtime evidence when the content describes behavior;
+- avoid rewriting the historical source unless it contains a serious legal,
+  security, or privacy problem.
+
+## Delete or move historical material only after review
+
+A deletion or move requires:
+
+- exact file inventory;
+- repository reference search;
+- Git history review;
+- external publication/link assessment when known;
+- data/code/license assessment;
+- replacement or reason no replacement is needed;
+- recovery commit, tag, or bundle for significant material;
+- focused PR with no unrelated cleanup.
+
+Do not mass-delete `docs/past/`, `docs/v0.1.0/`, `dev/`, `paper/`, `.claude/`, or
+`.codex/` in the name of repository neatness.
+
+## Current decisions
+
+The active documentation inventory and planned dispositions are recorded in
+[`docs/DOCUMENTATION_AUDIT.md`](../DOCUMENTATION_AUDIT.md). Release-supported
+behavior is defined separately by:
+
+- [`SUPPORTED_COMPONENTS.md`](../../SUPPORTED_COMPONENTS.md)
+- [`SUPPORTED_COMBINATIONS.md`](../../SUPPORTED_COMBINATIONS.md)
+- [`KNOWN_LIMITATIONS.md`](../../KNOWN_LIMITATIONS.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -77,12 +77,15 @@ work. Their presence does not expand the release-supported component matrix.
 
 ## Historical and research material
 
-The following locations are evidence or research records, not current user
-instructions:
+Read the [historical and research documentation policy](archive/README.md) before
+using, moving, or deleting archived material.
 
-- `docs/v0.1.0/`
-- `docs/past/`
+Preserved evidence includes:
+
+- [`docs/v0.1.0/`](v0.1.0/README.md)
+- [`docs/past/`](past/README.md)
 - `src/configs/plan/`
+- `configs/v0.0.9/`
 - `dev/`
 - `paper/`
 - `.claude/` and `.codex/`

--- a/docs/past/README.md
+++ b/docs/past/README.md
@@ -1,0 +1,18 @@
+# Historical Guides
+
+Files in this directory describe earlier PHM-Vibench interfaces, workflows, or
+project states. They are preserved for provenance and old links; they are not
+maintained user instructions.
+
+Use the current documentation instead:
+
+- [Documentation index](../index.md)
+- [Installation](../installation.md)
+- [Quickstart](../quickstart.md)
+- [Configuration system](../../configs/README.md)
+- [Testing and evidence](../testing.md)
+- [Contributor guide](../../CONTRIBUTING.md)
+
+Before reusing a command from this directory, verify it against the current
+commit, public CLI, registries, configs, tests, and support documents. See the
+[archive policy](../archive/README.md).

--- a/docs/v0.1.0/README.md
+++ b/docs/v0.1.0/README.md
@@ -1,0 +1,18 @@
+# PHM-Vibench v0.1 Historical Records
+
+This directory preserves planning, migration, validation, and change records from
+the v0.1 development period. It is release history, not the current documentation
+entrypoint.
+
+For current behavior, use:
+
+- [Documentation index](../index.md)
+- [Migration from v0.1 to v0.2](../../MIGRATION_v0.1_to_v0.2.md)
+- [Changelog](../../CHANGELOG.md)
+- [Supported components](../../SUPPORTED_COMPONENTS.md)
+- [Supported combinations](../../SUPPORTED_COMBINATIONS.md)
+- [Known limitations](../../KNOWN_LIMITATIONS.md)
+
+Commands and status statements in v0.1 records apply only to the commit or phase
+they describe unless they have been revalidated on current `main`. See the
+[archive policy](../archive/README.md).


### PR DESCRIPTION
## Purpose

Complete the documentation information architecture by defining how historical, research, paper, development, and agent-workflow material is preserved without appearing as current user guidance.

## Added

- `docs/archive/README.md` — retention, promotion, deletion/move, and recovery rules for historical/research material;
- `docs/past/README.md` — explicit historical banner and links to current docs;
- `docs/v0.1.0/README.md` — release-history banner and current migration/support links.

## Updated

- `docs/index.md` now links the archive policy and the two historical indexes instead of listing opaque directories only.

## Boundary

This PR does **not** move or delete:

- `docs/v0.1.0/**` records;
- `docs/past/**` guides;
- `src/configs/plan/**`;
- `configs/v0.0.9/**`;
- `dev/**`;
- `paper/**`;
- `.claude/**` or `.codex/**`.

Those paths may contain release evidence, paper references, experiment provenance, failure records, or external links. Future deletion/move work requires a separate inventory, reference/license review, recovery reference, and focused PR.

## Scope

Documentation only. No runtime, config, registry, generated Atlas, dependency, test, CI, data, model, task, trainer, or release-support change.

## Required validation

```bash
python -m scripts.validate_docs
python -m scripts.validate_configs
python -m scripts.gen_config_atlas
git diff --exit-code docs/CONFIG_ATLAS.md
git diff --check
```

The GitHub connector has not executed these commands. CI/local evidence is required before ready-for-review.

## Merge order

1. merge #64;
2. retarget and merge #66;
3. retarget and merge #68;
4. retarget and merge #70;
5. retarget this PR to `main`;
6. verify links and the final archive boundary;
7. review and squash merge.
