### PR TITLE
docs(v0.3): apply PHMFactory branding and migration notes

### DIFF
--- a/.github/workflows/phmfactory-release-readiness.yml
+++ b/.github/workflows/phmfactory-release-readiness.yml
@@ -6,11 +6,13 @@ on:
       - "pyproject.toml"
       - "phmfactory/__init__.py"
       - "README.md"
+      - "README_CN.md"
       - "CITATION.cff"
       - "CHANGELOG.md"
       - "RELEASE_NOTES_v0.3.0.md"
       - "phmfactory/data_sources/manifests/cwru-demo-v1.yaml"
       - "docs/PHMFACTORY_V0_3_RELEASE_READINESS.md"
+      - "docs/index.md"
       - "tools/repo/check_release_readiness.py"
       - ".github/workflows/phmfactory-release-readiness.yml"
   push:
@@ -47,7 +49,7 @@ jobs:
       - name: Record current blockers
         run: python tools/repo/check_release_readiness.py --mode audit | tee release-readiness.txt
 
-      - name: Require the pre-release gate to remain blocked
+      - name: Require only the remaining pre-release blockers
         shell: bash
         run: |
           set -euo pipefail
@@ -55,10 +57,29 @@ jobs:
             echo "Release mode unexpectedly passed before final release preparation." >&2
             exit 1
           fi
-          grep -q 'VERSION_NOT_FINAL' release-readiness.txt
-          grep -q 'README_BRAND_PENDING' release-readiness.txt
-          grep -q 'CWRU_REVISION_FLOATING' release-readiness.txt
-          grep -q 'CWRU_HASH_MISSING' release-readiness.txt
+
+          for blocker in \
+            VERSION_NOT_FINAL \
+            CWRU_REVISION_FLOATING \
+            CWRU_HASH_MISSING \
+            V020_PROVENANCE_UNRESOLVED \
+            REPOSITORY_RENAME_PENDING
+          do
+            grep -q "${blocker}" release-readiness.txt
+          done
+
+          for resolved in \
+            README_BRAND_PENDING \
+            CITATION_BRAND_PENDING \
+            CITATION_REPOSITORY_PENDING \
+            CHANGELOG_V030_MISSING \
+            RELEASE_NOTES_V030_MISSING
+          do
+            if grep -q "${resolved}" release-readiness.txt; then
+              echo "Resolved branding/documentation blocker returned: ${resolved}" >&2
+              exit 1
+            fi
+          done
 
       - name: Upload readiness report
         uses: actions/upload-artifact@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,218 @@
 # Changelog
 
