### PR TITLE
build(deps): colocate optional requirements by subsystem

### DIFF
--- a/.github/workflows/phmfactory-cwru-bundle.yml
+++ b/.github/workflows/phmfactory-cwru-bundle.yml
@@ -7,6 +7,7 @@ on:
       - "phmfactory/cli.py"
       - "examples/cwru_quickstart.py"
       - "test/test_phmfactory_data_sources.py"
+      - "test/requirements.txt"
       - "docs/CWRU_DEMO_V0_3.md"
       - "pyproject.toml"
       - ".github/workflows/phmfactory-cwru-bundle.yml"
@@ -18,6 +19,7 @@ on:
       - "phmfactory/cli.py"
       - "examples/cwru_quickstart.py"
       - "test/test_phmfactory_data_sources.py"
+      - "test/requirements.txt"
       - "docs/CWRU_DEMO_V0_3.md"
       - "pyproject.toml"
       - ".github/workflows/phmfactory-cwru-bundle.yml"
@@ -56,7 +58,8 @@ jobs:
       - name: Install focused dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install "build>=1.2" "pytest>=7" PyYAML h5py openpyxl
+          python -m pip install "build>=1.2" PyYAML h5py openpyxl
+          python -m pip install -r test/requirements.txt
 
       - name: Compile provider and example code
         run: |
@@ -115,9 +118,14 @@ jobs:
           python-version: "3.10"
 
       - name: Install provider dependencies
+        shell: bash
         run: |
+          set -euo pipefail
           python -m pip install --upgrade pip
-          python -m pip install PyYAML h5py openpyxl huggingface_hub modelscope
+          python -m pip install PyYAML h5py openpyxl huggingface_hub
+          if [ "${{ inputs.source }}" = "modelscope" ]; then
+            python -m pip install -r phmfactory/data_sources/modelscope/requirements.txt
+          fi
 
       - name: Download and validate pinned provider bundle
         run: >-

--- a/.github/workflows/phmfactory-requirements.yml
+++ b/.github/workflows/phmfactory-requirements.yml
@@ -1,0 +1,120 @@
+name: PHMFactory dependency ownership
+
+on:
+  pull_request:
+    paths:
+      - "requirements.txt"
+      - "apps/streamlit/requirements.txt"
+      - "phmfactory/data_sources/modelscope/**"
+      - "plot/requirements.txt"
+      - "test/requirements.txt"
+      - "tools/repo/check_requirements.py"
+      - "docs/DEPENDENCY_BOUNDARIES_V0_3.md"
+      - "pyproject.toml"
+      - ".github/workflows/phmfactory-requirements.yml"
+  push:
+    branches:
+      - main
+    paths:
+      - "requirements.txt"
+      - "apps/streamlit/requirements.txt"
+      - "phmfactory/data_sources/modelscope/**"
+      - "plot/requirements.txt"
+      - "test/requirements.txt"
+      - "tools/repo/check_requirements.py"
+      - "docs/DEPENDENCY_BOUNDARIES_V0_3.md"
+      - "pyproject.toml"
+      - ".github/workflows/phmfactory-requirements.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  ownership-contract:
+    name: Dependency ownership contract
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+
+      - name: Compile and enforce ownership
+        run: |
+          python -m py_compile tools/repo/check_requirements.py
+          python tools/repo/check_requirements.py
+
+      - name: Build distribution metadata
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install "build>=1.2"
+          python -m build
+
+      - name: Inspect wheel dependency and package boundaries
+        run: |
+          python - <<'PY'
+          from email.parser import Parser
+          from pathlib import Path
+          from zipfile import ZipFile
+
+          wheels = sorted(Path("dist").glob("*.whl"))
+          assert len(wheels) == 1, wheels
+          with ZipFile(wheels[0]) as archive:
+              names = set(archive.namelist())
+              metadata_name = next(
+                  name for name in names if name.endswith(".dist-info/METADATA")
+              )
+              metadata = Parser().parsestr(
+                  archive.read(metadata_name).decode("utf-8")
+              )
+
+          requires = {
+              value.split(" ", 1)[0].lower().replace("_", "-")
+              for value in metadata.get_all("Requires-Dist", [])
+          }
+          assert "huggingface-hub" in requires, requires
+          forbidden = {
+              "modelscope",
+              "pytest",
+              "scienceplots",
+              "streamlit",
+              "umap-learn",
+              "plotly",
+              "torchaudio",
+              "torchvision",
+              "urllib3",
+          }
+          assert not (requires & forbidden), sorted(requires & forbidden)
+
+          required_files = {
+              "phmfactory/data_sources/modelscope/__init__.py",
+              "phmfactory/data_sources/modelscope/requirements.txt",
+          }
+          assert not (required_files - names), sorted(required_files - names)
+          PY
+
+      - name: Verify optional files contain only incremental packages
+        run: |
+          python - <<'PY'
+          from pathlib import Path
+
+          expected = {
+              Path("apps/streamlit/requirements.txt"): {"streamlit"},
+              Path("phmfactory/data_sources/modelscope/requirements.txt"): {"modelscope"},
+              Path("plot/requirements.txt"): {"scienceplots", "umap-learn"},
+              Path("test/requirements.txt"): {"pytest"},
+          }
+          for path, packages in expected.items():
+              observed = {
+                  line.split("=", 1)[0].split("<", 1)[0].split(">", 1)[0].strip()
+                  for line in path.read_text(encoding="utf-8").splitlines()
+                  if line.strip() and not line.lstrip().startswith("#")
+              }
+              assert observed == packages, (path, observed, packages)
+          PY

