### PR TITLE
feat(pipeline06): add guarded generative runtime shell

### DIFF
--- a/.github/workflows/core-quality-gates.yml
+++ b/.github/workflows/core-quality-gates.yml
@@ -48,6 +48,57 @@ jobs:
       - name: Check whitespace errors
         run: git diff --check
 
+  pipeline06-shell:
+    name: Pipeline 06 shell contract
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+
+      - name: Install focused test dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install "pytest>=7"
+
+      - name: Compile Pipeline 06 shell and tests
+        run: |
+          python -m py_compile \
+            src/Pipeline_06_generative.py \
+            test/generative/test_pipeline06_import.py \
+            test/generative/test_pipeline06_preflight.py \
+            test/generative/test_pipeline06_dispatch.py
+
+      - name: Record focused environment
+        run: python -m pip freeze > pipeline06-shell-environment.txt
+
+      - name: Run Pipeline 06 shell tests
+        shell: bash
+        run: |
+          set -o pipefail
+          python -m pytest -vv --tb=long \
+            test/generative/test_pipeline06_import.py \
+            test/generative/test_pipeline06_preflight.py \
+            test/generative/test_pipeline06_dispatch.py \
+            2>&1 | tee pipeline06-shell-pytest.log
+
+      - name: Upload focused diagnostics
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: pipeline06-shell-diagnostics
+          path: |
+            pipeline06-shell-pytest.log
+            pipeline06-shell-environment.txt
+          if-no-files-found: warn
+          retention-days: 7
+
   uxfd-focused:
     name: UXFD focused contract
     runs-on: ubuntu-latest