+## v0.3.0 - Unreleased
+
+### Summary
+
+PHM-Vibench is renamed to **PHMFactory**.
+
+v0.3.0 is a compatibility-first repository-boundary, packaging, public-interface,
+and reproducibility release. It introduces the public `phmfactory` Python package
+without mechanically rewriting the established reader, factory, trainer, task, or
+Pipeline algorithms.
+
+The upstream repository is narrowed to maintained framework code, public interfaces,
+configurations, tests, documentation, bounded examples, and governed optional
+integrations. Personal Agent workspaces, development scratchpads, paper-specific
+results, and historical prototypes are moved to their correct ownership boundaries.
+
+### Added
+
+- Added the canonical public Python namespace and distribution:
+
+  ```python
+  import phmfactory
+  ```
+
+- Added three equivalent public entrypoints:
+
+  ```bash
+  python main.py --config <yaml>
+  python -m phmfactory --config <yaml>
+  phmfactory --config <yaml>
+  ```
+
+- Added `phmfactory.config` as the lightweight public configuration resolver for:
+  maintained aliases, YAML composition, dotted overrides, Pipeline canonicalization,
+  source-path resolution, and cycle detection.
+- Added descriptive canonical Pipeline identifiers:
+
+  ```text
+  Pipeline_01_Fault_Diagnosis
+  Pipeline_02_Pretraining_Few_Shot
+  Pipeline_03_Multitask_Pretraining_Finetuning
+  Pipeline_04_Unified_Evaluation
+  Pipeline_05_Explainable_Fault_Diagnosis
+  Pipeline_06_Generative_Modeling
+  ```
+
+- Added a provider-neutral CWRU demo-bundle interface supporting Hugging Face,
+  ModelScope, and local validation.
+- Added one maintained non-interactive CWRU quickstart under
+  `examples/cwru_quickstart.py`.
+- Added deterministic reader/runtime inventories and protected-file fingerprints.
+- Added repository checks for case-insensitive path collisions, dependency ownership,
+  release readiness, and bounded workspace migration.
+- Added explicit PHMFactory v0.3 repository, reader-preservation, Pipeline-name,
+  dependency-boundary, CWRU, and release-readiness documents.
+
+### Changed
+
+- Renamed the project display name from PHM-Vibench to PHMFactory.
+- Set the intended GitHub repository identity to `PHMbench/phmfactory`.
+- Kept root `main.py` as a thin public dispatcher rather than a second CLI
+  implementation.
+- Changed maintained Pipeline module filenames directly to their descriptive names.
+  No six-file old-module wrapper layer is introduced.
+- Updated maintained configurations, configuration registry entries, generated Atlas
+  output, tests, and current documentation to use canonical Pipeline names.
+- Standardized `apps/streamlit/app.py` as the only maintained Streamlit entrypoint.
+- Kept root `requirements.txt` for the core runtime and default Hugging Face path;
+  moved incremental optional dependencies into the subsystem that owns them.
+- Changed the CWRU demo contract to require:
+
+  ```text
+  metadata.xlsx
+  RM_001_CWRU.h5
+  ```
+
+  while treating `corpus.xlsx` as optional for the current fault-diagnosis quickstart.
+- Added a public façade around the established `src.*` runtime instead of moving the
+  four mature factory trees during v0.3.0.
+
+### Preserved
+
+- Preserved `src/data_factory/reader/` at its existing path.
+- Preserved established reader signatures, parsing behavior, channel ordering, output
+  rank, dtype handling, and numerical behavior unless a separately reviewed bugfix
+  states otherwise.
+- Preserved `src.data_factory`, `src.model_factory`, `src.task_factory`, and
+  `src.trainer_factory` as the protected v0.3 compatibility engine.
+- Preserved root `configs/`, the five-block configuration contract, root
+  `requirements.txt`, root `main.py`, and the existing `test/` path.
+- Preserved the fully offline `Dummy_Data` smoke path as a required per-PR gate.
+- Preserved historical directories and paper gitlinks when runtime references or
+  content-level destination verification were not yet sufficient for safe deletion.
+
+### Removed or migrated
+
+- Removed root and hidden Agent/vendor workspaces from the public framework after
+  exact preservation in the approved personal fork.
+- Removed the legacy `app/` Streamlit prototype and root `streamlit_app.py` launcher
+  after exact personal-fork archival.
+- Removed `.archive/` and `dev/` from the public framework after Git-object
+  preservation.
+- Removed generated-output placeholder directories `results/` and `metrics_reports/`
+  from source control; runtime code may still create output directories locally.
+- Removed the personal `data/Rotor_simulation` and `paper/LQ_vibench_fix` gitlinks
+  after complete fixed-commit tree archival.
+- Removed case-colliding lowercase duplicates such as `citation.cff`,
+  `contributing.md`, and lowercase module README compatibility paths.
+- Removed generated Python bytecode and other tracked local artifacts where present.
+
+### Compatibility and breaking changes
+
+- `python main.py --config <yaml>` remains supported.
+- New integrations should import `phmfactory.*`; the `src.*` tree remains an internal
+  compatibility engine in v0.3.0.
+- No `phm_factory`, `phm_vibench`, or other transitional Python namespace is added.
+- Legacy Pipeline values in YAML remain accepted through explicit aliases and emit a
+  deprecation warning.
+- Direct Python imports of old Pipeline module filenames are breaking changes. For
+  example:
+
+  ```python
+  # v0.2
+  from src.Pipeline_01_default import pipeline
+
+  # v0.3
+  from src.Pipeline_01_Fault_Diagnosis import pipeline
+  ```
+
+- The removed personal, Agent, paper-result, development, and prototype workspaces are
+  not runtime dependencies of PHMFactory. Their archival repositories are recovery
+  and research records only.
+
+### Data and reproducibility
+
+- The CWRU bundle validator joins metadata and HDF5 signals by `Id` and checks the
+  two-dimensional `(L, C)` signal contract against metadata aliases.
+- Provider downloads are separated from reader/DataLoader execution.
+- Hugging Face and ModelScope must publish byte-identical required bundle files at
+  immutable revisions before v0.3.0 can be released.
+- `corpus.xlsx` participates in parity only when it is published on both providers.
+- Run evidence should record the exact config, overrides, data provider, immutable
+  revision, file hashes, seed, environment, and PHMFactory commit or tag.
+
+### Repository ownership boundaries
+
+- Paper repositories, personal forks, and third-party projects may depend on
+  PHMFactory.
+- PHMFactory must not depend on a personal fork, paper repository, or Agent tool at
+  runtime, build time, test time, data time, or release time.
+- One governed optional `phm-data-factory` backend remains a candidate exception. It
+  must use a public HTTPS URL, immutable commit, compatible license, and remain
+  optional when uninitialized.
+- Remaining paper gitlinks are not removed merely because similarly named destination
+  repositories exist; content-level verification remains mandatory.
+
+### Validation state
+
+The staged v0.3 PR chain includes focused gates for:
+
+- documentation, maintained configuration, and generated Atlas consistency;
+- fully offline Dummy_Data smoke execution;
+- public package, wheel content, module entrypoint, and CLI parity;
+- canonical Pipeline selection and Pipeline 06 contracts;
+- UXFD assembly;
+- CWRU bundle validation and provider command construction;
+- dependency ownership;
+- Streamlit imports and lifecycle behavior on Linux and Windows;
+- case-insensitive repository paths;
+- release-readiness blocker reporting.
+
+Passing smoke and contract tests establishes software-path evidence, not benchmark
+performance or universal component compatibility.
+
+### Remaining release blockers
+
+v0.3.0 must not be tagged or published until all of the following are resolved:
+
+- the staged PR chain is reviewed and merged in dependency order;
+- the v0.2 baseline or release-candidate provenance is explicitly resolved;
+- Hugging Face and ModelScope CWRU revisions and SHA-256 values are pinned;
+- cross-provider required-file parity passes against the public services;
+- the optional `phm-data-factory` backend disposition is finalized;
+- repository branding and redirects are verified after the GitHub rename;
+- versions are changed from `0.3.0.dev0` to `0.3.0`;
+- final wheel, source distribution, cross-platform imports, and required gates pass on
+  the release commit;
+- tag `v0.3.0` is created only after the release-readiness gate reports zero blockers.
+
+### v0.2 to v0.3 migration map
+
+| v0.2 surface | v0.3 surface |
+| --- | --- |
+| PHM-Vibench | PHMFactory |
+| `PHMbench/PHM-Vibench` | `PHMbench/phmfactory` |
+| no canonical installed namespace | `phmfactory` |
+| root-only `main.py` entrypoint | root, module, and installed CLI entrypoints |
+| arbitrary Pipeline module string import | explicit canonical Pipeline registry |
+| `Pipeline_01_default` | `Pipeline_01_Fault_Diagnosis` |
+| `Pipeline_02_pretrain_fewshot` | `Pipeline_02_Pretraining_Few_Shot` |
+| `Pipeline_03_multitask_pretrain_finetune` | `Pipeline_03_Multitask_Pretraining_Finetuning` |
+| `Pipeline_04_unified_metric` | `Pipeline_04_Unified_Evaluation` |
+| `Pipeline_05_default_w_explain` | `Pipeline_05_Explainable_Fault_Diagnosis` |
+| `Pipeline_06_generative` | `Pipeline_06_Generative_Modeling` |
+| `app/` plus `apps/streamlit/` | only `apps/streamlit/` |
+| mixed root dependency ownership | core root requirements plus subsystem increment files |
+| personal/Agent/research workspaces in upstream | personal fork and paper repositories |
+| duplicate case-sensitive authority files | one canonical spelling with CI guard |
+| local-path CWRU assumptions | provider-neutral validated bundle interface |
+
+See [RELEASE_NOTES_v0.3.0.md](RELEASE_NOTES_v0.3.0.md) for the user-facing migration
+procedure and release limitations.
+
 ## v0.2.0 Release Candidate - 2026-07-11
 
 ### Added
@@ -33,4 +246,3 @@
   `SUPPORTED_COMBINATIONS.md`.
 - The evidence is functional smoke and contract evidence, not a performance
   benchmark.
-

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,14 +1,14 @@
 cff-version: 1.2.0
 message: >-
