### PR TITLE
docs(v0.3): resolve v0.2 release-candidate provenance

### DIFF
--- a/.github/workflows/phmfactory-release-readiness.yml
+++ b/.github/workflows/phmfactory-release-readiness.yml
@@ -12,6 +12,8 @@ on:
       - "RELEASE_NOTES_v0.3.0.md"
       - "phmfactory/data_sources/manifests/cwru-demo-v1.yaml"
       - "docs/PHMFACTORY_V0_3_RELEASE_READINESS.md"
+      - "docs/releases/v0.2.0-rc-provenance.yaml"
+      - "docs/releases/v0.2.0-rc-provenance.md"
       - "docs/index.md"
       - "tools/repo/check_release_readiness.py"
       - ".github/workflows/phmfactory-release-readiness.yml"
@@ -62,7 +64,6 @@ jobs:
             VERSION_NOT_FINAL \
             CWRU_REVISION_FLOATING \
             CWRU_HASH_MISSING \
-            V020_PROVENANCE_UNRESOLVED \
             REPOSITORY_RENAME_PENDING
           do
             grep -q "${blocker}" release-readiness.txt
@@ -73,10 +74,11 @@ jobs:
             CITATION_BRAND_PENDING \
             CITATION_REPOSITORY_PENDING \
             CHANGELOG_V030_MISSING \
-            RELEASE_NOTES_V030_MISSING
+            RELEASE_NOTES_V030_MISSING \
+            V020_PROVENANCE_UNRESOLVED
           do
             if grep -q "${resolved}" release-readiness.txt; then
-              echo "Resolved branding/documentation blocker returned: ${resolved}" >&2
+              echo "Resolved blocker returned: ${resolved}" >&2
               exit 1
             fi
           done

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,9 @@ results, and historical prototypes are moved to their correct ownership boundari
   release readiness, and bounded workspace migration.
 - Added explicit PHMFactory v0.3 repository, reader-preservation, Pipeline-name,
   dependency-boundary, CWRU, and release-readiness documents.
+- Added machine-readable and human-readable v0.2.0 release-candidate provenance under
+  `docs/releases/`, anchored to commit
+  `a331769d4005018bc833534ecf4efeb5e8a5a78d`.
 
 ### Changed
 
@@ -79,6 +82,8 @@ results, and historical prototypes are moved to their correct ownership boundari
   while treating `corpus.xlsx` as optional for the current fault-diagnosis quickstart.
 - Added a public façade around the established `src.*` runtime instead of moving the
   four mature factory trees during v0.3.0.
+- Resolved the missing-v0.2-tag ambiguity by recording v0.2.0 as a release-candidate
+  baseline rather than creating a retroactive final tag.
 
 ### Preserved
 
@@ -156,6 +161,22 @@ results, and historical prototypes are moved to their correct ownership boundari
 - Remaining paper gitlinks are not removed merely because similarly named destination
   repositories exist; content-level verification remains mandatory.
 
+### v0.2 release-candidate provenance
+
+The v0.3 migration uses this immutable baseline:
+
+```text
+project:         PHM-Vibench
+version label:   v0.2.0
+status:          release_candidate
+formal release:  false
+baseline commit: a331769d4005018bc833534ecf4efeb5e8a5a78d
+tag present:     false
+```
+
+The authority is `docs/releases/v0.2.0-rc-provenance.yaml`. A final v0.2.0 tag is not
+created retroactively, and published history is not rewritten.
+
 ### Validation state
 
 The staged v0.3 PR chain includes focused gates for:
@@ -169,7 +190,7 @@ The staged v0.3 PR chain includes focused gates for:
 - dependency ownership;
 - Streamlit imports and lifecycle behavior on Linux and Windows;
 - case-insensitive repository paths;
-- release-readiness blocker reporting.
+- release-readiness blocker reporting, including exact v0.2 provenance validation.
 
 Passing smoke and contract tests establishes software-path evidence, not benchmark
 performance or universal component compatibility.
@@ -179,7 +200,6 @@ performance or universal component compatibility.
 v0.3.0 must not be tagged or published until all of the following are resolved:
 
 - the staged PR chain is reviewed and merged in dependency order;
-- the v0.2 baseline or release-candidate provenance is explicitly resolved;
 - Hugging Face and ModelScope CWRU revisions and SHA-256 values are pinned;
 - cross-provider required-file parity passes against the public services;
 - the optional `phm-data-factory` backend disposition is finalized;

