### PR TITLE
feat(generative): add Conditional Flow Matching core contracts

### DIFF
--- a/.github/workflows/pipeline06-cfm-quality-gates.yml
+++ b/.github/workflows/pipeline06-cfm-quality-gates.yml
@@ -83,7 +83,8 @@ jobs:
             test/generative/test_pipeline06_preflight.py \
             test/generative/test_pipeline06_dispatch.py \
             test/generative/test_cfm_core_contract.py \
-            test/generative/test_cfm_dtype_contract.py
+            test/generative/test_cfm_dtype_contract.py \
+            test/generative/test_cfm_factory_contract.py
 
       - name: Inspect exploratory CFM configuration
         shell: bash
@@ -108,6 +109,7 @@ jobs:
             test/generative/test_pipeline06_dispatch.py \
             test/generative/test_cfm_core_contract.py \
             test/generative/test_cfm_dtype_contract.py \
+            test/generative/test_cfm_factory_contract.py \
             2>&1 | tee pipeline06-cfm-pytest.log
 
       - name: Upload focused diagnostics

--- a/.github/workflows/pipeline06-cfm-quality-gates.yml
+++ b/.github/workflows/pipeline06-cfm-quality-gates.yml
@@ -1,0 +1,121 @@
+name: Pipeline 06 CFM quality gates
+
+on:
+  pull_request:
+    paths:
+      - "src/Pipeline_06_generative.py"
+      - "src/model_factory/generative_model/**"
+      - "src/task_factory/Components/generative/**"
+      - "src/task_factory/task/generative/**"
+      - "configs/base/model/generative_*.yaml"
+      - "configs/base/task/generative_*.yaml"
+      - "configs/experiments/generative/**"
+      - "test/generative/**"
+      - ".github/workflows/pipeline06-cfm-quality-gates.yml"
+  push:
+    branches:
+      - main
+    paths:
+      - "src/Pipeline_06_generative.py"
+      - "src/model_factory/generative_model/**"
+      - "src/task_factory/Components/generative/**"
+      - "src/task_factory/task/generative/**"
+      - "configs/base/model/generative_*.yaml"
+      - "configs/base/task/generative_*.yaml"
+      - "configs/experiments/generative/**"
+      - "test/generative/**"
+      - ".github/workflows/pipeline06-cfm-quality-gates.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: pipeline06-cfm-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  cfm-core:
+    name: CFM core contract
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    env:
+      MPLBACKEND: Agg
+      WANDB_MODE: disabled
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+
+      - name: Install CPU Torch
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install --index-url https://download.pytorch.org/whl/cpu "torch==2.6.0"
+
+      - name: Install focused dependencies
+        run: |
+          python -m pip install \
+            "numpy>=1.20" \
+            "pandas>=1.3" \
+            "pytorch-lightning>=1.5" \
+            "torchmetrics>=1.0" \
+            "PyYAML>=6.0" \
+            "pydantic>=2.0" \
+            "tensorboard" \
+            "pytest>=7"
+
+      - name: Compile Pipeline 06 and CFM modules
+        run: |
+          python -m py_compile \
+            src/Pipeline_06_generative.py \
+            src/model_factory/generative_model/condition_encoder.py \
+            src/model_factory/generative_model/film.py \
+            src/model_factory/generative_model/phm_cfm_mlp1d.py \
+            src/task_factory/Components/generative/flow_matching.py \
+            src/task_factory/Components/generative/euler_ode.py \
+            src/task_factory/task/generative/conditional_flow_matching.py \
+            test/generative/test_pipeline06_import.py \
+            test/generative/test_pipeline06_preflight.py \
+            test/generative/test_pipeline06_dispatch.py \
+            test/generative/test_cfm_core_contract.py
+
+      - name: Inspect exploratory CFM configuration
+        shell: bash
+        run: |
+          set -o pipefail
+          python -m scripts.config_inspect \
+            --config configs/experiments/generative/dummy_generative_cfm.yaml \
+            --dump targets \
+            --format yaml \
+            2>&1 | tee pipeline06-cfm-config-inspect.log
+
+      - name: Record focused environment
+        run: python -m pip freeze > pipeline06-cfm-environment.txt
+
+      - name: Run G1 and CFM focused tests
+        shell: bash
+        run: |
+          set -o pipefail
+          python -m pytest -vv --tb=long \
+            test/generative/test_pipeline06_import.py \
+            test/generative/test_pipeline06_preflight.py \
+            test/generative/test_pipeline06_dispatch.py \
+            test/generative/test_cfm_core_contract.py \
+            2>&1 | tee pipeline06-cfm-pytest.log
+
+      - name: Upload focused diagnostics
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: pipeline06-cfm-core-diagnostics
+          path: |
+            pipeline06-cfm-config-inspect.log
+            pipeline06-cfm-pytest.log
+            pipeline06-cfm-environment.txt
+          if-no-files-found: warn
+          retention-days: 7

--- a/.github/workflows/pipeline06-cfm-quality-gates.yml
+++ b/.github/workflows/pipeline06-cfm-quality-gates.yml
@@ -82,7 +82,8 @@ jobs:
             test/generative/test_pipeline06_import.py \
             test/generative/test_pipeline06_preflight.py \
             test/generative/test_pipeline06_dispatch.py \
-            test/generative/test_cfm_core_contract.py
+            test/generative/test_cfm_core_contract.py \
+            test/generative/test_cfm_dtype_contract.py
 
       - name: Inspect exploratory CFM configuration
         shell: bash
@@ -106,6 +107,7 @@ jobs:
             test/generative/test_pipeline06_preflight.py \
             test/generative/test_pipeline06_dispatch.py \
             test/generative/test_cfm_core_contract.py \
+            test/generative/test_cfm_dtype_contract.py \
             2>&1 | tee pipeline06-cfm-pytest.log
 
       - name: Upload focused diagnostics

--- a/configs/base/model/generative_cfm.yaml
+++ b/configs/base/model/generative_cfm.yaml
@@ -1,0 +1,8 @@
+model:
+  type: "generative_model"
+  name: "phm_cfm_mlp1d"
+  in_channels: 2
+  hidden_dim: 64
+  condition_dim: 32
+  num_fault_classes: 2
+  num_domains: 2

--- a/configs/base/task/generative_cfm.yaml
+++ b/configs/base/task/generative_cfm.yaml
@@ -1,0 +1,22 @@
+task:
+  type: "generative"
+  name: "conditional_flow_matching"
+  target_system_id: null
+  lr: 0.0001
+  weight_decay: 0.0001
+  optimizer: "adamw"
+  t_eps: 0.001
+
+  generative:
+    mode: "train"
+    source_split: "train"
+    eval_split: "train"
+    run_test_loss_after_train: false
+    checkpoint_path: null
+    generated_path: null
+    allow_untrained_smoke: false
+    num_steps: 8
+    num_samples: 2
+    length: 128
+    condition_sampling_policy: "first_metadata_repeated"
+    validity_status: "exploratory"

