### PR TITLE
feat(data): add CWRU dual-source bundle quickstart

### DIFF
--- a/.github/workflows/phmfactory-cwru-bundle.yml
+++ b/.github/workflows/phmfactory-cwru-bundle.yml
@@ -1,0 +1,129 @@
+name: PHMFactory CWRU bundle contract
+
+on:
+  pull_request:
+    paths:
+      - "phmfactory/data_sources/**"
+      - "phmfactory/cli.py"
+      - "examples/cwru_quickstart.py"
+      - "test/test_phmfactory_data_sources.py"
+      - "docs/CWRU_DEMO_V0_3.md"
+      - "pyproject.toml"
+      - ".github/workflows/phmfactory-cwru-bundle.yml"
+  push:
+    branches:
+      - main
+    paths:
+      - "phmfactory/data_sources/**"
+      - "phmfactory/cli.py"
+      - "examples/cwru_quickstart.py"
+      - "test/test_phmfactory_data_sources.py"
+      - "docs/CWRU_DEMO_V0_3.md"
+      - "pyproject.toml"
+      - ".github/workflows/phmfactory-cwru-bundle.yml"
+  workflow_dispatch:
+    inputs:
+      source:
+        description: Public provider to verify online
+        required: true
+        type: choice
+        options:
+          - huggingface
+          - modelscope
+      revision:
+        description: Immutable provider revision
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  offline-contract:
+    name: Offline CWRU bundle contract
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+
+      - name: Install focused dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install "build>=1.2" "pytest>=7" PyYAML h5py openpyxl
+
+      - name: Compile provider and example code
+        run: |
+          python -m compileall -q phmfactory/data_sources
+          python -m py_compile phmfactory/cli.py examples/cwru_quickstart.py
+
+      - name: Run offline bundle tests
+        run: >-
+          python -m pytest -vv
+          --junitxml=pytest-cwru-bundle.xml
+          test/test_phmfactory_data_sources.py
+
+      - name: Upload focused diagnostics
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: phmfactory-cwru-bundle-pytest
+          path: pytest-cwru-bundle.xml
+          if-no-files-found: error
+          retention-days: 7
+
+      - name: Build distribution and inspect manifest packaging
+        run: |
+          python -m build
+          python - <<'PY'
+          from pathlib import Path
+          from zipfile import ZipFile
+
+          wheels = sorted(Path("dist").glob("*.whl"))
+          assert len(wheels) == 1, wheels
+          with ZipFile(wheels[0]) as archive:
+              names = set(archive.namelist())
+          required = {
+              "phmfactory/data_sources/__init__.py",
+              "phmfactory/data_sources/bundle.py",
+              "phmfactory/data_sources/manifests/__init__.py",
+              "phmfactory/data_sources/manifests/cwru-demo-v1.yaml",
+          }
+          missing = sorted(required - names)
+          assert not missing, missing
+          PY
+
+  online-provider:
+    name: Manual online provider verification
+    if: github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+
+      - name: Install provider dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install PyYAML h5py openpyxl huggingface_hub modelscope
+
+      - name: Download and validate pinned provider bundle
+        run: >-
+          python main.py data download
+          --bundle cwru-demo-v1
+          --source "${{ inputs.source }}"
+          --revision "${{ inputs.revision }}"
+          --destination /tmp/cwru-demo-v1
+          --force

--- a/docs/CWRU_DEMO_V0_3.md
+++ b/docs/CWRU_DEMO_V0_3.md
@@ -1,0 +1,113 @@
+# PHMFactory v0.3 CWRU Demo Contract
+
+## Scope
+
+The v0.3 quickstart uses a prebuilt, provider-neutral local bundle and then hands
+its directory to the existing Data Factory. It does not modify
+`src/data_factory/reader/RM_001_CWRU.py`, rebuild raw MAT files, or replace the
+existing `<Name>.h5 -> cache.h5` runtime path.
+
+## Bundle files
+
+Required:
+
+```text
+metadata.xlsx
+RM_001_CWRU.h5
+```
+
+Optional:
+
+```text
+corpus.xlsx
+```
+
+The metadata and HDF5 files are joined by `Id`. For rows whose `Name` is
+`RM_001_CWRU`, every metadata Id must exist as an HDF5 key. Each signal dataset
+must be two-dimensional with shape `(L, C)`, matching the accepted metadata
+aliases for sample length and channel count.
+
+`corpus.xlsx` is not required for the v0.3 fault-diagnosis demo. When present,
+its Id values must be a subset of metadata Id values. Explainable or generative
+workflows that require text remain responsible for rejecting a missing corpus.
+
+## Public providers
+
+The bundled manifest declares two explicit sources:
+
+- Hugging Face: `PHMbench/PHM-Vibench`
+- ModelScope: `PHMbench/PHM-Vibench`
+
+The provider layer downloads only the declared filenames. It does not download
+the whole dataset repository and does not perform network access from a DataLoader
+or reader.
+
+Development commands currently use the provider branch names recorded in the
+manifest. These floating revisions are not sufficient for a v0.3.0 release. The
+release gate must publish the same bundle to both services, replace both revisions
+with immutable revisions, populate expected SHA-256 values, and prove provider
+parity.
+
+## CLI
+
+Hugging Face:
+
+```bash
+python main.py data download \
+  --bundle cwru-demo-v1 \
+  --source huggingface
+```
+
+ModelScope:
+
+```bash
+python main.py data download \
+  --bundle cwru-demo-v1 \
+  --source modelscope
+```
+
+Validate an existing local bundle:
+
+```bash
+python main.py data validate \
+  --bundle cwru-demo-v1 \
+  --path ~/.cache/phmfactory/cwru-demo-v1
+```
+
+Compare independently downloaded provider materializations:
+
+```bash
+python main.py data compare \
+  --left /tmp/cwru-huggingface \
+  --right /tmp/cwru-modelscope
+```
+
+All commands are also available through `python -m phmfactory` and the installed
+`phmfactory` executable.
+
+## Minimal experiment
+
+```bash
+python examples/cwru_quickstart.py --source huggingface
+```
+
+The example downloads and validates the bundle, then runs the maintained CWRU
+cross-domain configuration for one CPU epoch with a small window count. Switching
+providers changes only `--source`.
+
+## Validation levels
+
+Every pull request runs offline contract tests with a generated metadata workbook
+and HDF5 cache. Those tests cover:
+
+- required files;
+- optional corpus behavior;
+- metadata/HDF5 Id integrity;
+- `(L, C)` shape and metadata consistency;
+- provider command construction;
+- local provider-hash parity;
+- `phmfactory data validate`.
+
+Online Hugging Face and ModelScope downloads are a nightly/release gate after the
+versioned remote bundle is published. The prebuilt-HDF5 path does not claim to
+revalidate raw MAT conversion in v0.3.0.