-  If you use PHM-Vibench, cite the exact release tag or Git commit used for the
-  experiment and record the configuration, overrides, data source, seed, and
-  environment.
-title: PHM-Vibench
+  If you use PHMFactory, cite the exact release tag or Git commit used for the
+  experiment and record the configuration, overrides, data source and revision,
+  random seed, and environment.
+title: PHMFactory
 type: software
 authors:
-  - name: PHMbench contributors
-repository-code: https://github.com/PHMbench/PHM-Vibench
-url: https://github.com/PHMbench/PHM-Vibench
+  - name: PHMFactory contributors
+repository-code: https://github.com/PHMbench/phmfactory
+url: https://github.com/PHMbench/phmfactory
 license: Apache-2.0
 keywords:
   - prognostics and health management
@@ -17,6 +17,7 @@ keywords:
   - benchmark
   - PyTorch
 abstract: >-
-  PHM-Vibench is a configuration-first research-software workbench for industrial
-  vibration fault-diagnosis experiments. Its documented support surface is
-  limited to maintained configurations with explicit runtime evidence.
+  PHMFactory is a configuration-first PHM research and evaluation framework for
+  industrial vibration signals. Version 0.3 introduces the public phmfactory
+  package while preserving the established PHM-Vibench runtime as a protected
+  compatibility engine.

--- a/README.md
+++ b/README.md
@@ -1,45 +1,48 @@
-# PHM-Vibench
+# PHMFactory
 
 <div align="center">
-  <img src="pic/PHM-Vibench.png" alt="PHM-Vibench logo" width="280"/>
+  <img src="pic/PHM-Vibench.png" alt="PHMFactory logo" width="280"/>
 
   <p>
     <a href="README.md"><strong>English</strong></a> |
     <a href="README_CN.md">中文</a>
   </p>
 
-  <p><strong>A configuration-first workbench for industrial vibration fault-diagnosis experiments.</strong></p>
+  <p><strong>A configuration-first PHM research and evaluation framework for industrial vibration signals.</strong></p>
 
   <p>
     <img src="https://img.shields.io/badge/status-alpha-orange" alt="Status: alpha"/>
-    <img src="https://img.shields.io/badge/maintained%20demos-7-blue" alt="Seven maintained demos"/>
-    <a href="https://github.com/PHMbench/PHM-Vibench/actions/workflows/core-quality-gates.yml"><img src="https://github.com/PHMbench/PHM-Vibench/actions/workflows/core-quality-gates.yml/badge.svg" alt="Core quality gates"/></a>
+    <img src="https://img.shields.io/badge/v0.3-pre--release-blue" alt="v0.3 pre-release"/>
+    <a href="https://github.com/PHMbench/phmfactory/actions/workflows/core-quality-gates.yml"><img src="https://github.com/PHMbench/phmfactory/actions/workflows/core-quality-gates.yml/badge.svg" alt="Core quality gates"/></a>
     <img src="https://img.shields.io/badge/license-Apache%202.0-green" alt="Apache 2.0 license"/>
   </p>
 </div>
 
-PHM-Vibench connects data loading, model construction, task logic, training, and
-experiment configuration through one public entrypoint:
+PHMFactory connects data loading, model construction, task logic, training, evaluation,
+and experiment configuration through one public dispatcher. The following entrypoints
+have the same semantics:
 
 ```bash
 python main.py --config <yaml> [--override key=value ...]
+python -m phmfactory --config <yaml> [--override key=value ...]
+phmfactory --config <yaml> [--override key=value ...]
 ```
 
-The project is in alpha. Release support is intentionally limited to the
-maintained configurations documented in
-[SUPPORTED_COMBINATIONS.md](SUPPORTED_COMBINATIONS.md). Files, registry entries,
-research notes, and historical configs outside that surface are not automatically
-supported.
+PHMFactory is the v0.3 successor to PHM-Vibench. The v0.3 compatibility release adds
+the public `phmfactory` package while retaining the established `src.*` runtime as a
+protected internal engine. The project remains in alpha; release support is limited to
+the maintained configurations documented in
+[SUPPORTED_COMBINATIONS.md](SUPPORTED_COMBINATIONS.md).
 
 ## Run the offline example
 
-Install the environment, then execute the repository-shipped dummy configuration:
+Install the core environment, then execute the repository-shipped Dummy configuration:
 
 ```bash
-git clone https://github.com/PHMbench/PHM-Vibench.git
-cd PHM-Vibench
-conda create -n phm-vibench python=3.10
-conda activate phm-vibench
+git clone https://github.com/PHMbench/phmfactory.git
+cd phmfactory
+conda create -n phmfactory python=3.10
+conda activate phmfactory
 python -m pip install -r requirements.txt
 
 python main.py --config configs/demo/00_smoke/dummy_dg.yaml \
@@ -47,37 +50,61 @@ python main.py --config configs/demo/00_smoke/dummy_dg.yaml \
   --override data.num_workers=0
 ```
 
-A successful run exits cleanly, prints the completion message, and writes output
-below `results/demo/dummy_dg_smoke/`. This verifies the software path; it is not a
-benchmark-performance result.
+A successful run exits cleanly, prints the completion message, and writes output below
+`results/demo/dummy_dg_smoke/`. This validates the maintained software path; it is not
+a benchmark-performance claim.
 
-Detailed setup, expected behavior, and troubleshooting:
+Detailed setup and troubleshooting:
 
 - [Installation](docs/installation.md)
 - [Quickstart](docs/quickstart.md)
 - [Known limitations](KNOWN_LIMITATIONS.md)
+- [v0.2 to v0.3 migration](RELEASE_NOTES_v0.3.0.md)
 
-## What is maintained
+## Public data bundle interface
 
-The current maintained demo surface covers:
+The v0.3 source tree includes a provider-neutral CWRU bundle interface for:
 
-- offline dummy domain-generalization smoke;
+```text
+metadata.xlsx          required
+RM_001_CWRU.h5         required
+corpus.xlsx            optional
+```
+
+The public commands are:
+
+```bash
+python main.py data download --source huggingface
+python main.py data download --source modelscope
+python main.py data validate --path <bundle-dir>
+python main.py data compare --left <hf-dir> --right <modelscope-dir>
+```
+
+The final v0.3 release remains blocked until both public providers use immutable
+revisions and byte-identical required-file SHA-256 values. See
+[docs/CWRU_DEMO_V0_3.md](docs/CWRU_DEMO_V0_3.md).
+
+## Maintained surface
+
+The maintained demo surface covers:
+
+- the fully offline Dummy domain-generalization smoke;
 - cross-domain and cross-system classification examples;
 - few-shot and generalized few-shot examples;