--- a/.github/workflows/phmfactory-requirements.yml
+++ b/.github/workflows/phmfactory-requirements.yml
@@ -61,7 +61,13 @@ jobs:
           python - <<'PY'
           from email.parser import Parser
           from pathlib import Path
+          import re
           from zipfile import ZipFile
+
+          from packaging.requirements import Requirement
+
+          def canonical(name: str) -> str:
+              return re.sub(r"[-_.]+", "-", name).lower()
 
           wheels = sorted(Path("dist").glob("*.whl"))
           assert len(wheels) == 1, wheels
@@ -75,7 +81,7 @@ jobs:
               )
 
           requires = {
-              value.split(" ", 1)[0].lower().replace("_", "-")
+              canonical(Requirement(value).name)
               for value in metadata.get_all("Requires-Dist", [])
           }
           assert "huggingface-hub" in requires, requires

--- a/.github/workflows/streamlit-quality-gates.yml
+++ b/.github/workflows/streamlit-quality-gates.yml
@@ -6,6 +6,7 @@ on:
       - "apps/streamlit/**"
       - "streamlit_app.py"
       - "test/test_streamlit_*.py"
+      - "test/requirements.txt"
       - ".github/workflows/streamlit-quality-gates.yml"
   push:
     branches:
@@ -14,6 +15,7 @@ on:
       - "apps/streamlit/**"
       - "streamlit_app.py"
       - "test/test_streamlit_*.py"
+      - "test/requirements.txt"
       - ".github/workflows/streamlit-quality-gates.yml"
   workflow_dispatch:
 
@@ -43,10 +45,12 @@ jobs:
         with:
           python-version: "3.10"
 
-      - name: Install optional UI and test dependencies
+      - name: Install optional UI and focused test dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install -r apps/streamlit/requirements.txt "pytest>=7"
+          python -m pip install PyYAML
+          python -m pip install -r apps/streamlit/requirements.txt
+          python -m pip install -r test/requirements.txt
 
       - name: Compile optional UI modules
         run: >-

--- a/apps/streamlit/requirements.txt
+++ b/apps/streamlit/requirements.txt
@@ -1,4 +1,3 @@
-# Optional PHM-Vibench Streamlit UI dependencies.
-# Install the repository's core requirements separately before running experiments.
+# Incremental dependencies for the maintained optional Streamlit UI.
+# Install the repository root requirements first.
 streamlit>=1.37,<2
-PyYAML>=6.0

--- a/docs/CWRU_DEMO_V0_3.md
+++ b/docs/CWRU_DEMO_V0_3.md
@@ -48,6 +48,21 @@ release gate must publish the same bundle to both services, replace both revisio
 with immutable revisions, populate expected SHA-256 values, and prove provider
 parity.
 