--- a/configs/experiments/generative/README.md
+++ b/configs/experiments/generative/README.md
@@ -1,0 +1,26 @@
+# Generative experiments
+
+This directory contains **unpromoted** Pipeline 06 configurations. Files here
+may be useful for config inspection and focused development, but they are not
+part of the maintained demo or release-supported surface.
+
+The public entrypoint remains:
+
+```bash
+python main.py --config <yaml> [--override key=value ...]
+```
+
+A generative configuration may move to `configs/demo/10_generative/` and receive
+`status=sanity_ok` only after the exact method/model/data combination completes:
+
+```text
+CPU seed 0: train -> checkpoint -> sample -> synthetic manifest -> eval -> evidence manifest
+GPU seed 0: train -> checkpoint -> sample -> synthetic manifest -> eval -> evidence manifest
+```
+
+Additional requirements include strict checkpoint loading, finite-value and
+shape/device contracts, provenance hashes, leakage/duplicate checks, focused
+and maintained tests, and green post-merge CI.
+
+`sanity_ok` is functional smoke evidence. It is not benchmark-performance or
+scientific-validity evidence.

--- a/configs/experiments/generative/dummy_generative_cfm.yaml
+++ b/configs/experiments/generative/dummy_generative_cfm.yaml
@@ -1,0 +1,58 @@
+# Exploratory CFM wiring config.
+#
+# This file is intentionally under configs/experiments/. It is not a maintained
+# demo and must not be added to configs/config_registry.csv until the complete
+# train -> checkpoint -> sample -> manifest -> eval chain passes on CPU and GPU.
+
+pipeline: "Pipeline_06_generative"
+
+base_configs:
+  environment: "configs/base/environment/base.yaml"
+  data: "configs/base/data/base_cross_domain.yaml"
+  model: "configs/base/model/generative_cfm.yaml"
+  task: "configs/base/task/generative_cfm.yaml"
+  trainer: "configs/base/trainer/default_single_gpu.yaml"
+
+environment:
+  project: "experiment_dummy_generative_cfm"
+  seed: 0
+  iterations: 1
+  output_dir: "results/experiments/dummy_generative_cfm"
+  notes: "Exploratory CFM wiring on repository-shipped Dummy_Data."
+  wandb: false
+  swanlab: false
+
+data:
+  data_dir: "data"
+  metadata_file: "metadata_dummy.csv"
+  batch_size: 2
+  num_workers: 0
+  train_ratio: 0.8
+  val_ratio: 0.2
+  test_ratio: 0.0
+  normalization: "standardization"
+  window_size: 128
+  stride: 16
+  num_window: 4
+  dtype: "float32"
+  pin_memory: false
+
+model:
+  hidden_dim: 32
+  condition_dim: 16
+
+task:
+  target_system_id: null
+  generative:
+    mode: "train"
+    synthetic_dataset_id: "dummy_generative_cfm"
+    validity_status: "exploratory"
+
+trainer:
+  monitor: "val_loss"
+  num_epochs: 1
+  gpus: 1
+  device: "cpu"
+  early_stopping: false
+  log_every_n_steps: 1
+  save_top_k: 1

--- a/src/model_factory/generative_model/__init__.py
+++ b/src/model_factory/generative_model/__init__.py
@@ -1,0 +1,8 @@
+"""Dependency-bounded generative model namespace.
+
+Models are resolved dynamically by ``model.type`` / ``model.name``. Keep this
+package free of eager model imports so selecting one generative model never
+requires unrelated research backbones or optional dependencies.
+"""
+
+__all__: list[str] = []

--- a/src/model_factory/generative_model/condition_encoder.py
+++ b/src/model_factory/generative_model/condition_encoder.py
@@ -1,0 +1,167 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, Iterable
+
+import torch
+import torch.nn as nn
+
+
+def _metadata_rows(metadata: Any) -> Iterable[Mapping[str, Any]]:
+    """Yield metadata rows without importing pandas at module import time."""
+
+    if metadata is None:
+        return []
+
+    dataframe = getattr(metadata, "df", None)
+    if dataframe is not None and hasattr(dataframe, "iterrows"):
+        return [row.to_dict() for _, row in dataframe.iterrows()]
+
+    if isinstance(metadata, Mapping):
+        values = metadata.values()
+    elif hasattr(metadata, "values") and callable(metadata.values):
+        values = metadata.values()
+    else:
+        return []
+
+    return [row for row in values if isinstance(row, Mapping)]
+
+
+def _infer_cardinality(metadata: Any, key: str, default: int) -> int:
+    values: list[int] = []
+    for row in _metadata_rows(metadata):
+        value = row.get(key)
+        if value is None:
+            continue
+        try:
+            parsed = int(value)
+        except (TypeError, ValueError):
+            continue
+        if parsed >= 0:
+            values.append(parsed)
+    return max(values) + 1 if values else int(default)
+
+
+def _resolve_cardinality(
+    explicit: int | None,
+    metadata: Any,
+    key: str,
+    default: int,
+) -> int:
+    cardinality = int(explicit) if explicit is not None else _infer_cardinality(
+        metadata,
+        key,
+        default,
+    )
+    if cardinality <= 0:
+        raise ValueError(f"{key} cardinality must be positive, got {cardinality}")
+    return cardinality
+
+
+class ConditionEncoder(nn.Module):
+    """Encode the v0.2.1 PHM condition contract.
+
+    The direct model inputs are deliberately limited to ``fault_label`` and
+    ``domain_id``. Operating variables such as RPM/load may be recorded through
+    a domain map but are not direct control inputs in this release slice.
+    """
+
+    def __init__(
+        self,
+        metadata: Any = None,
+        embedding_dim: int = 32,
+        num_fault_classes: int | None = None,
+        num_domains: int | None = None,
+    ) -> None:
+        super().__init__()
+        self.embedding_dim = int(embedding_dim)
+        if self.embedding_dim <= 0:
+            raise ValueError(
+                f"embedding_dim must be positive, got {self.embedding_dim}"
+            )
+
+        self.num_fault_classes = _resolve_cardinality(
+            num_fault_classes,
+            metadata,
+            "Label",
+            2,
+        )
+        self.num_domains = _resolve_cardinality(
+            num_domains,
+            metadata,
+            "Domain_id",
+            2,
+        )
+
+        self.fault_embedding = nn.Embedding(
+            self.num_fault_classes,
+            self.embedding_dim,
+        )
+        self.domain_embedding = nn.Embedding(
+            self.num_domains,
+            self.embedding_dim,
+        )
+        self.projection = nn.Sequential(
+            nn.Linear(self.embedding_dim * 2 + 1, self.embedding_dim),
+            nn.SiLU(),
+            nn.Linear(self.embedding_dim, self.embedding_dim),
+        )
+
+    def forward(
+        self,
+        condition: dict[str, torch.Tensor],
+        t: torch.Tensor,
+    ) -> torch.Tensor:
+        if not isinstance(condition, dict):
+            raise ValueError(
+                "condition must be a dict containing fault_label and domain_id"
+            )
+        for key in ("fault_label", "domain_id"):
+            if key not in condition:
+                raise ValueError(f"condition missing required key: {key}")
+
+        t = torch.as_tensor(t, device=self.fault_embedding.weight.device).float()
+        t = t.reshape(-1)
+        if not torch.isfinite(t).all():
+            raise ValueError("t contains NaN/Inf")
+
+        fault = torch.as_tensor(
+            condition["fault_label"],
+            device=t.device,
+            dtype=torch.long,
+        ).reshape(-1)
+        domain = torch.as_tensor(
+            condition["domain_id"],
+            device=t.device,
+            dtype=torch.long,
+        ).reshape(-1)
+
+        if fault.numel() != t.numel() or domain.numel() != t.numel():
+            raise ValueError(
+                "condition batch mismatch: "
+                f"fault={fault.numel()}, domain={domain.numel()}, t={t.numel()}"
+            )
+        if fault.numel() == 0:
+            raise ValueError("condition batch must not be empty")
+        if torch.any(fault < 0) or torch.any(domain < 0):
+            raise ValueError("fault_label and domain_id must be non-negative")
+        if int(fault.max().item()) >= self.num_fault_classes:
+            raise ValueError(
+                "fault_label exceeds configured embedding size: "
+                f"max={int(fault.max().item())}, size={self.num_fault_classes}"
+            )
+        if int(domain.max().item()) >= self.num_domains:
+            raise ValueError(
+                "domain_id exceeds configured embedding size: "
+                f"max={int(domain.max().item())}, size={self.num_domains}"
+            )
+
+        encoded = torch.cat(
+            (
+                self.fault_embedding(fault),
+                self.domain_embedding(domain),
+                t.unsqueeze(1),
+            ),
+            dim=1,
+        )
+        return self.projection(encoded)