-- bounded HSE pretraining examples.
+- bounded HSE pretraining examples;
+- an optional Streamlit workspace around the same public CLI.
 
-Only the dummy example is fully offline. Other demos require local PHM-Vibench
-metadata and raw data supplied through configuration overrides. The exact model,
-task, data, and trainer combinations are listed in:
+Files, registry entries, research notes, and historical configurations outside the
+maintained surface are not automatically supported. The exact model, task, data, and
+trainer combinations are listed in:
 
 - [Supported components](SUPPORTED_COMPONENTS.md)
 - [Supported combinations](SUPPORTED_COMBINATIONS.md)
 - [Configuration registry](configs/config_registry.csv)
 - [Generated configuration atlas](docs/CONFIG_ATLAS.md)
 
-`sanity_ok` means smoke evidence exists. It does not mean state-of-the-art
-performance, universal component compatibility, or permission to redistribute an
-external dataset.
+`sanity_ok` means smoke evidence exists. It does not mean state-of-the-art performance,
+universal component compatibility, or permission to redistribute an external dataset.
 
 ## Configuration-first workflow
 
@@ -87,8 +114,8 @@ Maintained configurations use five logical blocks:
 environment / data / model / task / trainer
 ```
 
-Start from the nearest file under `configs/demo/`, place local variants under
-`configs/experiments/`, and use CLI overrides for machine-specific values:
+Start from the nearest file under `configs/demo/`, place local experiment variants
+under `configs/experiments/`, and use CLI overrides for machine-specific values:
 
 ```bash
 python -m scripts.config_inspect \
@@ -96,34 +123,38 @@ python -m scripts.config_inspect \
   --override trainer.num_epochs=1
 ```
 
-The authoritative composition and precedence rules are in the
-[configuration guide](configs/README.md). Data layout and external-source
-boundaries are in the [data guide](data/README.md).
+The authoritative composition and precedence rules are in
+[configs/README.md](configs/README.md). Data layout and external-source boundaries are
+in [data/README.md](data/README.md).
 
 ## Architecture
 
 ```text
-main.py
-  └── configured pipeline
-      ├── data factory
-      ├── model factory
-      ├── task factory
-      └── trainer factory
+main.py / python -m phmfactory / phmfactory
+  └── phmfactory.cli
+      └── resolved configuration + canonical Pipeline
+          └── protected src runtime
+              ├── data factory
+              ├── model factory
+              ├── task factory
+              └── trainer factory
 ```
 
 Primary paths:
 
-- `configs/` — base blocks, maintained demos, experiments, and config registry;
+- `phmfactory/` — public package, CLI, configuration resolver, Pipeline registry, and data providers;
+- `configs/` — base blocks, maintained demos, experiments, and configuration registry;
 - `src/data_factory/` — metadata, readers, datasets, samplers, and data wiring;
 - `src/model_factory/` — model families, components, and model construction;
 - `src/task_factory/` — tasks, losses, metrics, and task registry;
 - `src/trainer_factory/` — trainer construction and extensions;
 - `apps/streamlit/` — optional browser workspace around the same CLI;
 - `test/` — maintained pytest suite;
-- `docs/` — user, development, release, and historical documentation.
+- `docs/` — user, development, migration, release, and historical documentation.
 
-Do not add dataset- or model-specific branches to `main.py`; extend the existing
-factory boundary.
+The v0.3 release does not mechanically move or rewrite the mature dataset readers.
+Extend the existing factory boundaries rather than adding dataset- or model-specific
+branches to `main.py`.
 
 ## Validate a change
 
@@ -133,44 +164,41 @@ python -m scripts.validate_configs
 python -m scripts.gen_config_atlas
 git diff --exit-code docs/CONFIG_ATLAS.md
 python -m pytest test/ -q
+python tools/repo/check_case_collisions.py
+python tools/repo/check_release_readiness.py --mode audit
 ```
 
 Runtime or configuration changes should also run the offline smoke command above.
-GitHub Actions currently enforce documentation/configuration consistency and the
-focused UXFD assembly contract. See the [testing guide](docs/testing.md) for
-evidence terminology and narrower commands.
+The [testing guide](docs/testing.md) defines evidence terminology and focused commands.
 
-## Documentation
-
-Use the [documentation index](docs/index.md) to find installation, configuration,
-data, development, testing, Streamlit, release, and historical material.
-
-For the optional web interface:
+## Optional Streamlit workspace
 
 ```bash
+python -m pip install -r requirements.txt
 python -m pip install -r apps/streamlit/requirements.txt
 streamlit run apps/streamlit/app.py
 ```
 
-See [apps/streamlit/README.md](apps/streamlit/README.md) for its local
-single-worker boundary.
+`apps/streamlit/app.py` is the only maintained web entrypoint. It delegates experiment
+execution to the public CLI and does not define a second training framework.
 
 ## Contributing and support
 
-Read [CONTRIBUTING.md](CONTRIBUTING.md) before opening an issue or pull request.
-Keep changes small, update the authoritative document rather than copying it, and
-report the exact commit, config, overrides, environment, and logs. Participation
-is governed by [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md).
+Read [CONTRIBUTING.md](CONTRIBUTING.md) before opening an issue or pull request. Keep
+changes bounded, update the authoritative document instead of copying it, and report
+the exact commit, configuration, overrides, environment, and logs. Participation is
+governed by [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md).
 
