### PR TITLE
feat(config): add public config resolver

### DIFF
--- a/.github/workflows/phmfactory-public-package.yml
+++ b/.github/workflows/phmfactory-public-package.yml
@@ -8,6 +8,7 @@ on:
       - "pyproject.toml"
       - "requirements.txt"
       - "test/test_phmfactory_entrypoints.py"
+      - "test/test_phmfactory_config_resolver.py"
       - "test/test_pipeline_name_migration.py"
       - ".github/workflows/phmfactory-public-package.yml"
   push:
@@ -19,6 +20,7 @@ on:
       - "pyproject.toml"
       - "requirements.txt"
       - "test/test_phmfactory_entrypoints.py"
+      - "test/test_phmfactory_config_resolver.py"
       - "test/test_pipeline_name_migration.py"
       - ".github/workflows/phmfactory-public-package.yml"
   workflow_dispatch:
@@ -52,13 +54,15 @@ jobs:
           phmfactory/*.py
           main.py
           test/test_phmfactory_entrypoints.py
+          test/test_phmfactory_config_resolver.py
           test/test_pipeline_name_migration.py
 
-      - name: Run focused entrypoint tests
+      - name: Run focused public API tests
         run: >-
           python -m pytest -vv
           --junitxml=pytest-public-package.xml
           test/test_phmfactory_entrypoints.py
+          test/test_phmfactory_config_resolver.py
           test/test_pipeline_name_migration.py
 
       - name: Upload focused pytest diagnostics
@@ -86,6 +90,8 @@ jobs:
               "phmfactory/__init__.py",
               "phmfactory/__main__.py",
               "phmfactory/cli.py",
+              "phmfactory/config.py",
+              "phmfactory/pipelines.py",
               "src/__init__.py",
           }
           missing = sorted(required - names)
@@ -97,7 +103,7 @@ jobs:
         run: |
           python -m venv /tmp/phmfactory-wheel
           /tmp/phmfactory-wheel/bin/python -m pip install --no-deps dist/*.whl
-          /tmp/phmfactory-wheel/bin/python -c "import phmfactory, src; print(phmfactory.__version__)"
           /tmp/phmfactory-wheel/bin/python -m pip install PyYAML
+          /tmp/phmfactory-wheel/bin/python -c "import phmfactory, phmfactory.config, src; print(phmfactory.__version__)"
           /tmp/phmfactory-wheel/bin/phmfactory --help
           /tmp/phmfactory-wheel/bin/python -m phmfactory --help

--- a/phmfactory/cli.py
+++ b/phmfactory/cli.py
@@ -5,15 +5,10 @@ from __future__ import annotations
 import argparse
 import importlib
 from collections.abc import Sequence
-from pathlib import Path
 from typing import Any
 
-import yaml
-
-from phmfactory.pipelines import canonical_pipeline_name, pipeline_module_name
-
-DEFAULT_CONFIG = "configs/demo/01_cross_domain/cwru_dg.yaml"
-DEFAULT_PIPELINE = "Pipeline_01_Fault_Diagnosis"
+from phmfactory.config import DEFAULT_CONFIG, resolve_config
+from phmfactory.pipelines import pipeline_module_name
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -48,40 +43,6 @@ def build_parser() -> argparse.ArgumentParser:
     return parser
 
 
-def _set_nested_value(config: dict[str, Any], key: str, value: Any) -> None:
-    current = config
-    parts = key.split(".")
-    for part in parts[:-1]:
-        existing = current.get(part)
-        if existing is None:
-            current[part] = {}
-        elif not isinstance(existing, dict):
-            raise ValueError(f"Cannot set nested key '{key}': '{part}' is not a dict")
-        current = current[part]
-    current[parts[-1]] = value
-
-
-def _parse_overrides(values: Sequence[str] | None) -> dict[str, Any]:
-    """Parse CLI overrides without importing the heavy protected runtime."""
-    parsed: dict[str, Any] = {}
-    for item in values or ():
-        if "=" not in item:
-            raise ValueError(f"Invalid override format: '{item}'. Use key=value format.")
-        key, raw_value = item.split("=", 1)
-        key = key.strip()
-        if not key:
-            raise ValueError("Override key must be non-empty")
-        try:
-            value = yaml.safe_load(raw_value.strip())
-        except yaml.YAMLError:
-            value = raw_value.strip()
-        if "." in key:
-            _set_nested_value(parsed, key, value)
-        else:
-            parsed[key] = value
-    return parsed
-
-
 def _resolve_config_path(args: argparse.Namespace) -> str:
     if args.config is not None:
         return args.config
@@ -90,41 +51,27 @@ def _resolve_config_path(args: argparse.Namespace) -> str:
     return DEFAULT_CONFIG
 
 
-def _pipeline_from_yaml(config_path: str) -> str:
-    path = Path(config_path)
-    if not path.exists():
-        return DEFAULT_PIPELINE
-    try:
-        with path.open("r", encoding="utf-8") as handle:
-            config = yaml.safe_load(handle) or {}
-    except (OSError, UnicodeDecodeError, yaml.YAMLError):
-        return DEFAULT_PIPELINE
-    if isinstance(config, dict):
-        pipeline = config.get("pipeline")
-        if isinstance(pipeline, str) and pipeline.strip():
-            return pipeline.strip()
-    return DEFAULT_PIPELINE
-
-
 def _resolve_pipeline(args: argparse.Namespace, config_path: str) -> str:
-    pipeline_name = _pipeline_from_yaml(config_path)
-    if args.override:
-        overrides = _parse_overrides(args.override)
-        override_pipeline = overrides.get("pipeline")
-        if override_pipeline is not None:
-            if not isinstance(override_pipeline, str) or not override_pipeline.strip():
-                raise ValueError("pipeline override must be a non-empty string")
-            pipeline_name = override_pipeline.strip()
-    return canonical_pipeline_name(pipeline_name)
+    """Resolve the canonical Pipeline through the public config API."""
+    return resolve_config(
+        config_path,
+        override_values=args.override,
+    ).pipeline
 
 
 def run(args: argparse.Namespace) -> Any:
     """Dispatch a parsed argument namespace to the protected runtime."""
-    config_path = _resolve_config_path(args)
-    args.config_path = config_path
-    pipeline_name = _resolve_pipeline(args, config_path)
+    requested_config = _resolve_config_path(args)
+    resolved = resolve_config(requested_config, override_values=args.override)
+
+    # Preserve the historical downstream contract: Pipelines receive the source
+    # requested by the user rather than a generated temporary file.
+    args.config_path = requested_config
+    args.resolved_config_path = str(resolved.path)
+    args.resolved_pipeline = resolved.pipeline
+
     pipeline_module = importlib.import_module(
-        pipeline_module_name(pipeline_name, warn=False)
+        pipeline_module_name(resolved.pipeline, warn=False)
     )
     result = pipeline_module.pipeline(args)
     print("完成所有实验！")

--- a/phmfactory/config.py
+++ b/phmfactory/config.py
@@ -1,0 +1,151 @@
+"""Public configuration resolution for PHMFactory.
+
+This module resolves a maintained preset or YAML path, applies CLI-style dotted
+key overrides, and returns a plain dictionary without importing the protected
+training runtime.
+"""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+import yaml
+
+from phmfactory.pipelines import canonical_pipeline_name
+
+DEFAULT_CONFIG = "configs/demo/01_cross_domain/cwru_dg.yaml"
+DEFAULT_PIPELINE = "Pipeline_01_Fault_Diagnosis"
+
+# Public, maintained aliases only. Historical v0.0.9 aliases stay in the
+# protected compatibility loader and are not promoted as v0.3 public API.
+MAINTAINED_PRESETS: dict[str, str] = {
+    "quickstart": DEFAULT_CONFIG,
+    "smoke": "configs/demo/00_smoke/dummy_dg.yaml",
+    "cross-domain": "configs/demo/01_cross_domain/cwru_dg.yaml",
+    "cross-system": "configs/demo/02_cross_system/cwru_to_thu.yaml",
+    "few-shot": "configs/demo/03_fewshot/cwru_fewshot.yaml",
+}
+
+
+@dataclass(frozen=True)
+class ResolvedConfig:
+    """Resolved public configuration metadata and payload."""
+
+    requested: str
+    path: Path
+    data: dict[str, Any]
+    pipeline: str
+    overrides: dict[str, Any]
+
+
+def parse_overrides(values: Sequence[str] | None) -> dict[str, Any]:
+    """Parse repeated ``key=value`` overrides into a nested dictionary."""
+    parsed: dict[str, Any] = {}
+    for item in values or ():
+        if "=" not in item:
+            raise ValueError(f"Invalid override format: {item!r}. Use key=value format.")
+        key, raw_value = item.split("=", 1)
+        key = key.strip()
+        if not key:
+            raise ValueError("Override key must be non-empty")
+        try:
+            value = yaml.safe_load(raw_value.strip())
+        except yaml.YAMLError:
+            value = raw_value.strip()
+        _set_dotted(parsed, key, value)
+    return parsed
+
+
+def resolve_config_path(source: str | Path | None) -> Path:
+    """Resolve a public preset or YAML path without changing the working tree."""
+    requested = str(source or DEFAULT_CONFIG)
+    candidate = Path(MAINTAINED_PRESETS.get(requested, requested)).expanduser()
+    if not candidate.is_file():
+        known = ", ".join(sorted(MAINTAINED_PRESETS))
+        raise FileNotFoundError(
+            f"Configuration {requested!r} was not found. Maintained presets: {known}"
+        )
+    return candidate.resolve()
+
+
+def load_config_dict(path: str | Path) -> dict[str, Any]:
+    """Load YAML and recursively merge its ordered ``base_configs`` entries."""
+    return _load_recursive(Path(path).resolve(), stack=())
+
+
+def resolve_config(
+    source: str | Path | None = None,
+    *,
+    override_values: Sequence[str] | None = None,
+) -> ResolvedConfig:
+    """Resolve path, base configs, overrides, and canonical Pipeline name."""
+    requested = str(source or DEFAULT_CONFIG)
+    path = resolve_config_path(source)
+    data = load_config_dict(path)
+    overrides = parse_overrides(override_values)
+    _deep_merge(data, overrides)
+    raw_pipeline = data.get("pipeline", DEFAULT_PIPELINE)
+    if not isinstance(raw_pipeline, str) or not raw_pipeline.strip():
+        raise ValueError("pipeline must be a non-empty string")
+    pipeline = canonical_pipeline_name(raw_pipeline.strip())
+    data["pipeline"] = pipeline
+    return ResolvedConfig(
+        requested=requested,
+        path=path,
+        data=data,
+        pipeline=pipeline,
+        overrides=overrides,
+    )
+
+
+def _load_recursive(path: Path, *, stack: tuple[Path, ...]) -> dict[str, Any]:
+    if path in stack:
+        chain = " -> ".join(str(item) for item in (*stack, path))
+        raise ValueError(f"Cyclic base_configs reference: {chain}")
+    try:
+        payload = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+    except UnicodeDecodeError:
+        payload = yaml.safe_load(path.read_text(encoding="gb18030", errors="ignore")) or {}
+    if not isinstance(payload, dict):
+        raise TypeError(f"Top-level YAML object must be a mapping: {path}")
+
+    merged: dict[str, Any] = {}
+    base_configs = payload.get("base_configs") or {}
+    if not isinstance(base_configs, Mapping):
+        raise TypeError(f"base_configs must be a mapping: {path}")
+    for base_source in base_configs.values():
+        base_path = Path(str(base_source)).expanduser()
+        if not base_path.is_absolute() and not str(base_path).startswith("configs/"):
+            base_path = path.parent / base_path
+        else:
+            base_path = base_path.resolve()
+        _deep_merge(merged, _load_recursive(base_path.resolve(), stack=(*stack, path)))
+
+    current = {key: value for key, value in payload.items() if key != "base_configs"}
+    _deep_merge(merged, current)
+    return merged
+
+
+def _set_dotted(target: dict[str, Any], key: str, value: Any) -> None:
+    current = target
+    parts = key.split(".")
+    for part in parts[:-1]:
+        existing = current.get(part)
+        if existing is None:
+            existing = {}
+            current[part] = existing
+        if not isinstance(existing, dict):
+            raise ValueError(f"Cannot set nested key {key!r}: {part!r} is not a mapping")
+        current = existing
+    current[parts[-1]] = value
+
+
+def _deep_merge(target: dict[str, Any], source: Mapping[str, Any]) -> None:
+    for key, value in source.items():
+        if isinstance(value, Mapping) and isinstance(target.get(key), dict):
+            _deep_merge(target[key], value)
+        else:
+            target[key] = deepcopy(value)

--- a/test/test_phmfactory_config_resolver.py
+++ b/test/test_phmfactory_config_resolver.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from phmfactory.config import (
+    DEFAULT_PIPELINE,
+    load_config_dict,
+    parse_overrides,
+    resolve_config,
+)
+from phmfactory.pipelines import PipelineNameDeprecationWarning
+
+
+def test_parse_overrides_expands_dotted_keys_and_yaml_types() -> None:
+    assert parse_overrides(
+        ["trainer.max_epochs=2", "task.enabled=true", "labels=[1, 2]"]
+    ) == {
+        "trainer": {"max_epochs": 2},
+        "task": {"enabled": True},
+        "labels": [1, 2],
+    }
+
+
+def test_recursive_base_config_merge_is_ordered(tmp_path: Path) -> None:
+    base_a = tmp_path / "base_a.yaml"
+    base_b = tmp_path / "base_b.yaml"
+    child = tmp_path / "child.yaml"
+    base_a.write_text("model:\n  width: 32\ntrainer:\n  epochs: 1\n", encoding="utf-8")
+    base_b.write_text("model:\n  depth: 4\ntrainer:\n  epochs: 2\n", encoding="utf-8")
+    child.write_text(
+        "base_configs:\n"
+        "  a: base_a.yaml\n"
+        "  b: base_b.yaml\n"
+        "pipeline: Pipeline_01_default\n"
+        "model:\n  width: 64\n",
+        encoding="utf-8",
+    )
+
+    resolved = load_config_dict(child)
+    assert resolved["model"] == {"width": 64, "depth": 4}
+    assert resolved["trainer"] == {"epochs": 2}
+
+
+def test_resolve_config_canonicalizes_pipeline_and_applies_override(
+    tmp_path: Path,
+) -> None:
+    config = tmp_path / "config.yaml"
+    config.write_text(
+        "pipeline: Pipeline_01_default\ntrainer:\n  max_epochs: 5\n",
+        encoding="utf-8",
+    )
+
+    with pytest.warns(PipelineNameDeprecationWarning):
+        resolved = resolve_config(
+            config,
+            override_values=[
+                "pipeline=Pipeline_04_unified_metric",
+                "trainer.max_epochs=1",
+            ],
+        )
+
+    assert resolved.pipeline == "Pipeline_04_Unified_Evaluation"
+    assert resolved.data["pipeline"] == "Pipeline_04_Unified_Evaluation"
+    assert resolved.data["trainer"]["max_epochs"] == 1
+    assert resolved.path == config.resolve()
+
+
+def test_resolve_config_rejects_missing_source(tmp_path: Path) -> None:
+    with pytest.raises(FileNotFoundError):
+        resolve_config(tmp_path / "missing.yaml")
+
+
+def test_cycle_detection(tmp_path: Path) -> None:
+    first = tmp_path / "first.yaml"
+    second = tmp_path / "second.yaml"
+    first.write_text("base_configs:\n  second: second.yaml\n", encoding="utf-8")
+    second.write_text("base_configs:\n  first: first.yaml\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="Cyclic base_configs"):
+        load_config_dict(first)
+
+
+def test_pipeline_defaults_when_omitted(tmp_path: Path) -> None:
+    config = tmp_path / "config.yaml"
+    config.write_text("trainer:\n  max_epochs: 1\n", encoding="utf-8")
+    assert resolve_config(config).pipeline == DEFAULT_PIPELINE

--- a/test/test_phmfactory_entrypoints.py
+++ b/test/test_phmfactory_entrypoints.py
@@ -11,6 +11,7 @@ import pytest
 
 from phmfactory import __version__
 from phmfactory import cli
+from phmfactory.config import ResolvedConfig
 from phmfactory.pipelines import PipelineNameDeprecationWarning
 
 
@@ -39,13 +40,15 @@ def test_config_takes_precedence_over_legacy_alias() -> None:
     assert cli._resolve_config_path(args) == "public.yaml"
 
 
-def test_run_dispatches_legacy_identifier_to_canonical_module(
+def test_run_dispatches_resolved_canonical_module(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     observed: dict[str, object] = {}
 
     def pipeline(args: argparse.Namespace) -> str:
         observed["config_path"] = args.config_path
+        observed["resolved_config_path"] = args.resolved_config_path
+        observed["resolved_pipeline"] = args.resolved_pipeline
         observed["notes"] = args.notes
         return "sentinel"
 
@@ -53,6 +56,18 @@ def test_run_dispatches_legacy_identifier_to_canonical_module(
         observed["module"] = name
         return SimpleNamespace(pipeline=pipeline)
 
+    def fake_resolve(source: str, *, override_values: list[str] | None = None) -> ResolvedConfig:
+        assert source == "missing.yaml"
+        assert override_values == ["pipeline=Pipeline_04_unified_metric"]
+        return ResolvedConfig(
+            requested=source,
+            path=Path("/tmp/missing.yaml"),
+            data={"pipeline": "Pipeline_04_Unified_Evaluation"},
+            pipeline="Pipeline_04_Unified_Evaluation",
+            overrides={"pipeline": "Pipeline_04_unified_metric"},
+        )
+
+    monkeypatch.setattr(cli, "resolve_config", fake_resolve)
     monkeypatch.setattr(cli.importlib, "import_module", fake_import)
     args = argparse.Namespace(
         config="missing.yaml",
@@ -61,11 +76,12 @@ def test_run_dispatches_legacy_identifier_to_canonical_module(
         override=["pipeline=Pipeline_04_unified_metric"],
     )
 
-    with pytest.warns(PipelineNameDeprecationWarning):
-        assert cli.run(args) == "sentinel"
+    assert cli.run(args) == "sentinel"
     assert observed == {
         "module": "src.Pipeline_04_Unified_Evaluation",
         "config_path": "missing.yaml",
+        "resolved_config_path": "/tmp/missing.yaml",
+        "resolved_pipeline": "Pipeline_04_Unified_Evaluation",
         "notes": "entrypoint-parity",
     }
 


### PR DESCRIPTION
## What changed

This is the bounded PHMFactory v0.3 PR-06 public configuration resolver.

It adds `phmfactory.config` as the single lightweight public surface for:

- maintained preset or YAML-path resolution;
- ordered recursive `base_configs` merging;
- dotted `key=value` CLI overrides with YAML type parsing;
- canonical Pipeline-name resolution;
- cycle detection and clear missing-source errors;
- a plain-dictionary result that does not import the protected training runtime.

The CLI now delegates config-path, override, and Pipeline resolution to this public resolver. It still dispatches the selected canonical module under `src` and preserves the downstream `args.config_path` contract.

## Public API

```python
from phmfactory.config import (
    ResolvedConfig,
    load_config_dict,
    parse_overrides,
    resolve_config,
    resolve_config_path,
)
```

`ResolvedConfig` records:

```text
requested source
resolved absolute path
merged plain dictionary
canonical Pipeline identifier
parsed override dictionary
```

## Maintained presets

The public v0.3 API exposes only maintained aliases:

```text
quickstart
smoke
cross-domain
cross-system
few-shot
```

Historical v0.0.9 aliases remain in the protected compatibility loader; they are not promoted as public v0.3 presets.

## Compatibility boundary

- `--config` remains preferred;
- `--config_path` remains accepted;
- `--config` keeps precedence;
- `args.config_path` still contains the user-requested source;
- `args.resolved_config_path` exposes the resolved absolute file path;
- `args.resolved_pipeline` exposes the canonical Pipeline;
- no Pipeline, reader, factory, model, task, trainer, data split, metric, checkpoint, shape, dtype, or channel behavior changes.

## Changed files

```text
phmfactory/config.py
phmfactory/cli.py
test/test_phmfactory_config_resolver.py
test/test_phmfactory_entrypoints.py
.github/workflows/phmfactory-public-package.yml
```

## Validation

The focused workflow compiles the public package, runs config/entrypoint/Pipeline-name tests, builds wheel and sdist, verifies `phmfactory/config.py` is packaged, performs a clean no-dependency wheel install plus minimal PyYAML install, and exercises both installed CLI entrypoints.

Existing Core, Pipeline 06, and Streamlit gates remain required.

## Base and dependency

```text
base: agent/v030-pipeline-descriptive-names-pr05
base SHA: 9b1337dc4f51d313b9be2da187e4d598c6731a9e
head: agent/v030-public-config-resolver-pr06
```

## Non-goals

- no rewrite of `src/configs/config_utils.py`;
- no replacement of Pipeline-internal config objects;
- no config-file mass formatting;
- no requirements reorganization;
- no CWRU provider work;
- no app consolidation;
- no repository rename.

## Rollback

A normal revert restores CLI-local resolution and removes the public resolver and its focused tests. Protected runtime files remain unchanged.