--- a/RELEASE_NOTES_v0.3.0.md
+++ b/RELEASE_NOTES_v0.3.0.md
@@ -18,6 +18,29 @@ public interface and repository boundary cleanup
 without an unreviewed core-algorithm rewrite
 ```
 
+## v0.2 migration baseline
+
+The source baseline for this migration is explicitly recorded as a release candidate:
+
+```text
+project:         PHM-Vibench
+version label:   v0.2.0
+status:          release_candidate
+formal release:  false
+baseline commit: a331769d4005018bc833534ecf4efeb5e8a5a78d
+tag present:     false
+```
+
+Authorities:
+
+```text
+docs/releases/v0.2.0-rc-provenance.yaml
+docs/releases/v0.2.0-rc-provenance.md
+```
+
+No retroactive final `v0.2.0` tag is created. The immutable commit above anchors the
+reader/runtime fingerprints and v0.2-to-v0.3 compatibility comparison.
+
 ## Names
 
 | Object | v0.3.0 value |
@@ -268,6 +291,7 @@ CWRU local bundle validation
 requirements ownership checks
 Streamlit Ubuntu and Windows tests
 case-insensitive path checks
+v0.2 release-candidate provenance validation
 release-readiness blocker audit
 ```
 
@@ -278,7 +302,6 @@ Functional smoke evidence is not a performance benchmark.
 The release is not ready while any of these remain:
 
 - Draft PRs have not been reviewed and merged in dependency order;
-- v0.2 release-candidate provenance remains unresolved;
 - CWRU provider revisions or required hashes are not immutable and complete;
 - cross-provider public download parity has not passed;
 - optional `phm-data-factory` backend disposition remains undecided;

--- a/docs/PHMFACTORY_V0_3_RELEASE_READINESS.md
+++ b/docs/PHMFACTORY_V0_3_RELEASE_READINESS.md
@@ -33,9 +33,23 @@ The checker currently evaluates:
 5. `RELEASE_NOTES_v0.3.0.md` exists;
 6. Hugging Face and ModelScope CWRU revisions are immutable rather than `main` or `master`;
 7. required CWRU bundle SHA-256 values are populated;
-8. v0.2 provenance has a visible resolution;
+8. v0.2 provenance is resolved either by a visible historical tag or by the exact approved release-candidate provenance record;
 9. no v0.3.0 tag already exists before the release gate passes;
 10. when running in GitHub Actions, the repository has the final `PHMbench/phmfactory` identity.
+
+## Resolved staged records
+
+The staged v0.3 chain now includes:
+
+- PHMFactory README and citation branding;
+- a v0.3 changelog section and draft release notes;
+- an explicit v0.2.0 release-candidate provenance authority at
+  `docs/releases/v0.2.0-rc-provenance.yaml`;
+- the immutable v0.2 runtime baseline commit
+  `a331769d4005018bc833534ecf4efeb5e8a5a78d`;
+- an explicit decision not to create a retroactive final v0.2.0 tag.
+
+These records are only effective after their stacked PRs are reviewed and merged.
 
 ## Human-reviewed blockers
 
