### PR TITLE
feat(data): add phm-data-factory training backend

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -30,3 +30,6 @@
 	path = paper/LQ_vibench_fix
 	url = git@github.com:liq22/LQ_vibench_fix.git
 	branch = lqfix_25-12
+[submodule "phm-data-factory"]
+	path = packages/phm-data-factory
+	url = https://github.com/liq22/P01-phm-data-factory.git

--- a/KNOWN_LIMITATIONS.md
+++ b/KNOWN_LIMITATIONS.md
@@ -13,6 +13,9 @@
 - Only the dummy smoke demo is offline and repo-shipped.
 - Non-dummy demos require local PHM-Vibench metadata/raw data and may need a
   machine-specific `data.data_dir` override.
+- The `phm_data` data-factory adapter is experimental. It requires the pinned
+  public provider submodule plus an external provider configuration and has no
+  maintained real-data demo or live-IoTDB evidence in this repository.
 - Maintained validation uses the `LQ_signal` conda environment. Base Python may
   lack required packages such as `pytorch_lightning`.
 
@@ -31,4 +34,3 @@
 - Dataset adapter fallback to `Default_dataset` remains a behavior to inspect
   carefully when adding new task names.
 - Unknown pipeline, model, and task values are expected to fail explicitly.
-

--- a/docs/index.md
+++ b/docs/index.md
@@ -23,6 +23,7 @@ Documentation uses four status labels:
 | Understand YAML composition and overrides | [Configuration guide](../configs/README.md) |
 | Find maintained configurations | [Configuration atlas](CONFIG_ATLAS.md) |
 | Prepare local datasets | [Data directory guide](../data/README.md) |
+| Use the experimental shared data backend | [phm-data-factory backend](phm_data_factory.md) |
 | See the supported release surface | [Supported components](../SUPPORTED_COMPONENTS.md) and [supported combinations](../SUPPORTED_COMBINATIONS.md) |
 | Check known constraints | [Known limitations](../KNOWN_LIMITATIONS.md) |
 | Use the optional web interface | [Streamlit workspace](../apps/streamlit/README.md) |

--- a/docs/phm_data_factory.md
+++ b/docs/phm_data_factory.md
@@ -1,0 +1,31 @@
+# phm-data-factory backend
+
+**Status: Experimental.** This adapter is implemented and covered by a synthetic
+contract test, but it is not part of the v0.2 release-supported demo matrix and
+has no real-dataset performance claim.
+
+PHM-Vibench can keep its existing `build_data()` pipeline while delegating
+typed metadata and dense signal reads to the standalone provider.
+
+```yaml
+data:
+  factory_name: phm_data
+  phm_data_config: configs/data/cwru-iotdb.yaml
+  dataset_name: CWRU
+```
+
+Initialize the exact provider revision and install it locally:
+
+```bash
+git submodule update --init packages/phm-data-factory
+pip install -e 'packages/phm-data-factory[yaml,legacy]'
+python -m scripts.validate_configs
+python -m pytest -q test/test_phm_data_factory_backend.py
+```
+
+`phm_data_config` is mandatory; there is no silent HDF5 fallback. The provider
+may select local HDF5 or IoTDB. PHM-Vibench continues to own dataset filtering,
+splits, windowing, normalization, Dataset/DataLoader, task and trainer logic.
+
+Older IoTDB imports with indexed/string-only metadata must be upgraded with
+`phm-data-iotdb sync-metadata` before training.

--- a/scripts/validate_docs.py
+++ b/scripts/validate_docs.py
@@ -6,6 +6,7 @@ links resolve and that per-directory AI docs defer shared content to README.md.
 
 from __future__ import annotations
 
+import configparser
 import re
 import sys
 from dataclasses import dataclass
