### PR TITLE
chore(v0.3): archive and migrate paper and result workspaces

### DIFF
--- a/.github/workflows/v030-archive-paper-results.yml
+++ b/.github/workflows/v030-archive-paper-results.yml
@@ -1,0 +1,165 @@
+name: Archive PHMFactory paper and result workspaces
+
+on:
+  push:
+    branches:
+      - agent/v030-paper-results-migration-pr10
+    paths:
+      - .github/workflows/v030-archive-paper-results.yml
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  archive:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Check out migration branch
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          submodules: false
+
+      - name: Build immutable paper and result archive
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          archive_root=/tmp/phmfactory-paper-results
+          rm -rf "${archive_root}"
+          mkdir -p "${archive_root}/tree"
+
+          tracked_roots=()
+          for path in paper results metrics_reports; do
+            if git cat-file -e "HEAD:${path}" 2>/dev/null; then
+              tracked_roots+=("${path}")
+            fi
+          done
+
+          if [ "${#tracked_roots[@]}" -eq 0 ]; then
+            echo "No governed paper/result roots exist." >&2
+            exit 1
+          fi
+
+          git archive HEAD -- "${tracked_roots[@]}" \
+            | tar -x -C "${archive_root}/tree"
+
+          git ls-tree -r HEAD -- "${tracked_roots[@]}" \
+            | awk '{print $1 "\t" $2 "\t" $3 "\t" $4}' \
+            > "${archive_root}/SOURCE_TREE_MANIFEST.tsv"
+
+          awk -F '\t' '$2 == "blob"' "${archive_root}/SOURCE_TREE_MANIFEST.tsv" \
+            > "${archive_root}/SOURCE_BLOB_MANIFEST.tsv"
+          awk -F '\t' '$2 == "commit"' "${archive_root}/SOURCE_TREE_MANIFEST.tsv" \
+            > "${archive_root}/SOURCE_GITLINK_MANIFEST.tsv"
+
+          if [ -f .gitmodules ]; then
+            cp .gitmodules "${archive_root}/GITMODULES.original"
+          else
+            : > "${archive_root}/GITMODULES.original"
+          fi
+
+          git grep -nE '(paper/|results/|metrics_reports/)' HEAD -- \
+            ':!paper/**' ':!results/**' ':!metrics_reports/**' \
+            ':!.github/workflows/v030-archive-paper-results.yml' \
+            > "${archive_root}/EXTERNAL_REFERENCE_INVENTORY.txt" || true
+
+          python - <<'PY'
+          from __future__ import annotations
+
+          import csv
+          import hashlib
+          from pathlib import Path
+
+          root = Path('/tmp/phmfactory-paper-results')
+          tree = root / 'tree'
+
+          source_rows = []
+          with (root / 'SOURCE_TREE_MANIFEST.tsv').open(encoding='utf-8') as handle:
+              for line in handle:
+                  mode, kind, sha, path = line.rstrip('\n').split('\t', 3)
+                  source_rows.append((mode, kind, sha, path))
+
+          archived_files = sorted(path for path in tree.rglob('*') if path.is_file())
+          blob_rows = [row for row in source_rows if row[1] == 'blob']
+          gitlink_rows = [row for row in source_rows if row[1] == 'commit']
+
+          if len(archived_files) != len(blob_rows):
+              raise SystemExit(
+                  f'archive/blob count mismatch: {len(archived_files)} != {len(blob_rows)}'
+              )
+
+          source_by_path = {path: sha for _, kind, sha, path in blob_rows if kind == 'blob'}
+          verification = []
+          for path in archived_files:
+              relative = path.relative_to(tree).as_posix()
+              data = path.read_bytes()
+              git_blob = hashlib.sha1(
+                  f'blob {len(data)}\0'.encode() + data
+              ).hexdigest()
+              expected = source_by_path.get(relative)
+              if expected != git_blob:
+                  raise SystemExit(
+                      f'blob mismatch for {relative}: {git_blob} != {expected}'
+                  )
+              verification.append(
+                  {
+                      'path': relative,
+                      'bytes': len(data),
+                      'git_blob_sha': git_blob,
+                      'sha256': hashlib.sha256(data).hexdigest(),
+                  }
+              )
+
+          with (root / 'ARCHIVED_FILE_MANIFEST.tsv').open(
+              'w', encoding='utf-8', newline=''
+          ) as handle:
+              writer = csv.DictWriter(
+                  handle,
+                  fieldnames=('path', 'bytes', 'git_blob_sha', 'sha256'),
+                  delimiter='\t',
+              )
+              writer.writeheader()
+              writer.writerows(verification)
+
+          roots = sorted({row[3].split('/', 1)[0] for row in source_rows})
+          total_bytes = sum(row['bytes'] for row in verification)
+          references = (root / 'EXTERNAL_REFERENCE_INVENTORY.txt').read_text(
+              encoding='utf-8'
+          ).splitlines()
+
+          (root / 'ARCHIVE_README.md').write_text(
+              '# PHMFactory v0.3 paper/result migration archive\n\n'
+              'This artifact preserves the exact regular files and Git tree metadata '
+              'under the governed paper/result roots before any public-upstream deletion.\n\n'
+              '```text\n'
+              f'source commit: {Path("/github/workspace").name if False else "'"${GITHUB_SHA}"'"}\n'
+              f'roots: {", ".join(roots)}\n'
+              f'regular files: {len(blob_rows)}\n'
+              f'gitlinks: {len(gitlink_rows)}\n'
+              f'archived bytes: {total_bytes}\n'
+              f'external reference lines: {len(references)}\n'
+              '```\n\n'
+              '`SOURCE_TREE_MANIFEST.tsv` records every blob and gitlink. '
+              '`ARCHIVED_FILE_MANIFEST.tsv` verifies every regular file by Git blob SHA '
+              'and SHA-256. Gitlink contents remain external and require destination '
+              'repository verification before removal.\n',
+              encoding='utf-8',
+          )
+          PY
+
+          test -s "${archive_root}/SOURCE_TREE_MANIFEST.tsv"
+          test -s "${archive_root}/SOURCE_BLOB_MANIFEST.tsv"
+          test -s "${archive_root}/ARCHIVED_FILE_MANIFEST.tsv"
+          test -s "${archive_root}/ARCHIVE_README.md"
+
+      - name: Upload immutable archive
+        uses: actions/upload-artifact@v4
+        with:
+          name: phmfactory-v030-paper-results
+          path: /tmp/phmfactory-paper-results
+          if-no-files-found: error
+          retention-days: 30