+## Installation
+
+The root requirements include the default Hugging Face provider:
+
+```bash
+python -m pip install -r requirements.txt
+```
+
+ModelScope is optional and is installed from its owning subsystem:
+
+```bash
+python -m pip install -r requirements.txt
+python -m pip install -r phmfactory/data_sources/modelscope/requirements.txt
+```
+
 ## CLI
 
 Hugging Face:
@@ -93,7 +108,8 @@ python examples/cwru_quickstart.py --source huggingface
 
 The example downloads and validates the bundle, then runs the maintained CWRU
 cross-domain configuration for one CPU epoch with a small window count. Switching
-providers changes only `--source`.
+providers changes only `--source` after the corresponding provider dependency is
+installed.
 
 ## Validation levels
 

--- a/docs/DEPENDENCY_BOUNDARIES_V0_3.md
+++ b/docs/DEPENDENCY_BOUNDARIES_V0_3.md
@@ -1,0 +1,127 @@
+# PHMFactory v0.3 Dependency Ownership
+
+## Rule
+
+The root `requirements.txt` describes the maintained core runtime and the default
+Hugging Face CWRU quickstart. Optional subsystems keep only their incremental
+packages beside the code that owns them.
+
+Install order is always:
+
+```bash
+python -m pip install -r requirements.txt
+python -m pip install -r <subsystem>/requirements.txt
+```
+
+Subsystem files do not include `-r ../../requirements.txt` and do not repeat core
+packages. This keeps ownership visible and avoids two independent version sources.
+
+## Governed files
+
+| Owner | Requirements file | Packages moved from root |
+| --- | --- | --- |
+| Core runtime and default HF provider | `requirements.txt` | — |
+| Maintained Streamlit UI | `apps/streamlit/requirements.txt` | `streamlit` |
+| Optional ModelScope provider | `phmfactory/data_sources/modelscope/requirements.txt` | `modelscope` |
+| Plot and post-run utilities | `plot/requirements.txt` | `scienceplots`, `umap-learn` |
+| Repository tests | `test/requirements.txt` | `pytest` |
+
+The legacy `app/requirements_gui.txt` remains outside this v0.3 ownership contract
+until the separate `app/` versus `apps/streamlit/` consolidation PR. It already
+owns legacy-only `plotly`; therefore `plotly` is no longer a core dependency.
+
+## Core additions and removals
+
+Added to core:
+
+```text
+huggingface_hub
+```
+
+The maintained CWRU quickstart defaults to Hugging Face, so its provider library is
+part of the default runtime.
+
+Removed from core because no maintained runtime import was found in the frozen
+audit:
+
+```text
+torchaudio
+torchvision
+urllib3
+```
+
+`urllib3` remains available transitively where required by HTTP clients; PHMFactory
+does not declare transitive packages as direct dependencies without a direct import
+or API contract.
+
+The following packages intentionally remain in core for v0.3 even though they could
+become optional later:
+
+```text
+transformers
+timm
+reformer_pytorch
+wandb
+swanlab
+tensorboard
+```
+
+Protected model, Pipeline, trainer, or utility modules still import them directly.
+Moving them before introducing tested lazy-import boundaries would make a nominally
+cleaner requirements file while breaking runtime imports.
+
+## Installation examples
+
+Core plus Hugging Face CWRU:
+
+```bash
+python -m pip install -r requirements.txt
+```
+
+ModelScope provider:
+
+```bash
+python -m pip install -r requirements.txt
+python -m pip install -r phmfactory/data_sources/modelscope/requirements.txt
+```
+
+Streamlit UI:
+
+```bash
+python -m pip install -r requirements.txt
+python -m pip install -r apps/streamlit/requirements.txt
+```
+
+Tests:
+
+```bash
+python -m pip install -r requirements.txt
+python -m pip install -r test/requirements.txt
+```
+
+Plotting and post-run tools:
+
+```bash
+python -m pip install -r requirements.txt
+python -m pip install -r plot/requirements.txt
+```
+
+## Enforcement
+
+Run:
+
+```bash
+python tools/repo/check_requirements.py
+```
+
+The check rejects:
+
+- missing governed requirements files;
+- optional packages leaking back into root;
+- duplicate ownership between core and optional files;
+- unexpected packages in bounded subsystem files;
+- requirement indirection from optional files;
+- local paths, personal SSH URLs, and editable/VCS dependencies.
+
+Dependency ownership changes must update the corresponding code, requirement file,
+documentation, and focused CI in the same PR.