@@ -55,11 +69,11 @@ The following cannot be inferred safely from repository files alone:
 
 ```text
 1. merge the reviewed v0.3 PR stack in dependency order
-2. resolve the v0.2 provenance record
+2. retain the approved v0.2 release-candidate provenance record
 3. publish and pin the dual-source CWRU bundle
 4. finalize repository branding and citation metadata
 5. change versions from 0.3.0.dev0 to 0.3.0
-6. create and validate RELEASE_NOTES_v0.3.0.md
+6. validate RELEASE_NOTES_v0.3.0.md against the final tree
 7. rename the GitHub repository to PHMbench/phmfactory
 8. rerun all required checks on the final repository identity
 9. build wheel and sdist from the final commit

--- a/docs/index.md
+++ b/docs/index.md
@@ -13,6 +13,7 @@ This index is the maintained entry point for PHMFactory documentation.
 - [Known limitations](../KNOWN_LIMITATIONS.md)
 - [v0.3.0 release and migration notes](../RELEASE_NOTES_v0.3.0.md)
 - [v0.3.0 release readiness](PHMFACTORY_V0_3_RELEASE_READINESS.md)
+- [v0.2.0 release-candidate provenance](releases/v0.2.0-rc-provenance.md)
 
 ## Architecture and extension
 
@@ -68,6 +69,7 @@ Generated experiment outputs are local artifacts and are not tracked through
 | Project positioning and shortest successful path | `README.md` | Link to the README or the detailed page below |
 | Installation | `docs/installation.md` | Keep only a minimal command and link |
 | First successful run | `docs/quickstart.md` | Avoid copying the complete walkthrough |
+| v0.2 release-candidate baseline | `docs/releases/v0.2.0-rc-provenance.yaml` | Do not create or imply a retroactive final v0.2.0 tag |
 | v0.2 to v0.3 user migration | `RELEASE_NOTES_v0.3.0.md` | Link rather than duplicate the full migration map |
 | Release blockers | `docs/PHMFACTORY_V0_3_RELEASE_READINESS.md` | Do not claim release completion while blockers remain |
 | Configuration semantics | `configs/README.md` | Link rather than redefine precedence |

--- a/docs/releases/v0.2.0-rc-provenance.md
+++ b/docs/releases/v0.2.0-rc-provenance.md
@@ -1,0 +1,64 @@
+# PHM-Vibench v0.2.0 Release-Candidate Provenance
+
+## Decision
+
+PHM-Vibench v0.2.0 is recorded as a **release-candidate baseline**, not as a
+retrospectively reconstructed final release.
+
+```text
+project:          PHM-Vibench
+version label:    v0.2.0
+status:           release_candidate
+formal release:   false
+baseline commit:  a331769d4005018bc833534ecf4efeb5e8a5a78d
+evidence date:    2026-07-11
+tag present:      false
+superseded by:    PHMFactory v0.3.0
+```
+
+The machine-readable authority is:
+
+```text
+docs/releases/v0.2.0-rc-provenance.yaml
+```
+
+## Why this record exists
+
+The repository changelog already described v0.2.0 as a release candidate, while the
+frozen migration audit found no visible `v0.2*` Git tag. Creating a final v0.2.0 tag
+after the fact would blur the distinction between the evidence that existed at the
+time and a later governance repair.
+
+The v0.3 migration therefore uses the exact commit above as its immutable runtime and
+reader baseline without claiming that a formal v0.2.0 release was published.
+
+## Consequences
+
+- The v0.3 migration can refer to one exact, immutable v0.2 release-candidate source.
+- Reader and protected-runtime fingerprints remain anchored to the same commit.
+- No Git history is rewritten.
+- No retroactive `v0.2.0` final tag is created.
+- Documentation must use **v0.2.0 release candidate** when referring to this baseline.
+- The first formal release under the PHMFactory identity is intended to be v0.3.0,
+  subject to all release-readiness gates.
+
+## Validation authority
+
+The baseline commit is also recorded by the v0.3 runtime and reader inventory. The
+release-readiness checker accepts this provenance file only when all of the following
+match exactly:
+
+```text
+status          release_candidate
+formal_release  false
+baseline_commit a331769d4005018bc833534ecf4efeb5e8a5a78d
+tag_present     false
+superseded_by   v0.3.0
+```
+
+A malformed or contradictory provenance record keeps the v0.3 release blocked.
+
+## Rollback
+
+Reverting this record restores the unresolved-provenance blocker. It does not change
+code, tags, branches, packages, data, or the immutable baseline commit.

--- a/docs/releases/v0.2.0-rc-provenance.yaml
+++ b/docs/releases/v0.2.0-rc-provenance.yaml
@@ -1,0 +1,14 @@
+schema_version: 1
+project_name: PHM-Vibench
+repository: PHMbench/PHM-Vibench
+version_label: v0.2.0
+status: release_candidate
+formal_release: false
+evidence_date: 2026-07-11
+baseline_commit: a331769d4005018bc833534ecf4efeb5e8a5a78d
+tag_present: false
+superseded_by: v0.3.0
+resolution: >-
+  Treat the recorded commit as the immutable v0.2.0 release-candidate baseline for
+  the PHMFactory v0.3 migration. Do not create a retroactive final v0.2.0 tag or
+  rewrite published history.

--- a/tools/repo/check_release_readiness.py
+++ b/tools/repo/check_release_readiness.py
@@ -9,7 +9,7 @@ import re
 import subprocess
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Iterable
+from typing import Any, Iterable
 
 import yaml
 
@@ -19,6 +19,17 @@ TARGET_VERSION = "0.3.0"
 TARGET_REPOSITORY = "PHMbench/phmfactory"
 REQUIRED_BUNDLE_HASHES = ("metadata", "signals")
 FLOATING_REVISIONS = {"main", "master", "latest", "develop", "development", ""}
+V020_PROVENANCE_PATH = "docs/releases/v0.2.0-rc-provenance.yaml"
+V020_BASELINE_COMMIT = "a331769d4005018bc833534ecf4efeb5e8a5a78d"
+V020_EXPECTED_PROVENANCE: dict[str, Any] = {
+    "project_name": "PHM-Vibench",
+    "version_label": "v0.2.0",
+    "status": "release_candidate",
+    "formal_release": False,
+    "baseline_commit": V020_BASELINE_COMMIT,
+    "tag_present": False,
+    "superseded_by": "v0.3.0",
+}
 
 
 @dataclass(frozen=True)
@@ -50,6 +61,29 @@ def _git_tags() -> tuple[str, ...]:
         stdout=subprocess.PIPE,
     )
     return tuple(line.strip() for line in result.stdout.splitlines() if line.strip())
+
+
+def _v020_provenance_error() -> str:
+    path = ROOT / V020_PROVENANCE_PATH
+    if not path.is_file():
+        return f"no visible v0.2* Git tag and {V020_PROVENANCE_PATH} is absent"
+
+    try:
+        payload = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+    except (OSError, yaml.YAMLError) as exc:
+        return f"could not parse {V020_PROVENANCE_PATH}: {exc}"
+
+    if not isinstance(payload, dict):
+        return f"{V020_PROVENANCE_PATH} must contain a YAML mapping"
+
+    mismatches = []
+    for key, expected in V020_EXPECTED_PROVENANCE.items():
+        actual = payload.get(key)
+        if actual != expected:
+            mismatches.append(f"{key}={actual!r}, expected {expected!r}")
+    if mismatches:
+        return "; ".join(mismatches)
+    return ""
 
 
 def collect_findings() -> tuple[Finding, ...]:
@@ -126,9 +160,9 @@ def collect_findings() -> tuple[Finding, ...]:
 
     tags = _git_tags()
     if not any(tag.startswith("v0.2") for tag in tags):
-        findings.append(
-            Finding("V020_PROVENANCE_UNRESOLVED", "no visible v0.2* Git tag")
-        )
+        provenance_error = _v020_provenance_error()
+        if provenance_error:
+            findings.append(Finding("V020_PROVENANCE_UNRESOLVED", provenance_error))
     if any(tag in {"v0.3.0", "0.3.0"} for tag in tags):
         findings.append(
             Finding("V030_TAG_ALREADY_EXISTS", "release tag exists before readiness pass")


### PR DESCRIPTION
## What changed

This PR resolves the v0.2 provenance ambiguity without creating a retroactive final tag.

It adds:

```text
docs/releases/v0.2.0-rc-provenance.yaml
docs/releases/v0.2.0-rc-provenance.md
```

and updates:

```text
tools/repo/check_release_readiness.py
.github/workflows/phmfactory-release-readiness.yml
docs/PHMFACTORY_V0_3_RELEASE_READINESS.md
docs/index.md
CHANGELOG.md
RELEASE_NOTES_v0.3.0.md
```

## Provenance decision

```text
project:         PHM-Vibench
version label:   v0.2.0
status:          release_candidate
formal release:  false
baseline commit: a331769d4005018bc833534ecf4efeb5e8a5a78d
tag present:     false
superseded by:   v0.3.0
```

The repository previously described v0.2.0 as a release candidate, and the frozen migration audit found no visible `v0.2*` tag. This PR therefore records the exact commit as the immutable RC baseline rather than manufacturing a later final `v0.2.0` tag.

## Readiness behavior

The release checker now accepts either:

1. an existing historical `v0.2*` tag; or
2. the exact approved RC provenance mapping above.

Any missing, malformed, or contradictory provenance value keeps `V020_PROVENANCE_UNRESOLVED` active.

The readiness workflow now requires that blocker to be absent while continuing to require:

```text
VERSION_NOT_FINAL
CWRU_REVISION_FLOATING
CWRU_HASH_MISSING
REPOSITORY_RENAME_PENDING
```

Strict release mode must continue to fail.

## Explicit non-actions

This PR does not:

- create a `v0.2.0` or `v0.3.0` tag;
- rewrite Git history;
- change package versions;
- modify CWRU provider revisions or hashes;
- rename the GitHub repository;
- change reader, Data Factory, model, task, trainer, Pipeline, configuration, dependency, or Streamlit runtime behavior.

## Base

```text
base: agent/v030-branding-changelog-pr12b
base SHA: b2941db404514f8af8d13dccddacd8aebefef84d
head: agent/v030-v02-provenance-pr12c
```

## Validation contract

Required before review or merge:

```text
PHMFactory release readiness
Core documentation/configuration gates
Repository layout gate
```

The readiness report must omit `V020_PROVENANCE_UNRESOLVED` and remain blocked only by genuine remaining release conditions.

## Rollback

A normal revert removes the provenance authority and restores the unresolved-provenance blocker. It does not change code, tags, packages, data, or external repositories.