### PR TITLE
feat(generative): add population-aware CFM regularization

### DIFF
--- a/configs/base/task/generative_cfm.yaml
+++ b/configs/base/task/generative_cfm.yaml
@@ -7,6 +7,14 @@ task:
   optimizer: "adamw"
   t_eps: 0.001
 
+  population_regularization:
+    enabled: false
+    weight: 0.1
+    dependency: "pearson_correlation"
+    estimator: "biased"
+    rbf_bandwidths: [0.1, 0.5, 1.0, 2.0]
+    same_time_per_batch: true
+
   generative:
     mode: "train"
     source_split: "train"

--- a/configs/experiments/README.md
+++ b/configs/experiments/README.md
@@ -15,3 +15,13 @@ python -m scripts.config_inspect --config configs/experiments/<name>/exp.yaml --
 # Validate schema (demos are checked by default; add new configs to the registry if you want CI coverage)
 python -m scripts.validate_configs
 ```
+
+Generative research contracts:
+
+- `generative/dummy_generative_cfm.yaml` keeps the baseline velocity-MSE CFM;
+- `generative/dummy_generative_cfm_population.yaml` enables a same-time,
+  population-correlation MMD regularizer.
+
+The population variant is a CFM adaptation inspired by population-aware
+generation objectives. It is not a DDPM or a full PaD-TS implementation, and
+its evidence remains exploratory.

--- a/configs/experiments/generative/dummy_generative_cfm_population.yaml
+++ b/configs/experiments/generative/dummy_generative_cfm_population.yaml
@@ -1,0 +1,61 @@
+# Experimental population-aware CFM adaptation on repository Dummy_Data.
+# This is not a full PaD-TS/DDPM implementation and carries no benchmark claim.
+pipeline: "Pipeline_06_generative"
+
+base_configs:
+  environment: "configs/base/environment/base.yaml"
+  data: "configs/base/data/base_cross_domain.yaml"
+  model: "configs/base/model/generative_cfm.yaml"
+  task: "configs/base/task/generative_cfm.yaml"
+  trainer: "configs/base/trainer/default_single_gpu.yaml"
+
+environment:
+  project: "experiment_dummy_population_aware_cfm"
+  seed: 0
+  iterations: 1
+  output_dir: "results/experiments/dummy_population_aware_cfm"
+  notes: "Population correlation MMD adaptation; exploratory offline evidence only."
+  wandb: false
+  swanlab: false
+
+data:
+  data_dir: "data"
+  metadata_file: "metadata_dummy.csv"
+  batch_size: 2
+  num_workers: 0
+  train_ratio: 0.8
+  val_ratio: 0.2
+  test_ratio: 0.0
+  normalization: "standardization"
+  window_size: 128
+  stride: 16
+  num_window: 4
+  dtype: "float32"
+  pin_memory: false
+
+model:
+  hidden_dim: 32
+  condition_dim: 16
+
+task:
+  target_system_id: null
+  population_regularization:
+    enabled: true
+    weight: 0.1
+    dependency: "pearson_correlation"
+    estimator: "biased"
+    rbf_bandwidths: [0.1, 0.5, 1.0, 2.0]
+    same_time_per_batch: true
+  generative:
+    mode: "train"
+    synthetic_dataset_id: "dummy_population_aware_cfm"
+    validity_status: "exploratory"
+
+trainer:
+  monitor: "val_loss"
+  num_epochs: 1
+  gpus: 1
+  device: "cpu"
+  early_stopping: false
+  log_every_n_steps: 1
+  save_top_k: 1

--- a/src/Pipeline_06_generative.py
+++ b/src/Pipeline_06_generative.py
@@ -715,7 +715,9 @@ def _run_sample_stage(args: Any, configs: Any, iteration: int) -> Any:
             synthetic_dataset_id=str(
                 _get_attr(gen_cfg, "synthetic_dataset_id", f"{name}-iter-{iteration}")
             ),
-            method_id="conditional_flow_matching",
+            method_id=str(
+                getattr(task, "method_id", "conditional_flow_matching")
+            ),
             model_type=str(args_model.type),
             model_name=str(args_model.name),
             loss_id=str(getattr(task, "loss_id", "conditional_flow_matching")),
@@ -745,6 +747,11 @@ def _run_sample_stage(args: Any, configs: Any, iteration: int) -> Any:
             leakage_metrics={
                 name: leakage_bundle[name]
                 for name in ("nearest_neighbor_leakage_l2", "duplicate_rate")
+            },
+            population_metrics={
+                "population_dependency_mmd": leakage_bundle[
+                    "population_dependency_mmd"
+                ]
             },
             sampler_metadata=dict(getattr(task, "sampler_metadata", lambda: {})()),
             scientific_status=str(_get_attr(gen_cfg, "validity_status", "exploratory")),

--- a/src/config_schema/__init__.py
+++ b/src/config_schema/__init__.py
@@ -1,11 +1,19 @@
-from .models import DataConfig, EnvironmentConfig, ExperimentConfig, ModelConfig, TaskConfig, TrainerConfig
+from .models import (
+    DataConfig,
+    EnvironmentConfig,
+    ExperimentConfig,
+    ModelConfig,
+    PopulationRegularizationConfig,
+    TaskConfig,
+    TrainerConfig,
+)
 
 __all__ = [
     "EnvironmentConfig",
     "DataConfig",
     "ModelConfig",
+    "PopulationRegularizationConfig",
     "TaskConfig",
     "TrainerConfig",
     "ExperimentConfig",
 ]
-

--- a/src/config_schema/models.py
+++ b/src/config_schema/models.py
@@ -50,7 +50,42 @@ class ModelConfig(BaseModel):
         return self
 
 
-TaskType = Literal["DG", "CDDG", "FS", "GFS", "pretrain", "Default_task"]
+TaskType = Literal[
+    "DG",
+    "CDDG",
+    "FS",
+    "GFS",
+    "pretrain",
+    "Default_task",
+    "generative",
+]
+
+
+class PopulationRegularizationConfig(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    enabled: bool = False
+    weight: float = Field(0.1, gt=0.0)
+    dependency: Literal["pearson_correlation"] = "pearson_correlation"
+    estimator: Literal["biased"] = "biased"
+    rbf_bandwidths: List[float] = Field(
+        default_factory=lambda: [0.1, 0.5, 1.0, 2.0]
+    )
+    same_time_per_batch: bool = True
+
+    @model_validator(mode="after")
+    def _check_population_contract(self) -> "PopulationRegularizationConfig":
+        if not self.rbf_bandwidths or any(
+            value <= 0.0 for value in self.rbf_bandwidths
+        ):
+            raise ValueError(
+                "task.population_regularization.rbf_bandwidths must be positive"
+            )
+        if self.enabled and not self.same_time_per_batch:
+            raise ValueError(
+                "enabled population regularization requires same_time_per_batch=true"
+            )
+        return self
 
 
 class TaskConfig(BaseModel):
@@ -60,6 +95,7 @@ class TaskConfig(BaseModel):
     name: str = Field(..., description="Task name under task.type.")
 
     target_system_id: Optional[List[int]] = None
+    population_regularization: Optional[PopulationRegularizationConfig] = None
 
     @model_validator(mode="after")
     def _check_target_system_id(self) -> "TaskConfig":
@@ -97,4 +133,17 @@ class ExperimentConfig(BaseModel):
     def _basic_coupling_checks(self) -> "ExperimentConfig":
         if self.pipeline and not self.pipeline.startswith("Pipeline_"):
             raise ValueError("pipeline should be a src/Pipeline_*.py module name")
+        population = self.task.population_regularization
+        if population is not None and population.enabled:
+            if (
+                self.task.type != "generative"
+                or self.task.name != "conditional_flow_matching"
+            ):
+                raise ValueError(
+                    "population_regularization is supported only by conditional_flow_matching"
+                )
+            if int(getattr(self.model, "in_channels", 0)) < 2:
+                raise ValueError(
+                    "population_regularization requires model.in_channels >= 2"
+                )
         return self

--- a/src/task_factory/Components/generative/__init__.py
+++ b/src/task_factory/Components/generative/__init__.py
@@ -9,15 +9,23 @@ from .normalization import (
     load_normalization_evidence,
     write_normalization_evidence,
 )
+from .population import (
+    PopulationCorrelationMMD,
+    multi_rbf_mmd,
+    pearson_correlation_vectors,
+)
 
 __all__ = [
     "ConditionalFlowMatchingLoss",
+    "PopulationCorrelationMMD",
     "REQUIRED_METRICS",
     "build_evaluation_manifest",
     "build_normalization_evidence",
     "build_synthetic_manifest",
     "evaluate_smoke_metrics",
     "load_normalization_evidence",
+    "multi_rbf_mmd",
+    "pearson_correlation_vectors",
     "sample_euler_ode",
     "write_normalization_evidence",
 ]

--- a/src/task_factory/Components/generative/manifests.py
+++ b/src/task_factory/Components/generative/manifests.py
@@ -43,6 +43,7 @@ def build_synthetic_manifest(
     data_evidence: dict[str, str],
     generated_evidence: dict[str, str],
     leakage_metrics: dict[str, Any],
+    population_metrics: dict[str, Any] | None = None,
     sampler_metadata: dict[str, Any] | None = None,
     scientific_status: str = "exploratory",
 ) -> dict[str, Any]:
@@ -91,6 +92,12 @@ def build_synthetic_manifest(
         leakage_metrics.get(name, {}).get("status") == "ok"
         for name in ("nearest_neighbor_leakage_l2", "duplicate_rate")
     )
+    population_required = method_id == "population_aware_cfm"
+    population_metrics = dict(population_metrics or {})
+    population_ok = (
+        population_metrics.get("population_dependency_mmd", {}).get("status")
+        == "ok"
+    )
 
     evidence = {
         "strict_checkpoint": checkpoint_ok,
@@ -104,6 +111,8 @@ def build_synthetic_manifest(
         "condition_counts": bool(condition_counts),
         "leakage_metrics": leakage_ok,
     }
+    if population_required:
+        evidence["population_metrics"] = population_ok
     missing = [name for name, passed in evidence.items() if not passed]
 
     return {
@@ -142,6 +151,7 @@ def build_synthetic_manifest(
             "sampler_metadata": dict(sampler_metadata or {}),
         },
         "leakage": leakage_metrics,
+        "population": population_metrics,
         "validity": {
             "scientific_status": scientific_status,
             "runtime_smoke_eligible": not missing,

--- a/src/task_factory/Components/generative/metrics.py
+++ b/src/task_factory/Components/generative/metrics.py
@@ -5,6 +5,8 @@ from typing import Any, Callable
 
 import torch
 
+from .population import PopulationCorrelationMMD
+
 
 REQUIRED_METRICS = (
     "time_domain_statistics_distance",
@@ -239,6 +241,14 @@ def evaluate_smoke_metrics(
             lambda: _spectral_distance(real_tensor, fake_tensor)
         ),
     }
+    metrics["population_dependency_mmd"] = _safe_metric(
+        lambda: float(
+            PopulationCorrelationMMD([0.1, 0.5, 1.0, 2.0])(
+                real_tensor,
+                fake_tensor,
+            ).item()
+        )
+    )
 
     if any(
         value is None
@@ -307,6 +317,7 @@ def evaluate_smoke_metrics(
     )
     metrics["summary"] = {
         "required": list(REQUIRED_METRICS),
+        "optional": ["population_dependency_mmd"],
         "ok": sum(
             metrics[name]["status"] == "ok" for name in REQUIRED_METRICS
         ),

--- a/src/task_factory/Components/generative/population.py
+++ b/src/task_factory/Components/generative/population.py
@@ -1,0 +1,93 @@
+"""Population-level dependency regularization for multichannel windows."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import torch
+import torch.nn as nn
+
+
+def pearson_correlation_vectors(
+    windows: torch.Tensor,
+    eps: float = 1e-8,
+) -> torch.Tensor:
+    """Return upper-triangle channel correlations for each ``[N,C,L]`` window."""
+    tensor = torch.as_tensor(windows)
+    if tensor.ndim != 3:
+        raise ValueError(f"population windows must be [N,C,L], got {tuple(tensor.shape)}")
+    if tensor.shape[0] < 2:
+        raise ValueError("population regularization requires batch_size >= 2")
+    if tensor.shape[1] < 2:
+        raise ValueError("population regularization requires at least two channels")
+    if tensor.shape[2] < 2:
+        raise ValueError("population regularization requires window length >= 2")
+    if not torch.isfinite(tensor).all():
+        raise ValueError("population windows contain NaN/Inf")
+
+    centered = tensor - tensor.mean(dim=2, keepdim=True)
+    norms = centered.square().sum(dim=2, keepdim=True).sqrt().clamp_min(float(eps))
+    normalized = centered / norms
+    correlations = torch.einsum("ncl,ndl->ncd", normalized, normalized)
+    indices = torch.triu_indices(
+        tensor.shape[1],
+        tensor.shape[1],
+        offset=1,
+        device=tensor.device,
+    )
+    return correlations[:, indices[0], indices[1]]
+
+
+def multi_rbf_mmd(
+    real_features: torch.Tensor,
+    fake_features: torch.Tensor,
+    bandwidths: Sequence[float],
+) -> torch.Tensor:
+    """Biased multi-kernel RBF MMD squared."""
+    real = torch.as_tensor(real_features)
+    fake = torch.as_tensor(fake_features, device=real.device, dtype=real.dtype)
+    if real.ndim != 2 or fake.ndim != 2:
+        raise ValueError("MMD features must both be [N,D]")
+    if real.shape[0] < 2 or fake.shape[0] < 2:
+        raise ValueError("population MMD requires at least two real and fake samples")
+    if real.shape[1] != fake.shape[1]:
+        raise ValueError("real and fake population feature dimensions must match")
+    parsed_bandwidths = tuple(float(value) for value in bandwidths)
+    if not parsed_bandwidths or any(value <= 0.0 for value in parsed_bandwidths):
+        raise ValueError("population RBF bandwidths must be non-empty and positive")
+    if not torch.isfinite(real).all() or not torch.isfinite(fake).all():
+        raise ValueError("population MMD features contain NaN/Inf")
+
+    def kernel(left: torch.Tensor, right: torch.Tensor) -> torch.Tensor:
+        squared_distance = torch.cdist(left, right).square()
+        values = [
+            torch.exp(-squared_distance / (2.0 * bandwidth * bandwidth))
+            for bandwidth in parsed_bandwidths
+        ]
+        return torch.stack(values).mean(dim=0)
+
+    value = kernel(real, real).mean() + kernel(fake, fake).mean()
+    value = value - 2.0 * kernel(real, fake).mean()
+    if not torch.isfinite(value):
+        raise ValueError("population MMD returned NaN/Inf")
+    return value.clamp_min(0.0)
+
+
+class PopulationCorrelationMMD(nn.Module):
+    """Compare distributions of within-window channel correlations."""
+
+    def __init__(self, bandwidths: Sequence[float], eps: float = 1e-8):
+        super().__init__()
+        self.bandwidths = tuple(float(value) for value in bandwidths)
+        self.eps = float(eps)
+        if self.eps <= 0.0:
+            raise ValueError("population correlation eps must be positive")
+        if not self.bandwidths or any(value <= 0.0 for value in self.bandwidths):
+            raise ValueError("population RBF bandwidths must be non-empty and positive")
+
+    def forward(self, real: torch.Tensor, fake: torch.Tensor) -> torch.Tensor:
+        return multi_rbf_mmd(
+            pearson_correlation_vectors(real, eps=self.eps),
+            pearson_correlation_vectors(fake, eps=self.eps),
+            self.bandwidths,
+        )

--- a/src/task_factory/task/generative/README.md
+++ b/src/task_factory/task/generative/README.md
@@ -1,0 +1,29 @@
+# Generative Tasks
+
+`conditional_flow_matching.py` is the experimental Pipeline 06 task for the
+path `x_t=(1-t)z+t*x_1` and velocity target `x_1-z`. The default configuration
+uses velocity MSE only.
+
+## Population-aware CFM
+
+An optional regularizer compares the distribution of upper-triangle Pearson
+channel correlations between real windows and reconstructed clean predictions.
+It uses a biased multi-kernel RBF MMD and one shared flow time for the batch:
+
+```yaml
+task:
+  population_regularization:
+    enabled: true
+    weight: 0.1
+    dependency: pearson_correlation
+    estimator: biased
+    rbf_bandwidths: [0.1, 0.5, 1.0, 2.0]
+    same_time_per_batch: true
+```
+
+The setting requires at least two samples and two channels. It logs the base
+velocity MSE, population MMD, and combined loss. Generated evidence uses method
+ID `population_aware_cfm` and requires an `ok` population dependency metric.
+
+This is a PHM CFM adaptation, not a full PaD-TS/DDPM reproduction. It remains
+exploratory and cannot be described as benchmark-valid.

--- a/src/task_factory/task/generative/conditional_flow_matching.py
+++ b/src/task_factory/task/generative/conditional_flow_matching.py
@@ -9,6 +9,7 @@ import torch.nn as nn
 
 from src.task_factory.Components.generative import (
     ConditionalFlowMatchingLoss,
+    PopulationCorrelationMMD,
     sample_euler_ode,
 )
 
@@ -46,10 +47,47 @@ class ConditionalFlowMatchingTask(pl.LightningModule):
         self.args_environment = args_environment
         self.metadata = metadata
         self.loss_id = "conditional_flow_matching"
+        self.method_id = "conditional_flow_matching"
         self.sampler_id = "euler_ode"
         self.loss_fn = ConditionalFlowMatchingLoss(
             eps=float(getattr(args_task, "t_eps", 1e-3))
         )
+        population = getattr(args_task, "population_regularization", None)
+        if isinstance(population, Mapping):
+            population_get = population.get
+        else:
+            population_get = lambda key, default=None: getattr(
+                population, key, default
+            )
+        self.population_regularization_enabled = bool(
+            population_get("enabled", False) if population is not None else False
+        )
+        self.population_weight = 0.0
+        self.population_loss = None
+        if self.population_regularization_enabled:
+            dependency = str(population_get("dependency", "pearson_correlation"))
+            estimator = str(population_get("estimator", "biased"))
+            same_time = bool(population_get("same_time_per_batch", True))
+            self.population_weight = float(population_get("weight", 0.1))
+            bandwidths = population_get(
+                "rbf_bandwidths",
+                [0.1, 0.5, 1.0, 2.0],
+            )
+            if dependency != "pearson_correlation":
+                raise ValueError(
+                    "population_regularization.dependency must be pearson_correlation"
+                )
+            if estimator != "biased":
+                raise ValueError("population_regularization.estimator must be biased")
+            if not same_time:
+                raise ValueError(
+                    "population_regularization requires same_time_per_batch=true"
+                )
+            if self.population_weight <= 0.0:
+                raise ValueError("population_regularization.weight must be positive")
+            self.population_loss = PopulationCorrelationMMD(bandwidths)
+            self.method_id = "population_aware_cfm"
+            self.loss_id = "conditional_flow_matching+population_correlation_mmd"
         self.save_hyperparameters(
             {
                 "task_type": getattr(args_task, "type", "generative"),
@@ -72,6 +110,10 @@ class ConditionalFlowMatchingTask(pl.LightningModule):
                 "weight_decay": float(
                     getattr(args_task, "weight_decay", 1e-4)
                 ),
+                "population_regularization_enabled": (
+                    self.population_regularization_enabled
+                ),
+                "population_weight": self.population_weight,
             }
         )
 
@@ -192,15 +234,24 @@ class ConditionalFlowMatchingTask(pl.LightningModule):
         x1 = self._to_ncl(batch["x"])
         condition = self._extract_condition(batch, x1.shape[0])
         noise = torch.randn_like(x1)
+        time_batch_size = 1 if self.population_regularization_enabled else x1.shape[0]
         t = self.loss_fn.sample_t(
-            x1.shape[0],
+            time_batch_size,
             x1.device,
             dtype=x1.dtype,
         )
+        if self.population_regularization_enabled:
+            t = t.expand(x1.shape[0]).clone()
         x_t = self.loss_fn.sample_xt(x1, noise, t)
         predicted_velocity = self.forward(x_t, t, condition)
         loss_values = self.loss_fn(predicted_velocity, x1, noise, t)
         loss = loss_values["loss"]
+        population_mmd = None
+        if self.population_regularization_enabled:
+            t_view = t.to(device=x1.device, dtype=x1.dtype).view(-1, 1, 1)
+            predicted_clean = x_t + (1.0 - t_view) * predicted_velocity
+            population_mmd = self.population_loss(x1, predicted_clean)
+            loss = loss + self.population_weight * population_mmd
         self.log(
             f"{stage}_loss",
             loss,
@@ -219,6 +270,16 @@ class ConditionalFlowMatchingTask(pl.LightningModule):
             logger=True,
             batch_size=x1.shape[0],
         )
+        if population_mmd is not None:
+            self.log(
+                f"{stage}_population_correlation_mmd",
+                population_mmd,
+                on_step=(stage == "train"),
+                on_epoch=True,
+                prog_bar=False,
+                logger=True,
+                batch_size=x1.shape[0],
+            )
         return loss
 
     def training_step(

--- a/test/generative/test_g3_evidence_contract.py
+++ b/test/generative/test_g3_evidence_contract.py
@@ -86,6 +86,33 @@ def test_docs_only_manifest_remains_non_promotional() -> None:
     assert manifest["validity"]["paper_ready"] is False
 
 
+def test_population_aware_manifest_requires_population_metric() -> None:
+    kwargs = _synthetic_manifest_kwargs()
+    kwargs["method_id"] = "population_aware_cfm"
+    kwargs["population_metrics"] = {
+        "population_dependency_mmd": {
+            "value": 0.1,
+            "status": "ok",
+            "reason": "",
+        }
+    }
+
+    manifest = build_synthetic_manifest(**kwargs)
+
+    assert manifest["validity"]["evidence"]["population_metrics"] is True
+    assert manifest["validity"]["runtime_smoke_eligible"] is True
+
+
+def test_population_aware_manifest_downgrades_missing_population_metric() -> None:
+    kwargs = _synthetic_manifest_kwargs()
+    kwargs["method_id"] = "population_aware_cfm"
+
+    manifest = build_synthetic_manifest(**kwargs)
+
+    assert manifest["validity"]["runtime_smoke_eligible"] is False
+    assert "population_metrics" in manifest["validity"]["missing_evidence"]
+
+
 @pytest.mark.parametrize("missing_key", ["protocol_evidence", "generated_evidence"])
 def test_synthetic_manifest_downgrades_missing_provenance(missing_key: str) -> None:
     kwargs = _synthetic_manifest_kwargs()

--- a/test/generative/test_population_cfm.py
+++ b/test/generative/test_population_cfm.py
@@ -1,0 +1,131 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+import torch.nn as nn
+
+from src.model_factory.generative_model.phm_cfm_mlp1d import Model
+from src.task_factory.Components.generative import (
+    PopulationCorrelationMMD,
+    evaluate_smoke_metrics,
+    multi_rbf_mmd,
+    pearson_correlation_vectors,
+)
+from src.task_factory.task.generative.conditional_flow_matching import (
+    ConditionalFlowMatchingTask,
+)
+
+
+METADATA = {
+    1: {"Label": 0, "Domain_id": 0},
+    2: {"Label": 1, "Domain_id": 1},
+}
+
+
+def test_population_features_and_mmd_contract() -> None:
+    real = torch.randn(4, 3, 32)
+    fake = torch.randn(4, 3, 32, requires_grad=True)
+    real_features = pearson_correlation_vectors(real)
+    fake_features = pearson_correlation_vectors(fake)
+
+    assert real_features.shape == (4, 3)
+    forward = multi_rbf_mmd(real_features, fake_features, [0.1, 0.5, 1.0])
+    reverse = multi_rbf_mmd(fake_features, real_features, [0.1, 0.5, 1.0])
+    assert forward.item() >= 0.0
+    torch.testing.assert_close(forward, reverse)
+    forward.backward()
+    assert fake.grad is not None
+    assert torch.isfinite(fake.grad).all()
+
+
+def test_population_mmd_is_zero_for_identical_windows() -> None:
+    windows = torch.randn(4, 2, 16)
+    value = PopulationCorrelationMMD([0.1, 0.5, 1.0, 2.0])(windows, windows)
+    assert value.item() == pytest.approx(0.0, abs=1e-7)
+
+
+@pytest.mark.parametrize("shape", [(1, 2, 16), (2, 1, 16), (2, 2, 1)])
+def test_population_features_reject_insufficient_population(shape) -> None:
+    with pytest.raises(ValueError, match="requires"):
+        pearson_correlation_vectors(torch.randn(*shape))
+
+
+class _RecordingModel(nn.Module):
+    def __init__(self, model: nn.Module):
+        super().__init__()
+        self.model = model
+        self.last_t = None
+
+    def forward(self, x, t, condition):
+        self.last_t = t.detach().clone()
+        return self.model(x, t, condition)
+
+
+def _population_task() -> tuple[ConditionalFlowMatchingTask, _RecordingModel]:
+    model_args = SimpleNamespace(
+        type="generative_model",
+        name="phm_cfm_mlp1d",
+        in_channels=2,
+        hidden_dim=16,
+        condition_dim=8,
+        num_fault_classes=2,
+        num_domains=2,
+    )
+    recording = _RecordingModel(Model(model_args, METADATA))
+    task_args = SimpleNamespace(
+        type="generative",
+        name="conditional_flow_matching",
+        lr=1e-4,
+        weight_decay=1e-4,
+        optimizer="adamw",
+        t_eps=1e-3,
+        population_regularization=SimpleNamespace(
+            enabled=True,
+            weight=0.1,
+            dependency="pearson_correlation",
+            estimator="biased",
+            rbf_bandwidths=[0.1, 0.5, 1.0, 2.0],
+            same_time_per_batch=True,
+        ),
+    )
+    task = ConditionalFlowMatchingTask(
+        network=recording,
+        args_data=SimpleNamespace(normalization="standardization"),
+        args_model=model_args,
+        args_task=task_args,
+        args_trainer=SimpleNamespace(),
+        args_environment=SimpleNamespace(),
+        metadata=METADATA,
+    )
+    return task, recording
+
+
+def test_population_cfm_uses_shared_time_and_backpropagates() -> None:
+    task, recording = _population_task()
+    logged = {}
+    task.log = lambda name, value, **kwargs: logged.setdefault(name, value)
+    loss = task.training_step(
+        {
+            "x": torch.randn(3, 32, 2),
+            "y": torch.tensor([0, 1, 0]),
+            "file_id": torch.tensor([1, 2, 1]),
+        }
+    )
+
+    assert task.method_id == "population_aware_cfm"
+    assert torch.unique(recording.last_t).numel() == 1
+    assert "train_population_correlation_mmd" in logged
+    assert torch.isfinite(loss)
+    loss.backward()
+    assert next(recording.model.parameters()).grad is not None
+
+
+def test_population_metric_is_optional_but_structured() -> None:
+    real = torch.randn(3, 2, 16)
+    fake = torch.randn(3, 2, 16)
+    metrics = evaluate_smoke_metrics(real, fake)
+
+    assert metrics["population_dependency_mmd"]["status"] == "ok"
+    assert "population_dependency_mmd" in metrics["summary"]["optional"]


### PR DESCRIPTION
## Summary

- add an optional population-aware regularizer to Conditional Flow Matching
- compare upper-triangular channel-correlation vectors with biased multi-kernel RBF MMD
- enforce same-time population comparison and explicit finite, batch, and channel contracts
- propagate the optional population metric through Pipeline 06 manifests and evidence status
- add a disabled-by-default base contract, runnable dummy experiment, documentation, and tests

## Validation

- `conda run -n LQ_signal python -m pytest test/ -q`: 125 passed, 1 skipped
- `python -m scripts.validate_docs`
- `python -m scripts.validate_configs`
- `python -m scripts.gen_config_atlas` with no Atlas drift
- `git diff --check`
- dummy train -> sample -> eval smoke completed

## Evidence boundary

The smoke uses repository dummy data and validates runtime/evidence wiring only. It does not establish benchmark validity or paper-ready metrics. Population regularization is disabled by default.