--- a/phmfactory/data_sources/modelscope/__init__.py
+++ b/phmfactory/data_sources/modelscope/__init__.py
@@ -1,0 +1,1 @@
+"""Optional ModelScope provider dependency boundary."""

--- a/phmfactory/data_sources/modelscope/requirements.txt
+++ b/phmfactory/data_sources/modelscope/requirements.txt
@@ -1,0 +1,3 @@
+# Incremental dependency for the optional ModelScope bundle provider.
+# Install the repository root requirements first.
+modelscope

--- a/plot/requirements.txt
+++ b/plot/requirements.txt
@@ -1,0 +1,4 @@
+# Incremental dependencies for repository plotting and post-run analysis tools.
+# Install the repository root requirements first.
+scienceplots
+umap-learn

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ exclude = ["test*", "tests*", "dev*", "paper*", "results*"]
 
 [tool.setuptools.package-data]
 "phmfactory.data_sources.manifests" = ["*.yaml"]
+"phmfactory.data_sources.modelscope" = ["requirements.txt"]
 
 [tool.setuptools.dynamic]
 dependencies = { file = ["requirements.txt"] }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,37 +1,37 @@
+# PHMFactory core runtime dependencies.
+# Optional subsystems are intentionally colocated with their owning directories:
+#   apps/streamlit/requirements.txt
+#   phmfactory/data_sources/modelscope/requirements.txt
+#   plot/requirements.txt
+#   test/requirements.txt
+
+# Numerical and tabular data
 numpy>=1.20.0
 pandas>=1.3.0
-# For PyTorch, torchvision, and torchaudio, consider using the specified index URL during installation:
-# pip install torch==2.6.0 torchvision==0.21.0 torchaudio==2.6.0 --index-url https://download.pytorch.org/whl/cu126
-torch==2.6.0
-torchvision==0.21.0
-torchaudio==2.6.0
-pytorch-lightning>=1.5.0
-torchmetrics>=1.0.0
+scipy
 scikit-learn>=1.0.0
 h5py
-wandb
-einops
-matplotlib
-scipy
-seaborn
-umap-learn
-urllib3
-modelscope
 xlrd>2.0.0
 openpyxl
-tensorboard
-swanlab
-plotly
+
+# Core training runtime
+# Select a platform-appropriate PyTorch index URL when required by the host.
+torch==2.6.0
+pytorch-lightning>=1.5.0
+torchmetrics>=1.0.0
+einops
 reformer_pytorch
-scienceplots
 transformers
 timm
 
-streamlit
+# Evaluation and maintained runtime logging
+matplotlib
+seaborn
+wandb
+swanlab
+tensorboard
 
-# Config tooling (schema validate + inspect)
+# Configuration and default Hugging Face data provider
 pydantic>=2.0.0
 PyYAML>=6.0
-
-# Tests (CI + local)
-pytest>=7.0.0
+huggingface_hub>=0.23

--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -1,0 +1,3 @@
+# Incremental dependencies for repository tests.
+# Install the repository root requirements first for integration and smoke tests.
+pytest>=7.0.0

