### PR TITLE
chore(v0.3): stage research workspace migration inventory

### DIFF
--- a/.github/workflows/v030-archive-research-workspaces.yml
+++ b/.github/workflows/v030-archive-research-workspaces.yml
@@ -1,6 +1,11 @@
 name: Archive PHMFactory research workspaces
 
 on:
+  pull_request:
+    branches:
+      - agent/v030-ui-consolidation-pr09
+    paths:
+      - .github/workflows/v030-archive-research-workspaces.yml
   push:
     branches:
       - agent/v030-research-workspace-migration-pr10

--- a/.github/workflows/v030-archive-research-workspaces.yml
+++ b/.github/workflows/v030-archive-research-workspaces.yml
@@ -1,0 +1,160 @@
+name: Archive PHMFactory research workspaces
+
+on:
+  push:
+    branches:
+      - agent/v030-research-workspace-migration-pr10
+    paths:
+      - .github/workflows/v030-archive-research-workspaces.yml
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  archive:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Check out migration branch
+        uses: actions/checkout@v4
+        with:
+          ref: agent/v030-research-workspace-migration-pr10
+          fetch-depth: 0
+          submodules: false
+
+      - name: Build immutable research-workspace archive
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          archive_root=/tmp/phmfactory-research-workspaces
+          rm -rf "${archive_root}"
+          mkdir -p "${archive_root}/tree"
+
+          candidates=(paper results metrics_reports reports dev .archive)
+          existing=()
+          : > "${archive_root}/ROOTS.tsv"
+
+          for root in "${candidates[@]}"; do
+            tracked_count="$(git ls-files -- "${root}" | wc -l | tr -d ' ')"
+            tree_count="$(git ls-tree -r HEAD -- "${root}" | wc -l | tr -d ' ')"
+            if [ "${tree_count}" -gt 0 ]; then
+              existing+=("${root}")
+            fi
+            printf '%s\t%s\t%s\n' "${root}" "${tracked_count}" "${tree_count}" \
+              >> "${archive_root}/ROOTS.tsv"
+          done
+
+          if [ "${#existing[@]}" -eq 0 ]; then
+            echo 'No approved research roots exist on this branch.' >&2
+            exit 1
+          fi
+
+          git ls-tree -r HEAD -- "${existing[@]}" \
+            | awk '{print $1 "\t" $2 "\t" $3 "\t" $4}' \
+            > "${archive_root}/SOURCE_TREE_MANIFEST.tsv"
+
+          awk -F '\t' '$1 == "160000" {print}' \
+            "${archive_root}/SOURCE_TREE_MANIFEST.tsv" \
+            > "${archive_root}/GITLINK_MANIFEST.tsv"
+          awk -F '\t' '$2 == "blob" {print}' \
+            "${archive_root}/SOURCE_TREE_MANIFEST.tsv" \
+            > "${archive_root}/SOURCE_BLOB_MANIFEST.tsv"
+
+          git archive HEAD -- "${existing[@]}" \
+            | tar -x -C "${archive_root}/tree"
+
+          python - <<'PY'
+          from __future__ import annotations
+
+          import csv
+          from pathlib import Path
+          import subprocess
+
+          archive_root = Path('/tmp/phmfactory-research-workspaces')
+          tree_root = archive_root / 'tree'
+          manifest = archive_root / 'SOURCE_BLOB_MANIFEST.tsv'
+          rows = []
+          with manifest.open('r', encoding='utf-8') as handle:
+              for raw in handle:
+                  mode, kind, expected, path = raw.rstrip('\n').split('\t', 3)
+                  archived = tree_root / path
+                  if not archived.is_file():
+                      raise SystemExit(f'archived blob is missing: {path}')
+                  actual = subprocess.check_output(
+                      ['git', 'hash-object', str(archived)],
+                      text=True,
+                  ).strip()
+                  if actual != expected:
+                      raise SystemExit(
+                          f'blob mismatch for {path}: expected {expected}, got {actual}'
+                      )
+                  rows.append(
+                      {
+                          'path': path,
+                          'mode': mode,
+                          'git_blob': expected,
+                          'bytes': archived.stat().st_size,
+                      }
+                  )
+
+          with (archive_root / 'VERIFIED_BLOBS.tsv').open(
+              'w', encoding='utf-8', newline=''
+          ) as handle:
+              writer = csv.DictWriter(
+                  handle,
+                  fieldnames=('path', 'mode', 'git_blob', 'bytes'),
+                  delimiter='\t',
+              )
+              writer.writeheader()
+              writer.writerows(rows)
+
+          if not rows:
+              raise SystemExit('archive contains no regular blobs')
+          PY
+
+          git grep -nE \
+            '(^|[^A-Za-z0-9_])(paper/|results/|metrics_reports/|reports/|dev/|\.archive/)' \
+            HEAD -- \
+            ':!paper/**' ':!results/**' ':!metrics_reports/**' ':!reports/**' \
+            ':!dev/**' ':!.archive/**' \
+            ':!.github/workflows/v030-archive-research-workspaces.yml' \
+            > "${archive_root}/REFERENCE_INVENTORY.txt" || true
+
+          cat > "${archive_root}/ARCHIVE_README.md" <<'EOF'
+          # PHMFactory v0.3 research-workspace archive
+
+          This artifact records the exact Git objects under the bounded candidate roots:
+
+          ```text
+          paper/
+          results/
+          metrics_reports/
+          reports/
+          dev/
+          .archive/
+          ```
+
+          Regular files are reconstructed under `tree/` and verified by Git blob SHA.
+          Gitlinks are recorded separately in `GITLINK_MANIFEST.tsv`; their external
+          repository contents are not silently treated as ordinary files.
+
+          This artifact is inventory and preservation evidence only. It does not authorize
+          deletion. Each paper/result/submodule still requires a destination, immutable
+          source commit, content or hash verification, and reviewer confirmation.
+          EOF
+
+          test -s "${archive_root}/ROOTS.tsv"
+          test -s "${archive_root}/SOURCE_TREE_MANIFEST.tsv"
+          test -s "${archive_root}/SOURCE_BLOB_MANIFEST.tsv"
+          test -s "${archive_root}/VERIFIED_BLOBS.tsv"
+
+      - name: Upload archive and migration inventory
+        uses: actions/upload-artifact@v4
+        with:
+          name: phmfactory-v030-research-workspaces
+          path: /tmp/phmfactory-research-workspaces
+          if-no-files-found: error
+          retention-days: 30


