### PR TITLE
feat(streamlit): add guided first-run readiness

### DIFF
--- a/.github/workflows/streamlit-quality-gates.yml
+++ b/.github/workflows/streamlit-quality-gates.yml
@@ -49,7 +49,10 @@ jobs:
           python -m pip install -r apps/streamlit/requirements.txt "pytest>=7"
 
       - name: Compile optional UI modules
-        run: python -m py_compile apps/streamlit/*.py streamlit_app.py
+        run: >-
+          python -c "import glob, py_compile;
+          [py_compile.compile(path, doraise=True)
+          for path in glob.glob('apps/streamlit/*.py') + ['streamlit_app.py']]"
 
       - name: Import UI with real Streamlit
         run: python -c "import apps.streamlit.app; import streamlit_app"

--- a/.github/workflows/streamlit-quality-gates.yml
+++ b/.github/workflows/streamlit-quality-gates.yml
@@ -1,0 +1,62 @@
+name: Streamlit quality gates
+
+on:
+  pull_request:
+    paths:
+      - "apps/streamlit/**"
+      - "streamlit_app.py"
+      - "test/test_streamlit_*.py"
+      - ".github/workflows/streamlit-quality-gates.yml"
+  push:
+    branches:
+      - main
+    paths:
+      - "apps/streamlit/**"
+      - "streamlit_app.py"
+      - "test/test_streamlit_*.py"
+      - ".github/workflows/streamlit-quality-gates.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: streamlit-quality-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  focused-tests:
+    name: Streamlit focused tests (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+
+      - name: Install focused dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install "PyYAML>=6.0" "pytest>=7"
+
+      - name: Compile optional UI modules
+        run: python -m py_compile apps/streamlit/*.py streamlit_app.py
+
+      - name: Run focused Streamlit tests
+        run: >-
+          python -m pytest -q
+          test/test_streamlit_config_service.py
+          test/test_streamlit_runtime_policy.py
+          test/test_streamlit_onboarding.py
+          test/test_streamlit_run_service.py
+          test/test_streamlit_result_service.py
+          test/test_streamlit_ui_imports.py

--- a/.github/workflows/streamlit-quality-gates.yml
+++ b/.github/workflows/streamlit-quality-gates.yml
@@ -43,13 +43,16 @@ jobs:
         with:
           python-version: "3.10"
 
-      - name: Install focused dependencies
+      - name: Install optional UI and test dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install "PyYAML>=6.0" "pytest>=7"
+          python -m pip install -r apps/streamlit/requirements.txt "pytest>=7"
 
       - name: Compile optional UI modules
         run: python -m py_compile apps/streamlit/*.py streamlit_app.py
+
+      - name: Import UI with real Streamlit
+        run: python -c "import apps.streamlit.app; import streamlit_app"
 
       - name: Run focused Streamlit tests
         run: >-

--- a/apps/streamlit/README.md
+++ b/apps/streamlit/README.md
@@ -6,6 +6,7 @@ training framework.
 
 ```text
 validated registry template
++ first-run readiness checks
 + portable YAML snapshot
 + typed CLI overrides
 + managed main.py process
@@ -36,10 +37,14 @@ independent live-log refresh through `st.fragment`.
 
 ## First experiment
 
-Keep the onboarding defaults:
+Use the sidebar action **Use safe CPU smoke defaults**. It resets only the
+configuration editor; existing run history is preserved.
+
+The safe defaults are:
 
 ```text
 Template: demo_00_smoke_dummy_dg
+Mode:     Quick Start
 Device:   cpu
 Epochs:   1
 ```
@@ -47,12 +52,39 @@ Epochs:   1
 The template uses repository-shipped dummy data and is the recommended way to
 verify the environment before selecting an external dataset or GPU.
 
+The workspace now checks, before launch:
+
+- repository entrypoint and config directory;
+- Streamlit, PyYAML, PyTorch, and Lightning availability;
+- repository-shipped smoke assets;
+- write access for `outputs/streamlit/`;
+- whether `configs/local/local.yaml` is changing machine-local defaults;
+- whether the selected template's data directory and metadata file exist.
+
+A failed readiness check does not prevent users from inspecting or downloading a
+valid configuration, but the **Run experiment** action stays disabled until the
+environment and selected data are ready.
+
 The workspace guides the user through four steps:
 
 1. select a maintained registry template;
 2. adjust a small catalog-approved parameter surface;
 3. validate and launch the public CLI;
 4. inspect live logs, metrics, images, artifacts, and the immutable command.
+
+## Template guidance
+
+User-facing template guidance is declarative in `template_profiles.yaml`. Each
+maintained demo can describe:
+
+- difficulty;
+- bundled or external data requirements;
+- recommended device;
+- honest runtime guidance;
+- onboarding badges and the next action.
+
+Adding a new template profile must not add model-specific branches to
+`workspace.py`. Unknown registry templates receive a conservative generic profile.
 
 ## Experience modes
 
@@ -131,27 +163,33 @@ still receives the process status, command, manifest, and raw log.
 - `configs/config_registry.csv` remains the source of template identity/status.
 - `field_catalog.yaml` remains the source of editable fields, aliases, widgets,
   and template groups.
+- `template_profiles.yaml` remains the source of user-facing difficulty, data,
+  device, and first-action guidance.
 - Unknown future registry columns are retained as metadata.
 - Key migrations should add an alias in `field_catalog.yaml`, not a model-specific
   conditional in `app.py`.
 - Process lifecycle is isolated in `run_service.py`.
 - Artifact parsing is isolated in `result_service.py`.
 - Runtime/local-config precedence is isolated in `runtime_policy.py`.
-- Visual components and live-run views are isolated in `ui_theme.py` and
-  `ui_runtime.py`.
+- First-run checks and template data resolution are isolated in `onboarding.py`.
+- Visual components and live-run views are isolated in `ui_theme.py`,
+  `ui_onboarding.py`, and `ui_runtime.py`.
 
 New metric formats should be added to `result_service.py`; new safe user-facing
-fields should be added to `field_catalog.yaml`.
+fields should be added to `field_catalog.yaml`; new user guidance should be added
+to `template_profiles.yaml`.
 
 ## Validation
 
 ```bash
-python -m py_compile apps/streamlit/*.py
+python -m py_compile apps/streamlit/*.py streamlit_app.py
 python -m pytest \
   test/test_streamlit_config_service.py \
   test/test_streamlit_runtime_policy.py \
+  test/test_streamlit_onboarding.py \
   test/test_streamlit_run_service.py \
-  test/test_streamlit_result_service.py
+  test/test_streamlit_result_service.py \
+  test/test_streamlit_ui_imports.py
 python -m scripts.validate_configs
 python -m scripts.validate_docs
 python -m scripts.config_inspect \
@@ -159,25 +197,31 @@ python -m scripts.config_inspect \
   --override trainer.num_epochs=1
 python main.py \
   --config configs/demo/00_smoke/dummy_dg.yaml \
-  --override trainer.num_epochs=1
+  --override trainer.num_epochs=1 \
+  --override data.num_workers=0
 ```
+
+The focused Streamlit service tests run on Linux and Windows through
+`.github/workflows/streamlit-quality-gates.yml`.
 
 ## Troubleshooting
 
 ### The inspector reports a missing module
 
 Install the repository's core dependencies. The optional UI requirements do not
-replace the training environment.
+replace the training environment. The readiness panel lists the missing module and
+the relevant installation action.
 
 ### A data path does not exist
 
-Use the CPU smoke template, edit `data.data_dir` in Advanced mode, or put the
+The selected template card displays the resolved data root and metadata path. Use
+the offline CPU smoke template, edit `data.data_dir` in Advanced mode, or put the
 machine-specific path in `configs/local/local.yaml`.
 
 ### A GPU run fails
 
-Return to `trainer.device=cpu`, verify the smoke template, then validate CUDA and
-PyTorch independently.
+Return to **Use safe CPU smoke defaults**, verify the offline run, then validate
+CUDA and PyTorch independently.
 
 ### The worker restarted during a run
 

--- a/apps/streamlit/onboarding.py
+++ b/apps/streamlit/onboarding.py
@@ -1,0 +1,413 @@
+"""First-run readiness and template guidance for the Streamlit workspace.
+
+This module deliberately has no Streamlit dependency. It converts repository,
+Python-environment, and selected-template facts into small immutable reports that
+the UI can render without duplicating runtime logic.
+"""
+
+from __future__ import annotations
+
+import importlib.metadata
+import importlib.util
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable, Dict, Mapping, MutableMapping, Tuple
+
+import yaml
+
+
+class OnboardingError(RuntimeError):
+    """Raised when declarative onboarding metadata is invalid."""
+
+
+@dataclass(frozen=True)
+class TemplateProfile:
+    template_id: str
+    title: str
+    summary: str
+    difficulty: str
+    data_label: str
+    device_label: str
+    estimated_time: str
+    requires_external_data: bool
+    badges: Tuple[str, ...] = ()
+    required_paths: Tuple[str, ...] = ()
+    next_step: str = ""
+
+
+@dataclass(frozen=True)
+class ReadinessCheck:
+    key: str
+    label: str
+    status: str
+    detail: str
+    action: str = ""
+
+    @property
+    def is_blocking(self) -> bool:
+        return self.status == "blocked"
+
+
+@dataclass(frozen=True)
+class ReadinessReport:
+    checks: Tuple[ReadinessCheck, ...]
+
+    @property
+    def blocked(self) -> Tuple[ReadinessCheck, ...]:
+        return tuple(item for item in self.checks if item.status == "blocked")
+
+    @property
+    def warnings(self) -> Tuple[ReadinessCheck, ...]:
+        return tuple(item for item in self.checks if item.status == "warning")
+
+    @property
+    def can_execute(self) -> bool:
+        return not self.blocked
+
+
+@dataclass(frozen=True)
+class TemplateDataStatus:
+    ready: bool
+    detail: str
+    action: str = ""
+    data_root: str = ""
+    metadata_path: str = ""
+
+
+_DEPENDENCIES = (
+    (
+        "streamlit",
+        "streamlit",
+        "Streamlit UI",
+        "Install the optional UI layer: pip install -r apps/streamlit/requirements.txt",
+    ),
+    (
+        "yaml",
+        "PyYAML",
+        "YAML configuration support",
+        "Install the optional UI layer: pip install -r apps/streamlit/requirements.txt",
+    ),
+    (
+        "torch",
+        "torch",
+        "PyTorch runtime",
+        "Install the maintained core environment before launching experiments.",
+    ),
+    (
+        "pytorch_lightning",
+        "pytorch-lightning",
+        "Lightning runtime",
+        "Install the maintained core environment before launching experiments.",
+    ),
+)
+
+
+def _read_yaml_mapping(path: Path) -> Mapping[str, Any]:
+    try:
+        value = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+    except FileNotFoundError as exc:
+        raise OnboardingError(f"Template profile file does not exist: {path}") from exc
+    except (OSError, UnicodeDecodeError) as exc:
+        raise OnboardingError(f"Could not read template profile file: {path}") from exc
+    except yaml.YAMLError as exc:
+        raise OnboardingError(f"Invalid YAML in template profile file: {path}") from exc
+    if not isinstance(value, dict):
+        raise OnboardingError("Template profile YAML root must be a mapping.")
+    return value
+
+
+def _string_list(value: Any, name: str) -> Tuple[str, ...]:
+    if value is None:
+        return ()
+    if not isinstance(value, list) or not all(
+        isinstance(item, str) and item.strip() for item in value
+    ):
+        raise OnboardingError(f"{name} must be a list of non-empty strings.")
+    return tuple(item.strip() for item in value)
+
+
+def _safe_relative_paths(value: Any, name: str) -> Tuple[str, ...]:
+    paths = _string_list(value, name)
+    for item in paths:
+        path = Path(item)
+        if path.is_absolute() or ".." in path.parts:
+            raise OnboardingError(f"{name} must stay repository-relative: {item}")
+    return paths
+
+
+def load_template_profiles(path: Path) -> Mapping[str, TemplateProfile]:
+    """Load declarative user-facing metadata keyed by registry template id."""
+
+    raw = _read_yaml_mapping(path)
+    version = raw.get("version", 1)
+    if not isinstance(version, int) or version < 1:
+        raise OnboardingError("template_profiles.yaml version must be a positive integer.")
+    raw_profiles = raw.get("profiles")
+    if not isinstance(raw_profiles, dict) or not raw_profiles:
+        raise OnboardingError("template_profiles.yaml must define a non-empty profiles mapping.")
+
+    profiles: Dict[str, TemplateProfile] = {}
+    for template_id, item in raw_profiles.items():
+        if not isinstance(template_id, str) or not template_id.strip():
+            raise OnboardingError("Template profile ids must be non-empty strings.")
+        if not isinstance(item, dict):
+            raise OnboardingError(f"Template profile {template_id!r} must be a mapping.")
+        requires_external_data = item.get("requires_external_data", True)
+        if not isinstance(requires_external_data, bool):
+            raise OnboardingError(
+                f"{template_id}.requires_external_data must be true or false."
+            )
+        profiles[template_id] = TemplateProfile(
+            template_id=template_id,
+            title=str(item.get("title") or template_id),
+            summary=str(item.get("summary") or "Registry-backed experiment template."),
+            difficulty=str(item.get("difficulty") or "Advanced"),
+            data_label=str(item.get("data_label") or "Check template"),
+            device_label=str(item.get("device_label") or "Check config"),
+            estimated_time=str(item.get("estimated_time") or "Environment-dependent"),
+            requires_external_data=requires_external_data,
+            badges=_string_list(item.get("badges"), f"{template_id}.badges"),
+            required_paths=_safe_relative_paths(
+                item.get("required_paths"), f"{template_id}.required_paths"
+            ),
+            next_step=str(item.get("next_step") or ""),
+        )
+    return profiles
+
+
+def profile_for(
+    profiles: Mapping[str, TemplateProfile], template_id: str
+) -> TemplateProfile:
+    """Return explicit metadata or a conservative generic profile."""
+
+    profile = profiles.get(template_id)
+    if profile is not None:
+        return profile
+    return TemplateProfile(
+        template_id=template_id,
+        title=template_id,
+        summary="Registry-backed template. Review its contract before running.",
+        difficulty="Advanced",
+        data_label="Check template",
+        device_label="Check config",
+        estimated_time="Environment-dependent",
+        requires_external_data=True,
+        badges=("Registry template",),
+        next_step="Inspect the resolved data and trainer settings before execution.",
+    )
+
+
+def apply_safe_defaults(
+    state: MutableMapping[str, Any], default_template_id: str
+) -> None:
+    """Reset only configuration UI state; never discard run history."""
+
+    for key in tuple(state.keys()):
+        if str(key).startswith("field::"):
+            state.pop(key, None)
+    state.update(
+        {
+            "ui_mode": "Quick Start",
+            "template_group": "quick_start",
+            "selected_template_id": default_template_id,
+            "advanced_yaml_template_id": "",
+            "advanced_yaml_text": "",
+            "advanced_override_text": "",
+            "validation_report": None,
+            "validation_signature": "",
+        }
+    )
+
+
+def _module_available(module_name: str, finder: Callable[[str], Any]) -> bool:
+    try:
+        return finder(module_name) is not None
+    except (ImportError, ModuleNotFoundError, ValueError):
+        return False
+
+
+def _distribution_version(distribution: str, reader: Callable[[str], str]) -> str:
+    try:
+        return reader(distribution)
+    except importlib.metadata.PackageNotFoundError:
+        return ""
+    except Exception:
+        return ""
+
+
+def _nearest_existing_parent(path: Path) -> Path:
+    candidate = path
+    while not candidate.exists() and candidate.parent != candidate:
+        candidate = candidate.parent
+    return candidate
+
+
+def collect_environment_readiness(
+    repo_root: Path,
+    default_profile: TemplateProfile,
+    *,
+    module_finder: Callable[[str], Any] = importlib.util.find_spec,
+    version_reader: Callable[[str], str] = importlib.metadata.version,
+    access_checker: Callable[[os.PathLike[str], int], bool] = os.access,
+) -> ReadinessReport:
+    """Check whether the safest offline CPU path can be executed."""
+
+    root = Path(repo_root).resolve()
+    checks = []
+    repository_ready = (root / "main.py").is_file() and (root / "configs").is_dir()
+    checks.append(
+        ReadinessCheck(
+            "repository",
+            "Repository contract",
+            "ready" if repository_ready else "blocked",
+            "main.py and configs/ are available."
+            if repository_ready
+            else "The app is not running from a PHM-Vibench checkout.",
+            "Start Streamlit from the repository root."
+            if not repository_ready
+            else "",
+        )
+    )
+
+    for module_name, distribution, label, action in _DEPENDENCIES:
+        present = _module_available(module_name, module_finder)
+        version = _distribution_version(distribution, version_reader) if present else ""
+        checks.append(
+            ReadinessCheck(
+                f"dependency:{module_name}",
+                label,
+                "ready" if present else "blocked",
+                f"Installed{f' ({version})' if version else ''}."
+                if present
+                else f"Python module {module_name!r} is unavailable.",
+                "" if present else action,
+            )
+        )
+
+    missing_paths = [
+        path for path in default_profile.required_paths if not (root / path).exists()
+    ]
+    checks.append(
+        ReadinessCheck(
+            "offline-smoke-assets",
+            "Offline smoke assets",
+            "ready" if not missing_paths else "blocked",
+            "Repository-shipped smoke configuration and data are present."
+            if not missing_paths
+            else "Missing: " + ", ".join(missing_paths),
+            "Restore the repository-shipped smoke files before the first run."
+            if missing_paths
+            else "",
+        )
+    )
+
+    output_root = root / "outputs" / "streamlit"
+    writable_parent = _nearest_existing_parent(output_root)
+    writable = writable_parent.is_dir() and access_checker(writable_parent, os.W_OK)
+    checks.append(
+        ReadinessCheck(
+            "output",
+            "Run workspace",
+            "ready" if writable else "blocked",
+            f"Runs can be written below {output_root}."
+            if writable
+            else f"No writable parent is available for {output_root}.",
+            "Grant write access to the checkout or use a writable clone."
+            if not writable
+            else "",
+        )
+    )
+
+    local_config = root / "configs" / "local" / "local.yaml"
+    checks.append(
+        ReadinessCheck(
+            "local-config",
+            "Machine-local override",
+            "warning" if local_config.is_file() else "ready",
+            "configs/local/local.yaml is active and can change smoke defaults."
+            if local_config.is_file()
+            else "No machine-local override is active.",
+            "Review configs/local/local.yaml before the first run."
+            if local_config.is_file()
+            else "",
+        )
+    )
+    return ReadinessReport(tuple(checks))
+
+
+def _expanded_path(repo_root: Path, raw: str) -> Path:
+    expanded = os.path.expandvars(os.path.expanduser(raw))
+    path = Path(expanded)
+    return path if path.is_absolute() else repo_root / path
+
+
+def assess_template_data(
+    repo_root: Path,
+    resolved: Mapping[str, Any],
+    profile: TemplateProfile,
+) -> TemplateDataStatus:
+    """Resolve the selected template's data and return an actionable status."""
+
+    root = Path(repo_root).resolve()
+    missing_required = [
+        path for path in profile.required_paths if not (root / path).exists()
+    ]
+    if missing_required:
+        return TemplateDataStatus(
+            False,
+            "Required repository assets are missing: " + ", ".join(missing_required),
+            "Restore the missing files or switch to another maintained template.",
+        )
+
+    data = resolved.get("data") if isinstance(resolved.get("data"), Mapping) else {}
+    data_dir = data.get("data_dir") if isinstance(data, Mapping) else None
+    metadata_file = data.get("metadata_file") if isinstance(data, Mapping) else None
+
+    if not profile.requires_external_data:
+        return TemplateDataStatus(
+            True,
+            "The selected template uses repository-shipped data and is ready for a first run.",
+            data_root=str(data_dir or "data"),
+            metadata_path=str(metadata_file or ""),
+        )
+
+    if not isinstance(data_dir, str) or not data_dir.strip():
+        return TemplateDataStatus(
+            False,
+            "The selected template does not resolve a data.data_dir value.",
+            "Set data.data_dir in Advanced mode or configs/local/local.yaml.",
+        )
+    if not isinstance(metadata_file, str) or not metadata_file.strip():
+        return TemplateDataStatus(
+            False,
+            "The selected template does not resolve a data.metadata_file value.",
+            "Set data.metadata_file in Advanced mode or the selected experiment YAML.",
+        )
+
+    data_root = _expanded_path(root, data_dir.strip()).resolve()
+    metadata_value = Path(os.path.expandvars(os.path.expanduser(metadata_file.strip())))
+    metadata_path = (
+        metadata_value.resolve()
+        if metadata_value.is_absolute()
+        else (data_root / metadata_value).resolve()
+    )
+    missing = []
+    if not data_root.is_dir():
+        missing.append(str(data_root))
+    if not metadata_path.is_file():
+        missing.append(str(metadata_path))
+    if missing:
+        return TemplateDataStatus(
+            False,
+            "External data is not ready. Missing: " + ", ".join(missing),
+            "Set data.data_dir in Advanced mode or configs/local/local.yaml, then validate again.",
+            data_root=str(data_root),
+            metadata_path=str(metadata_path),
+        )
+    return TemplateDataStatus(
+        True,
+        "External data and metadata were found for the selected template.",
+        data_root=str(data_root),
+        metadata_path=str(metadata_path),
+    )

--- a/apps/streamlit/onboarding.py
+++ b/apps/streamlit/onboarding.py
@@ -1,8 +1,8 @@
 """First-run readiness and template guidance for the Streamlit workspace.
 
 This module deliberately has no Streamlit dependency. It converts repository,
-Python-environment, and selected-template facts into small immutable reports that
-the UI can render without duplicating runtime logic.
+Python-environment, and selected-template facts into immutable reports that the
+UI can render without duplicating runtime logic.
 """
 
 from __future__ import annotations
@@ -145,7 +145,9 @@ def load_template_profiles(path: Path) -> Mapping[str, TemplateProfile]:
         raise OnboardingError("template_profiles.yaml version must be a positive integer.")
     raw_profiles = raw.get("profiles")
     if not isinstance(raw_profiles, dict) or not raw_profiles:
-        raise OnboardingError("template_profiles.yaml must define a non-empty profiles mapping.")
+        raise OnboardingError(
+            "template_profiles.yaml must define a non-empty profiles mapping."
+        )
 
     profiles: Dict[str, TemplateProfile] = {}
     for template_id, item in raw_profiles.items():
@@ -342,12 +344,33 @@ def _expanded_path(repo_root: Path, raw: str) -> Path:
     return path if path.is_absolute() else repo_root / path
 
 
+def _resolved_data_paths(
+    repo_root: Path, resolved: Mapping[str, Any]
+) -> Tuple[Path, Path] | None:
+    data = resolved.get("data") if isinstance(resolved.get("data"), Mapping) else {}
+    data_dir = data.get("data_dir") if isinstance(data, Mapping) else None
+    metadata_file = data.get("metadata_file") if isinstance(data, Mapping) else None
+    if not isinstance(data_dir, str) or not data_dir.strip():
+        return None
+    if not isinstance(metadata_file, str) or not metadata_file.strip():
+        return None
+
+    data_root = _expanded_path(repo_root, data_dir.strip()).resolve()
+    metadata_value = Path(os.path.expandvars(os.path.expanduser(metadata_file.strip())))
+    metadata_path = (
+        metadata_value.resolve()
+        if metadata_value.is_absolute()
+        else (data_root / metadata_value).resolve()
+    )
+    return data_root, metadata_path
+
+
 def assess_template_data(
     repo_root: Path,
     resolved: Mapping[str, Any],
     profile: TemplateProfile,
 ) -> TemplateDataStatus:
-    """Resolve the selected template's data and return an actionable status."""
+    """Resolve the final selected-template data and return an actionable status."""
 
     root = Path(repo_root).resolve()
     missing_required = [
@@ -360,54 +383,38 @@ def assess_template_data(
             "Restore the missing files or switch to another maintained template.",
         )
 
-    data = resolved.get("data") if isinstance(resolved.get("data"), Mapping) else {}
-    data_dir = data.get("data_dir") if isinstance(data, Mapping) else None
-    metadata_file = data.get("metadata_file") if isinstance(data, Mapping) else None
-
-    if not profile.requires_external_data:
-        return TemplateDataStatus(
-            True,
-            "The selected template uses repository-shipped data and is ready for a first run.",
-            data_root=str(data_dir or "data"),
-            metadata_path=str(metadata_file or ""),
-        )
-
-    if not isinstance(data_dir, str) or not data_dir.strip():
+    resolved_paths = _resolved_data_paths(root, resolved)
+    if resolved_paths is None:
         return TemplateDataStatus(
             False,
-            "The selected template does not resolve a data.data_dir value.",
-            "Set data.data_dir in Advanced mode or configs/local/local.yaml.",
+            "The selected configuration needs data.data_dir and data.metadata_file.",
+            "Set the missing data fields in Advanced mode or configs/local/local.yaml.",
         )
-    if not isinstance(metadata_file, str) or not metadata_file.strip():
-        return TemplateDataStatus(
-            False,
-            "The selected template does not resolve a data.metadata_file value.",
-            "Set data.metadata_file in Advanced mode or the selected experiment YAML.",
-        )
+    data_root, metadata_path = resolved_paths
 
-    data_root = _expanded_path(root, data_dir.strip()).resolve()
-    metadata_value = Path(os.path.expandvars(os.path.expanduser(metadata_file.strip())))
-    metadata_path = (
-        metadata_value.resolve()
-        if metadata_value.is_absolute()
-        else (data_root / metadata_value).resolve()
-    )
     missing = []
     if not data_root.is_dir():
         missing.append(str(data_root))
     if not metadata_path.is_file():
         missing.append(str(metadata_path))
     if missing:
+        kind = "External data" if profile.requires_external_data else "Configured smoke data"
         return TemplateDataStatus(
             False,
-            "External data is not ready. Missing: " + ", ".join(missing),
+            f"{kind} is not ready. Missing: " + ", ".join(missing),
             "Set data.data_dir in Advanced mode or configs/local/local.yaml, then validate again.",
             data_root=str(data_root),
             metadata_path=str(metadata_path),
         )
+
+    detail = (
+        "External data and metadata were found for the selected template."
+        if profile.requires_external_data
+        else "Repository-shipped data and metadata are ready for the first run."
+    )
     return TemplateDataStatus(
         True,
-        "External data and metadata were found for the selected template.",
+        detail,
         data_root=str(data_root),
         metadata_path=str(metadata_path),
     )

--- a/apps/streamlit/template_profiles.yaml
+++ b/apps/streamlit/template_profiles.yaml
@@ -12,6 +12,8 @@ profiles:
     required_paths:
       - configs/demo/00_smoke/dummy_dg.yaml
       - data/metadata_dummy.csv
+      - data/raw/Dummy_Data/dummy1.csv
+      - data/raw/Dummy_Data/dummy2.csv
     next_step: "Keep CPU, one epoch, and zero data workers for the broadest compatibility."
 
   demo_01_cross_domain:

--- a/apps/streamlit/template_profiles.yaml
+++ b/apps/streamlit/template_profiles.yaml
@@ -1,0 +1,81 @@
+version: 1
+profiles:
+  demo_00_smoke_dummy_dg:
+    title: "离线 CPU 入门 | Offline CPU starter"
+    summary: "Uses repository-shipped dummy data to verify configuration, training, logging, and result discovery without a download."
+    difficulty: "Beginner"
+    data_label: "Bundled"
+    device_label: "CPU"
+    estimated_time: "Short smoke run"
+    requires_external_data: false
+    badges: ["Offline", "No download", "Recommended first run"]
+    required_paths:
+      - configs/demo/00_smoke/dummy_dg.yaml
+      - data/metadata_dummy.csv
+    next_step: "Keep CPU, one epoch, and zero data workers for the broadest compatibility."
+
+  demo_01_cross_domain:
+    title: "跨域故障诊断 | Cross-domain diagnosis"
+    summary: "A maintained domain-generalization example for users who already have PHM-Vibench data locally."
+    difficulty: "Intermediate"
+    data_label: "External"
+    device_label: "CPU first"
+    estimated_time: "Dataset-dependent"
+    requires_external_data: true
+    badges: ["Domain generalization", "External data"]
+    next_step: "Point data.data_dir at the local dataset root before validation."
+
+  demo_02_cross_system:
+    title: "跨系统泛化 | Cross-system generalization"
+    summary: "A multi-system CDDG example with a larger data and configuration surface."
+    difficulty: "Advanced"
+    data_label: "External"
+    device_label: "CPU/GPU"
+    estimated_time: "Dataset-dependent"
+    requires_external_data: true
+    badges: ["CDDG", "Multi-system", "External data"]
+    next_step: "Confirm metadata system ids and the local data root before running."
+
+  demo_03_fewshot:
+    title: "小样本故障诊断 | Few-shot diagnosis"
+    summary: "A maintained few-shot classification example using the standard factory and registry path."
+    difficulty: "Intermediate"
+    data_label: "External"
+    device_label: "CPU first"
+    estimated_time: "Dataset-dependent"
+    requires_external_data: true
+    badges: ["Few-shot", "External data"]
+    next_step: "Verify the episode and target-system fields after the data path is ready."
+
+  demo_04_cross_system_fewshot:
+    title: "跨系统小样本 | Cross-system few-shot"
+    summary: "A generalized few-shot example spanning systems and requiring careful metadata selection."
+    difficulty: "Advanced"
+    data_label: "External"
+    device_label: "CPU/GPU"
+    estimated_time: "Dataset-dependent"
+    requires_external_data: true
+    badges: ["GFS", "Multi-system", "External data"]
+    next_step: "Inspect target-system and domain settings before increasing epochs."
+
+  demo_05_pretrain_fewshot:
+    title: "HSE 对比预训练 | HSE contrastive pretrain"
+    summary: "The maintained single-stage pretraining view through Pipeline_02; it is not a general multi-stage scheduler."
+    difficulty: "Advanced"
+    data_label: "External"
+    device_label: "GPU recommended"
+    estimated_time: "Dataset-dependent"
+    requires_external_data: true
+    badges: ["Pretrain", "Pipeline 02", "External data"]
+    next_step: "Start with one epoch and confirm memory use before a longer pretraining run."
+
+  demo_06_pretrain_cddg:
+    title: "跨系统预训练 | Cross-system pretrain"
+    summary: "A maintained cross-system HSE pretraining perspective with external data requirements."
+    difficulty: "Advanced"
+    data_label: "External"
+    device_label: "GPU recommended"
+    estimated_time: "Dataset-dependent"
+    requires_external_data: true
+    badges: ["Pretrain", "Cross-system", "External data"]
+    next_step: "Validate the system ids, data root, and accelerator before extending the run."

--- a/apps/streamlit/ui_onboarding.py
+++ b/apps/streamlit/ui_onboarding.py
@@ -1,0 +1,99 @@
+"""Streamlit components for first-run readiness and template guidance."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+import streamlit as st
+
+try:
+    from .onboarding import ReadinessReport, TemplateDataStatus, TemplateProfile
+except ImportError:  # pragma: no cover - Streamlit executes app.py as a script.
+    from onboarding import ReadinessReport, TemplateDataStatus, TemplateProfile  # type: ignore
+
+
+_STATUS_ICON = {"ready": "✓", "warning": "!", "blocked": "×"}
+
+
+def template_option_label(template_id: str, profile: TemplateProfile) -> str:
+    """Keep the select box readable while exposing the experiment intent."""
+
+    return f"{profile.title} — {template_id}"
+
+
+def render_readiness_sidebar(report: ReadinessReport) -> None:
+    st.sidebar.markdown("### First-run readiness")
+    if report.can_execute and not report.warnings:
+        st.sidebar.success("CPU smoke prerequisites look ready.")
+    elif report.can_execute:
+        st.sidebar.warning("Ready with a machine-local configuration warning.")
+    else:
+        st.sidebar.error(f"{len(report.blocked)} prerequisite(s) need attention.")
+
+    with st.sidebar.expander("Environment checks", expanded=not report.can_execute):
+        for item in report.checks:
+            icon = _STATUS_ICON.get(item.status, "•")
+            st.markdown(f"**{icon} {item.label}**")
+            st.caption(item.detail)
+            if item.action:
+                st.code(item.action, language="text")
+
+
+def render_readiness_banner(report: ReadinessReport) -> None:
+    """Show only information that changes the user's next action."""
+
+    if report.blocked:
+        st.error(
+            "The workspace can be explored, but experiment launch is disabled until "
+            "the blocked first-run checks are fixed."
+        )
+    elif report.warnings:
+        st.warning(
+            "The environment is runnable, but configs/local/local.yaml is active. "
+            "Review it before treating the smoke run as a clean baseline."
+        )
+    else:
+        st.success("Environment ready for the repository-shipped CPU smoke experiment.")
+
+
+def render_template_profile(profile: TemplateProfile) -> None:
+    with st.container(border=True):
+        st.markdown(f"#### {profile.title}")
+        st.caption(profile.summary)
+        columns = st.columns(4)
+        columns[0].metric("Difficulty", profile.difficulty)
+        columns[1].metric("Data", profile.data_label)
+        columns[2].metric("Recommended device", profile.device_label)
+        columns[3].metric("Time", profile.estimated_time)
+        if profile.badges:
+            st.caption(" · ".join(profile.badges))
+        if profile.next_step:
+            st.info(profile.next_step)
+
+
+def render_template_data_status(status: TemplateDataStatus) -> None:
+    if status.ready:
+        st.success(status.detail)
+    else:
+        st.error(status.detail)
+        if status.action:
+            st.markdown(f"**Next action:** {status.action}")
+    if status.data_root or status.metadata_path:
+        with st.expander("Resolved data paths"):
+            if status.data_root:
+                st.code(status.data_root, language="text")
+            if status.metadata_path:
+                st.code(status.metadata_path, language="text")
+
+
+def render_launch_blockers(
+    readiness: ReadinessReport,
+    data_status: Optional[TemplateDataStatus],
+) -> None:
+    reasons = [item.label for item in readiness.blocked]
+    if data_status is not None and not data_status.ready:
+        reasons.append("Selected template data")
+    if reasons:
+        st.warning(
+            "Run is disabled until these checks pass: " + ", ".join(reasons) + "."
+        )

--- a/apps/streamlit/workspace.py
+++ b/apps/streamlit/workspace.py
@@ -287,16 +287,6 @@ def main() -> None:
         )
         st.stop()
 
-    data_status = assess_template_data(repo_root, runtime_report.resolved, profile)
-    render_template_data_status(data_status)
-    if not data_status.ready and selected_id != catalog.default_template_id:
-        if st.button(
-            "Switch to the offline CPU smoke template",
-            type="secondary",
-            use_container_width=True,
-        ):
-            _safe_smoke_reset(catalog.default_template_id)
-
     with st.spinner("Preparing a portable standalone YAML before local overrides..."):
         portable_report = _cached_inspection(str(repo_root), str(config_path), (), False)
     if not portable_report.resolved:
@@ -386,6 +376,21 @@ def main() -> None:
             st.error(str(exc))
             preview_config = {}
             configuration_has_error = True
+
+    data_status = assess_template_data(
+        repo_root,
+        preview_config if preview_config else runtime_report.resolved,
+        profile,
+    )
+    render_template_data_status(data_status)
+    if not data_status.ready and selected_id != catalog.default_template_id:
+        if st.button(
+            "Switch to the offline CPU smoke template",
+            type="secondary",
+            use_container_width=True,
+            key="switch-to-offline-smoke",
+        ):
+            _safe_smoke_reset(catalog.default_template_id)
 
     output_dir = get_nested(preview_config, "environment.output_dir", "save")
     device = get_nested(preview_config, "trainer.device", "unspecified")

--- a/apps/streamlit/workspace.py
+++ b/apps/streamlit/workspace.py
@@ -377,11 +377,7 @@ def main() -> None:
             preview_config = {}
             configuration_has_error = True
 
-    data_status = assess_template_data(
-        repo_root,
-        preview_config if preview_config else runtime_report.resolved,
-        profile,
-    )
+    data_status = assess_template_data(repo_root, preview_config, profile)
     render_template_data_status(data_status)
     if not data_status.ready and selected_id != catalog.default_template_id:
         if st.button(

--- a/apps/streamlit/workspace.py
+++ b/apps/streamlit/workspace.py
@@ -30,12 +30,27 @@ try:
         parse_yaml_text,
         resolve_repo_path,
     )
+    from .onboarding import (
+        OnboardingError,
+        apply_safe_defaults,
+        assess_template_data,
+        collect_environment_readiness,
+        load_template_profiles,
+        profile_for,
+    )
     from .run_service import RunConflictError, RunRequest, RunServiceError, start_run
     from .runtime_policy import inspect_execution_yaml, inspect_portable_config
+    from .ui_onboarding import (
+        render_launch_blockers,
+        render_readiness_banner,
+        render_readiness_sidebar,
+        render_template_data_status,
+        render_template_profile,
+        template_option_label,
+    )
     from .ui_runtime import _render_live_run, _render_run_selector
     from .ui_theme import (
         _ensure_advanced_yaml,
-        _entry_label,
         _group_label,
         _inject_style,
         _render_diff,
@@ -67,6 +82,14 @@ except ImportError:  # pragma: no cover
         parse_yaml_text,
         resolve_repo_path,
     )
+    from onboarding import (  # type: ignore
+        OnboardingError,
+        apply_safe_defaults,
+        assess_template_data,
+        collect_environment_readiness,
+        load_template_profiles,
+        profile_for,
+    )
     from run_service import (  # type: ignore
         RunConflictError,
         RunRequest,
@@ -74,10 +97,17 @@ except ImportError:  # pragma: no cover
         start_run,
     )
     from runtime_policy import inspect_execution_yaml, inspect_portable_config  # type: ignore
+    from ui_onboarding import (  # type: ignore
+        render_launch_blockers,
+        render_readiness_banner,
+        render_readiness_sidebar,
+        render_template_data_status,
+        render_template_profile,
+        template_option_label,
+    )
     from ui_runtime import _render_live_run, _render_run_selector  # type: ignore
     from ui_theme import (  # type: ignore
         _ensure_advanced_yaml,
-        _entry_label,
         _group_label,
         _inject_style,
         _render_diff,
@@ -99,6 +129,11 @@ def _cached_registry(repo_root: str) -> Tuple[RegistryEntry, ...]:
 @st.cache_data(show_spinner=False, ttl=5)
 def _cached_catalog(path: str) -> Catalog:
     return load_catalog(Path(path))
+
+
+@st.cache_data(show_spinner=False, ttl=5)
+def _cached_profiles(path: str):
+    return load_template_profiles(Path(path))
 
 
 @st.cache_data(show_spinner=False, ttl=5)
@@ -148,6 +183,11 @@ def _initialize_state() -> None:
             st.session_state[key] = value
 
 
+def _safe_smoke_reset(default_template_id: str) -> None:
+    apply_safe_defaults(st.session_state, default_template_id)
+    st.rerun()
+
+
 def main() -> None:
     st.set_page_config(
         page_title="PHM-Vibench Experiment Workspace",
@@ -162,10 +202,26 @@ def main() -> None:
     try:
         repo_root = find_repo_root(APP_DIR)
         catalog = _cached_catalog(str(APP_DIR / "field_catalog.yaml"))
+        profiles = _cached_profiles(str(APP_DIR / "template_profiles.yaml"))
         registry = _cached_registry(str(repo_root))
-    except ConfigServiceError as exc:
+    except (ConfigServiceError, OnboardingError) as exc:
         _render_error("The application contract could not be loaded.", exc)
         st.stop()
+
+    default_profile = profile_for(profiles, catalog.default_template_id)
+    readiness = collect_environment_readiness(repo_root, default_profile)
+    render_readiness_banner(readiness)
+
+    st.sidebar.markdown("### First run")
+    if st.sidebar.button(
+        "Use safe CPU smoke defaults",
+        type="primary",
+        use_container_width=True,
+        help="Return to Quick Start, the bundled dummy template, CPU, and one epoch.",
+    ):
+        _safe_smoke_reset(catalog.default_template_id)
+    render_readiness_sidebar(readiness)
+    st.sidebar.divider()
 
     st.sidebar.markdown("### Experiment workspace")
     mode = st.sidebar.radio(
@@ -205,11 +261,15 @@ def main() -> None:
         "Experiment template",
         available_ids,
         index=available_ids.index(preferred_id),
-        format_func=lambda value: _entry_label(entry_by_id(available, value)),
+        format_func=lambda value: template_option_label(
+            value, profile_for(profiles, value)
+        ),
     )
     st.session_state.selected_template_id = selected_id
     entry = entry_by_id(available, selected_id)
+    profile = profile_for(profiles, selected_id)
     _render_template_summary(entry)
+    render_template_profile(profile)
 
     try:
         config_path = resolve_repo_path(repo_root, entry.path, yaml_only=True)
@@ -226,6 +286,16 @@ def main() -> None:
             details=runtime_report.stderr,
         )
         st.stop()
+
+    data_status = assess_template_data(repo_root, runtime_report.resolved, profile)
+    render_template_data_status(data_status)
+    if not data_status.ready and selected_id != catalog.default_template_id:
+        if st.button(
+            "Switch to the offline CPU smoke template",
+            type="secondary",
+            use_container_width=True,
+        ):
+            _safe_smoke_reset(catalog.default_template_id)
 
     with st.spinner("Preparing a portable standalone YAML before local overrides..."):
         portable_report = _cached_inspection(str(repo_root), str(config_path), (), False)
@@ -371,8 +441,13 @@ def main() -> None:
             "The configuration changed after validation. Validate it again before running."
         )
 
-    can_run = bool(report_is_current and report.ok and not configuration_has_error)
-    if can_run:
+    can_download = bool(
+        report_is_current and report.ok and not configuration_has_error
+    )
+    can_run = bool(can_download and readiness.can_execute and data_status.ready)
+    render_launch_blockers(readiness, data_status)
+
+    if can_download:
         download_col.download_button(
             "Download execution YAML",
             data=execution_yaml_text,
@@ -392,7 +467,10 @@ def main() -> None:
         type="primary",
         disabled=not can_run,
         use_container_width=True,
-        help="Runs the public main.py --config contract in a managed process group.",
+        help=(
+            "Runs the public main.py --config contract after environment, data, "
+            "and configuration checks pass."
+        ),
     ):
         assert isinstance(report, ValidationReport)
         resolved_output = get_nested(report.resolved, "environment.output_dir", output_dir)
@@ -410,6 +488,9 @@ def main() -> None:
                         "registry_path": entry.path,
                         "pipeline": entry.pipeline or "Pipeline_01_default",
                         "description": entry.description,
+                        "difficulty": profile.difficulty,
+                        "data_requirement": profile.data_label,
+                        "recommended_device": profile.device_label,
                     },
                 )
             )

--- a/configs/base/trainer/default_multi_gpu.yaml**
+++ b/configs/base/trainer/default_multi_gpu.yaml**
@@ -1,8 +1,0 @@
-trainer:
-  name: "Default_trainer"
-  num_epochs: 10
-  gpus: 2
-  device: "cuda"
-  early_stopping: true
-  patience: 5
-

--- a/configs/base/trainer/fast_debug.yaml**
+++ b/configs/base/trainer/fast_debug.yaml**
@@ -1,8 +1,0 @@
-trainer:
-  name: "Default_trainer"
-  num_epochs: 1
-  gpus: 1
-  device: "cuda"
-  early_stopping: false
-  patience: 1
-

--- a/test/test_streamlit_onboarding.py
+++ b/test/test_streamlit_onboarding.py
@@ -1,0 +1,189 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from apps.streamlit import onboarding as ob
+
+
+def _profile(**changes):
+    values = {
+        "template_id": "smoke",
+        "title": "Smoke",
+        "summary": "Offline smoke",
+        "difficulty": "Beginner",
+        "data_label": "Bundled",
+        "device_label": "CPU",
+        "estimated_time": "Short",
+        "requires_external_data": False,
+        "required_paths": ("configs/demo/smoke.yaml", "data/meta.csv"),
+    }
+    values.update(changes)
+    return ob.TemplateProfile(**values)
+
+
+def _repo(tmp_path: Path) -> Path:
+    (tmp_path / "main.py").write_text("# test\n", encoding="utf-8")
+    (tmp_path / "configs" / "demo").mkdir(parents=True)
+    (tmp_path / "configs" / "demo" / "smoke.yaml").write_text(
+        "x: 1\n", encoding="utf-8"
+    )
+    (tmp_path / "data").mkdir()
+    (tmp_path / "data" / "meta.csv").write_text("id\n1\n", encoding="utf-8")
+    return tmp_path
+
+
+def test_load_template_profiles_preserves_user_guidance(tmp_path: Path) -> None:
+    path = tmp_path / "profiles.yaml"
+    path.write_text(
+        "version: 1\n"
+        "profiles:\n"
+        "  smoke:\n"
+        "    title: Offline starter\n"
+        "    summary: First run\n"
+        "    difficulty: Beginner\n"
+        "    data_label: Bundled\n"
+        "    device_label: CPU\n"
+        "    estimated_time: Short\n"
+        "    requires_external_data: false\n"
+        "    badges: [Offline, CPU]\n"
+        "    required_paths: [configs/demo/smoke.yaml]\n",
+        encoding="utf-8",
+    )
+
+    profile = ob.load_template_profiles(path)["smoke"]
+
+    assert profile.badges == ("Offline", "CPU")
+    assert profile.required_paths == ("configs/demo/smoke.yaml",)
+    assert profile.requires_external_data is False
+
+
+def test_profile_paths_reject_repository_escape(tmp_path: Path) -> None:
+    path = tmp_path / "profiles.yaml"
+    path.write_text(
+        "profiles:\n"
+        "  smoke:\n"
+        "    requires_external_data: false\n"
+        "    required_paths: [../secret]\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ob.OnboardingError, match="repository-relative"):
+        ob.load_template_profiles(path)
+
+
+def test_apply_safe_defaults_keeps_run_history() -> None:
+    state = {
+        "ui_mode": "Advanced",
+        "selected_template_id": "other",
+        "validation_report": object(),
+        "field::other::device": "cuda",
+        "active_run_id": "run-1",
+        "selected_run_id": "run-1",
+    }
+
+    ob.apply_safe_defaults(state, "smoke")
+
+    assert state["ui_mode"] == "Quick Start"
+    assert state["selected_template_id"] == "smoke"
+    assert state["validation_report"] is None
+    assert "field::other::device" not in state
+    assert state["active_run_id"] == "run-1"
+    assert state["selected_run_id"] == "run-1"
+
+
+def test_readiness_is_ready_for_complete_offline_environment(tmp_path: Path) -> None:
+    root = _repo(tmp_path)
+    modules = {"streamlit", "yaml", "torch", "pytorch_lightning"}
+
+    report = ob.collect_environment_readiness(
+        root,
+        _profile(),
+        module_finder=lambda name: object() if name in modules else None,
+        version_reader=lambda name: "1.0",
+        access_checker=lambda path, mode: True,
+    )
+
+    assert report.can_execute is True
+    assert report.blocked == ()
+
+
+def test_readiness_blocks_missing_training_dependency(tmp_path: Path) -> None:
+    root = _repo(tmp_path)
+    modules = {"streamlit", "yaml", "torch"}
+
+    report = ob.collect_environment_readiness(
+        root,
+        _profile(),
+        module_finder=lambda name: object() if name in modules else None,
+        version_reader=lambda name: "1.0",
+        access_checker=lambda path, mode: True,
+    )
+
+    assert report.can_execute is False
+    assert [item.key for item in report.blocked] == ["dependency:pytorch_lightning"]
+
+
+def test_local_config_is_visible_warning_not_blocker(tmp_path: Path) -> None:
+    root = _repo(tmp_path)
+    local = root / "configs" / "local"
+    local.mkdir()
+    (local / "local.yaml").write_text("trainer: {}\n", encoding="utf-8")
+
+    report = ob.collect_environment_readiness(
+        root,
+        _profile(),
+        module_finder=lambda name: object(),
+        version_reader=lambda name: "1.0",
+        access_checker=lambda path, mode: True,
+    )
+
+    assert report.can_execute is True
+    assert [item.key for item in report.warnings] == ["local-config"]
+
+
+def test_bundled_template_requires_declared_assets(tmp_path: Path) -> None:
+    root = _repo(tmp_path)
+    (root / "data" / "meta.csv").unlink()
+
+    status = ob.assess_template_data(root, {"data": {}}, _profile())
+
+    assert status.ready is False
+    assert "data/meta.csv" in status.detail
+
+
+def test_external_template_resolves_data_root_and_metadata(tmp_path: Path) -> None:
+    root = _repo(tmp_path)
+    external = tmp_path / "external"
+    external.mkdir()
+    (external / "metadata.xlsx").write_bytes(b"test")
+    profile = _profile(
+        requires_external_data=True,
+        required_paths=(),
+        data_label="External",
+    )
+
+    status = ob.assess_template_data(
+        root,
+        {"data": {"data_dir": str(external), "metadata_file": "metadata.xlsx"}},
+        profile,
+    )
+
+    assert status.ready is True
+    assert status.data_root == str(external.resolve())
+    assert status.metadata_path == str((external / "metadata.xlsx").resolve())
+
+
+def test_external_template_returns_actionable_missing_path(tmp_path: Path) -> None:
+    root = _repo(tmp_path)
+    profile = _profile(requires_external_data=True, required_paths=())
+
+    status = ob.assess_template_data(
+        root,
+        {"data": {"data_dir": "missing", "metadata_file": "meta.xlsx"}},
+        profile,
+    )
+
+    assert status.ready is False
+    assert "configs/local/local.yaml" in status.action

--- a/test/test_streamlit_onboarding.py
+++ b/test/test_streamlit_onboarding.py
@@ -154,6 +154,19 @@ def test_bundled_template_requires_declared_assets(tmp_path: Path) -> None:
     assert "data/meta.csv" in status.detail
 
 
+def test_bundled_template_validates_final_overridden_data_path(tmp_path: Path) -> None:
+    root = _repo(tmp_path)
+
+    status = ob.assess_template_data(
+        root,
+        {"data": {"data_dir": "missing", "metadata_file": "meta.csv"}},
+        _profile(),
+    )
+
+    assert status.ready is False
+    assert "Configured smoke data" in status.detail
+
+
 def test_external_template_resolves_data_root_and_metadata(tmp_path: Path) -> None:
     root = _repo(tmp_path)
     external = tmp_path / "external"
@@ -203,3 +216,15 @@ def test_every_maintained_demo_has_explicit_user_profile() -> None:
 
     assert maintained
     assert maintained.issubset(profiles.keys())
+
+
+def test_default_smoke_profile_assets_exist() -> None:
+    root = Path(__file__).parents[1]
+    profiles = ob.load_template_profiles(
+        root / "apps" / "streamlit" / "template_profiles.yaml"
+    )
+    smoke = profiles["demo_00_smoke_dummy_dg"]
+
+    assert smoke.requires_external_data is False
+    assert smoke.required_paths
+    assert all((root / path).exists() for path in smoke.required_paths)

--- a/test/test_streamlit_onboarding.py
+++ b/test/test_streamlit_onboarding.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 import pytest
 
+from apps.streamlit import config_service as cs
 from apps.streamlit import onboarding as ob
 
 
@@ -187,3 +188,18 @@ def test_external_template_returns_actionable_missing_path(tmp_path: Path) -> No
 
     assert status.ready is False
     assert "configs/local/local.yaml" in status.action
+
+
+def test_every_maintained_demo_has_explicit_user_profile() -> None:
+    root = Path(__file__).parents[1]
+    profiles = ob.load_template_profiles(
+        root / "apps" / "streamlit" / "template_profiles.yaml"
+    )
+    maintained = {
+        entry.id
+        for entry in cs.load_registry(root)
+        if entry.category == "demo" and entry.status == "sanity_ok"
+    }
+
+    assert maintained
+    assert maintained.issubset(profiles.keys())

--- a/test/test_streamlit_ui_imports.py
+++ b/test/test_streamlit_ui_imports.py
@@ -25,6 +25,8 @@ def test_ui_modules_import_with_optional_streamlit_stub(monkeypatch):
 
     _install_streamlit_stub(monkeypatch)
     modules = (
+        "apps.streamlit.onboarding",
+        "apps.streamlit.ui_onboarding",
         "apps.streamlit.ui_theme",
         "apps.streamlit.ui_runtime",
         "apps.streamlit.workspace",


### PR DESCRIPTION
## Purpose

Make the optional Streamlit workspace easier for a new user to understand and run safely on the first attempt, without turning the UI into a second training framework.

## User experience

- Adds a prominent **Use safe CPU smoke defaults** action that resets only configuration-editor state and preserves run history.
- Adds first-run readiness checks for:
  - repository entrypoint/config layout;
  - Streamlit, PyYAML, PyTorch, and Lightning availability;
  - the complete repository-shipped smoke asset set;
  - write access for the managed run workspace;
  - active `configs/local/local.yaml` overrides.
- Adds declarative template cards with honest difficulty, data, device, runtime, badges, and next-action guidance.
- Shows the selected template's resolved data root and metadata file before launch.
- Disables **Run experiment** until environment, selected-data, and configuration validation all pass.
- Keeps validated YAML downloadable even when local execution is blocked, so configuration work is not lost.
- Provides a direct fallback from an unavailable external-data template to the offline CPU smoke template.

## Architecture

- `onboarding.py` is a pure, Streamlit-free readiness/data service.
- `template_profiles.yaml` is the declarative user-guidance source; no model-specific UI conditionals were added.
- `ui_onboarding.py` contains only presentation components.
- The core execution contract remains `python main.py --config <yaml> [--override key=value ...]`.
- No changes to `main.py`, pipelines, factories, config schema, or `configs/config_registry.csv`.

## Reviewer-driven fixes applied

1. Data readiness is recomputed from the final preview configuration after safe fields, full YAML, and raw overrides. Correcting `data.data_dir` can therefore unblock the run immediately.
2. Bundled templates also validate their final resolved data path, so an Advanced override cannot silently point the smoke demo at a missing directory.
3. Invalid Advanced YAML no longer falls back to the original template and incorrectly displays a green data-ready message.
4. The smoke readiness check covers the config, metadata, and both repository-shipped dummy signal files.
5. Every maintained `category=demo,status=sanity_ok` registry entry must have an explicit user profile.
6. The new workflow installs the real optional Streamlit requirements and imports the actual UI modules on both Linux and Windows.
7. Python, rather than the shell, expands the compile file list so the Windows PowerShell job does not fail on an unexpanded wildcard.
8. Windows CI exposed two historical duplicate filenames ending in `**`. They were unreferenced duplicates of valid trainer configs and were removed so Windows can check out the repository at all:
   - `configs/base/trainer/default_multi_gpu.yaml**`
   - `configs/base/trainer/fast_debug.yaml**`

## Validation evidence

Locally executed in an isolated implementation workspace during the first implementation pass:

```bash
python -m py_compile \
  apps/streamlit/onboarding.py \
  apps/streamlit/ui_onboarding.py \
  apps/streamlit/workspace.py
PYTHONPATH=. python -m pytest -q test/test_streamlit_onboarding.py
```

Initial service slice result: `9 passed`. Additional readiness, profile-coverage, bundled-asset, final-data-path, and UI import cases were then added and exercised by GitHub Actions.

Current head `51a38c805ad0032ccf5af847060e17ae2e3ff45d`:

- **Core quality gates**: success;
- **Streamlit focused tests (ubuntu-latest)**: success;
- **Streamlit focused tests (windows-latest)**: success;
- both Streamlit jobs passed checkout, Python setup, optional dependency installation, cross-platform compilation, real Streamlit imports, and the focused test suite;
- no unresolved inline review threads.

The initial Windows workflow attempts failed before tests because the base tree contained Windows-invalid filenames. Removing both unreferenced duplicates allowed Windows checkout and the complete job to pass.

Repository-wide manual commands remain available for release validation:

```bash
python -m scripts.validate_docs
python -m scripts.validate_configs
python -m scripts.gen_config_atlas && git diff --exit-code docs/CONFIG_ATLAS.md
python -m pytest test/ -q
python main.py \
  --config configs/demo/00_smoke/dummy_dg.yaml \
  --override trainer.num_epochs=1 \
  --override data.num_workers=0
```

## Review and merge policy

Compatibility and first-run UX review is complete with no remaining blocking finding. The PR is Ready for maintainer review. Recommended merge method: **squash**.