### PR TITLE
fix(engine): route default task and honor task registry

### DIFF
--- a/src/data_factory/samplers/Get_sampler.py
+++ b/src/data_factory/samplers/Get_sampler.py
@@ -126,6 +126,10 @@ def Get_sampler(args_task, args_data, dataset, mode='train'):
         sampler = _get_pretrain_sampler(args_data, dataset, mode)  # Reuse pretrain sampler
     elif args_task.type == 'In_distribution':
         sampler = _get_pretrain_sampler(args_data, dataset, mode)
+    elif args_task.type == 'Default_task':
+        # Leakage-safe in-domain classification path: grouped_metadata with
+        # test_policy=partition must use the standard supervised batching path.
+        sampler = _get_dg_sampler(args_data, dataset, mode)
     else:
         raise ValueError(f"Unknown task type for sampler: {args_task.type}")
         

--- a/src/task_factory/task_factory.py
+++ b/src/task_factory/task_factory.py
@@ -45,26 +45,33 @@ def task_factory(
         module_path = resolve_task_module(args_task)
         try:
             task_module = importlib.import_module(module_path)
-            # 智能检测类名，支持多种命名约定
-            task_cls = None
+            # Importing the module runs any @register_task decorators. Re-check
+            # the authoritative registry before using naming heuristics.
+            try:
+                task_cls = TASK_REGISTRY.get(key)
+            except KeyError:
+                task_cls = None
 
-            # 优先级1：查找与文件名相同的类名（如 hse_contrastive.py 中的 HseContrastiveTask）
+            # 智能检测类名，支持多种命名约定（fallback）
             class_name_from_file = module_path.split('.')[-1].replace('_', ' ').title().replace(' ', '')
-            if hasattr(task_module, class_name_from_file):
+            if task_cls is None and hasattr(task_module, class_name_from_file):
                 task_cls = getattr(task_module, class_name_from_file)
 
             # 优先级2：查找标准化的类名（Task后缀）
             task_name = args_task.name
             standard_name = task_name.replace('_', ' ').title().replace(' ', '') + 'Task'
-            if hasattr(task_module, standard_name):
+            if task_cls is None and hasattr(task_module, standard_name):
                 task_cls = getattr(task_module, standard_name)
 
             # 优先级3：向后兼容 - 查找 'task' 类名
-            if hasattr(task_module, 'task'):
+            if task_cls is None and hasattr(task_module, 'task'):
                 task_cls = getattr(task_module, 'task')
 
             if task_cls is None:
-                raise AttributeError(f"No task class found in {module_path} (tried: {class_name_from_file}, {standard_name}, task)")
+                raise AttributeError(
+                    f"No task class found in {module_path} "
+                    f"(tried: registry, {class_name_from_file}, {standard_name}, task)"
+                )
 
         except Exception as exc:  # pragma: no cover - runtime safeguard
             print(f"Failed to import task from {module_path}: {exc}")
@@ -83,7 +90,6 @@ def task_factory(
     except Exception as exc:  # pragma: no cover - runtime safeguard
         print(f"Failed to create task {key}: {exc}")
         return None
-
 
 
 


### PR DESCRIPTION
## What changed

- Route `Default_task` through the supervised DG sampler so leakage-safe grouped partitions reach training intact.
- Re-check the task registry after module import before falling back to class-name heuristics.

## Why

The grouped paper configurations use `Default_task`, and decorator registration is the authoritative task-resolution path. The previous fallback could reject valid snake_case task classes.

## Validation

- `python -m pytest test/`
- Result: 128 passed, 1 skipped.