### PR DESCRIPTION
## Status

Archive-first staging PR for PHMFactory v0.3 PR-10.

The current branch adds only a one-shot, read-only workflow that inventories and exports the exact Git objects under these bounded candidate roots:

```text
paper/
results/
metrics_reports/
reports/
dev/
.archive/
```

No public-upstream research file, result file, historical workspace, or gitlink has been deleted in this staging commit.

## What the archive records

The workflow produces:

```text
ROOTS.tsv
SOURCE_TREE_MANIFEST.tsv
SOURCE_BLOB_MANIFEST.tsv
VERIFIED_BLOBS.tsv
GITLINK_MANIFEST.tsv
REFERENCE_INVENTORY.txt
ARCHIVE_README.md
tree/**
```

Regular files are reconstructed with `git archive` and verified one by one against their Git blob SHA. Mode-160000 gitlinks are recorded separately; external submodule contents are not silently treated as ordinary files.

## Deletion gate

Deletion remains blocked until every proposed removal has:

1. a destination repository or approved private-fork archive path;
2. an immutable source commit or Git blob manifest;
3. file/hash or content-coverage verification;
4. reviewer confirmation;
5. a public audit and rollback path.

Paper and result workspaces will be mapped to the appropriate `AI4Engineering-L` repositories. Personal/dev/history material will be preserved in the approved personal fork. The public PHMFactory repository must not depend on either destination after migration.

## Protected boundary

This staging PR does not modify:

- dataset readers or Data Factory behavior;
- model, task, trainer, or Pipeline algorithms;
- config schema or CWRU bundle contract;
- requirements ownership;
- maintained Streamlit code;
- package or repository naming;
- `.gitmodules` or gitlinks.

## Base

```text
base: agent/v030-ui-consolidation-pr09
base SHA: 46a0872cee7e1e292eec7a123f46d54580559de8
head: agent/v030-research-workspace-migration-pr10
```

After the artifact is copied to the personal fork and verified, this PR will be split or updated only in bounded migration groups; paper submodules will not be removed merely because a destination repository name exists.