--- a/src/Pipeline_06_generative.py
+++ b/src/Pipeline_06_generative.py
@@ -1,0 +1,176 @@
+"""Guarded runtime shell for PHM generative pipelines.
+
+The public entrypoint remains::
+
+    python main.py --config <yaml> [--override key=value ...]
+
+This first migration slice deliberately implements configuration loading,
+preflight validation, stage selection, and iteration dispatch only. Concrete
+train/sample/eval implementations are added by later focused PRs so the
+unrelated-history source snapshot is never merged wholesale.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+STAGE_NAMES = frozenset({"train", "sample", "eval"})
+REQUIRED_CONFIG_SECTIONS = ("environment", "data", "model", "task", "trainer")
+
+
+def _get_attr(value: Any, key: str, default: Any = None) -> Any:
+    """Read one config field from mapping- or namespace-style objects."""
+
+    if isinstance(value, Mapping):
+        return value.get(key, default)
+    return getattr(value, key, default)
+
+
+def _validate_required_sections(configs: Any) -> None:
+    """Reject incomplete five-block configurations before factory dispatch."""
+
+    missing = [
+        section
+        for section in REQUIRED_CONFIG_SECTIONS
+        if _get_attr(configs, section, None) is None
+    ]
+    if missing:
+        raise ValueError(
+            "generative config is missing required section(s): "
+            + ", ".join(missing)
+        )
+
+
+def _load_configs(args: Any) -> Any:
+    """Load the public config path and apply normal local/CLI overrides."""
+
+    from src.configs.config_utils import merge_with_local_override
+    from src.utils.config_utils import apply_overrides_to_config, parse_overrides
+
+    config_path = getattr(args, "config_path", None)
+    if not isinstance(config_path, str) or not config_path.strip():
+        raise ValueError("Pipeline_06_generative requires args.config_path")
+
+    configs = merge_with_local_override(
+        config_path,
+        getattr(args, "local_config", None),
+    )
+    overrides = getattr(args, "override", None)
+    if overrides:
+        configs = apply_overrides_to_config(configs, parse_overrides(overrides))
+
+    _validate_required_sections(configs)
+    return configs
+
+
+def _generative_cfg(configs: Any) -> Any:
+    """Return ``task.generative`` and reject non-generative task configs."""
+
+    task_cfg = _get_attr(configs, "task", None)
+    generative_cfg = _get_attr(task_cfg, "generative", None)
+    if generative_cfg is None:
+        raise ValueError(
+            "Pipeline_06_generative requires task.generative configuration"
+        )
+    return generative_cfg
+
+
+def _resolve_mode(configs: Any) -> str:
+    """Resolve and validate the explicit Pipeline 06 stage."""
+
+    mode = str(_get_attr(_generative_cfg(configs), "mode", "train")).strip().lower()
+    if mode not in STAGE_NAMES:
+        supported = ", ".join(sorted(STAGE_NAMES))
+        raise ValueError(
+            f"unsupported generative mode {mode!r}; expected one of: {supported}"
+        )
+    return mode
+
+
+def _resolve_iterations(configs: Any) -> int:
+    """Return the positive number of independently recorded iterations."""
+
+    environment_cfg = _get_attr(configs, "environment", None)
+    iterations = int(_get_attr(environment_cfg, "iterations", 1))
+    if iterations <= 0:
+        raise ValueError(
+            f"environment.iterations must be positive, got {iterations}"
+        )
+    return iterations
+
+
+def _validate_stage_inputs(mode: str, generative_cfg: Any) -> None:
+    """Fail before deep runtime code when required stage artifacts are absent."""
+
+    if mode == "sample":
+        checkpoint_path = _get_attr(generative_cfg, "checkpoint_path", None)
+        allow_untrained_smoke = bool(
+            _get_attr(generative_cfg, "allow_untrained_smoke", False)
+        )
+        if not checkpoint_path and not allow_untrained_smoke:
+            raise ValueError(
+                "generative sample mode requires "
+                "task.generative.checkpoint_path; set "
+                "allow_untrained_smoke=true only for an explicitly untrained smoke"
+            )
+
+    if mode == "eval" and not _get_attr(
+        generative_cfg,
+        "generated_path",
+        None,
+    ):
+        raise ValueError(
+            "generative eval mode requires task.generative.generated_path"
+        )
+
+
+def _stage_not_integrated(mode: str) -> RuntimeError:
+    return RuntimeError(
+        f"Pipeline 06 {mode} runtime is not integrated in the G1 shell; "
+        "use a later reviewed migration slice that provides the concrete stage"
+    )
+
+
+def _run_train_stage(args: Any, configs: Any, iteration: int) -> Any:
+    """G1 placeholder replaced by the reviewed CFM/runtime implementation."""
+
+    raise _stage_not_integrated("train")
+
+
+def _run_sample_stage(args: Any, configs: Any, iteration: int) -> Any:
+    """G1 placeholder replaced by the reviewed sampler/artifact implementation."""
+
+    raise _stage_not_integrated("sample")
+
+
+def _run_eval_stage(args: Any, configs: Any, iteration: int) -> Any:
+    """G1 placeholder replaced by the reviewed evaluation implementation."""
+
+    raise _stage_not_integrated("eval")
+
+
+def pipeline(args: Any) -> list[Any]:
+    """Load, preflight, and dispatch one explicit generative stage.
+
+    Train, sample, and eval remain separate invocations. A future optional
+    orchestrator may invoke ``main.py`` three times, but it must not bypass this
+    public entrypoint or hide intermediate checkpoint/sample paths.
+    """
+
+    configs = _load_configs(args)
+    mode = _resolve_mode(configs)
+    generative_cfg = _generative_cfg(configs)
+    _validate_stage_inputs(mode, generative_cfg)
+
+    handlers = {
+        "train": _run_train_stage,
+        "sample": _run_sample_stage,
+        "eval": _run_eval_stage,
+    }
+    handler = handlers[mode]
+
+    results: list[Any] = []
+    for iteration in range(_resolve_iterations(configs)):
+        results.append(handler(args, configs, iteration))
+    return results

--- a/test/generative/test_pipeline06_dispatch.py
+++ b/test/generative/test_pipeline06_dispatch.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+import src.Pipeline_06_generative as pipeline06
+
+
+def _configs(mode: str, iterations: int = 2, **generative_values) -> SimpleNamespace:
+    return SimpleNamespace(
+        environment=SimpleNamespace(iterations=iterations),
+        data=SimpleNamespace(),
+        model=SimpleNamespace(),
+        task=SimpleNamespace(
+            generative=SimpleNamespace(mode=mode, **generative_values)
+        ),
+        trainer=SimpleNamespace(),
+    )
+
+
+@pytest.mark.parametrize(
+    ("mode", "handler_name", "stage_values"),
+    [
+        ("train", "_run_train_stage", {}),
+        (
+            "sample",
+            "_run_sample_stage",
+            {"checkpoint_path": "checkpoint.ckpt"},
+        ),
+        (
+            "eval",
+            "_run_eval_stage",
+            {"generated_path": "samples.pt"},
+        ),
+    ],
+)
+def test_pipeline_dispatches_only_the_selected_stage(
+    monkeypatch,
+    mode: str,
+    handler_name: str,
+    stage_values: dict[str, str],
+) -> None:
+    configs = _configs(mode, iterations=2, **stage_values)
+    calls: list[tuple[str, int]] = []
+
+    monkeypatch.setattr(pipeline06, "_load_configs", lambda args: configs)
+
+    for candidate in ["_run_train_stage", "_run_sample_stage", "_run_eval_stage"]:
+        if candidate == handler_name:
+            monkeypatch.setattr(
+                pipeline06,
+                candidate,
+                lambda args, current_configs, iteration, selected=mode: (
+                    calls.append((selected, iteration))
+                    or {"mode": selected, "iteration": iteration}
+                ),
+            )
+        else:
+            monkeypatch.setattr(
+                pipeline06,
+                candidate,
+                lambda *args, unexpected=candidate, **kwargs: pytest.fail(
+                    f"unexpected handler called: {unexpected}"
+                ),
+            )
+
+    results = pipeline06.pipeline(SimpleNamespace(config_path="unused.yaml"))
+
+    assert calls == [(mode, 0), (mode, 1)]
+    assert results == [
+        {"mode": mode, "iteration": 0},
+        {"mode": mode, "iteration": 1},
+    ]
+
+
+def test_g1_placeholder_fails_explicitly() -> None:
+    with pytest.raises(RuntimeError, match="not integrated in the G1 shell"):
+        pipeline06._run_train_stage(None, None, 0)

--- a/test/generative/test_pipeline06_import.py
+++ b/test/generative/test_pipeline06_import.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+import importlib
+import inspect
+
+
+def test_pipeline06_imports_without_optional_generative_dependencies() -> None:
+    module = importlib.import_module("src.Pipeline_06_generative")
+
+    assert callable(module.pipeline)
+    assert module.STAGE_NAMES == frozenset({"train", "sample", "eval"})
+
+
+def test_pipeline06_has_no_independent_cli_entrypoint() -> None:
+    module = importlib.import_module("src.Pipeline_06_generative")
+    source = inspect.getsource(module)
+
+    assert "argparse" not in source
+    assert "if __name__ ==" not in source
+    assert "--config_path" not in source

--- a/test/generative/test_pipeline06_preflight.py
+++ b/test/generative/test_pipeline06_preflight.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+import src.Pipeline_06_generative as pipeline06
+
+
+def _configs(
+    *,
+    mode: str = "train",
+    iterations: int = 1,
+    **generative_values,
+) -> SimpleNamespace:
+    generative = SimpleNamespace(mode=mode, **generative_values)
+    return SimpleNamespace(
+        environment=SimpleNamespace(iterations=iterations),
+        data=SimpleNamespace(),
+        model=SimpleNamespace(),
+        task=SimpleNamespace(generative=generative),
+        trainer=SimpleNamespace(),
+    )
+
+
+def test_required_five_block_config_is_enforced() -> None:
+    incomplete = SimpleNamespace(
+        environment=SimpleNamespace(),
+        data=SimpleNamespace(),
+        model=SimpleNamespace(),
+        task=SimpleNamespace(),
+    )
+
+    with pytest.raises(ValueError, match="trainer"):
+        pipeline06._validate_required_sections(incomplete)
+
+
+def test_unknown_mode_is_rejected_before_runtime_dispatch() -> None:
+    with pytest.raises(ValueError, match="unsupported generative mode"):
+        pipeline06._resolve_mode(_configs(mode="paperpack"))
+
+
+def test_sample_requires_checkpoint_by_default() -> None:
+    config = _configs(mode="sample")
+
+    with pytest.raises(ValueError, match="checkpoint_path"):
+        pipeline06._validate_stage_inputs(
+            "sample",
+            pipeline06._generative_cfg(config),
+        )
+
+
+def test_explicit_untrained_sample_smoke_is_allowed() -> None:
+    config = _configs(mode="sample", allow_untrained_smoke=True)
+
+    pipeline06._validate_stage_inputs(
+        "sample",
+        pipeline06._generative_cfg(config),
+    )
+
+
+def test_eval_requires_generated_sample_path() -> None:
+    config = _configs(mode="eval")
+
+    with pytest.raises(ValueError, match="generated_path"):
+        pipeline06._validate_stage_inputs(
+            "eval",
+            pipeline06._generative_cfg(config),
+        )
+
+
+def test_iterations_must_be_positive() -> None:
+    with pytest.raises(ValueError, match="must be positive"):
+        pipeline06._resolve_iterations(_configs(iterations=0))


### PR DESCRIPTION
## Objective

Start the v0.2.1 Pipeline 06 migration from the locked unrelated-history source snapshot without merging its history.

This G1 PR establishes only the public runtime shell and focused CI contract. It does **not** claim that a generative model can train, sample, or evaluate yet.

## Architecture

The only public entrypoint remains:

```bash
python main.py --config <yaml> [--override key=value ...]
```

`Pipeline_06_generative`:

- supports only explicit `train`, `sample`, and `eval` stages;
- has no standalone `argparse` / `--config_path` CLI;
- preserves the five required config blocks;
- applies normal local and CLI overrides;
- rejects unknown modes before deep runtime dispatch;
- rejects sample mode without a checkpoint unless an explicitly untrained smoke is requested;
- rejects eval mode without generated samples;
- rejects non-positive iteration counts;
- keeps concrete stage implementations as explicit G1 placeholders for later reviewed slices.

## Scope

Exactly five files differ from `main`:

```text
.github/workflows/core-quality-gates.yml
src/Pipeline_06_generative.py
test/generative/test_pipeline06_import.py
test/generative/test_pipeline06_preflight.py
test/generative/test_pipeline06_dispatch.py
```

No model, task, sampler, config, registry, generated atlas, support document, or paper configuration is added.

## Validation

The PR adds a focused GitHub Actions job that runs:

```bash
python -m py_compile \
  src/Pipeline_06_generative.py \
  test/generative/test_pipeline06_import.py \
  test/generative/test_pipeline06_preflight.py \
  test/generative/test_pipeline06_dispatch.py

python -m pytest -vv --tb=long \
  test/generative/test_pipeline06_import.py \
  test/generative/test_pipeline06_preflight.py \
  test/generative/test_pipeline06_dispatch.py
```

Existing docs/config, UXFD, and offline config-first smoke jobs remain required.

## Source provenance

Reference-only source snapshot:

```text
cleanup/repo-slim-2026-07-05
7b97deb213c02727e73ba61bc1c508a9e61a5826
```

Recovery refs created before this PR:

```text
archive/pre-pipeline06-v021-908fdb3
archive/pipeline06-source-20260705-7b97deb
```

No unrelated-history merge or cherry-pick was used.

## Follow-up

- G2: CFM model/task/loss/Euler core under `configs/experiments/`;
- G3: normalization/checkpoint/manifest/leakage/metrics evidence contract;
- G4: CPU/GPU full train → sample → eval promotion to `sanity_ok`.

## Merge policy

Keep draft until all four Core quality jobs are green. Then perform maintainer review and squash merge.