-- Bugs and feature requests: [GitHub Issues](https://github.com/PHMbench/PHM-Vibench/issues)
+- Bugs and feature requests: [GitHub Issues](https://github.com/PHMbench/phmfactory/issues)
 - Security reports: [SECURITY.md](SECURITY.md)
 - Development workflow: [docs/developer_guide.md](docs/developer_guide.md)
+- Release readiness: [docs/PHMFACTORY_V0_3_RELEASE_READINESS.md](docs/PHMFACTORY_V0_3_RELEASE_READINESS.md)
 
 ## Citation and license
 
-PHM-Vibench is licensed under the [Apache License 2.0](LICENSE). Dataset and model
-artifacts can have separate source licenses.
+PHMFactory is licensed under the [Apache License 2.0](LICENSE). Dataset and model
+artifacts may have separate source licenses.
 
-Use [CITATION.cff](CITATION.cff) as the software citation metadata. Cite the exact
-Git commit or release tag used for an experiment and record the configuration,
-overrides, data source, seed, and environment.
+Use [CITATION.cff](CITATION.cff) as the software citation metadata. Cite the exact Git
+commit or release tag used for an experiment and record the configuration, overrides,
+data source and revision, random seed, and environment.

--- a/README_CN.md
+++ b/README_CN.md
@@ -1,42 +1,46 @@
-# PHM-Vibench
+# PHMFactory
 
 <div align="center">
-  <img src="pic/PHM-Vibench.png" alt="PHM-Vibench 标志" width="280"/>
+  <img src="pic/PHM-Vibench.png" alt="PHMFactory 标志" width="280"/>
 
   <p>
     <a href="README.md">English</a> |
     <a href="README_CN.md"><strong>中文</strong></a>
   </p>
 
-  <p><strong>面向工业振动故障诊断实验的配置优先工作台。</strong></p>
+  <p><strong>面向工业振动信号的配置优先 PHM 研究与评估框架。</strong></p>
 
   <p>
     <img src="https://img.shields.io/badge/状态-alpha-orange" alt="状态：alpha"/>
-    <img src="https://img.shields.io/badge/维护中%20demo-7-blue" alt="7 个维护中 demo"/>
-    <a href="https://github.com/PHMbench/PHM-Vibench/actions/workflows/core-quality-gates.yml"><img src="https://github.com/PHMbench/PHM-Vibench/actions/workflows/core-quality-gates.yml/badge.svg" alt="核心质量门禁"/></a>
+    <img src="https://img.shields.io/badge/v0.3-预发布-blue" alt="v0.3 预发布"/>
+    <a href="https://github.com/PHMbench/phmfactory/actions/workflows/core-quality-gates.yml"><img src="https://github.com/PHMbench/phmfactory/actions/workflows/core-quality-gates.yml/badge.svg" alt="核心质量门禁"/></a>
     <img src="https://img.shields.io/badge/许可-Apache%202.0-green" alt="Apache 2.0 许可"/>
   </p>
 </div>
 
-PHM-Vibench 通过一个公开入口连接数据加载、模型构建、任务逻辑、训练和实验配置：
+PHMFactory 通过一个公开 dispatcher 连接数据加载、模型构建、任务逻辑、训练、
+评估和实验配置。以下三个入口具有相同语义：
 
 ```bash
 python main.py --config <yaml> [--override key=value ...]
+python -m phmfactory --config <yaml> [--override key=value ...]
+phmfactory --config <yaml> [--override key=value ...]
 ```
 
-项目仍处于 alpha 阶段。发布支持范围仅限
-[SUPPORTED_COMBINATIONS.md](SUPPORTED_COMBINATIONS.md) 中列出的维护配置。
-仓库中的其他文件、注册表条目、研究笔记和历史配置不应自动视为受支持能力。
+PHMFactory 是 PHM-Vibench 的 v0.3 后继项目。v0.3 兼容性版本增加公开的
+`phmfactory` Python 包，同时将成熟的 `src.*` 运行时保留为受保护的内部内核。
+项目仍处于 alpha 阶段；发布支持范围仅限
+[SUPPORTED_COMBINATIONS.md](SUPPORTED_COMBINATIONS.md) 中记录的维护配置。
 
 ## 运行离线示例
 
-安装环境后，运行仓库自带的 Dummy 配置：
+安装核心环境后，运行仓库自带的 Dummy 配置：
 
 ```bash
-git clone https://github.com/PHMbench/PHM-Vibench.git
-cd PHM-Vibench
-conda create -n phm-vibench python=3.10
-conda activate phm-vibench
+git clone https://github.com/PHMbench/phmfactory.git
+cd phmfactory
+conda create -n phmfactory python=3.10
+conda activate phmfactory
 python -m pip install -r requirements.txt
 
 python main.py --config configs/demo/00_smoke/dummy_dg.yaml \
@@ -45,25 +49,50 @@ python main.py --config configs/demo/00_smoke/dummy_dg.yaml \
 ```
 
 成功运行应正常退出、打印完成信息，并在 `results/demo/dummy_dg_smoke/`
-下写入输出。该命令验证软件链路，不代表基准性能。
+下写入输出。该命令验证维护中的软件链路，不代表基准性能。
 
-详细安装、预期行为和故障排查：
+详细安装和故障排查：
 
 - [安装指南](docs/installation.md)
 - [快速开始](docs/quickstart.md)
 - [已知限制](KNOWN_LIMITATIONS.md)
+- [v0.2 到 v0.3 迁移说明](RELEASE_NOTES_v0.3.0.md)
+
+## 公共数据包接口
+
+v0.3 源码提供面向 CWRU 的 provider-neutral 数据包接口：
+
+```text
+metadata.xlsx          必需
+RM_001_CWRU.h5         必需
+corpus.xlsx            可选
+```
+
+公开命令：
+
+```bash
+python main.py data download --source huggingface
+python main.py data download --source modelscope
+python main.py data validate --path <bundle-dir>
+python main.py data compare --left <hf-dir> --right <modelscope-dir>
+```
+
+最终 v0.3 发布仍被阻塞，直到 Hugging Face 与 ModelScope 均使用不可变 revision，
+且必需文件的 SHA-256 完全一致。详见
+[docs/CWRU_DEMO_V0_3.md](docs/CWRU_DEMO_V0_3.md)。
 
 ## 当前维护范围
 
-当前维护中的 demo 覆盖：
+维护中的 demo 覆盖：
 
-- 离线 Dummy 域泛化冒烟；
+- 完全离线的 Dummy 域泛化冒烟；
 - 跨域和跨系统分类示例；
 - 小样本和广义小样本示例；
-- 边界明确的 HSE 预训练示例。
+- 边界明确的 HSE 预训练示例；
+- 围绕同一公共 CLI 的可选 Streamlit 工作区。
 
-只有 Dummy 示例完全离线。其他 demo 需要通过配置覆盖传入本地
-PHM-Vibench metadata 和原始数据。准确的模型、任务、数据和训练器组合见：
+维护范围之外的文件、注册表条目、研究笔记和历史配置不应自动视为受支持能力。
+准确的模型、任务、数据和训练器组合见：
 
 - [支持组件](SUPPORTED_COMPONENTS.md)
 - [支持组合](SUPPORTED_COMBINATIONS.md)
@@ -90,22 +119,25 @@ python -m scripts.config_inspect \
   --override trainer.num_epochs=1
 ```
 
-配置组合和优先级的权威说明位于[配置指南](configs/README.md)，数据布局和
-外部数据边界位于[数据指南](data/README.md)。
+配置组合和优先级的权威说明位于 [configs/README.md](configs/README.md)，数据布局和
+外部数据边界位于 [data/README.md](data/README.md)。
 
 ## 架构
 
 ```text
-main.py
-  └── 配置选择的 pipeline
-      ├── data factory
-      ├── model factory
-      ├── task factory
-      └── trainer factory
+main.py / python -m phmfactory / phmfactory
+  └── phmfactory.cli
+      └── 已解析配置 + canonical Pipeline
+          └── 受保护的 src 运行时
+              ├── data factory
+              ├── model factory
+              ├── task factory
+              └── trainer factory
 ```
 
 主要目录：
 
+- `phmfactory/`：公开 Python 包、CLI、配置解析器、Pipeline 注册表和数据 provider；
 - `configs/`：base block、维护 demo、实验配置和配置注册表；
 - `src/data_factory/`：metadata、reader、dataset、sampler 与数据装配；
 - `src/model_factory/`：模型家族、组件与模型构建；
@@ -113,9 +145,10 @@ main.py
 - `src/trainer_factory/`：训练器构建和扩展；
 - `apps/streamlit/`：围绕同一 CLI 的可选浏览器工作区；
 - `test/`：维护中的 pytest 测试；
-- `docs/`：用户、开发、发布和历史文档。
+- `docs/`：用户、开发、迁移、发布和历史文档。
 
-添加数据集或模型时，应扩展现有 factory，不要在 `main.py` 中加入专用分支。
+v0.3 不会机械移动或重写成熟的数据 reader。添加数据集或模型时应扩展现有 factory，
+不要在 `main.py` 中加入专用分支。
 
 ## 验证改动
 
@@ -125,41 +158,39 @@ python -m scripts.validate_configs
 python -m scripts.gen_config_atlas
 git diff --exit-code docs/CONFIG_ATLAS.md
 python -m pytest test/ -q
+python tools/repo/check_case_collisions.py
+python tools/repo/check_release_readiness.py --mode audit
 ```
 
-运行时或配置改动还应执行前面的离线冒烟命令。GitHub Actions 当前执行
-文档/配置一致性和聚焦的 UXFD 装配测试。证据术语和更聚焦的命令见
+运行时或配置改动还应执行前面的离线冒烟命令。证据术语和聚焦命令见
 [测试指南](docs/testing.md)。
 
-## 文档
-
-通过[文档索引](docs/index.md)查找安装、配置、数据、开发、测试、Streamlit、
-发布和历史材料。
-
-可选 Web 界面：
+## 可选 Streamlit 工作区
 
 ```bash
+python -m pip install -r requirements.txt
 python -m pip install -r apps/streamlit/requirements.txt
 streamlit run apps/streamlit/app.py
 ```
 
-其本地单 worker 边界见 [apps/streamlit/README.md](apps/streamlit/README.md)。
+`apps/streamlit/app.py` 是唯一维护中的 Web 入口。它将实验执行委托给公共 CLI，
+不会定义第二套训练框架。
 
 ## 贡献与支持
 
 提交 Issue 或 Pull Request 前请阅读 [CONTRIBUTING_CN.md](CONTRIBUTING_CN.md)。
-保持改动小而可审查，修改权威文档而不是复制内容，并提供准确的 commit、
-配置、override、环境和日志。社区参与遵循
-[CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)。
+保持改动边界清晰，修改权威文档而不是复制内容，并提供准确的 commit、配置、
+override、环境和日志。社区参与遵循 [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)。
 
-- Bug 与功能建议：[GitHub Issues](https://github.com/PHMbench/PHM-Vibench/issues)
+- Bug 与功能建议：[GitHub Issues](https://github.com/PHMbench/phmfactory/issues)
 - 安全问题：[SECURITY.md](SECURITY.md)
 - 开发流程：[docs/developer_guide.md](docs/developer_guide.md)
+- 发布就绪状态：[docs/PHMFACTORY_V0_3_RELEASE_READINESS.md](docs/PHMFACTORY_V0_3_RELEASE_READINESS.md)
 
 ## 引用与许可
 
-PHM-Vibench 使用 [Apache License 2.0](LICENSE)。数据集和模型产物可能适用
+PHMFactory 使用 [Apache License 2.0](LICENSE)。数据集和模型产物可能适用
 原始来源的独立许可。
 
-软件引用元数据见 [CITATION.cff](CITATION.cff)。请引用实验所使用的准确 Git
-commit 或 release tag，并记录配置、override、数据来源、随机种子和运行环境。
+软件引用元数据见 [CITATION.cff](CITATION.cff)。请引用实验所使用的准确 Git commit
+或 release tag，并记录配置、override、数据来源及 revision、随机种子和运行环境。

--- a/RELEASE_NOTES_v0.3.0.md
+++ b/RELEASE_NOTES_v0.3.0.md
@@ -1,0 +1,307 @@
+# PHMFactory v0.3.0 Release Notes
+
+> Status: **pre-release draft**  
+> Final tag, package publication, repository rename, and data-provider pins are not yet complete.
+
+## Overview
+
+PHM-Vibench becomes **PHMFactory** in v0.3.0.
+
+This release establishes a stable public project identity and Python entrypoint while
+preserving the mature runtime that already implements dataset readers, factories,
+tasks, trainers, and Pipeline behavior.
+
+The guiding rule is:
+
+```text
+public interface and repository boundary cleanup
+without an unreviewed core-algorithm rewrite
+```
+
+## Names
+
+| Object | v0.3.0 value |
+| --- | --- |
+| Project | `PHMFactory` |
+| GitHub repository | `PHMbench/phmfactory` |
+| Python distribution | `phmfactory` |
+| Python import namespace | `phmfactory` |
+| CLI command | `phmfactory` |
+| Root entrypoint | `python main.py` |
+| Module entrypoint | `python -m phmfactory` |
+
+No `phm_factory` or `phm_vibench` compatibility namespace is introduced.
+
+## Installation
+
+Core environment:
+
+```bash
+git clone https://github.com/PHMbench/phmfactory.git
+cd phmfactory
+python -m pip install -r requirements.txt
+python -m pip install -e .
+```
+
+The root `requirements.txt` remains the core dependency authority.
+
+Optional subsystems install their incremental requirements separately:
+
+```bash
+# Streamlit workspace
+python -m pip install -r apps/streamlit/requirements.txt
+
+# ModelScope data provider
+python -m pip install -r phmfactory/data_sources/modelscope/requirements.txt
+
+# Test environment
+python -m pip install -r test/requirements.txt
+
+# Plotting tools
+python -m pip install -r plot/requirements.txt
+```
+
+## Public entrypoints
+
+These commands use one parser and dispatcher:
+
+```bash
+python main.py --config configs/demo/00_smoke/dummy_dg.yaml
+python -m phmfactory --config configs/demo/00_smoke/dummy_dg.yaml
+phmfactory --config configs/demo/00_smoke/dummy_dg.yaml
+```
+
+`--config_path` remains accepted as a compatibility alias. `--config` is preferred.
+
+## Python API migration
+
+New integrations should use:
+
+```python
+import phmfactory
+from phmfactory.config import resolve_config
+```
+
+The mature runtime remains under `src.*` during v0.3.0. It is packaged because the
+public façade delegates to it, but new third-party integrations should not add new
+hard dependencies on internal `src.*` paths unless no public surface exists.
+
+## Pipeline migration
+
+Canonical v0.3 module names are:
+
+| v0.2 name | v0.3 name |
+| --- | --- |
+| `Pipeline_01_default` | `Pipeline_01_Fault_Diagnosis` |
+| `Pipeline_02_pretrain_fewshot` | `Pipeline_02_Pretraining_Few_Shot` |
+| `Pipeline_03_multitask_pretrain_finetune` | `Pipeline_03_Multitask_Pretraining_Finetuning` |
+| `Pipeline_04_unified_metric` | `Pipeline_04_Unified_Evaluation` |
+| `Pipeline_05_default_w_explain` | `Pipeline_05_Explainable_Fault_Diagnosis` |
+| `Pipeline_06_generative` | `Pipeline_06_Generative_Modeling` |
+
+Legacy YAML values remain accepted through explicit aliases and emit a deprecation
+warning. Direct imports of removed filenames must change:
+
+```python
+# v0.2
+from src.Pipeline_01_default import pipeline
+
+# v0.3
+from src.Pipeline_01_Fault_Diagnosis import pipeline
+```
+
+The rename does not change Pipeline function bodies, seeds, splitting, metrics,
+checkpoint formats, model construction, or reader behavior.
+
+## Configuration
+
+The public resolver is:
+
+```python
+from phmfactory.config import resolve_config
+
+resolved = resolve_config(
+    "configs/demo/00_smoke/dummy_dg.yaml",
+    overrides=("trainer.num_epochs=1",),
+)
+```
+
+It provides maintained preset/path resolution, ordered `base_configs` composition,
+dotted overrides, YAML value parsing, canonical Pipeline selection, and cycle errors.
+
+The established five-block configuration contract remains:
+
+```text
+environment / data / model / task / trainer
+```
+
+Historical internal loaders remain available for compatibility in v0.3.0. Their
+physical consolidation is deferred to a later, separately reviewed release.
+
+## Data readers and factories
+
+The following areas are deliberately preserved in place:
+
+```text
+src/data_factory/reader/
+src/data_factory/dataset_task/
+src/data_factory/samplers/
+src/data_factory/H5DataDict.py
+src/data_factory/data_factory.py
+src/model_factory/
+src/task_factory/
+src/trainer_factory/
+```
+
+v0.3.0 does not mechanically class-convert readers, unify all reader signatures,
+change channel ordering, alter `(L, C)` signal semantics, or merge dataset-specific
+implementations.
+
+## CWRU quickstart
+
+The v0.3 bundle contract is:
+
+```text
+metadata.xlsx          required
+RM_001_CWRU.h5         required
+corpus.xlsx            optional
+```
+
+Commands:
+
+```bash
+python main.py data download --source huggingface
+python main.py data download --source modelscope
+python main.py data validate --path <bundle-dir>
+python main.py data compare --left <hf-dir> --right <modelscope-dir>
+```
+
+Python example:
+
+```bash
+python examples/cwru_quickstart.py --source huggingface
+```
+
+The fault-diagnosis quickstart does not require `corpus.xlsx`. A Pipeline that requires
+textual evidence must fail clearly when corpus data is absent.
+
+The final release requires immutable provider revisions and identical SHA-256 values
+for `metadata.xlsx` and `RM_001_CWRU.h5`. Until those values are published and pinned,
+the online CWRU path is a pre-release interface rather than final release evidence.
+
+## Streamlit
+
+The only maintained web entrypoint is:
+
+```bash
+streamlit run apps/streamlit/app.py
+```
+
+The historical `app/` prototype and root `streamlit_app.py` launcher were preserved in
+the approved personal archive and removed from the public framework.
+
+The maintained workspace delegates execution to the public CLI. It does not import a
+Pipeline directly or maintain a second training implementation.
+
+## Repository ownership boundaries
+
+Allowed direction:
+
+```text
+paper repositories ────────┐
+personal forks ────────────┼──> PHMFactory
+third-party projects ──────┘
+```
+
+Forbidden reverse dependencies:
+
+```text
+PHMFactory ─X─> personal fork
+PHMFactory ─X─> paper repository
+PHMFactory ─X─> Agent tooling
+```
+
+Public documentation may cite a paper repository or DOI. Removing that link must not
+break installation, runtime, tests, data access, or release publication.
+
+Personal Agent content, development scratchpads, historical prototypes, and personal
+submodules were moved out of the public framework after exact Git-object preservation.
+Remaining paper gitlinks require destination-level content verification before removal.
+
+## Removed public paths
+
+The staged v0.3 migration removes or normalizes:
+
+```text
+app/
+streamlit_app.py
+.claude/
+.codex/
+dev/
+.archive/
+results/                tracked placeholder only
+metrics_reports/        tracked placeholder only
+data/Rotor_simulation   personal gitlink
+paper/LQ_vibench_fix    personal gitlink
+```
+
+It also removes lowercase path duplicates that collide on case-insensitive filesystems,
+while retaining canonical authorities such as `CITATION.cff`, `CONTRIBUTING.md`,
+`configs/README.md`, and `src/README.md`.
+
+The removed content remains recoverable from immutable public Git history and the
+approved personal-fork archive. PHMFactory does not depend on that archive.
+
+## Validation
+
+The v0.3 PR chain adds or exercises:
+
+```text
+document and maintained-config validation
+generated configuration Atlas parity
+fully offline Dummy_Data smoke
+public package / wheel / CLI parity
+canonical Pipeline selection
+Pipeline 06 contract tests
+UXFD assembly tests
+CWRU local bundle validation
+requirements ownership checks
+Streamlit Ubuntu and Windows tests
+case-insensitive path checks
+release-readiness blocker audit
+```
+
+Functional smoke evidence is not a performance benchmark.
+
+## Release blockers
+
+The release is not ready while any of these remain:
+
+- Draft PRs have not been reviewed and merged in dependency order;
+- v0.2 release-candidate provenance remains unresolved;
+- CWRU provider revisions or required hashes are not immutable and complete;
+- cross-provider public download parity has not passed;
+- optional `phm-data-factory` backend disposition remains undecided;
+- versions remain `0.3.0.dev0`;
+- GitHub repository rename and redirect have not been verified;
+- final checks have not run under the `PHMbench/phmfactory` identity;
+- wheel and source distribution have not been built from the final release commit;
+- tag `v0.3.0` has not been created from a zero-blocker readiness state.
+
+Audit locally with:
+
+```bash
+python tools/repo/check_release_readiness.py --mode audit
+```
+
+The strict release mode must fail until all blockers are resolved:
+
+```bash
+python tools/repo/check_release_readiness.py --mode release
+```
+
+## Rollback
+
+Before tagging, revert the relevant staged PR or keep the package at `0.3.0.dev0`.
+After publishing `v0.3.0`, do not move or recreate the tag; publish a corrective patch
+release instead.

--- a/docs/index.md
+++ b/docs/index.md
@@ -11,6 +11,8 @@ This index is the maintained entry point for PHMFactory documentation.
 - [Supported components](../SUPPORTED_COMPONENTS.md)
 - [Supported combinations](../SUPPORTED_COMBINATIONS.md)
 - [Known limitations](../KNOWN_LIMITATIONS.md)
+- [v0.3.0 release and migration notes](../RELEASE_NOTES_v0.3.0.md)
+- [v0.3.0 release readiness](PHMFACTORY_V0_3_RELEASE_READINESS.md)
 
 ## Architecture and extension
 
@@ -38,9 +40,10 @@ This index is the maintained entry point for PHMFactory documentation.
 - [PHMFactory v0.3.0 task and PR plan](PHMFACTORY_V0_3_TASK_PLAN.md)
 - [Pipeline 06 migration contract](PIPELINE_06_GENERATIVE_MIGRATION.md)
 
-The PHMFactory v0.3.0 documents describe an accepted staged migration plan.
-They do not by themselves claim that the repository, package, Pipeline files,
-data providers, or GitHub repository have already been renamed or migrated.
+The PHMFactory v0.3.0 documents describe a staged migration and pre-release state.
+They do not by themselves claim that the GitHub repository rename, public data pins,
+final version, tag, or package publication have completed. The release-readiness page
+is the authority for those blockers.
 
 ## Generated and historical material
 
@@ -65,6 +68,8 @@ Generated experiment outputs are local artifacts and are not tracked through
 | Project positioning and shortest successful path | `README.md` | Link to the README or the detailed page below |
 | Installation | `docs/installation.md` | Keep only a minimal command and link |
 | First successful run | `docs/quickstart.md` | Avoid copying the complete walkthrough |
+| v0.2 to v0.3 user migration | `RELEASE_NOTES_v0.3.0.md` | Link rather than duplicate the full migration map |
+| Release blockers | `docs/PHMFACTORY_V0_3_RELEASE_READINESS.md` | Do not claim release completion while blockers remain |
 | Configuration semantics | `configs/README.md` | Link rather than redefine precedence |
 | Maintained config inventory | `configs/config_registry.csv` | Regenerate `docs/CONFIG_ATLAS.md` |
 | Supported components and combinations | `SUPPORTED_COMPONENTS.md`, `SUPPORTED_COMBINATIONS.md` | Do not infer support from registry presence |


### PR DESCRIPTION
## What changed

This is the bounded PHMFactory v0.3 branding and migration-documentation PR, stacked on the release-readiness gate.

It updates:

```text
README.md
README_CN.md
CITATION.cff
CHANGELOG.md
docs/index.md
.github/workflows/phmfactory-release-readiness.yml
```

and adds:

```text
RELEASE_NOTES_v0.3.0.md
```

## Branding

The maintained public identity is now documented as:

```text
project:             PHMFactory
repository target:   PHMbench/phmfactory
Python distribution: phmfactory
Python namespace:    phmfactory
CLI:                 phmfactory
```

The README documents the three equivalent entrypoints:

```bash
python main.py --config <yaml>
python -m phmfactory --config <yaml>
phmfactory --config <yaml>
```

The release remains pre-release. This PR does not rename the GitHub repository or change package versions.

## v0.2 to v0.3 transition

`CHANGELOG.md` now records:

- the PHM-Vibench to PHMFactory rename;
- the public package and CLI;
- direct descriptive Pipeline module renames;
- preserved reader/factory/runtime behavior;
- CWRU bundle and optional corpus contract;
- requirements ownership boundaries;
- Agent, development, legacy UI, personal-submodule, and case-collision cleanup;
- compatibility and breaking-change boundaries;
- a complete v0.2-to-v0.3 migration table;
- remaining release blockers.

`RELEASE_NOTES_v0.3.0.md` provides user-facing installation, API, Pipeline, configuration, CWRU, Streamlit, ownership, validation, and rollback guidance.

## Readiness progression

The release-readiness workflow now requires the branding/documentation blockers to be absent while continuing to require these blockers:

```text
VERSION_NOT_FINAL
CWRU_REVISION_FLOATING
CWRU_HASH_MISSING
V020_PROVENANCE_UNRESOLVED
REPOSITORY_RENAME_PENDING
```

Release mode must remain non-zero on this PR.

## Explicit non-actions

This PR does not:

- change `0.3.0.dev0` to `0.3.0`;
- change reader, Data Factory, model, task, trainer, or Pipeline algorithms;
- modify CWRU provider revisions or hashes;
- rename the GitHub repository;
- create a tag or GitHub release;
- publish a wheel or source distribution;
- remove remaining paper gitlinks or historical directories.

## Base

```text
base: agent/v030-release-readiness-pr12-r2
base SHA: 8d1853c7627a311d400e2a6be7e1555049a3105f
head: agent/v030-branding-changelog-pr12b
```

## Validation contract

Required before review or merge:

```text
PHMFactory release readiness
Core quality gates / documentation and config contracts
Repository layout / case-insensitive path contract
```

The strict readiness command must still fail, but the README, citation, changelog, and release-notes blocker codes must be absent.

## Rollback

A normal revert restores the previous pre-branding documentation. No runtime, data, package version, repository identity, or release state is changed.