--- a/.github/workflows/v030-archive-paper-results.yml
+++ b/.github/workflows/v030-archive-paper-results.yml
@@ -72,6 +72,7 @@ jobs:
 
           import csv
           import hashlib
+          import os
           from pathlib import Path
 
           root = Path('/tmp/phmfactory-paper-results')
@@ -136,7 +137,7 @@ jobs:
               'This artifact preserves the exact regular files and Git tree metadata '
               'under the governed paper/result roots before any public-upstream deletion.\n\n'
               '```text\n'
-              f'source commit: {Path("/github/workspace").name if False else "'"${GITHUB_SHA}"'"}\n'
+              f'source commit: {os.environ["GITHUB_SHA"]}\n'
               f'roots: {", ".join(roots)}\n'
               f'regular files: {len(blob_rows)}\n'
               f'gitlinks: {len(gitlink_rows)}\n'


### PR DESCRIPTION
## Status

Archive-first staging PR for PHMFactory v0.3 PR-10.

The branch currently adds a one-shot workflow that exports the exact public-upstream content and Git tree metadata under:

```text
paper/
results/
metrics_reports/
```

No paper, result, metric report, gitlink, or `.gitmodules` entry has been deleted yet.

## Archive contract

The workflow records:

- every regular file and Git blob identity;
- every paper gitlink and pinned commit;
- the exact `.gitmodules` file;
- per-file SHA-256 values;
- references from maintained paths into paper/result workspaces;
- counts and bytes for all archived regular files.

Regular files will be copied to the approved personal-fork archive and verified by Git blob identity before any deletion.

Gitlink contents remain external repositories. A gitlink will be removed only after its corresponding AI4Engineering-L paper repository or personal-fork destination is explicitly mapped and verified. Repository existence alone is not sufficient evidence.

## Protected boundary

This PR does not modify:

```text
src/data_factory/reader/
src/data_factory/data_factory.py
src/data_factory/H5DataDict.py
src/model_factory/
src/task_factory/
src/trainer_factory/
src/Pipeline_*.py
configs/
```

It also does not modify the CWRU bundle, requirements ownership, maintained Streamlit UI, package name, or repository name.

## Base

```text
base: agent/v030-ui-consolidation-pr09
base SHA: 46a0872cee7e1e292eec7a123f46d54580559de8
head: agent/v030-paper-results-migration-pr10
```

## Deletion gate

Deletion remains blocked until:

1. the archive workflow succeeds;
2. the regular-file archive is committed to `liq22/PHM-Vibench` under `upstream-archive/phmfactory-v0.3.0/paper-results/`;
3. source and destination Git blobs match;
4. external references are classified;
5. each gitlink has a verified destination commit and reviewer status;
6. repository-native quality gates pass after any bounded removal.

## Rollback

Until deletion begins, rollback is a normal revert of the staging workflow. After deletion, immutable Git history and the verified personal archive remain available for restoration.