--- a/examples/cwru_quickstart.py
+++ b/examples/cwru_quickstart.py
@@ -1,0 +1,70 @@
+"""Download the maintained CWRU bundle and run a one-epoch CPU demo."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from phmfactory import cli
+from phmfactory.data_sources import download_bundle
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--source",
+        choices=("huggingface", "modelscope"),
+        default="huggingface",
+    )
+    parser.add_argument("--destination", default=None)
+    parser.add_argument("--revision", default=None)
+    parser.add_argument("--force", action="store_true")
+    parser.add_argument("--download-only", action="store_true")
+    return parser
+
+
+def main() -> object:
+    args = build_parser().parse_args()
+    bundle = download_bundle(
+        "cwru-demo-v1",
+        source=args.source,
+        destination=args.destination,
+        revision=args.revision,
+        force=args.force,
+    )
+    if args.download_only:
+        return bundle
+
+    data_dir = json.dumps(str(bundle.directory))
+    output_dir = json.dumps(str(Path("outputs") / "demo" / "cwru_fault_diagnosis"))
+    return cli.main(
+        [
+            "--config",
+            "configs/demo/01_cross_domain/cwru_dg.yaml",
+            "--override",
+            f"data.data_dir={data_dir}",
+            "--override",
+            "data.num_workers=0",
+            "--override",
+            "data.batch_size=32",
+            "--override",
+            "data.window_size=1024",
+            "--override",
+            "data.stride=1024",
+            "--override",
+            "data.num_window=8",
+            "--override",
+            "trainer.device=cpu",
+            "--override",
+            "trainer.gpus=0",
+            "--override",
+            "trainer.num_epochs=1",
+            "--override",
+            f"environment.output_dir={output_dir}",
+        ]
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/phmfactory/cli.py
+++ b/phmfactory/cli.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import argparse
 import importlib
+import sys
 from collections.abc import Sequence
 from typing import Any
 
@@ -12,7 +13,7 @@ from phmfactory.pipelines import pipeline_module_name
 
 
 def build_parser() -> argparse.ArgumentParser:
-    """Build the single parser shared by all supported public entrypoints."""
+    """Build the parser shared by the three experiment entrypoints."""
     parser = argparse.ArgumentParser(
         prog="phmfactory",
         description="PHMFactory task pipeline",
@@ -40,6 +41,39 @@ def build_parser() -> argparse.ArgumentParser:
         action="append",
         help="Configuration override in key=value form; may be repeated.",
     )
+    return parser
+
+
+def build_data_parser() -> argparse.ArgumentParser:
+    """Build the bounded dataset-bundle management command surface."""
+    parser = argparse.ArgumentParser(
+        prog="phmfactory data",
+        description="Download and validate PHMFactory dataset bundles.",
+    )
+    commands = parser.add_subparsers(dest="data_command", required=True)
+
+    download = commands.add_parser("download", help="Download one versioned bundle.")
+    download.add_argument("--bundle", default="cwru-demo-v1")
+    download.add_argument(
+        "--source",
+        choices=("huggingface", "modelscope"),
+        default="huggingface",
+    )
+    download.add_argument("--destination", default=None)
+    download.add_argument("--revision", default=None)
+    download.add_argument("--force", action="store_true")
+
+    validate = commands.add_parser("validate", help="Validate a local bundle.")
+    validate.add_argument("--bundle", default="cwru-demo-v1")
+    validate.add_argument("--path", required=True)
+
+    compare = commands.add_parser(
+        "compare",
+        help="Require identical core-file hashes for two local bundles.",
+    )
+    compare.add_argument("--bundle", default="cwru-demo-v1")
+    compare.add_argument("--left", required=True)
+    compare.add_argument("--right", required=True)
     return parser
 
 
@@ -78,8 +112,56 @@ def run(args: argparse.Namespace) -> Any:
     return result
 
 
+def _run_data_command(argv: Sequence[str]) -> Any:
+    from phmfactory.data_sources import (
+        compare_bundle_hashes,
+        download_bundle,
+        load_bundle_spec,
+        validate_bundle,
+    )
+
+    parser = build_data_parser()
+    args = parser.parse_args(list(argv))
+    spec = load_bundle_spec(args.bundle)
+
+    if args.data_command == "download":
+        result = download_bundle(
+            args.bundle,
+            source=args.source,
+            destination=args.destination,
+            revision=args.revision,
+            force=args.force,
+        )
+        validation = result.validation
+        print(f"bundle={validation.spec.bundle_id}")
+        print(f"provider={result.provider}")
+        print(f"revision={result.requested_revision}")
+        print(f"path={result.directory}")
+        print(f"selected_rows={validation.selected_rows}")
+        print(f"corpus_present={str(validation.corpus_present).lower()}")
+        return result
+
+    if args.data_command == "validate":
+        validation = validate_bundle(args.path, spec=spec)
+        print(f"bundle={validation.spec.bundle_id}")
+        print(f"path={validation.directory}")
+        print(f"metadata_rows={validation.metadata_rows}")
+        print(f"selected_rows={validation.selected_rows}")
+        print(f"signal_keys={validation.signal_keys}")
+        print(f"corpus_present={str(validation.corpus_present).lower()}")
+        return validation
+
+    hashes = compare_bundle_hashes(args.left, args.right, spec=spec)
+    for name, digest in hashes.items():
+        print(f"{name}={digest}")
+    return hashes
+
+
 def main(argv: Sequence[str] | None = None) -> Any:
-    """Parse command-line arguments and execute the selected Pipeline."""
+    """Execute a data subcommand or the backward-compatible experiment CLI."""
+    arguments = list(sys.argv[1:] if argv is None else argv)
+    if arguments[:1] == ["data"]:
+        return _run_data_command(arguments[1:])
     parser = build_parser()
-    args = parser.parse_args(argv)
+    args = parser.parse_args(arguments)
     return run(args)

--- a/phmfactory/data_sources/__init__.py
+++ b/phmfactory/data_sources/__init__.py
@@ -1,0 +1,25 @@
+"""Versioned public dataset-bundle providers for PHMFactory."""
+
+from phmfactory.data_sources.bundle import (
+    BundleDownload,
+    BundleFileReport,
+    BundleSpec,
+    BundleValidation,
+    BundleValidationError,
+    compare_bundle_hashes,
+    download_bundle,
+    load_bundle_spec,
+    validate_bundle,
+)
+
+__all__ = [
+    "BundleDownload",
+    "BundleFileReport",
+    "BundleSpec",
+    "BundleValidation",
+    "BundleValidationError",
+    "compare_bundle_hashes",
+    "download_bundle",
+    "load_bundle_spec",
+    "validate_bundle",
+]

--- a/phmfactory/data_sources/bundle.py
+++ b/phmfactory/data_sources/bundle.py
@@ -1,0 +1,552 @@
+"""Download and validate versioned PHMFactory dataset bundles.
+
+The provider layer is intentionally separate from the protected Data Factory. It
+materializes a local directory containing files that the existing runtime already
+understands, then returns that directory without changing reader or cache logic.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from hashlib import sha256
+from pathlib import Path
+import shutil
+import subprocess
+from typing import Any, Callable, Mapping, Sequence
+
+import yaml
+
+
+class BundleValidationError(ValueError):
+    """Raised when a downloaded bundle violates its declared data contract."""
+
+
+@dataclass(frozen=True)
+class BundleFileReport:
+    """Integrity information for one materialized bundle file."""
+
+    name: str
+    path: Path
+    size_bytes: int
+    sha256: str
+
+
+@dataclass(frozen=True)
+class BundleSpec:
+    """Parsed provider-independent bundle specification."""
+
+    bundle_id: str
+    dataset_name: str
+    release_pin_required: bool
+    metadata_file: str
+    signal_file: str
+    corpus_file: str | None
+    id_column: str
+    selector_column: str
+    selector_values: tuple[str, ...]
+    sample_length_aliases: tuple[str, ...]
+    channel_count_aliases: tuple[str, ...]
+    providers: Mapping[str, Mapping[str, Any]]
+    expected_sha256: Mapping[str, str]
+
+
+@dataclass(frozen=True)
+class BundleValidation:
+    """Validation summary returned to callers and CLI users."""
+
+    spec: BundleSpec
+    directory: Path
+    metadata_rows: int
+    selected_rows: int
+    signal_keys: int
+    corpus_present: bool
+    files: tuple[BundleFileReport, ...]
+
+
+@dataclass(frozen=True)
+class BundleDownload:
+    """Provider provenance plus the validated local materialization."""
+
+    provider: str
+    requested_revision: str
+    directory: Path
+    validation: BundleValidation
+
+
+def load_bundle_spec(bundle_id: str = "cwru-demo-v1") -> BundleSpec:
+    """Load a packaged YAML bundle specification by stable bundle id."""
+    path = Path(__file__).with_name("manifests") / f"{bundle_id}.yaml"
+    if not path.is_file():
+        raise FileNotFoundError(f"Unknown PHMFactory bundle: {bundle_id!r}")
+    payload = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+    if not isinstance(payload, Mapping):
+        raise TypeError(f"Bundle manifest must be a mapping: {path}")
+
+    files = _mapping(payload, "files")
+    metadata = _mapping(payload, "metadata")
+    selector = _mapping(metadata, "selector")
+    aliases = _mapping(metadata, "column_aliases")
+
+    metadata_file = _file_name(files, "metadata", required=True)
+    signal_file = _file_name(files, "signals", required=True)
+    corpus_file = _file_name(files, "corpus", required=False)
+    providers = _mapping(payload, "providers")
+    if not providers:
+        raise ValueError(f"Bundle {bundle_id!r} declares no providers")
+
+    return BundleSpec(
+        bundle_id=str(payload.get("bundle_id") or bundle_id),
+        dataset_name=str(payload.get("dataset_name") or ""),
+        release_pin_required=bool(payload.get("release_pin_required", True)),
+        metadata_file=metadata_file,
+        signal_file=signal_file,
+        corpus_file=corpus_file,
+        id_column=str(metadata.get("id_column") or "Id"),
+        selector_column=str(selector.get("column") or "Name"),
+        selector_values=tuple(str(value) for value in selector.get("values") or ()),
+        sample_length_aliases=tuple(
+            str(value) for value in aliases.get("sample_length") or ("Sample_lenth",)
+        ),
+        channel_count_aliases=tuple(
+            str(value) for value in aliases.get("channel_count") or ("Channel",)
+        ),
+        providers=providers,
+        expected_sha256={
+            str(name): str(value)
+            for name, value in _mapping(payload, "expected_sha256").items()
+            if value
+        },
+    )
+
+
+def validate_bundle(
+    directory: str | Path,
+    *,
+    spec: BundleSpec | None = None,
+) -> BundleValidation:
+    """Validate metadata, HDF5 signal keys/shapes, optional corpus, and hashes."""
+    bundle_spec = spec or load_bundle_spec()
+    root = Path(directory).expanduser().resolve()
+    if not root.is_dir():
+        raise BundleValidationError(f"Bundle directory does not exist: {root}")
+
+    metadata_path = root / bundle_spec.metadata_file
+    signal_path = root / bundle_spec.signal_file
+    for required_path in (metadata_path, signal_path):
+        if not required_path.is_file():
+            raise BundleValidationError(f"Required bundle file is missing: {required_path}")
+
+    headers, metadata_rows = _read_excel_rows(metadata_path)
+    _require_column(headers, bundle_spec.id_column, metadata_path)
+    _require_column(headers, bundle_spec.selector_column, metadata_path)
+    sample_length_column = _find_alias(headers, bundle_spec.sample_length_aliases)
+    channel_count_column = _find_alias(headers, bundle_spec.channel_count_aliases)
+    if sample_length_column is None:
+        raise BundleValidationError(
+            f"Metadata is missing a sample-length column; accepted aliases: "
+            f"{bundle_spec.sample_length_aliases}"
+        )
+    if channel_count_column is None:
+        raise BundleValidationError(
+            f"Metadata is missing a channel-count column; accepted aliases: "
+            f"{bundle_spec.channel_count_aliases}"
+        )
+
+    selected = [
+        row
+        for row in metadata_rows
+        if not bundle_spec.selector_values
+        or str(row.get(bundle_spec.selector_column, "")).strip()
+        in bundle_spec.selector_values
+    ]
+    if not selected:
+        raise BundleValidationError(
+            f"No rows matched {bundle_spec.selector_column} in "
+            f"{bundle_spec.selector_values}"
+        )
+
+    h5py = _import_h5py()
+    selected_ids = {_normalise_id(row[bundle_spec.id_column]) for row in selected}
+    with h5py.File(signal_path, "r") as handle:
+        signal_keys = {str(key) for key in handle.keys()}
+        missing_ids = sorted(selected_ids - signal_keys)
+        if missing_ids:
+            preview = ", ".join(missing_ids[:10])
+            raise BundleValidationError(
+                f"{len(missing_ids)} metadata Id values are absent from "
+                f"{signal_path.name}: {preview}"
+            )
+        for row in selected:
+            sample_id = _normalise_id(row[bundle_spec.id_column])
+            dataset = handle[sample_id]
+            if dataset.ndim != 2:
+                raise BundleValidationError(
+                    f"HDF5 dataset {sample_id!r} must have shape (L, C); "
+                    f"found {dataset.shape}"
+                )
+            expected_length = _positive_int(row.get(sample_length_column))
+            expected_channels = _positive_int(row.get(channel_count_column))
+            if expected_length is not None and dataset.shape[0] != expected_length:
+                raise BundleValidationError(
+                    f"HDF5 dataset {sample_id!r} length {dataset.shape[0]} does not "
+                    f"match metadata {expected_length}"
+                )
+            if expected_channels is not None and dataset.shape[1] != expected_channels:
+                raise BundleValidationError(
+                    f"HDF5 dataset {sample_id!r} channel count {dataset.shape[1]} "
+                    f"does not match metadata {expected_channels}"
+                )
+
+    corpus_present = False
+    if bundle_spec.corpus_file:
+        corpus_path = root / bundle_spec.corpus_file
+        if corpus_path.is_file():
+            corpus_present = True
+            corpus_headers, corpus_rows = _read_excel_rows(corpus_path)
+            _require_column(corpus_headers, bundle_spec.id_column, corpus_path)
+            corpus_ids = {
+                _normalise_id(row[bundle_spec.id_column])
+                for row in corpus_rows
+                if row.get(bundle_spec.id_column) is not None
+            }
+            unknown_ids = sorted(corpus_ids - {
+                _normalise_id(row[bundle_spec.id_column]) for row in metadata_rows
+            })
+            if unknown_ids:
+                preview = ", ".join(unknown_ids[:10])
+                raise BundleValidationError(
+                    f"corpus.xlsx references {len(unknown_ids)} unknown Id values: "
+                    f"{preview}"
+                )
+
+    reports = tuple(
+        _file_report(path)
+        for path in (
+            metadata_path,
+            signal_path,
+            *((root / bundle_spec.corpus_file,) if corpus_present else ()),
+        )
+    )
+    for report in reports:
+        expected = bundle_spec.expected_sha256.get(report.name)
+        if expected and report.sha256.lower() != expected.lower():
+            raise BundleValidationError(
+                f"SHA-256 mismatch for {report.name}: expected {expected}, "
+                f"found {report.sha256}"
+            )
+
+    return BundleValidation(
+        spec=bundle_spec,
+        directory=root,
+        metadata_rows=len(metadata_rows),
+        selected_rows=len(selected),
+        signal_keys=len(signal_keys),
+        corpus_present=corpus_present,
+        files=reports,
+    )
+
+
+def download_bundle(
+    bundle_id: str = "cwru-demo-v1",
+    *,
+    source: str = "huggingface",
+    destination: str | Path | None = None,
+    revision: str | None = None,
+    force: bool = False,
+) -> BundleDownload:
+    """Download required bundle files from one explicit public provider."""
+    spec = load_bundle_spec(bundle_id)
+    if source not in spec.providers:
+        available = ", ".join(sorted(spec.providers))
+        raise ValueError(f"Unknown data source {source!r}; choose one of: {available}")
+    provider = spec.providers[source]
+    requested_revision = str(revision or provider.get("revision") or "")
+    if not requested_revision:
+        raise ValueError(f"Provider {source!r} does not declare a revision")
+
+    root = Path(destination or Path.home() / ".cache" / "phmfactory" / bundle_id)
+    root = root.expanduser().resolve()
+    root.mkdir(parents=True, exist_ok=True)
+
+    required_names = (spec.metadata_file, spec.signal_file)
+    if not force and all((root / name).is_file() for name in required_names):
+        validation = validate_bundle(root, spec=spec)
+        _write_provenance(root, source, requested_revision, validation)
+        return BundleDownload(source, requested_revision, root, validation)
+
+    if source == "huggingface":
+        _download_huggingface(spec, provider, root, requested_revision)
+    elif source == "modelscope":
+        _download_modelscope(spec, provider, root, requested_revision)
+    else:  # guarded above; retained for explicit exhaustiveness
+        raise ValueError(f"Unsupported provider implementation: {source}")
+
+    validation = validate_bundle(root, spec=spec)
+    _write_provenance(root, source, requested_revision, validation)
+    return BundleDownload(source, requested_revision, root, validation)
+
+
+def compare_bundle_hashes(
+    left: str | Path,
+    right: str | Path,
+    *,
+    spec: BundleSpec | None = None,
+) -> Mapping[str, str]:
+    """Require identical core-file hashes across two provider materializations."""
+    bundle_spec = spec or load_bundle_spec()
+    left_report = validate_bundle(left, spec=bundle_spec)
+    right_report = validate_bundle(right, spec=bundle_spec)
+    left_hashes = {item.name: item.sha256 for item in left_report.files}
+    right_hashes = {item.name: item.sha256 for item in right_report.files}
+
+    compared_names = {bundle_spec.metadata_file, bundle_spec.signal_file}
+    if left_report.corpus_present or right_report.corpus_present:
+        if left_report.corpus_present != right_report.corpus_present:
+            raise BundleValidationError(
+                "Provider parity failed: corpus.xlsx exists in only one bundle"
+            )
+        assert bundle_spec.corpus_file is not None
+        compared_names.add(bundle_spec.corpus_file)
+
+    mismatches = {
+        name: (left_hashes.get(name), right_hashes.get(name))
+        for name in sorted(compared_names)
+        if left_hashes.get(name) != right_hashes.get(name)
+    }
+    if mismatches:
+        raise BundleValidationError(f"Provider bundle hashes differ: {mismatches}")
+    return {name: left_hashes[name] for name in sorted(compared_names)}
+
+
+def _download_huggingface(
+    spec: BundleSpec,
+    provider: Mapping[str, Any],
+    root: Path,
+    revision: str,
+) -> None:
+    try:
+        from huggingface_hub import hf_hub_download
+    except ImportError as exc:
+        raise ModuleNotFoundError(
+            "The Hugging Face provider requires huggingface_hub"
+        ) from exc
+
+    repo_id = str(provider.get("repo_id") or "")
+    repo_type = str(provider.get("repo_type") or "dataset")
+    file_map = _mapping(provider, "files")
+    for logical_name, local_name, required in _bundle_files(spec):
+        remote_name = str(file_map.get(logical_name) or local_name)
+        try:
+            downloaded = hf_hub_download(
+                repo_id=repo_id,
+                filename=remote_name,
+                repo_type=repo_type,
+                revision=revision,
+                local_dir=root,
+            )
+        except Exception:
+            if not required:
+                continue
+            raise
+        _materialise(Path(downloaded), root / local_name)
+
+
+def _download_modelscope(
+    spec: BundleSpec,
+    provider: Mapping[str, Any],
+    root: Path,
+    revision: str,
+    *,
+    runner: Callable[..., subprocess.CompletedProcess[str]] = subprocess.run,
+) -> None:
+    executable = shutil.which("modelscope")
+    if executable is None:
+        raise ModuleNotFoundError(
+            "The ModelScope provider requires the modelscope CLI"
+        )
+    repo_id = str(provider.get("repo_id") or "")
+    file_map = _mapping(provider, "files")
+    for logical_name, local_name, required in _bundle_files(spec):
+        remote_name = str(file_map.get(logical_name) or local_name)
+        command = [
+            executable,
+            "download",
+            "--dataset",
+            repo_id,
+            remote_name,
+            "--revision",
+            revision,
+            "--local_dir",
+            str(root),
+        ]
+        completed = runner(
+            command,
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=900,
+        )
+        if completed.returncode != 0:
+            if not required:
+                continue
+            raise RuntimeError(
+                f"ModelScope failed to download {remote_name!r}: "
+                f"{completed.stderr.strip()}"
+            )
+        candidate = root / remote_name
+        if not candidate.is_file():
+            matches = list(root.rglob(Path(remote_name).name))
+            if len(matches) != 1:
+                raise FileNotFoundError(
+                    f"ModelScope reported success but {remote_name!r} was not "
+                    f"materialized uniquely under {root}"
+                )
+            candidate = matches[0]
+        _materialise(candidate, root / local_name)
+
+
+def _bundle_files(spec: BundleSpec) -> Sequence[tuple[str, str, bool]]:
+    files: list[tuple[str, str, bool]] = [
+        ("metadata", spec.metadata_file, True),
+        ("signals", spec.signal_file, True),
+    ]
+    if spec.corpus_file:
+        files.append(("corpus", spec.corpus_file, False))
+    return tuple(files)
+
+
+def _write_provenance(
+    root: Path,
+    source: str,
+    revision: str,
+    validation: BundleValidation,
+) -> None:
+    payload = {
+        "schema_version": 1,
+        "bundle_id": validation.spec.bundle_id,
+        "provider": source,
+        "requested_revision": revision,
+        "corpus_present": validation.corpus_present,
+        "files": {
+            item.name: {
+                "size_bytes": item.size_bytes,
+                "sha256": item.sha256,
+            }
+            for item in validation.files
+        },
+    }
+    (root / ".phmfactory-bundle.yaml").write_text(
+        yaml.safe_dump(payload, sort_keys=True),
+        encoding="utf-8",
+    )
+
+
+def _read_excel_rows(path: Path) -> tuple[tuple[str, ...], list[dict[str, Any]]]:
+    try:
+        from openpyxl import load_workbook
+    except ImportError as exc:
+        raise ModuleNotFoundError(
+            "Bundle validation requires openpyxl"
+        ) from exc
+    workbook = load_workbook(path, read_only=True, data_only=True)
+    try:
+        sheet = workbook.active
+        iterator = sheet.iter_rows(values_only=True)
+        try:
+            raw_headers = next(iterator)
+        except StopIteration as exc:
+            raise BundleValidationError(f"Excel file is empty: {path}") from exc
+        headers = tuple("" if value is None else str(value).strip() for value in raw_headers)
+        if len(set(headers)) != len(headers):
+            raise BundleValidationError(f"Excel headers are not unique: {path}")
+        rows: list[dict[str, Any]] = []
+        for values in iterator:
+            row = {header: value for header, value in zip(headers, values) if header}
+            if any(value is not None for value in row.values()):
+                rows.append(row)
+        return headers, rows
+    finally:
+        workbook.close()
+
+
+def _import_h5py() -> Any:
+    try:
+        import h5py
+    except ImportError as exc:
+        raise ModuleNotFoundError("Bundle validation requires h5py") from exc
+    return h5py
+
+
+def _mapping(payload: Mapping[str, Any], key: str) -> Mapping[str, Any]:
+    value = payload.get(key) or {}
+    if not isinstance(value, Mapping):
+        raise TypeError(f"{key} must be a mapping")
+    return value
+
+
+def _file_name(files: Mapping[str, Any], key: str, *, required: bool) -> str | None:
+    entry = files.get(key)
+    if entry is None:
+        if required:
+            raise ValueError(f"Bundle manifest is missing files.{key}")
+        return None
+    if not isinstance(entry, Mapping):
+        raise TypeError(f"files.{key} must be a mapping")
+    filename = entry.get("filename")
+    if not filename:
+        if required:
+            raise ValueError(f"Bundle manifest is missing files.{key}.filename")
+        return None
+    return str(filename)
+
+
+def _require_column(headers: Sequence[str], name: str, path: Path) -> None:
+    if name not in headers:
+        raise BundleValidationError(f"Required column {name!r} is absent from {path}")
+
+
+def _find_alias(headers: Sequence[str], aliases: Sequence[str]) -> str | None:
+    return next((alias for alias in aliases if alias in headers), None)
+
+
+def _normalise_id(value: Any) -> str:
+    if value is None:
+        raise BundleValidationError("Metadata Id cannot be empty")
+    if isinstance(value, float) and value.is_integer():
+        return str(int(value))
+    text = str(value).strip()
+    if not text:
+        raise BundleValidationError("Metadata Id cannot be empty")
+    return text
+
+
+def _positive_int(value: Any) -> int | None:
+    if value is None or value == "":
+        return None
+    try:
+        parsed = int(float(value))
+    except (TypeError, ValueError) as exc:
+        raise BundleValidationError(f"Expected a positive integer, found {value!r}") from exc
+    if parsed <= 0:
+        raise BundleValidationError(f"Expected a positive integer, found {value!r}")
+    return parsed
+
+
+def _file_report(path: Path) -> BundleFileReport:
+    digest = sha256()
+    with path.open("rb") as handle:
+        for block in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(block)
+    return BundleFileReport(
+        name=path.name,
+        path=path,
+        size_bytes=path.stat().st_size,
+        sha256=digest.hexdigest(),
+    )
+
+
+def _materialise(source: Path, target: Path) -> None:
+    target.parent.mkdir(parents=True, exist_ok=True)
+    if source.resolve() == target.resolve():
+        return
+    shutil.copy2(source, target)