@@ -27,7 +28,25 @@ SKIP_TOP_DIRS = {
 SKIP_DIR_NAMES = {"__pycache__"}
 
 
-def is_skipped_path(rel: Path) -> bool:
+def configured_submodule_paths(repo_root: Path) -> tuple[Path, ...]:
+    gitmodules = repo_root / ".gitmodules"
+    if not gitmodules.is_file():
+        return ()
+    parser = configparser.ConfigParser(interpolation=None, strict=False)
+    parser.read(gitmodules, encoding="utf-8")
+    paths: list[Path] = []
+    for section in parser.sections():
+        if not section.startswith('submodule "') or not parser.has_option(section, "path"):
+            continue
+        value = parser.get(section, "path").strip()
+        if value:
+            paths.append(Path(value))
+    return tuple(paths)
+
+
+def is_skipped_path(rel: Path, submodule_paths: tuple[Path, ...] = ()) -> bool:
+    if any(rel == path or path in rel.parents for path in submodule_paths):
+        return True
     if rel.parts and rel.parts[0] in SKIP_TOP_DIRS:
         return True
     if len(rel.parts) >= 2 and rel.parts[:2] == (".claude", "handoffs"):
@@ -51,6 +70,7 @@ class Issue:
 
 
 def iter_doc_files(repo_root: Path) -> Iterable[Path]:
+    submodule_paths = configured_submodule_paths(repo_root)
     patterns = [
         "README.md",
         "CLAUDE.md",
@@ -61,7 +81,7 @@ def iter_doc_files(repo_root: Path) -> Iterable[Path]:
     for pattern in patterns:
         for path in repo_root.rglob(pattern):
             rel = path.relative_to(repo_root)
-            if is_skipped_path(rel):
+            if is_skipped_path(rel, submodule_paths):
                 continue
             yield path
 
@@ -107,10 +127,11 @@ def first_n_lines(path: Path, n: int = 40) -> str:
 
 def check_ai_docs_point_to_readme(repo_root: Path) -> list[Issue]:
     issues: list[Issue] = []
+    submodule_paths = configured_submodule_paths(repo_root)
     for doc_name in ["CLAUDE.md", "AGENTS.md", "GEMINI.md"]:
         for path in repo_root.rglob(doc_name):
             rel = path.relative_to(repo_root)
-            if is_skipped_path(rel):
+            if is_skipped_path(rel, submodule_paths):
                 continue
             readme = path.parent / "README.md"
             if not readme.exists():

--- a/src/config_schema/models.py
+++ b/src/config_schema/models.py
@@ -25,10 +25,22 @@ class EnvironmentConfig(BaseModel):
 class DataConfig(BaseModel):
     model_config = ConfigDict(extra="allow")
 
-    data_dir: str = Field(..., description="Dataset root dir containing metadata and processed files.")
-    metadata_file: str = Field(..., description="Metadata filename relative to data_dir (xlsx/csv).")
+    factory_name: str = "default"
+    data_dir: Optional[str] = Field(None, description="Dataset root dir containing metadata and processed files.")
+    metadata_file: Optional[str] = Field(None, description="Metadata filename relative to data_dir (xlsx/csv).")
+    phm_data_config: Optional[str] = None
+    dataset_name: Optional[str] = None
     batch_size: Optional[int] = Field(None, ge=1)
     num_workers: Optional[int] = Field(None, ge=0)
+
+    @model_validator(mode="after")
+    def _check_backend_fields(self) -> "DataConfig":
+        if self.factory_name == "phm_data":
+            if not self.phm_data_config:
+                raise ValueError("data.factory_name=phm_data requires phm_data_config")
+        elif not self.data_dir or not self.metadata_file:
+            raise ValueError("data_dir and metadata_file are required")
+        return self
 
 
 class ModelConfig(BaseModel):

--- a/src/configs/config_utils.py
+++ b/src/configs/config_utils.py
@@ -254,7 +254,7 @@ def _validate_config_wrapper(config: ConfigWrapper) -> None:
         ValueError: 缺少必需字段时
     """
     required_sections = {
-        'data': ['data_dir', 'metadata_file'],
+        'data': [],
         'model': ['name', 'type'],
         'task': ['name', 'type']
     }
@@ -270,6 +270,15 @@ def _validate_config_wrapper(config: ConfigWrapper) -> None:
         for field in fields:
             if not hasattr(section_obj, field):
                 raise ValueError(f"缺少必需字段: {section}.{field}")
+
+    data = config.data
+    if getattr(data, 'factory_name', 'default') == 'phm_data':
+        if not getattr(data, 'phm_data_config', None):
+            raise ValueError("data.factory_name=phm_data requires data.phm_data_config")
+    else:
+        for field in ('data_dir', 'metadata_file'):
+            if not getattr(data, field, None):
+                raise ValueError(f"缺少必需字段: data.{field}")
 
     # 扩展验证：对比学习配置验证
     _validate_contrastive_config(config)
@@ -411,7 +420,12 @@ def makedir(path):
 
 def build_experiment_name(configs) -> str:
     """Compose an experiment name from configuration sections."""
-    dataset_name = configs.data.metadata_file
+    dataset_name = getattr(configs.data, "dataset_name", None)
+    if not dataset_name:
+        source = getattr(configs.data, "metadata_file", None) or getattr(
+            configs.data, "phm_data_config", "dataset"
+        )
+        dataset_name = Path(str(source)).stem
     model_name = configs.model.name
     task_name = f"{configs.task.type}{configs.task.name}"
     timestamp = datetime.now().strftime("%d_%H%M%S")

--- a/src/data_factory/__init__.py
+++ b/src/data_factory/__init__.py
@@ -9,6 +9,8 @@ from .data_factory import (
 )
 from .dataset_task.Dataset_cluster import IdIncludedDataset
 from .id_data_factory import id_data_factory
+from .phm_data_factory import phm_data_factory
+from .standalone import build_agent_data_tools, build_data_backend, build_data_repository
 
 
 
@@ -58,9 +60,13 @@ def build_data(args_data: Any, args_task: Any) -> Any:
 # public exports
 __all__ = [
     "build_data",
+    "build_data_repository",
+    "build_data_backend",
+    "build_agent_data_tools",
     "resolve_data_factory_class",
     "register_data_factory",
     "DATA_FACTORY_REGISTRY",
     "IdIncludedDataset",
     "id_data_factory",
+    "phm_data_factory",
 ]

--- a/src/data_factory/data_factory.py
+++ b/src/data_factory/data_factory.py
@@ -380,6 +380,23 @@ class data_factory:
     def __len__(self):
         """返回数据集数量"""
         return len(self.data)
+
+    def close(self):
+        close = getattr(self.data, "close", None)
+        if callable(close):
+            close()
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.close()
+
+    def __del__(self):
+        try:
+            self.close()
+        except Exception:
+            pass
     
 
 

--- a/src/data_factory/phm_data_factory.py
+++ b/src/data_factory/phm_data_factory.py
@@ -1,0 +1,67 @@
+"""PHM-Vibench training factory backed by phm-data-factory."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator, Mapping
+from typing import Any
+
+import numpy as np
+
+from .data_factory import data_factory, register_data_factory
+from .data_utils import MetadataAccessor
+from .standalone import build_data_repository
+
+
+class RepositorySignalMapping(Mapping[str, np.ndarray]):
+    def __init__(self, repository: Any):
+        self.repository = repository
+
+    def __getitem__(self, sample_id: str | int) -> np.ndarray:
+        return self.repository.read_signal(sample_id)
+
+    def __iter__(self) -> Iterator[str]:
+        return iter(self.repository.metadata.keys())
+
+    def __len__(self) -> int:
+        return len(self.repository.metadata)
+
+    def close(self) -> None:
+        self.repository.close()
+
+
+@register_data_factory("phm_data")
+class phm_data_factory(data_factory):
+    """Keep existing splits/Datasets/DataLoaders over a repository backend."""
+
+    def __init__(self, args_data: Any, args_task: Any):
+        self._repository = None
+        self._closed = False
+        super().__init__(args_data, args_task)
+
+    def _init_metadata(self, args_data: Any) -> MetadataAccessor:
+        self._repository = build_data_repository(args_data)
+        frame = self._repository.metadata_frame("phm_vibench_v1")
+        return MetadataAccessor(frame, key_column="Id")
+
+    def _init_data(self, args_data: Any, **_: Any) -> RepositorySignalMapping:
+        del args_data
+        return RepositorySignalMapping(self._repository)
+
+    def close(self) -> None:
+        if self._closed:
+            return
+        self._closed = True
+        if self._repository is not None:
+            self._repository.close()
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb) -> None:
+        self.close()
+
+    def __del__(self):
+        try:
+            self.close()
+        except Exception:
+            pass

--- a/src/data_factory/standalone.py
+++ b/src/data_factory/standalone.py
@@ -1,0 +1,72 @@
+"""Bridge PHM-Vibench configuration to the standalone data backend."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Any
+
+
+def _load_module():
+    try:
+        import phm_data_factory
+    except ModuleNotFoundError:
+        package_src = (
+            Path(__file__).resolve().parents[2]
+            / "packages"
+            / "phm-data-factory"
+            / "src"
+        )
+        if not package_src.exists():
+            raise ModuleNotFoundError(
+                "Install phm-data-factory or initialize packages/phm-data-factory"
+            )
+        sys.path.insert(0, str(package_src))
+        import phm_data_factory
+    return phm_data_factory
+
+
+def _value(config: Any, name: str, default: Any = None) -> Any:
+    return config.get(name, default) if isinstance(config, dict) else getattr(
+        config, name, default
+    )
+
+
+def _configured_backend(args_data: Any):
+    configured = _value(args_data, "phm_data_config")
+    if not configured:
+        raise ValueError("data.factory_name=phm_data requires data.phm_data_config")
+    if isinstance(configured, dict):
+        return configured
+    path = Path(configured).expanduser()
+    if path.is_absolute():
+        return path.resolve()
+    base = Path(_value(args_data, "data_dir", ".") or ".").expanduser().resolve()
+    return (base / path).resolve()
+
+
+def build_data_repository(args_data: Any, signal_path=None):
+    """Return the configured repository; never silently select a fallback."""
+
+    del signal_path
+    return _load_module().connect(_configured_backend(args_data))
+
+
+def build_data_backend(args_data: Any, signal_path=None):
+    return build_data_repository(args_data, signal_path=signal_path)
+
+
+def build_agent_data_tools(
+    args_data: Any,
+    signal_path=None,
+    default_max_points: int | None = None,
+    profile: str = "benchmark_public",
+):
+    del signal_path
+    tools = _load_module().connect_agent(
+        _configured_backend(args_data), profile=profile
+    )
+    max_points = default_max_points or _value(args_data, "agent_max_points")
+    if max_points is not None:
+        tools.default_max_points = int(max_points)
+    return tools

--- a/test/test_phm_data_factory_backend.py
+++ b/test/test_phm_data_factory_backend.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import h5py
+import numpy as np
+import pandas as pd
+import pytest
+
+from src.config_schema.models import DataConfig
+from src.data_factory import build_data, build_data_repository
+from src.data_factory.data_factory import data_factory
+
+
+def _backend_config(tmp_path: Path) -> Path:
+    pd.DataFrame(
+        [
+            {
+                "Id": 1,
+                "Dataset_id": 7,
+                "Name": "fixture",
+                "Visiable": 1,
+                "Label": 2,
+                "Domain_id": 3,
+                "Sample_lenth": 8,
+                "Channel": 1,
+            }
+        ]
+    ).to_csv(tmp_path / "metadata.csv", index=False)
+    with h5py.File(tmp_path / "cache.h5", "w") as handle:
+        handle.create_dataset("1", data=np.arange(8, dtype=np.float64)[:, None])
+    config = tmp_path / "phm-data.yaml"
+    config.write_text(
+        "backend: local\n"
+        f"metadata_path: {tmp_path / 'metadata.csv'}\n"
+        f"signal_path: {tmp_path / 'cache.h5'}\n",
+        encoding="utf-8",
+    )
+    return config
+
+
+def test_data_config_requires_fields_conditionally():
+    DataConfig(factory_name="phm_data", phm_data_config="backend.yaml")
+    DataConfig(data_dir="data", metadata_file="metadata.csv")
+    with pytest.raises(ValueError, match="phm_data_config"):
+        DataConfig(factory_name="phm_data")
+    with pytest.raises(ValueError, match="data_dir"):
+        DataConfig()
+
+
+def test_registered_factory_uses_repository_and_preserves_training_metadata(
+    tmp_path: Path, monkeypatch
+):
+    config = _backend_config(tmp_path)
+    monkeypatch.setattr(
+        data_factory, "_init_dataset", lambda self: ("train", "val", "test")
+    )
+    monkeypatch.setattr(
+        data_factory, "_init_dataloader", lambda self: ("tl", "vl", "xl")
+    )
+    args_data = SimpleNamespace(
+        factory_name="phm_data", phm_data_config=str(config), num_workers=0
+    )
+    factory = build_data(args_data, SimpleNamespace(name="Default", type="DG"))
+    try:
+        assert factory.metadata["1"]["Dataset_id"] == 7
+        assert factory.metadata["1"]["Label"] == 2
+        np.testing.assert_array_equal(factory.data["1"][:, 0], np.arange(8))
+    finally:
+        factory.close()
+        factory.close()
+
+
+def test_bridge_rejects_silent_backend_fallback():
+    with pytest.raises(ValueError, match="phm_data_config"):
+        build_data_repository(SimpleNamespace(factory_name="phm_data"))

--- a/test/test_validate_docs_scope.py
+++ b/test/test_validate_docs_scope.py
@@ -24,3 +24,21 @@ def test_validate_docs_skips_local_agent_and_obsidian_dirs(tmp_path) -> None:
     scanned = {path.relative_to(tmp_path).as_posix() for path in iter_doc_files(tmp_path)}
 
     assert scanned == {"README.md", ".claude/README.md"}
+
+
+def test_validate_docs_skips_initialized_git_submodules(tmp_path) -> None:
+    (tmp_path / "README.md").write_text("# Root\n", encoding="utf-8")
+    (tmp_path / ".gitmodules").write_text(
+        '[submodule "provider"]\n'
+        "\tpath = packages/provider\n"
+        "\turl = https://example.invalid/provider.git\n",
+        encoding="utf-8",
+    )
+    provider = tmp_path / "packages" / "provider"
+    provider.mkdir(parents=True)
+    (provider / "README.md").write_text("[broken](missing.md)\n", encoding="utf-8")
+    (provider / "AGENTS.md").write_text("# External instructions\n", encoding="utf-8")
+
+    scanned = {path.relative_to(tmp_path).as_posix() for path in iter_doc_files(tmp_path)}
+
+    assert scanned == {"README.md"}


### PR DESCRIPTION
Superseded by PHMFactory v0.3 backend governance PR #119 and the required organization-ownership transfer.

This PR is retained as implementation evidence only. It must not be merged independently because it uses a personal-account submodule URL, targets the pre-cleanup repository topology, modifies protected Data Factory lifecycle behavior, and mutates `sys.path` to load the checkout.

The replacement integration must use the neutral organization-owned backend target, one immutable gitlink, no branch tracking, no personal URL, no protected base-factory changes, and must remain optional when uninitialized.