--- a/src/model_factory/generative_model/condition_encoder.py
+++ b/src/model_factory/generative_model/condition_encoder.py
@@ -120,8 +120,8 @@ class ConditionEncoder(nn.Module):
             if key not in condition:
                 raise ValueError(f"condition missing required key: {key}")
 
-        t = torch.as_tensor(t, device=self.fault_embedding.weight.device).float()
-        t = t.reshape(-1)
+        weight = self.fault_embedding.weight
+        t = torch.as_tensor(t, device=weight.device, dtype=weight.dtype).reshape(-1)
         if not torch.isfinite(t).all():
             raise ValueError("t contains NaN/Inf")
 

--- a/src/model_factory/generative_model/film.py
+++ b/src/model_factory/generative_model/film.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import torch
+import torch.nn as nn
+
+
+class FiLM1D(nn.Module):
+    """Apply stateless feature-wise affine conditioning to ``[N,C,L]`` data."""
+
+    def __init__(self, condition_dim: int, channels: int) -> None:
+        super().__init__()
+        self.condition_dim = int(condition_dim)
+        self.channels = int(channels)
+        if self.condition_dim <= 0 or self.channels <= 0:
+            raise ValueError(
+                "condition_dim and channels must both be positive, got "
+                f"{self.condition_dim} and {self.channels}"
+            )
+        self.affine = nn.Linear(self.condition_dim, self.channels * 2)
+
+    def forward(
+        self,
+        features: torch.Tensor,
+        condition_embedding: torch.Tensor,
+    ) -> torch.Tensor:
+        if features.ndim != 3:
+            raise ValueError(
+                f"features must be [N,C,L], got {tuple(features.shape)}"
+            )
+        if condition_embedding.ndim != 2:
+            raise ValueError(
+                "condition_embedding must be [N,D], got "
+                f"{tuple(condition_embedding.shape)}"
+            )
+        if features.shape[0] != condition_embedding.shape[0]:
+            raise ValueError(
+                "FiLM batch mismatch: "
+                f"features={features.shape[0]}, condition={condition_embedding.shape[0]}"
+            )
+        if features.shape[1] != self.channels:
+            raise ValueError(
+                f"FiLM channel mismatch: expected {self.channels}, "
+                f"got {features.shape[1]}"
+            )
+        if condition_embedding.shape[1] != self.condition_dim:
+            raise ValueError(
+                f"FiLM condition width mismatch: expected {self.condition_dim}, "
+                f"got {condition_embedding.shape[1]}"
+            )
+
+        scale, shift = self.affine(condition_embedding).chunk(2, dim=1)
+        return features * (1.0 + scale.unsqueeze(-1)) + shift.unsqueeze(-1)

--- a/src/model_factory/generative_model/phm_cfm_mlp1d.py
+++ b/src/model_factory/generative_model/phm_cfm_mlp1d.py
@@ -58,8 +58,20 @@ class Model(nn.Module):
             raise ValueError(
                 f"x_t channel mismatch: expected {self.channels}, got {x_t.shape[1]}"
             )
+        if not torch.is_floating_point(x_t):
+            raise ValueError(f"x_t must be floating point, got {x_t.dtype}")
         if not torch.isfinite(x_t).all():
             raise ValueError("x_t contains NaN/Inf")
+
+        parameter = self.input_projection.weight
+        if x_t.device != parameter.device:
+            raise ValueError(
+                f"x_t device mismatch: input={x_t.device}, model={parameter.device}"
+            )
+        if x_t.dtype != parameter.dtype:
+            raise ValueError(
+                f"x_t dtype mismatch: input={x_t.dtype}, model={parameter.dtype}"
+            )
 
         t = torch.as_tensor(t, device=x_t.device, dtype=x_t.dtype).reshape(-1)
         if t.numel() != x_t.shape[0]:
@@ -70,13 +82,21 @@ class Model(nn.Module):
             raise ValueError("t contains NaN/Inf")
 
         condition_embedding = self.condition_encoder(condition, t)
-        hidden = self.input_projection(x_t.float())
+        hidden = self.input_projection(x_t)
         hidden = self.conditioning(hidden, condition_embedding)
         velocity = self.velocity_head(hidden)
 
         if velocity.shape != x_t.shape:
             raise ValueError(
                 f"velocity shape mismatch: {tuple(velocity.shape)} vs {tuple(x_t.shape)}"
+            )
+        if velocity.dtype != x_t.dtype:
+            raise ValueError(
+                f"velocity dtype mismatch: {velocity.dtype} vs {x_t.dtype}"
+            )
+        if velocity.device != x_t.device:
+            raise ValueError(
+                f"velocity device mismatch: {velocity.device} vs {x_t.device}"
             )
         if not torch.isfinite(velocity).all():
             raise ValueError("predicted velocity contains NaN/Inf")