--- a/phmfactory/data_sources/manifests/__init__.py
+++ b/phmfactory/data_sources/manifests/__init__.py
@@ -1,0 +1,1 @@
+"""Bundled PHMFactory dataset manifests."""

--- a/phmfactory/data_sources/manifests/cwru-demo-v1.yaml
+++ b/phmfactory/data_sources/manifests/cwru-demo-v1.yaml
@@ -1,0 +1,52 @@
+schema_version: 1
+bundle_id: cwru-demo-v1
+dataset_name: CWRU
+release_pin_required: true
+
+files:
+  metadata:
+    filename: metadata.xlsx
+    required: true
+  signals:
+    filename: RM_001_CWRU.h5
+    required: true
+  corpus:
+    filename: corpus.xlsx
+    required: false
+
+metadata:
+  id_column: Id
+  selector:
+    column: Name
+    values:
+      - RM_001_CWRU
+  column_aliases:
+    sample_length:
+      - Sample_lenth
+      - Sample_lenth (L)
+      - Sample_length
+    channel_count:
+      - Channel
+      - Channel (C)
+
+providers:
+  huggingface:
+    repo_id: PHMbench/PHM-Vibench
+    revision: main
+    repo_type: dataset
+    files:
+      metadata: metadata.xlsx
+      signals: RM_001_CWRU.h5
+      corpus: corpus.xlsx
+  modelscope:
+    repo_id: PHMbench/PHM-Vibench
+    revision: master
+    files:
+      metadata: metadata.xlsx
+      signals: RM_001_CWRU.h5
+      corpus: corpus.xlsx
+
+# These values remain empty until the identical versioned bundle has been
+# published to both providers. The v0.3.0 release gate must replace floating
+# revisions with immutable revisions and populate these hashes.
+expected_sha256: {}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,5 +25,8 @@ where = ["."]
 include = ["phmfactory*", "src*"]
 exclude = ["test*", "tests*", "dev*", "paper*", "results*"]
 