--- a/tools/repo/check_requirements.py
+++ b/tools/repo/check_requirements.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python3
+"""Enforce PHMFactory v0.3 dependency ownership boundaries."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+import re
+import sys
+from typing import Iterable
+
+
+ROOT = Path(__file__).resolve().parents[2]
+NAME_PATTERN = re.compile(r"^([A-Za-z0-9][A-Za-z0-9_.-]*)")
+
+GOVERNED_FILES = {
+    "core": Path("requirements.txt"),
+    "streamlit": Path("apps/streamlit/requirements.txt"),
+    "modelscope": Path("phmfactory/data_sources/modelscope/requirements.txt"),
+    "plotting": Path("plot/requirements.txt"),
+    "tests": Path("test/requirements.txt"),
+}
+
+EXPECTED_OWNERS = {
+    "streamlit": {"streamlit"},
+    "modelscope": {"modelscope"},
+    "plotting": {"scienceplots", "umap-learn"},
+    "tests": {"pytest"},
+}
+
+FORBIDDEN_IN_CORE = set().union(*EXPECTED_OWNERS.values()) | {
+    "plotly",       # legacy app owns it through app/requirements_gui.txt
+    "torchaudio",   # no maintained runtime import in the frozen audit
+    "torchvision",  # no maintained runtime import in the frozen audit
+    "urllib3",      # transitive library; no direct maintained import
+}
+
+REQUIRED_IN_CORE = {
+    "h5py",
+    "huggingface-hub",
+    "openpyxl",
+    "pydantic",
+    "pyyaml",
+    "torch",
+}
+
+PROHIBITED_REFERENCE_MARKERS = (
+    "git+ssh://",
+    "git@github.com:",
+    "file://",
+    "/home/",
+    "/users/",
+    "c:\\users\\",
+)
+
+
+@dataclass(frozen=True)
+class RequirementFile:
+    owner: str
+    path: Path
+    packages: frozenset[str]
+
+
+def canonical_name(name: str) -> str:
+    """Return a PEP 503-style comparison key."""
+    return re.sub(r"[-_.]+", "-", name).lower()
+
+
+def parse_requirement_file(owner: str, relative_path: Path) -> RequirementFile:
+    path = ROOT / relative_path
+    if not path.is_file():
+        raise ValueError(f"Missing governed requirements file: {relative_path}")
+
+    packages: set[str] = set()
+    for line_number, raw_line in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
+        stripped = raw_line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        lowered = stripped.lower()
+        if any(marker in lowered for marker in PROHIBITED_REFERENCE_MARKERS):
+            raise ValueError(
+                f"{relative_path}:{line_number}: prohibited local/private reference"
+            )
+        if stripped.startswith(("-r", "--requirement", "-e", "--editable")):
+            raise ValueError(
+                f"{relative_path}:{line_number}: requirement indirection is not allowed; "
+                "subsystem files must contain incremental packages only"
+            )
+        match = NAME_PATTERN.match(stripped)
+        if match is None:
+            raise ValueError(
+                f"{relative_path}:{line_number}: cannot parse requirement {stripped!r}"
+            )
+        package = canonical_name(match.group(1))
+        if package in packages:
+            raise ValueError(
+                f"{relative_path}:{line_number}: duplicate package {package!r}"
+            )
+        packages.add(package)
+    return RequirementFile(owner, relative_path, frozenset(packages))
+
+
+def validate(files: Iterable[RequirementFile]) -> None:
+    by_owner = {item.owner: item for item in files}
+    core = by_owner["core"].packages
+
+    missing_core = sorted(REQUIRED_IN_CORE - core)
+    if missing_core:
+        raise ValueError(f"Core requirements are missing: {missing_core}")
+
+    leaked = sorted(core & FORBIDDEN_IN_CORE)
+    if leaked:
+        raise ValueError(f"Optional or unused packages leaked into core: {leaked}")
+
+    claimed_by: dict[str, str] = {}
+    for owner, expected in EXPECTED_OWNERS.items():
+        packages = by_owner[owner].packages
+        missing = sorted(expected - packages)
+        unexpected = sorted(packages - expected)
+        if missing or unexpected:
+            raise ValueError(
+                f"{by_owner[owner].path}: expected {sorted(expected)}, "
+                f"found {sorted(packages)}; missing={missing}, unexpected={unexpected}"
+            )
+        duplicates = sorted(packages & core)
+        if duplicates:
+            raise ValueError(
+                f"{by_owner[owner].path}: duplicates core packages: {duplicates}"
+            )
+        for package in packages:
+            previous = claimed_by.setdefault(package, owner)
+            if previous != owner:
+                raise ValueError(
+                    f"Optional package {package!r} is claimed by both "
+                    f"{previous!r} and {owner!r}"
+                )
+
+
+def main() -> int:
+    try:
+        files = [
+            parse_requirement_file(owner, path)
+            for owner, path in GOVERNED_FILES.items()
+        ]
+        validate(files)
+    except ValueError as exc:
+        print(f"requirements boundary check failed: {exc}", file=sys.stderr)
+        return 1
+
+    for item in files:
+        packages = ", ".join(sorted(item.packages)) or "(none)"
+        print(f"{item.owner:11} {item.path}: {packages}")
+    print("PHMFactory v0.3 dependency ownership: PASS")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## What changed

This is the bounded PHMFactory v0.3 PR-08 dependency-ownership change.

The root `requirements.txt` now describes only the maintained core runtime and the default Hugging Face CWRU provider. Optional packages are colocated with the subsystem that owns them:

```text
apps/streamlit/requirements.txt
phmfactory/data_sources/modelscope/requirements.txt
plot/requirements.txt
test/requirements.txt
```

Subsystem files are incremental: users install root requirements first, then exactly the optional owner file they need.

## Root dependency changes

Moved out of core:

```text
streamlit       -> apps/streamlit/requirements.txt
modelscope      -> phmfactory/data_sources/modelscope/requirements.txt
pytest          -> test/requirements.txt
scienceplots    -> plot/requirements.txt
umap-learn      -> plot/requirements.txt
plotly          -> legacy app/requirements_gui.txt until PR-09 removes app/
```

Added to core:

```text
huggingface_hub
```

The maintained CWRU quickstart defaults to Hugging Face, so its provider library is part of the default runtime.

Removed as undeclared transitive or frozen-audit-only dependencies with no maintained runtime import:

```text
torchaudio
torchvision
urllib3
```

The following remain in core intentionally because protected runtime modules still import them directly:

```text
transformers
timm
reformer_pytorch
wandb
swanlab
tensorboard
```

Moving those packages before tested lazy-import boundaries exist would create a smaller file but a broken runtime.

## Changed files

```text
requirements.txt
apps/streamlit/requirements.txt
phmfactory/data_sources/modelscope/__init__.py
phmfactory/data_sources/modelscope/requirements.txt
plot/requirements.txt
test/requirements.txt
tools/repo/check_requirements.py
docs/DEPENDENCY_BOUNDARIES_V0_3.md
docs/CWRU_DEMO_V0_3.md
pyproject.toml
.github/workflows/phmfactory-requirements.yml
.github/workflows/phmfactory-cwru-bundle.yml
.github/workflows/streamlit-quality-gates.yml
```

## Enforced ownership contract

`tools/repo/check_requirements.py` rejects:

- missing governed requirement files;
- optional packages leaking back into root;
- duplicate package ownership;
- unexpected packages in bounded optional files;
- `-r`/editable indirection in subsystem files;
- private SSH, local path, and VCS dependencies.

The new dependency workflow builds the wheel and verifies:

- `huggingface-hub` is present in wheel metadata;
- optional/unused packages are absent from wheel core dependencies;
- the ModelScope owner file is packaged beside its subsystem;
- each optional file contains only its approved incremental package set.

## CI consumers updated

- Streamlit gates install `apps/streamlit/requirements.txt` and `test/requirements.txt`, with the minimal core `PyYAML` dependency supplied explicitly for the focused environment.
- CWRU offline tests install `test/requirements.txt`.
- The manual ModelScope online job installs `phmfactory/data_sources/modelscope/requirements.txt` only when that source is selected.

## Protected runtime boundary

No reader, Pipeline, Data Factory, model, task, trainer, split, metric, checkpoint, signal shape, dtype, or channel behavior is changed.

This PR does not introduce lazy imports, consolidate apps, migrate paper/results, alter submodules, or rename the repository.

## Base and dependency

```text
base: agent/v030-cwru-dual-source-pr07
base SHA: fa4a0306fc2ee4aee846812b5ed0e05837a50807
head: agent/v030-requirements-ownership-pr08
```

## Rollback

A normal revert restores the previous combined root dependency list and prior focused CI installation commands. No data, checkpoint, or external repository state is modified.