--- a/src/model_factory/generative_model/phm_cfm_mlp1d.py
+++ b/src/model_factory/generative_model/phm_cfm_mlp1d.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+from typing import Any
+
+import torch
+import torch.nn as nn
+
+from .condition_encoder import ConditionEncoder
+from .film import FiLM1D
+
+
+class Model(nn.Module):
+    """Minimal stateless 1D velocity model for Conditional Flow Matching."""
+
+    def __init__(self, args_model: Any, metadata: Any = None) -> None:
+        super().__init__()
+        self.channels = int(getattr(args_model, "in_channels", 2))
+        hidden_dim = int(getattr(args_model, "hidden_dim", 64))
+        condition_dim = int(getattr(args_model, "condition_dim", 32))
+
+        if self.channels <= 0 or hidden_dim <= 0 or condition_dim <= 0:
+            raise ValueError(
+                "in_channels, hidden_dim, and condition_dim must be positive"
+            )
+
+        self.condition_encoder = ConditionEncoder(
+            metadata=metadata,
+            embedding_dim=condition_dim,
+            num_fault_classes=getattr(args_model, "num_fault_classes", None),
+            num_domains=getattr(args_model, "num_domains", None),
+        )
+        self.input_projection = nn.Conv1d(
+            self.channels,
+            hidden_dim,
+            kernel_size=3,
+            padding=1,
+        )
+        self.conditioning = FiLM1D(
+            condition_dim=condition_dim,
+            channels=hidden_dim,
+        )
+        self.velocity_head = nn.Sequential(
+            nn.SiLU(),
+            nn.Conv1d(hidden_dim, hidden_dim, kernel_size=3, padding=1),
+            nn.SiLU(),
+            nn.Conv1d(hidden_dim, self.channels, kernel_size=3, padding=1),
+        )
+
+    def forward(
+        self,
+        x_t: torch.Tensor,
+        t: torch.Tensor,
+        condition: dict[str, torch.Tensor],
+    ) -> torch.Tensor:
+        if x_t.ndim != 3:
+            raise ValueError(f"x_t must be [N,C,L], got {tuple(x_t.shape)}")
+        if x_t.shape[1] != self.channels:
+            raise ValueError(
+                f"x_t channel mismatch: expected {self.channels}, got {x_t.shape[1]}"
+            )
+        if not torch.isfinite(x_t).all():
+            raise ValueError("x_t contains NaN/Inf")
+
+        t = torch.as_tensor(t, device=x_t.device, dtype=x_t.dtype).reshape(-1)
+        if t.numel() != x_t.shape[0]:
+            raise ValueError(
+                f"t batch mismatch: expected {x_t.shape[0]}, got {t.numel()}"
+            )
+        if not torch.isfinite(t).all():
+            raise ValueError("t contains NaN/Inf")
+
+        condition_embedding = self.condition_encoder(condition, t)
+        hidden = self.input_projection(x_t.float())
+        hidden = self.conditioning(hidden, condition_embedding)
+        velocity = self.velocity_head(hidden)
+
+        if velocity.shape != x_t.shape:
+            raise ValueError(
+                f"velocity shape mismatch: {tuple(velocity.shape)} vs {tuple(x_t.shape)}"
+            )
+        if not torch.isfinite(velocity).all():
+            raise ValueError("predicted velocity contains NaN/Inf")
+        return velocity

--- a/src/task_factory/Components/generative/__init__.py
+++ b/src/task_factory/Components/generative/__init__.py
@@ -1,0 +1,6 @@
+"""Focused reusable components for PHM generative tasks."""
+
+from .euler_ode import sample_euler_ode
+from .flow_matching import ConditionalFlowMatchingLoss
+
+__all__ = ["ConditionalFlowMatchingLoss", "sample_euler_ode"]

--- a/src/task_factory/Components/generative/euler_ode.py
+++ b/src/task_factory/Components/generative/euler_ode.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+
+import torch
+
+
+def _normalized_condition(
+    condition: dict[str, torch.Tensor],
+    *,
+    batch_size: int,
+    device: torch.device,
+) -> dict[str, torch.Tensor]:
+    if not isinstance(condition, dict):
+        raise ValueError("condition must be a dict")
+    normalized: dict[str, torch.Tensor] = {}
+    for key in ("fault_label", "domain_id"):
+        if key not in condition:
+            raise ValueError(f"condition missing required key: {key}")
+        value = torch.as_tensor(
+            condition[key],
+            device=device,
+            dtype=torch.long,
+        ).reshape(-1)
+        if value.numel() == 1 and batch_size > 1:
+            value = value.repeat(batch_size)
+        if value.numel() != batch_size:
+            raise ValueError(
+                f"condition {key} must contain 1 or {batch_size} values, "
+                f"got {value.numel()}"
+            )
+        normalized[key] = value
+    return normalized
+
+
+@torch.no_grad()
+def sample_euler_ode(
+    model,
+    noise: torch.Tensor,
+    condition: dict[str, torch.Tensor],
+    num_steps: int,
+    t0: float = 0.0,
+    t1: float = 1.0,
+) -> torch.Tensor:
+    """Integrate a stateless velocity field using explicit Euler steps."""
+
+    if noise.ndim != 3:
+        raise ValueError(f"noise must be [N,C,L], got {tuple(noise.shape)}")
+    if not torch.is_floating_point(noise):
+        raise ValueError(f"noise must be floating point, got {noise.dtype}")
+    if not torch.isfinite(noise).all():
+        raise ValueError("noise contains NaN/Inf")
+    if int(num_steps) <= 0:
+        raise ValueError(f"num_steps must be positive, got {num_steps}")
+    if not float(t1) > float(t0):
+        raise ValueError(f"t1 must be greater than t0, got {t0} and {t1}")
+
+    condition = _normalized_condition(
+        condition,
+        batch_size=noise.shape[0],
+        device=noise.device,
+    )
+    state = noise
+    expected_shape = state.shape
+    expected_dtype = state.dtype
+    expected_device = state.device
+    dt = (float(t1) - float(t0)) / float(num_steps)
+
+    training_state = getattr(model, "training", None)
+    if hasattr(model, "eval"):
+        model.eval()
+    try:
+        for step in range(int(num_steps)):
+            t_value = float(t0) + step * dt
+            t = torch.full(
+                (state.shape[0],),
+                t_value,
+                dtype=state.dtype,
+                device=state.device,
+            )
+            velocity = model(state, t, condition)
+            if velocity.shape != expected_shape:
+                raise ValueError(
+                    f"velocity shape mismatch at step={step}: "
+                    f"{tuple(velocity.shape)} vs {tuple(expected_shape)}"
+                )
+            if velocity.dtype != expected_dtype:
+                raise ValueError(
+                    f"velocity dtype changed at step={step}: "
+                    f"{velocity.dtype} vs {expected_dtype}"
+                )
+            if velocity.device != expected_device:
+                raise ValueError(
+                    f"velocity device changed at step={step}: "
+                    f"{velocity.device} vs {expected_device}"
+                )
+            if not torch.isfinite(velocity).all():
+                raise ValueError(
+                    f"velocity contains NaN/Inf at step={step}, t={t_value}"
+                )
+
+            next_state = state + dt * velocity
+            if next_state.shape != expected_shape:
+                raise ValueError(
+                    f"state shape changed at step={step}: "
+                    f"{tuple(next_state.shape)} vs {tuple(expected_shape)}"
+                )
+            if next_state.dtype != expected_dtype:
+                raise ValueError(
+                    f"state dtype changed at step={step}: "
+                    f"{next_state.dtype} vs {expected_dtype}"
+                )
+            if next_state.device != expected_device:
+                raise ValueError(
+                    f"state device changed at step={step}: "
+                    f"{next_state.device} vs {expected_device}"
+                )
+            if not torch.isfinite(next_state).all():
+                raise ValueError(
+                    f"state contains NaN/Inf at step={step}, t={t_value}"
+                )
+            state = next_state
+    finally:
+        if training_state is not None and hasattr(model, "train"):
+            model.train(bool(training_state))
+
+    return state