+[tool.setuptools.package-data]
+"phmfactory.data_sources.manifests" = ["*.yaml"]
+
 [tool.setuptools.dynamic]
 dependencies = { file = ["requirements.txt"] }

--- a/test/test_phmfactory_data_sources.py
+++ b/test/test_phmfactory_data_sources.py
@@ -1,0 +1,192 @@
+from __future__ import annotations
+
+from pathlib import Path
+import shutil
+from types import SimpleNamespace
+
+import h5py
+from openpyxl import Workbook
+import pytest
+
+from phmfactory import cli
+from phmfactory.data_sources import (
+    BundleValidationError,
+    compare_bundle_hashes,
+    download_bundle,
+    load_bundle_spec,
+    validate_bundle,
+)
+from phmfactory.data_sources import bundle as bundle_module
+
+
+def _write_workbook(path: Path, headers: list[str], rows: list[list[object]]) -> None:
+    workbook = Workbook()
+    sheet = workbook.active
+    sheet.append(headers)
+    for row in rows:
+        sheet.append(row)
+    workbook.save(path)
+    workbook.close()
+
+
+def _write_bundle(
+    root: Path,
+    *,
+    include_corpus: bool = False,
+    missing_signal_id: bool = False,
+    signal_shape: tuple[int, ...] = (4, 2),
+) -> Path:
+    root.mkdir(parents=True, exist_ok=True)
+    _write_workbook(
+        root / "metadata.xlsx",
+        ["Id", "Name", "Sample_lenth", "Channel", "Dataset_id"],
+        [
+            [1, "RM_001_CWRU", 4, 2, 1],
+            [2, "RM_001_CWRU", 4, 2, 1],
+            [99, "OTHER", 4, 2, 2],
+        ],
+    )
+    with h5py.File(root / "RM_001_CWRU.h5", "w") as handle:
+        handle.create_dataset("1", shape=signal_shape, dtype="float32")
+        if not missing_signal_id:
+            handle.create_dataset("2", shape=(4, 2), dtype="float32")
+    if include_corpus:
+        _write_workbook(
+            root / "corpus.xlsx",
+            ["Id", "Text"],
+            [[1, "normal bearing"], [2, "fault bearing"]],
+        )
+    return root
+
+
+def test_manifest_declares_two_explicit_public_providers() -> None:
+    spec = load_bundle_spec()
+    assert spec.bundle_id == "cwru-demo-v1"
+    assert spec.metadata_file == "metadata.xlsx"
+    assert spec.signal_file == "RM_001_CWRU.h5"
+    assert spec.corpus_file == "corpus.xlsx"
+    assert set(spec.providers) == {"huggingface", "modelscope"}
+    assert spec.providers["huggingface"]["repo_id"] == "PHMbench/PHM-Vibench"
+    assert spec.providers["modelscope"]["repo_id"] == "PHMbench/PHM-Vibench"
+
+
+def test_validate_bundle_accepts_missing_optional_corpus(tmp_path: Path) -> None:
+    validation = validate_bundle(_write_bundle(tmp_path / "bundle"))
+    assert validation.metadata_rows == 3
+    assert validation.selected_rows == 2
+    assert validation.signal_keys == 2
+    assert validation.corpus_present is False
+    assert {item.name for item in validation.files} == {
+        "metadata.xlsx",
+        "RM_001_CWRU.h5",
+    }
+
+
+def test_validate_bundle_checks_optional_corpus_foreign_keys(tmp_path: Path) -> None:
+    root = _write_bundle(tmp_path / "bundle", include_corpus=True)
+    validation = validate_bundle(root)
+    assert validation.corpus_present is True
+
+    _write_workbook(root / "corpus.xlsx", ["Id", "Text"], [[777, "unknown"]])
+    with pytest.raises(BundleValidationError, match="unknown Id"):
+        validate_bundle(root)
+
+
+def test_validate_bundle_rejects_missing_signal_id(tmp_path: Path) -> None:
+    root = _write_bundle(tmp_path / "bundle", missing_signal_id=True)
+    with pytest.raises(BundleValidationError, match="absent"):
+        validate_bundle(root)
+
+
+def test_validate_bundle_requires_two_dimensional_lc_shape(tmp_path: Path) -> None:
+    root = _write_bundle(tmp_path / "bundle", signal_shape=(4, 2, 1))
+    with pytest.raises(BundleValidationError, match=r"shape \(L, C\)"):
+        validate_bundle(root)
+
+
+def test_compare_bundle_hashes_requires_provider_parity(tmp_path: Path) -> None:
+    left = _write_bundle(tmp_path / "left")
+    right = tmp_path / "right"
+    shutil.copytree(left, right)
+    hashes = compare_bundle_hashes(left, right)
+    assert set(hashes) == {"metadata.xlsx", "RM_001_CWRU.h5"}
+
+    with h5py.File(right / "RM_001_CWRU.h5", "a") as handle:
+        handle["1"][0, 0] = 3.0
+    with pytest.raises(BundleValidationError, match="hashes differ"):
+        compare_bundle_hashes(left, right)
+
+
+def test_huggingface_download_materializes_required_files_and_provenance(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    remote = _write_bundle(tmp_path / "remote")
+
+    def fake_hf_hub_download(**kwargs: object) -> str:
+        filename = str(kwargs["filename"])
+        if filename == "corpus.xlsx":
+            raise FileNotFoundError(filename)
+        destination = Path(str(kwargs["local_dir"])) / filename
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(remote / filename, destination)
+        return str(destination)
+
+    monkeypatch.setitem(
+        __import__("sys").modules,
+        "huggingface_hub",
+        SimpleNamespace(hf_hub_download=fake_hf_hub_download),
+    )
+    result = download_bundle(
+        source="huggingface",
+        destination=tmp_path / "downloaded",
+        revision="test-revision",
+    )
+    assert result.provider == "huggingface"
+    assert result.validation.corpus_present is False
+    assert (result.directory / ".phmfactory-bundle.yaml").is_file()
+
+
+def test_modelscope_provider_uses_argument_list_without_shell(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    spec = load_bundle_spec()
+    remote = _write_bundle(tmp_path / "remote")
+    destination = tmp_path / "downloaded"
+    commands: list[list[str]] = []
+
+    monkeypatch.setattr(bundle_module.shutil, "which", lambda name: "/usr/bin/modelscope")
+
+    def fake_runner(command: list[str], **kwargs: object) -> SimpleNamespace:
+        commands.append(command)
+        filename = command[command.index("PHMbench/PHM-Vibench") + 1]
+        if filename == "corpus.xlsx":
+            return SimpleNamespace(returncode=1, stderr="not published")
+        destination.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(remote / filename, destination / filename)
+        assert "shell" not in kwargs
+        return SimpleNamespace(returncode=0, stderr="")
+
+    bundle_module._download_modelscope(
+        spec,
+        spec.providers["modelscope"],
+        destination,
+        "test-revision",
+        runner=fake_runner,
+    )
+    assert commands
+    assert all(isinstance(command, list) for command in commands)
+    assert validate_bundle(destination).selected_rows == 2
+
+
+def test_data_validate_cli_uses_same_public_contract(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    root = _write_bundle(tmp_path / "bundle")
+    result = cli.main(["data", "validate", "--path", str(root)])
+    assert result.selected_rows == 2
+    output = capsys.readouterr().out
+    assert "bundle=cwru-demo-v1" in output
+    assert "corpus_present=false" in output


### PR DESCRIPTION
## What changed

This is the bounded PHMFactory v0.3 PR-07 CWRU dual-source bundle layer.

It adds a provider-neutral local bundle contract for:

```text
metadata.xlsx          required
RM_001_CWRU.h5         required
corpus.xlsx            optional
```

The files are joined by `Id`. Selected `RM_001_CWRU` metadata rows must have matching HDF5 keys, and every signal dataset must have two-dimensional `(L, C)` shape consistent with metadata sample-length and channel aliases.

## Public providers

The packaged `cwru-demo-v1` manifest declares:

```text
Hugging Face: PHMbench/PHM-Vibench
ModelScope:   PHMbench/PHM-Vibench
```

The provider layer downloads only the three declared filenames. It does not clone or download the entire dataset repository, perform network access from a reader/DataLoader, or alter the protected Data Factory.

Hugging Face uses a lazy `huggingface_hub` import. ModelScope uses its documented CLI with an argument list, `shell=False` semantics, bounded timeout, explicit revision, and one file per request so an absent optional corpus does not block the fault-diagnosis bundle.

## Public API and CLI

```python
from phmfactory.data_sources import (
    download_bundle,
    validate_bundle,
    compare_bundle_hashes,
)
```

```bash
python main.py data download --source huggingface
python main.py data download --source modelscope
python main.py data validate --path <bundle-dir>
python main.py data compare --left <hf-dir> --right <ms-dir>
```

The same commands are available through `python -m phmfactory` and the installed `phmfactory` executable.

## Minimal example

```bash
python examples/cwru_quickstart.py --source huggingface
```

After download and validation, the example reuses the maintained CWRU cross-domain config and runs a bounded one-epoch CPU experiment through the public CLI. It does not import a Pipeline module directly or modify `sys.path`.

## Changed files

```text
.github/workflows/phmfactory-cwru-bundle.yml
docs/CWRU_DEMO_V0_3.md
examples/cwru_quickstart.py
phmfactory/cli.py
phmfactory/data_sources/__init__.py
phmfactory/data_sources/bundle.py
phmfactory/data_sources/manifests/__init__.py
phmfactory/data_sources/manifests/cwru-demo-v1.yaml
pyproject.toml
test/test_phmfactory_data_sources.py
```

## Protected runtime boundary

This PR does not modify:

```text
src/data_factory/reader/
src/data_factory/data_factory.py
src/data_factory/H5DataDict.py
src/model_factory/
src/task_factory/
src/trainer_factory/
src/Pipeline_*.py
```

It also does not validate raw CWRU MAT conversion, restructure requirements, consolidate apps, migrate papers/results, or rename the repository.

## Offline validation

The focused PR gate generates legal local fixture workbooks and HDF5 files and verifies:

- required-file enforcement;
- optional `corpus.xlsx` behavior;
- corpus foreign-key integrity;
- metadata/HDF5 Id coverage;
- `(L, C)` and metadata shape equality;
- cross-directory core-file SHA-256 parity;
- Hugging Face materialization through a deterministic fake hub;
- ModelScope command construction without shell execution;
- `phmfactory data validate` output;
- manifest inclusion in the built wheel.

## Online release blocker

This PR does **not** claim that the dedicated prebuilt bundle is already published identically on both public services. The development manifest currently records provider branch names and empty expected hashes.

Before v0.3.0 release, a manual/release gate must:

1. publish the same files to both providers;
2. replace floating revisions with immutable revisions;
3. populate expected SHA-256 values;
4. execute one provider download from each service;
5. prove `metadata.xlsx` and `RM_001_CWRU.h5` hash parity;
6. include `corpus.xlsx` in parity only when it is published on both services.

A manual `workflow_dispatch` online job is included for that pinned verification. Pull requests remain fully offline.

## Base and dependency

```text
base: agent/v030-public-config-resolver-pr06
base SHA: 7508b8083d40fd303a86fa2092f0a8a99004d455
head: agent/v030-cwru-dual-source-pr07
```

## Rollback

A normal revert removes the public bundle layer, CLI subcommand, example, documentation, tests, and focused workflow. The existing Data Factory and readers remain unchanged.