--- a/src/task_factory/Components/generative/flow_matching.py
+++ b/src/task_factory/Components/generative/flow_matching.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+
+def _check_finite(
+    name: str,
+    tensor: torch.Tensor,
+    t: torch.Tensor | None = None,
+) -> None:
+    if torch.isfinite(tensor).all():
+        return
+    details = [
+        f"{name} contains NaN/Inf",
+        f"shape={tuple(tensor.shape)}",
+        f"dtype={tensor.dtype}",
+        f"device={tensor.device}",
+    ]
+    if t is not None and t.numel():
+        t_float = t.detach().float()
+        details.append(
+            f"t_range=({float(t_float.min()):.6g}, {float(t_float.max()):.6g})"
+        )
+    raise ValueError("; ".join(details))
+
+
+class ConditionalFlowMatchingLoss(nn.Module):
+    """Velocity matching for ``x_t=(1-t)z+t*x_1``."""
+
+    def __init__(self, eps: float = 1e-3) -> None:
+        super().__init__()
+        self.eps = float(eps)
+        if not 0.0 <= self.eps < 0.5:
+            raise ValueError(f"eps must be in [0, 0.5), got {self.eps}")
+
+    def sample_t(
+        self,
+        batch_size: int,
+        device: torch.device | str,
+        dtype: torch.dtype = torch.float32,
+    ) -> torch.Tensor:
+        if int(batch_size) <= 0:
+            raise ValueError(f"batch_size must be positive, got {batch_size}")
+        return (
+            torch.rand(int(batch_size), device=device, dtype=dtype)
+            * (1.0 - 2.0 * self.eps)
+            + self.eps
+        )
+
+    @staticmethod
+    def _view_t(t: torch.Tensor, x: torch.Tensor) -> torch.Tensor:
+        t = torch.as_tensor(t, device=x.device, dtype=x.dtype)
+        if t.ndim == 1:
+            t = t.view(-1, 1, 1)
+        elif t.ndim == 2 and t.shape[1] == 1:
+            t = t.view(-1, 1, 1)
+        elif t.ndim == 3 and tuple(t.shape[1:]) == (1, 1):
+            pass
+        else:
+            raise ValueError(
+                "t must have shape [N], [N,1], or [N,1,1], got "
+                f"{tuple(t.shape)}"
+            )
+        if t.shape[0] != x.shape[0]:
+            raise ValueError(
+                f"t batch mismatch: expected {x.shape[0]}, got {t.shape[0]}"
+            )
+        _check_finite("t", t, t)
+        if torch.any(t < 0.0) or torch.any(t > 1.0):
+            raise ValueError("t values must be in [0, 1]")
+        return t
+
+    def sample_xt(
+        self,
+        x1: torch.Tensor,
+        noise: torch.Tensor,
+        t: torch.Tensor,
+    ) -> torch.Tensor:
+        if x1.shape != noise.shape:
+            raise ValueError(
+                f"x1/noise shape mismatch: {tuple(x1.shape)} vs {tuple(noise.shape)}"
+            )
+        _check_finite("x1", x1, t)
+        _check_finite("noise", noise, t)
+        t_view = self._view_t(t, x1)
+        x_t = (1.0 - t_view) * noise + t_view * x1
+        _check_finite("x_t", x_t, t)
+        return x_t
+
+    @staticmethod
+    def target_velocity(
+        x1: torch.Tensor,
+        noise: torch.Tensor,
+    ) -> torch.Tensor:
+        if x1.shape != noise.shape:
+            raise ValueError(
+                f"x1/noise shape mismatch: {tuple(x1.shape)} vs {tuple(noise.shape)}"
+            )
+        return x1 - noise
+
+    def forward(
+        self,
+        predicted_velocity: torch.Tensor,
+        x1: torch.Tensor,
+        noise: torch.Tensor,
+        t: torch.Tensor,
+    ) -> dict[str, torch.Tensor]:
+        if predicted_velocity.shape != x1.shape:
+            raise ValueError(
+                "predicted_velocity/x1 shape mismatch: "
+                f"{tuple(predicted_velocity.shape)} vs {tuple(x1.shape)}"
+            )
+        self._view_t(t, x1)
+        _check_finite("predicted_velocity", predicted_velocity, t)
+        target = self.target_velocity(x1, noise)
+        _check_finite("target_velocity", target, t)
+        loss = F.mse_loss(predicted_velocity, target)
+        _check_finite("loss", loss, t)
+        return {"loss": loss, "mse_v": loss.detach()}

--- a/src/task_factory/task/generative/__init__.py
+++ b/src/task_factory/task/generative/__init__.py
@@ -1,0 +1,3 @@
+"""Generative task implementations loaded by the task factory."""
+
+__all__: list[str] = []

--- a/src/task_factory/task/generative/conditional_flow_matching.py
+++ b/src/task_factory/task/generative/conditional_flow_matching.py
@@ -1,0 +1,308 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+import pytorch_lightning as pl
+import torch
+import torch.nn as nn
+
+from src.task_factory.Components.generative import (
+    ConditionalFlowMatchingLoss,
+    sample_euler_ode,
+)
+
+
+def _flatten_values(value: Any) -> list[Any]:
+    if torch.is_tensor(value):
+        return value.detach().cpu().reshape(-1).tolist()
+    if isinstance(value, (list, tuple)):
+        flattened: list[Any] = []
+        for item in value:
+            flattened.extend(_flatten_values(item))
+        return flattened
+    return [value]
+
+
+class ConditionalFlowMatchingTask(pl.LightningModule):
+    """Lightning task for the first PHM Conditional Flow Matching slice."""
+
+    def __init__(
+        self,
+        network: nn.Module,
+        args_data: Any,
+        args_model: Any,
+        args_task: Any,
+        args_trainer: Any,
+        args_environment: Any,
+        metadata: Any,
+    ) -> None:
+        super().__init__()
+        self.network = network
+        self.args_data = args_data
+        self.args_model = args_model
+        self.args_task = args_task
+        self.args_trainer = args_trainer
+        self.args_environment = args_environment
+        self.metadata = metadata
+        self.loss_id = "conditional_flow_matching"
+        self.sampler_id = "euler_ode"
+        self.loss_fn = ConditionalFlowMatchingLoss(
+            eps=float(getattr(args_task, "t_eps", 1e-3))
+        )
+        self.save_hyperparameters(
+            {
+                "task_type": getattr(args_task, "type", "generative"),
+                "task_name": getattr(
+                    args_task,
+                    "name",
+                    "conditional_flow_matching",
+                ),
+                "model_type": getattr(
+                    args_model,
+                    "type",
+                    "generative_model",
+                ),
+                "model_name": getattr(
+                    args_model,
+                    "name",
+                    "phm_cfm_mlp1d",
+                ),
+                "lr": float(getattr(args_task, "lr", 1e-4)),
+                "weight_decay": float(
+                    getattr(args_task, "weight_decay", 1e-4)
+                ),
+            }
+        )
+
+    def forward(
+        self,
+        x_t: torch.Tensor,
+        t: torch.Tensor,
+        condition: dict[str, torch.Tensor],
+    ) -> torch.Tensor:
+        return self.network(x_t, t, condition)
+
+    def _to_ncl(self, x: Any) -> torch.Tensor:
+        tensor = torch.as_tensor(x, device=self.device).float()
+        if tensor.ndim != 3:
+            raise ValueError(
+                "expected x as [N,L,C] or [N,C,L], got "
+                f"{tuple(tensor.shape)}"
+            )
+        channels = int(getattr(self.args_model, "in_channels", 2))
+        if tensor.shape[1] == channels:
+            return tensor.contiguous()
+        if tensor.shape[2] == channels:
+            return tensor.transpose(1, 2).contiguous()
+        raise ValueError(
+            f"cannot infer channel axis for shape={tuple(tensor.shape)} "
+            f"and in_channels={channels}"
+        )
+
+    def _metadata_row(self, file_id: Any) -> Mapping[str, Any]:
+        candidates = [file_id]
+        try:
+            candidates.append(int(file_id))
+        except (TypeError, ValueError):
+            pass
+        candidates.append(str(file_id))
+
+        for key in candidates:
+            try:
+                row = self.metadata[key]
+            except (KeyError, TypeError, IndexError):
+                continue
+            if isinstance(row, Mapping):
+                return row
+        raise ValueError(f"file_id={file_id!r} is missing from metadata")
+
+    def _condition_values(
+        self,
+        batch: Mapping[str, Any],
+        *,
+        batch_key: str,
+        metadata_key: str,
+        file_ids: list[Any],
+        fallback_batch_key: str | None = None,
+    ) -> torch.Tensor:
+        if batch_key in batch:
+            values = _flatten_values(batch[batch_key])
+        elif fallback_batch_key and fallback_batch_key in batch:
+            values = _flatten_values(batch[fallback_batch_key])
+        else:
+            values = []
+            for file_id in file_ids:
+                row = self._metadata_row(file_id)
+                if metadata_key not in row:
+                    raise ValueError(
+                        f"metadata for file_id={file_id!r} is missing "
+                        f"required key {metadata_key}"
+                    )
+                values.append(row[metadata_key])
+
+        if len(values) != len(file_ids):
+            raise ValueError(
+                f"{batch_key} length mismatch: expected {len(file_ids)}, "
+                f"got {len(values)}"
+            )
+        return torch.as_tensor(
+            values,
+            device=self.device,
+            dtype=torch.long,
+        ).reshape(-1)
+
+    def _extract_condition(
+        self,
+        batch: Mapping[str, Any],
+        batch_size: int,
+    ) -> dict[str, torch.Tensor]:
+        if "file_id" not in batch:
+            raise ValueError(
+                "generative batches must contain file_id for condition provenance"
+            )
+        file_ids = _flatten_values(batch["file_id"])
+        if len(file_ids) != batch_size:
+            raise ValueError(
+                f"file_id length mismatch: expected {batch_size}, "
+                f"got {len(file_ids)}"
+            )
+        fault_label = self._condition_values(
+            batch,
+            batch_key="fault_label",
+            metadata_key="Label",
+            file_ids=file_ids,
+            fallback_batch_key="y",
+        )
+        domain_id = self._condition_values(
+            batch,
+            batch_key="domain_id",
+            metadata_key="Domain_id",
+            file_ids=file_ids,
+        )
+        return {"fault_label": fault_label, "domain_id": domain_id}
+
+    def _shared_step(
+        self,
+        batch: Mapping[str, Any],
+        stage: str,
+    ) -> torch.Tensor:
+        if "x" not in batch:
+            raise ValueError("generative batch is missing x")
+        x1 = self._to_ncl(batch["x"])
+        condition = self._extract_condition(batch, x1.shape[0])
+        noise = torch.randn_like(x1)
+        t = self.loss_fn.sample_t(
+            x1.shape[0],
+            x1.device,
+            dtype=x1.dtype,
+        )
+        x_t = self.loss_fn.sample_xt(x1, noise, t)
+        predicted_velocity = self.forward(x_t, t, condition)
+        loss_values = self.loss_fn(predicted_velocity, x1, noise, t)
+        loss = loss_values["loss"]
+        self.log(
+            f"{stage}_loss",
+            loss,
+            on_step=(stage == "train"),
+            on_epoch=True,
+            prog_bar=False,
+            logger=True,
+            batch_size=x1.shape[0],
+        )
+        self.log(
+            f"{stage}_mse_v",
+            loss_values["mse_v"],
+            on_step=(stage == "train"),
+            on_epoch=True,
+            prog_bar=False,
+            logger=True,
+            batch_size=x1.shape[0],
+        )
+        return loss
+
+    def training_step(
+        self,
+        batch: Mapping[str, Any],
+        *args: Any,
+        **kwargs: Any,
+    ) -> torch.Tensor:
+        return self._shared_step(batch, "train")
+
+    def validation_step(
+        self,
+        batch: Mapping[str, Any],
+        *args: Any,
+        **kwargs: Any,
+    ) -> torch.Tensor:
+        return self._shared_step(batch, "val")
+
+    def test_step(
+        self,
+        batch: Mapping[str, Any],
+        *args: Any,
+        **kwargs: Any,
+    ) -> torch.Tensor:
+        return self._shared_step(batch, "test")
+
+    def configure_optimizers(self):
+        optimizer_name = str(
+            getattr(self.args_task, "optimizer", "adamw")
+        ).lower()
+        lr = float(getattr(self.args_task, "lr", 1e-4))
+        weight_decay = float(getattr(self.args_task, "weight_decay", 1e-4))
+        if optimizer_name == "adam":
+            return torch.optim.Adam(
+                self.parameters(),
+                lr=lr,
+                weight_decay=weight_decay,
+            )
+        if optimizer_name == "adamw":
+            return torch.optim.AdamW(
+                self.parameters(),
+                lr=lr,
+                weight_decay=weight_decay,
+            )
+        raise ValueError(
+            f"unsupported optimizer for generative task: {optimizer_name}"
+        )
+
+    def sampler_metadata(self) -> dict[str, Any]:
+        return {"sampler_id": self.sampler_id, "integration": "explicit_euler"}
+
+    def sample(
+        self,
+        condition: dict[str, torch.Tensor],
+        *,
+        num_samples: int,
+        length: int,
+        channels: int,
+        num_steps: int,
+        device: torch.device | str | None = None,
+    ) -> torch.Tensor:
+        sample_device = torch.device(device or self.device)
+        if int(num_samples) <= 0 or int(length) <= 0 or int(channels) <= 0:
+            raise ValueError(
+                "num_samples, length, and channels must all be positive"
+            )
+        if int(channels) != int(getattr(self.args_model, "in_channels", 2)):
+            raise ValueError(
+                f"sample channel mismatch: requested {channels}, model expects "
+                f"{getattr(self.args_model, 'in_channels', 2)}"
+            )
+        noise = torch.randn(
+            int(num_samples),
+            int(channels),
+            int(length),
+            device=sample_device,
+        )
+        return sample_euler_ode(
+            self.network.to(sample_device),
+            noise,
+            condition,
+            num_steps=int(num_steps),
+        )
+
+
+# Backward-compatible task-factory discovery alias.
+task = ConditionalFlowMatchingTask

--- a/test/generative/test_cfm_core_contract.py
+++ b/test/generative/test_cfm_core_contract.py
@@ -1,0 +1,229 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+import torch.nn as nn
+
+from src.model_factory.generative_model.condition_encoder import ConditionEncoder
+from src.model_factory.generative_model.phm_cfm_mlp1d import Model
+from src.task_factory.Components.generative import (
+    ConditionalFlowMatchingLoss,
+    sample_euler_ode,
+)
+from src.task_factory.task.generative.conditional_flow_matching import (
+    ConditionalFlowMatchingTask,
+)
+
+
+METADATA = {
+    1: {"Label": 0, "Domain_id": 0},
+    2: {"Label": 1, "Domain_id": 1},
+}
+
+
+def _model_args() -> SimpleNamespace:
+    return SimpleNamespace(
+        type="generative_model",
+        name="phm_cfm_mlp1d",
+        in_channels=2,
+        hidden_dim=16,
+        condition_dim=8,
+        num_fault_classes=2,
+        num_domains=2,
+    )
+
+
+def _task_args() -> SimpleNamespace:
+    return SimpleNamespace(
+        type="generative",
+        name="conditional_flow_matching",
+        lr=1e-4,
+        weight_decay=1e-4,
+        optimizer="adamw",
+        t_eps=1e-3,
+    )
+
+
+def _task() -> ConditionalFlowMatchingTask:
+    model_args = _model_args()
+    task = ConditionalFlowMatchingTask(
+        network=Model(model_args, METADATA),
+        args_data=SimpleNamespace(normalization="standardization"),
+        args_model=model_args,
+        args_task=_task_args(),
+        args_trainer=SimpleNamespace(),
+        args_environment=SimpleNamespace(),
+        metadata=METADATA,
+    )
+    task.log = lambda *args, **kwargs: None
+    return task
+
+
+def test_condition_encoder_infers_metadata_cardinality() -> None:
+    encoder = ConditionEncoder(metadata=METADATA, embedding_dim=4)
+    encoded = encoder(
+        {
+            "fault_label": torch.tensor([0, 1]),
+            "domain_id": torch.tensor([1, 0]),
+        },
+        torch.tensor([0.25, 0.75]),
+    )
+
+    assert encoder.num_fault_classes == 2
+    assert encoder.num_domains == 2
+    assert encoded.shape == (2, 4)
+    assert torch.isfinite(encoded).all()
+
+
+def test_condition_encoder_rejects_invalid_contracts() -> None:
+    encoder = ConditionEncoder(
+        metadata=METADATA,
+        embedding_dim=4,
+        num_fault_classes=2,
+        num_domains=2,
+    )
+
+    with pytest.raises(ValueError, match="missing required key"):
+        encoder(
+            {"fault_label": torch.tensor([0])},
+            torch.tensor([0.5]),
+        )
+
+    with pytest.raises(ValueError, match="exceeds configured embedding"):
+        encoder(
+            {
+                "fault_label": torch.tensor([2]),
+                "domain_id": torch.tensor([0]),
+            },
+            torch.tensor([0.5]),
+        )
+
+
+def test_cfm_model_preserves_shape_and_finite_values() -> None:
+    model = Model(_model_args(), METADATA)
+    x_t = torch.randn(3, 2, 32)
+    velocity = model(
+        x_t,
+        torch.tensor([0.1, 0.5, 0.9]),
+        {
+            "fault_label": torch.tensor([0, 1, 0]),
+            "domain_id": torch.tensor([0, 1, 1]),
+        },
+    )
+
+    assert velocity.shape == x_t.shape
+    assert velocity.dtype == x_t.dtype
+    assert velocity.device == x_t.device
+    assert torch.isfinite(velocity).all()
+
+
+def test_cfm_interpolation_and_zero_loss_for_exact_velocity() -> None:
+    loss_fn = ConditionalFlowMatchingLoss(eps=0.0)
+    x1 = torch.tensor([[[2.0, 4.0]]])
+    noise = torch.tensor([[[0.0, 2.0]]])
+    t = torch.tensor([0.25])
+
+    x_t = loss_fn.sample_xt(x1, noise, t)
+    target = loss_fn.target_velocity(x1, noise)
+    result = loss_fn(target, x1, noise, t)
+
+    assert torch.allclose(x_t, torch.tensor([[[0.5, 2.5]]]))
+    assert torch.allclose(target, torch.tensor([[[2.0, 2.0]]]))
+    assert torch.allclose(result["loss"], torch.zeros(()))
+
+
+def test_cfm_loss_rejects_nonfinite_prediction() -> None:
+    loss_fn = ConditionalFlowMatchingLoss()
+    x1 = torch.zeros(1, 2, 4)
+    noise = torch.zeros_like(x1)
+    prediction = torch.full_like(x1, float("nan"))
+
+    with pytest.raises(ValueError, match="NaN/Inf"):
+        loss_fn(prediction, x1, noise, torch.tensor([0.5]))
+
+
+class _ConstantVelocity(nn.Module):
+    def __init__(self, value: float) -> None:
+        super().__init__()
+        self.value = float(value)
+
+    def forward(self, x, t, condition):
+        return torch.full_like(x, self.value)
+
+
+def test_euler_sampler_integrates_velocity_and_restores_mode() -> None:
+    model = _ConstantVelocity(0.5)
+    model.train()
+    noise = torch.zeros(2, 1, 4)
+
+    samples = sample_euler_ode(
+        model,
+        noise,
+        {
+            "fault_label": torch.tensor([0, 1]),
+            "domain_id": torch.tensor([0, 1]),
+        },
+        num_steps=4,
+    )
+
+    assert model.training is True
+    assert samples.shape == noise.shape
+    assert torch.allclose(samples, torch.full_like(samples, 0.5))
+
+
+def test_euler_sampler_rejects_invalid_steps() -> None:
+    with pytest.raises(ValueError, match="num_steps must be positive"):
+        sample_euler_ode(
+            _ConstantVelocity(0.0),
+            torch.zeros(1, 1, 4),
+            {
+                "fault_label": torch.tensor([0]),
+                "domain_id": torch.tensor([0]),
+            },
+            num_steps=0,
+        )
+
+
+def test_cfm_task_training_step_uses_file_condition_provenance() -> None:
+    task = _task()
+    batch = {
+        "x": torch.randn(2, 32, 2),
+        "y": torch.tensor([0, 1]),
+        "file_id": torch.tensor([1, 2]),
+    }
+
+    loss = task.training_step(batch)
+
+    assert loss.ndim == 0
+    assert torch.isfinite(loss)
+
+
+def test_cfm_task_rejects_missing_file_id() -> None:
+    task = _task()
+    with pytest.raises(ValueError, match="file_id"):
+        task.training_step(
+            {
+                "x": torch.randn(2, 32, 2),
+                "y": torch.tensor([0, 1]),
+            }
+        )
+
+
+def test_cfm_task_sample_contract() -> None:
+    task = _task()
+    samples = task.sample(
+        {
+            "fault_label": torch.tensor([0]),
+            "domain_id": torch.tensor([1]),
+        },
+        num_samples=2,
+        length=16,
+        channels=2,
+        num_steps=2,
+        device="cpu",
+    )
+
+    assert samples.shape == (2, 2, 16)
+    assert torch.isfinite(samples).all()

--- a/test/generative/test_cfm_dtype_contract.py
+++ b/test/generative/test_cfm_dtype_contract.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from src.model_factory.generative_model.phm_cfm_mlp1d import Model
+
+
+ARGS = SimpleNamespace(
+    in_channels=2,
+    hidden_dim=8,
+    condition_dim=4,
+    num_fault_classes=2,
+    num_domains=2,
+)
+CONDITION = {
+    "fault_label": torch.tensor([0, 1]),
+    "domain_id": torch.tensor([0, 1]),
+}
+
+
+def test_cfm_model_preserves_float64_when_model_is_float64() -> None:
+    model = Model(ARGS, metadata=None).double()
+    x_t = torch.randn(2, 2, 16, dtype=torch.float64)
+
+    output = model(
+        x_t,
+        torch.tensor([0.25, 0.75], dtype=torch.float64),
+        CONDITION,
+    )
+
+    assert output.dtype == torch.float64
+    assert output.shape == x_t.shape
+
+
+def test_cfm_model_rejects_silent_dtype_conversion() -> None:
+    model = Model(ARGS, metadata=None)
+    x_t = torch.randn(2, 2, 16, dtype=torch.float64)
+
+    with pytest.raises(ValueError, match="dtype mismatch"):
+        model(
+            x_t,
+            torch.tensor([0.25, 0.75], dtype=torch.float64),
+            CONDITION,
+        )

--- a/test/generative/test_cfm_factory_contract.py
+++ b/test/generative/test_cfm_factory_contract.py
@@ -4,7 +4,6 @@ from types import SimpleNamespace
 
 import pandas as pd
 
-from src.data_factory.data_utils import MetadataAccessor
 from src.model_factory import build_model
 from src.model_factory.generative_model.phm_cfm_mlp1d import Model
 from src.task_factory import build_task
@@ -13,9 +12,9 @@ from src.task_factory.task.generative.conditional_flow_matching import (
 )
 
 
-def _metadata() -> MetadataAccessor:
-    return MetadataAccessor(
-        pd.DataFrame(
+class _Metadata:
+    def __init__(self) -> None:
+        self.df = pd.DataFrame(
             [
                 {
                     "Id": 1,
@@ -30,13 +29,15 @@ def _metadata() -> MetadataAccessor:
                     "Domain_id": 1,
                 },
             ]
-        ),
-        key_column="Id",
-    )
+        )
+        self.df.set_index("Id", inplace=True, drop=False)
+
+    def __getitem__(self, key):
+        return self.df.loc[key].to_dict()
 
 
 def test_cfm_model_and_task_build_through_public_factories() -> None:
-    metadata = _metadata()
+    metadata = _Metadata()
     args_model = SimpleNamespace(
         type="generative_model",
         name="phm_cfm_mlp1d",

--- a/test/generative/test_cfm_factory_contract.py
+++ b/test/generative/test_cfm_factory_contract.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pandas as pd
+
+from src.data_factory.data_utils import MetadataAccessor
+from src.model_factory import build_model
+from src.model_factory.generative_model.phm_cfm_mlp1d import Model
+from src.task_factory import build_task
+from src.task_factory.task.generative.conditional_flow_matching import (
+    ConditionalFlowMatchingTask,
+)
+
+
+def _metadata() -> MetadataAccessor:
+    return MetadataAccessor(
+        pd.DataFrame(
+            [
+                {
+                    "Id": 1,
+                    "Dataset_id": 0,
+                    "Label": 0,
+                    "Domain_id": 0,
+                },
+                {
+                    "Id": 2,
+                    "Dataset_id": 0,
+                    "Label": 1,
+                    "Domain_id": 1,
+                },
+            ]
+        ),
+        key_column="Id",
+    )
+
+
+def test_cfm_model_and_task_build_through_public_factories() -> None:
+    metadata = _metadata()
+    args_model = SimpleNamespace(
+        type="generative_model",
+        name="phm_cfm_mlp1d",
+        in_channels=2,
+        hidden_dim=8,
+        condition_dim=4,
+        num_fault_classes=2,
+        num_domains=2,
+        weights_path=None,
+    )
+    args_task = SimpleNamespace(
+        type="generative",
+        name="conditional_flow_matching",
+        target_system_id=None,
+        lr=1e-4,
+        weight_decay=1e-4,
+        optimizer="adamw",
+        t_eps=1e-3,
+    )
+
+    model = build_model(args_model, metadata=metadata)
+    task = build_task(
+        args_task=args_task,
+        network=model,
+        args_data=SimpleNamespace(normalization="standardization"),
+        args_model=args_model,
+        args_trainer=SimpleNamespace(),
+        args_environment=SimpleNamespace(),
+        metadata=metadata,
+    )
+
+    assert isinstance(model, Model)
+    assert isinstance(task, ConditionalFlowMatchingTask)
+    assert args_model.num_classes == 2


### PR DESCRIPTION
## Objective

Add the v0.2.1 Pipeline 06 G2 Conditional Flow Matching core as a current-architecture implementation derived from the locked source snapshot, without importing unrelated history or prematurely promoting a maintained demo.

## Included

### Model

```text
src/model_factory/generative_model/
├── __init__.py
├── condition_encoder.py
├── film.py
└── phm_cfm_mlp1d.py
```

- dependency-bounded dynamic model namespace;
- direct conditions limited to `fault_label` and `domain_id`;
- explicit metadata cardinality inference and condition range checks;
- stateless FiLM conditioning;
- strict input/output shape, dtype, device, and finite-value contracts.

### Task, loss, and sampler

```text
src/task_factory/Components/generative/
├── __init__.py
├── flow_matching.py
└── euler_ode.py

src/task_factory/task/generative/
├── __init__.py
└── conditional_flow_matching.py
```

- interpolation contract: `x_t = (1-t) * noise + t * x_1`;
- target velocity: `x_1 - noise`;
- explicit Euler integration with shape/dtype/device/finite guards;
- batch condition provenance through `file_id` plus metadata `Label` / `Domain_id`;
- Adam and AdamW only;
- sampling remains a focused task API; checkpoint/provenance/evaluation behavior belongs to G3/G4.

### Configuration

```text
configs/base/model/generative_cfm.yaml
configs/base/task/generative_cfm.yaml
configs/experiments/generative/README.md
configs/experiments/generative/dummy_generative_cfm.yaml
```

The runnable configuration remains under `configs/experiments/`. This PR intentionally does **not** modify:

```text
configs/config_registry.csv
docs/CONFIG_ATLAS.md
configs/demo/**
SUPPORTED_COMPONENTS.md
SUPPORTED_COMBINATIONS.md
```

No `sanity_ok` or release-supported claim is made.

### Tests and CI

```text
test/generative/test_cfm_core_contract.py
test/generative/test_cfm_dtype_contract.py
.github/workflows/pipeline06-cfm-quality-gates.yml
```

The focused workflow:

- installs CPU Torch and the minimum Lightning/config test dependencies;
- compiles G1 and CFM modules/tests;
- runs `scripts.config_inspect` on the exploratory config;
- runs all G1 shell tests plus CFM condition/model/loss/sampler/task/dtype tests;
- retains diagnostic logs and environment metadata.

Existing Core quality gates remain required.

## Source provenance

Reference-only source snapshot:

```text
cleanup/repo-slim-2026-07-05
7b97deb213c02727e73ba61bc1c508a9e61a5826
```

The implementation was rewritten against current `main`; no unrelated-history merge or source commit cherry-pick was used.

## Review boundaries

This PR does not implement:

- Pipeline 06 concrete train/sample/eval stage handlers;
- strict checkpoint restore and provenance;
- train-only normalization artifact reuse;
- synthetic/evaluation manifests;
- leakage/duplicate/downstream/FID-like metrics;
- CPU/GPU full E-chain evidence;
- registry or supported-surface promotion.

Those remain G3/G4 and are required before `sanity_ok`.

## Required checks before merge

- `Core quality gates` — all jobs green;
- `Pipeline 06 CFM quality gates / CFM core contract` — green;
- no unresolved review finding;
- diff remains limited to the declared G2 core/config/tests/workflow scope.

## Merge policy

Keep draft until all workflows complete. Recommended merge method after acceptance: squash.