### PR TITLE
docs(v0.3): finalize PHMFactory release metadata

### DIFF
--- a/.github/workflows/phmfactory-release-readiness.yml
+++ b/.github/workflows/phmfactory-release-readiness.yml
@@ -58,6 +58,11 @@ jobs:
             exit 1
           fi
 
+          grep -q '^# PHMFactory$' README.md
+          grep -q '^# PHMFactory$' README_CN.md
+          grep -q 'Homepage = "https://github.com/PHMbench/phmfactory"' pyproject.toml
+          grep -q 'Repository = "https://github.com/PHMbench/phmfactory"' pyproject.toml
+
           grep -q 'VERSION_NOT_FINAL' release-readiness.txt
           grep -q 'CWRU_REVISION_FLOATING' release-readiness.txt
           grep -q 'CWRU_HASH_MISSING' release-readiness.txt

--- a/.github/workflows/phmfactory-release-readiness.yml
+++ b/.github/workflows/phmfactory-release-readiness.yml
@@ -6,11 +6,13 @@ on:
       - "pyproject.toml"
       - "phmfactory/__init__.py"
       - "README.md"
+      - "README_CN.md"
       - "CITATION.cff"
       - "CHANGELOG.md"
       - "RELEASE_NOTES_v0.3.0.md"
       - "phmfactory/data_sources/manifests/cwru-demo-v1.yaml"
       - "docs/PHMFACTORY_V0_3_RELEASE_READINESS.md"
+      - "docs/archive/audits/phmfactory-v0.2-provenance.md"
       - "tools/repo/check_release_readiness.py"
       - ".github/workflows/phmfactory-release-readiness.yml"
   push:
@@ -47,7 +49,7 @@ jobs:
       - name: Record current blockers
         run: python tools/repo/check_release_readiness.py --mode audit | tee release-readiness.txt
 
-      - name: Require the pre-release gate to remain blocked
+      - name: Require only unresolved external/finalization blockers
         shell: bash
         run: |
           set -euo pipefail
@@ -55,10 +57,18 @@ jobs:
             echo "Release mode unexpectedly passed before final release preparation." >&2
             exit 1
           fi
+
           grep -q 'VERSION_NOT_FINAL' release-readiness.txt
-          grep -q 'README_BRAND_PENDING' release-readiness.txt
           grep -q 'CWRU_REVISION_FLOATING' release-readiness.txt
           grep -q 'CWRU_HASH_MISSING' release-readiness.txt
+          grep -q 'REPOSITORY_RENAME_PENDING' release-readiness.txt
+
+          ! grep -q 'README_BRAND_PENDING' release-readiness.txt
+          ! grep -q 'CITATION_BRAND_PENDING' release-readiness.txt
+          ! grep -q 'CITATION_REPOSITORY_PENDING' release-readiness.txt
+          ! grep -q 'CHANGELOG_V030_MISSING' release-readiness.txt
+          ! grep -q 'RELEASE_NOTES_V030_MISSING' release-readiness.txt
+          ! grep -q 'V020_PROVENANCE_UNRESOLVED' release-readiness.txt
 
       - name: Upload readiness report
         uses: actions/upload-artifact@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,184 @@
 # Changelog
 
+## v0.3.0 - Unreleased
+
+### Summary
+
+PHM-Vibench is renamed to **PHMFactory**. v0.3.0 is a repository-boundary,
+public-interface, packaging, and reproducibility release rather than a core algorithm
+rewrite.
+
+The public project identities are standardized as:
+
+```text
+project:              PHMFactory
+GitHub repository:    PHMbench/phmfactory
+Python distribution:  phmfactory
+Python namespace:     phmfactory
+CLI:                  phmfactory
+```
+
+### Added
+
+- Public `phmfactory` Python package and three equivalent entrypoints:
+
+  ```bash
+  python main.py --config <yaml>
+  python -m phmfactory --config <yaml>
+  phmfactory --config <yaml>
+  ```
+
+- Explicit Pipeline-name registry, canonical-name validation, and legacy configuration
+  aliases.
+- Public `phmfactory.config.resolve_config()` surface for maintained YAML paths,
+  presets, `base_configs` composition, typed CLI overrides, and canonical Pipeline
+  resolution.
+- Provider-neutral CWRU demo-bundle contract for:
+
+  ```text
+  metadata.xlsx
+  RM_001_CWRU.h5
+  corpus.xlsx          optional
+  ```
+
+- Hugging Face and optional ModelScope provider adapters, offline fixture validation,
+  integrity checks, and a minimal `examples/cwru_quickstart.py` entrypoint.
+- Dependency-ownership enforcement for the root runtime, Streamlit, ModelScope,
+  plotting, and test requirement files.
+- Repository portability gate that rejects case-insensitive and Unicode-normalized
+  path collisions.
+- Release-readiness checker that keeps v0.3.0 blocked until version, data, repository,
+  provenance, and publication requirements are satisfied.
+- Public migration audits and immutable private-fork preservation manifests for
+  content removed from the upstream framework repository.
+
+### Changed
+
+- Renamed the six maintained Pipeline modules without changing their file bytes or
+  algorithm bodies:
+
+  ```text
+  Pipeline_01_default
+    -> Pipeline_01_Fault_Diagnosis
+  Pipeline_02_pretrain_fewshot
+    -> Pipeline_02_Pretraining_Few_Shot
+  Pipeline_03_multitask_pretrain_finetune
+    -> Pipeline_03_Multitask_Pretraining_Finetuning
+  Pipeline_04_unified_metric
+    -> Pipeline_04_Unified_Evaluation
+  Pipeline_05_default_w_explain
+    -> Pipeline_05_Explainable_Fault_Diagnosis
+  Pipeline_06_generative
+    -> Pipeline_06_Generative_Modeling
+  ```
+
+- Reduced root `main.py` to a thin dispatcher over the public `phmfactory` CLI.
+- Standardized the maintained optional web interface under `apps/streamlit/`.
+- Kept core runtime dependencies in the root `requirements.txt` and moved optional
+  requirements into the subsystem that owns them.
+- Reorganized maintained documentation around one index, canonical uppercase
+  authority files, and `docs/archive/` governance records.
+- Replaced stale or duplicated runtime/configuration overview documents with concise,
+  implementation-backed compatibility guidance.
+
+### Preserved
+
+- `src/data_factory/reader/` paths and dataset-specific reader implementations.
+- Reader parsing, channel selection, returned signal shapes, dtypes, and numerical
+  behavior.
+- Existing `src.data_factory`, `src.model_factory`, `src.task_factory`,
+  `src.trainer_factory`, and Pipeline implementations as the protected v0.3 runtime
+  engine.
+- Root `configs/` and the five-block public configuration model:
+
+  ```text
+  environment / data / model / task / trainer
+  ```
+
+- Fully offline `Dummy_Data` smoke validation.
+- `configs/v0.0.9/` while protected compatibility presets still reference it.
+- `test/` as the maintained test-directory name for v0.3.0.
+
+### Removed from the public upstream
+
+The following content was removed only after exact Git-object preservation in the
+approved personal fork or another verified destination:
+
+- duplicate legacy `app/` UI and root `streamlit_app.py` launcher;
+- `.archive/` and `dev/` non-runtime workspaces;
+- tracked `results/` and `metrics_reports/` placeholder files;
+- personal `Rotor_simulation` and `LQ_vibench_fix` submodules;
+- case-colliding lowercase compatibility documents;
+- public `docs/past/` and `docs/v0.1.0/` historical documentation trees.
+
+The eight remaining paper/research submodules are not removed until each destination
+repository has content-level verification. Repository names alone are not sufficient
+migration evidence.
+
+### Compatibility
+
+- `python main.py --config <yaml>` remains supported.
+- `--config_path` remains a deprecated alias for `--config`.
+- Legacy Pipeline identifiers remain accepted through explicit aliases and emit a
+  deprecation warning.
+- New integrations should import `phmfactory.*`; no `phm_factory` or `phm_vibench`
+  compatibility package is introduced.
+- `src.*` remains packaged for v0.3 compatibility but is not the preferred new public
+  namespace.
+- The root Streamlit compatibility launcher is removed; use:
+
+  ```bash
+  streamlit run apps/streamlit/app.py
+  ```
+
+### Breaking changes
+
+- Direct Python imports of the six former Pipeline module filenames must use the new
+  descriptive module names.
+- The GitHub repository, distribution, import namespace, and CLI are standardized as
+  `phmfactory`.
+- Personal, experimental, Agent-specific, paper-specific, and generated workspaces
+  are outside the public framework ownership boundary unless explicitly maintained.
+- Case-only filename aliases are no longer tracked, preventing ambiguous checkouts on
+  Windows and default macOS filesystems.
+
+### Data and reproducibility
+
+- Pull-request tests remain offline and use generated legal fixtures.
+- The CWRU quickstart does not validate raw MAT conversion and does not modify the
+  protected `RM_001_CWRU` reader.
+- Final v0.3.0 publication requires identical required CWRU bundle files on Hugging
+  Face and ModelScope, immutable provider revisions, and populated SHA-256 values.
+- Run evidence should record the exact Git commit or tag, resolved configuration,
+  overrides, data provider and revision, file hashes, seed, and environment.
+
+### Validation
+
+The staged v0.3 stack includes successful evidence for:
+
+- public package, wheel, module entrypoint, and CLI contracts;
+- documentation, maintained configuration, and generated Atlas consistency;
+- offline Dummy smoke;
+- Pipeline 06 and UXFD focused contracts;
+- Streamlit focused tests on Linux and Windows;
+- dependency ownership;
+- CWRU bundle validation and provider command construction;
+- repository path portability;
+- bounded archive and deletion scopes.
+
+### Release blockers
+
+The release remains blocked until:
+
+- the package version changes from `0.3.0.dev0` to `0.3.0`;
+- the CWRU bundle is published and pinned identically on both providers;
+- all staged PRs, including dedicated Agent-content cleanup, are reviewed and merged
+  in dependency order;
+- the optional `phm-data-factory` backend decision is finalized;
+- the repository is renamed to `PHMbench/phmfactory` and redirects/checks are verified;
+- final wheel, source distribution, tag, and release artifacts are produced from the
+  same reviewed commit.
+
 ## v0.2.0 Release Candidate - 2026-07-11
 
 ### Added
@@ -25,7 +204,7 @@
 - Current cycle-03 evidence covers all seven maintained public demo configs with
   one-epoch smoke runs.
 - Invalid smoke cases for unknown pipeline, model, and task now fail explicitly.
-- Maintained tests use `conda run -n LQ_signal python -m pytest test/ -q`.
+- Maintained tests were executed in the project development environment.
 
 ### Limitations
 
@@ -33,4 +212,5 @@
   `SUPPORTED_COMBINATIONS.md`.
 - The evidence is functional smoke and contract evidence, not a performance
   benchmark.
-
+- No final `v0.2.0` Git tag was published. The exact pre-v0.3 migration baseline is
+  recorded in `docs/archive/audits/phmfactory-v0.2-provenance.md`.

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,22 +1,25 @@
 cff-version: 1.2.0
 message: >-
-  If you use PHM-Vibench, cite the exact release tag or Git commit used for the
+  If you use PHMFactory, cite the exact release tag or Git commit used for the
   experiment and record the configuration, overrides, data source, seed, and
   environment.
-title: PHM-Vibench
+title: PHMFactory
 type: software
 authors:
-  - name: PHMbench contributors
-repository-code: https://github.com/PHMbench/PHM-Vibench
-url: https://github.com/PHMbench/PHM-Vibench
+  - name: PHMFactory contributors
+repository-code: https://github.com/PHMbench/phmfactory
+url: https://github.com/PHMbench/phmfactory
 license: Apache-2.0
 keywords:
   - prognostics and health management
   - vibration signals
   - fault diagnosis
+  - anomaly detection
+  - remaining useful life
   - benchmark
   - PyTorch
 abstract: >-
-  PHM-Vibench is a configuration-first research-software workbench for industrial
-  vibration fault-diagnosis experiments. Its documented support surface is
-  limited to maintained configurations with explicit runtime evidence.
+  PHMFactory is a configuration-first research-software framework for industrial
+  PHM signal experiments. It connects governed data, model, task, trainer,
+  evaluation, and user-interface boundaries through one public CLI while retaining
+  evidence-backed compatibility with the protected PHM-Vibench runtime core.

--- a/README.md
+++ b/README.md
@@ -1,45 +1,46 @@
-# PHM-Vibench
+# PHMFactory
 
 <div align="center">
-  <img src="pic/PHM-Vibench.png" alt="PHM-Vibench logo" width="280"/>
-
   <p>
     <a href="README.md"><strong>English</strong></a> |
     <a href="README_CN.md">中文</a>
   </p>
 
-  <p><strong>A configuration-first workbench for industrial vibration fault-diagnosis experiments.</strong></p>
+  <p><strong>A configuration-first factory for industrial PHM signal experiments.</strong></p>
 
   <p>
     <img src="https://img.shields.io/badge/status-alpha-orange" alt="Status: alpha"/>
     <img src="https://img.shields.io/badge/maintained%20demos-7-blue" alt="Seven maintained demos"/>
-    <a href="https://github.com/PHMbench/PHM-Vibench/actions/workflows/core-quality-gates.yml"><img src="https://github.com/PHMbench/PHM-Vibench/actions/workflows/core-quality-gates.yml/badge.svg" alt="Core quality gates"/></a>
+    <a href="https://github.com/PHMbench/phmfactory/actions/workflows/core-quality-gates.yml"><img src="https://github.com/PHMbench/phmfactory/actions/workflows/core-quality-gates.yml/badge.svg" alt="Core quality gates"/></a>
     <img src="https://img.shields.io/badge/license-Apache%202.0-green" alt="Apache 2.0 license"/>
   </p>
 </div>
 
-PHM-Vibench connects data loading, model construction, task logic, training, and
-experiment configuration through one public entrypoint:
+PHMFactory is the v0.3 continuation of PHM-Vibench. It connects data loading,
+model construction, task logic, training, evaluation, and experiment configuration
+through one public command contract:
 
 ```bash
 python main.py --config <yaml> [--override key=value ...]
+python -m phmfactory --config <yaml> [--override key=value ...]
+phmfactory --config <yaml> [--override key=value ...]
 ```
 
-The project is in alpha. Release support is intentionally limited to the
+The project remains in alpha. Release support is intentionally limited to the
 maintained configurations documented in
 [SUPPORTED_COMBINATIONS.md](SUPPORTED_COMBINATIONS.md). Files, registry entries,
-research notes, and historical configs outside that surface are not automatically
-supported.
+research repositories, and historical configurations outside that surface are not
+automatically supported.
 
 ## Run the offline example
 
-Install the environment, then execute the repository-shipped dummy configuration:
+Install the core environment, then execute the repository-shipped Dummy configuration:
 
 ```bash
-git clone https://github.com/PHMbench/PHM-Vibench.git
-cd PHM-Vibench
-conda create -n phm-vibench python=3.10
-conda activate phm-vibench
+git clone https://github.com/PHMbench/phmfactory.git
+cd phmfactory
+conda create -n phmfactory python=3.10
+conda activate phmfactory
 python -m pip install -r requirements.txt
 
 python main.py --config configs/demo/00_smoke/dummy_dg.yaml \
@@ -47,8 +48,8 @@ python main.py --config configs/demo/00_smoke/dummy_dg.yaml \
   --override data.num_workers=0
 ```
 
-A successful run exits cleanly, prints the completion message, and writes output
-below `results/demo/dummy_dg_smoke/`. This verifies the software path; it is not a
+A successful run exits cleanly, prints the completion message, and writes the
+configured local output. This verifies the software path; it is not a
 benchmark-performance result.
 
 Detailed setup, expected behavior, and troubleshooting:
@@ -57,17 +58,45 @@ Detailed setup, expected behavior, and troubleshooting:
 - [Quickstart](docs/quickstart.md)
 - [Known limitations](KNOWN_LIMITATIONS.md)
 
+## CWRU provider quickstart
+
+PHMFactory includes a provider-neutral contract for a prebuilt CWRU demo bundle:
+
+```text
+metadata.xlsx          required
+RM_001_CWRU.h5         required
+corpus.xlsx            optional
+```
+
+After the identical bundle is published at immutable Hugging Face and ModelScope
+revisions, run:
+
+```bash
+python examples/cwru_quickstart.py --source huggingface
+```
+
+For ModelScope, install its optional provider dependency first:
+
+```bash
+python -m pip install -r phmfactory/data_sources/modelscope/requirements.txt
+python examples/cwru_quickstart.py --source modelscope
+```
+
+The v0.3.0 release remains blocked until both services expose byte-identical required
+files at pinned revisions and the manifest contains their SHA-256 values. See
+[the CWRU demo contract](docs/CWRU_DEMO_V0_3.md).
+
 ## What is maintained
 
 The current maintained demo surface covers:
 
-- offline dummy domain-generalization smoke;
+- offline Dummy domain-generalization smoke;
 - cross-domain and cross-system classification examples;
 - few-shot and generalized few-shot examples;
 - bounded HSE pretraining examples.
 
-Only the dummy example is fully offline. Other demos require local PHM-Vibench
-metadata and raw data supplied through configuration overrides. The exact model,
+The Dummy example is fully offline. Other demos require a local compatible dataset
+or a published provider bundle selected through configuration. The exact model,
 task, data, and trainer combinations are listed in:
 
 - [Supported components](SUPPORTED_COMPONENTS.md)
@@ -103,27 +132,30 @@ boundaries are in the [data guide](data/README.md).
 ## Architecture
 
 ```text
-main.py
-  └── configured pipeline
-      ├── data factory
-      ├── model factory
-      ├── task factory
-      └── trainer factory
+main.py / python -m phmfactory / phmfactory
+  └── public config resolver
+      └── canonical Pipeline
+          ├── data factory
+          ├── model factory
+          ├── task factory
+          └── trainer factory
 ```
 
 Primary paths:
 
+- `phmfactory/` — public package, CLI, Pipeline registry, config resolver, and data providers;
 - `configs/` — base blocks, maintained demos, experiments, and config registry;
-- `src/data_factory/` — metadata, readers, datasets, samplers, and data wiring;
+- `src/data_factory/` — protected metadata, readers, datasets, samplers, and data wiring;
 - `src/model_factory/` — model families, components, and model construction;
 - `src/task_factory/` — tasks, losses, metrics, and task registry;
 - `src/trainer_factory/` — trainer construction and extensions;
 - `apps/streamlit/` — optional browser workspace around the same CLI;
 - `test/` — maintained pytest suite;
-- `docs/` — user, development, release, and historical documentation.
+- `docs/` — user, development, release, and governance documentation.
 
 Do not add dataset- or model-specific branches to `main.py`; extend the existing
-factory boundary.
+factory boundary. Dataset readers under `src/data_factory/reader/` are protected in
+v0.3.0 and are not reorganized as part of repository cleanup.
 
 ## Validate a change
 
@@ -136,14 +168,14 @@ python -m pytest test/ -q
 ```
 
 Runtime or configuration changes should also run the offline smoke command above.
-GitHub Actions currently enforce documentation/configuration consistency and the
-focused UXFD assembly contract. See the [testing guide](docs/testing.md) for
-evidence terminology and narrower commands.
+GitHub Actions enforce documentation/configuration consistency, repository path
+portability, and focused runtime contracts. See the
+[testing guide](docs/testing.md) for evidence terminology and narrower commands.
 
 ## Documentation
 
 Use the [documentation index](docs/index.md) to find installation, configuration,
-data, development, testing, Streamlit, release, and historical material.
+data, development, testing, Streamlit, release, and migration material.
 
 For the optional web interface:
 
@@ -155,6 +187,9 @@ streamlit run apps/streamlit/app.py
 See [apps/streamlit/README.md](apps/streamlit/README.md) for its local
 single-worker boundary.
 
+The v0.2-to-v0.3 transition, preserved compatibility boundaries, and release blockers
+are recorded in [RELEASE_NOTES_v0.3.0.md](RELEASE_NOTES_v0.3.0.md).
+
 ## Contributing and support
 
 Read [CONTRIBUTING.md](CONTRIBUTING.md) before opening an issue or pull request.
@@ -162,13 +197,13 @@ Keep changes small, update the authoritative document rather than copying it, an
 report the exact commit, config, overrides, environment, and logs. Participation
 is governed by [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md).
 
-- Bugs and feature requests: [GitHub Issues](https://github.com/PHMbench/PHM-Vibench/issues)
+- Bugs and feature requests: [GitHub Issues](https://github.com/PHMbench/phmfactory/issues)
 - Security reports: [SECURITY.md](SECURITY.md)
 - Development workflow: [docs/developer_guide.md](docs/developer_guide.md)
 
 ## Citation and license
 
-PHM-Vibench is licensed under the [Apache License 2.0](LICENSE). Dataset and model
+PHMFactory is licensed under the [Apache License 2.0](LICENSE). Dataset and model
 artifacts can have separate source licenses.
 
 Use [CITATION.cff](CITATION.cff) as the software citation metadata. Cite the exact

--- a/README_CN.md
+++ b/README_CN.md
@@ -1,42 +1,43 @@
-# PHM-Vibench
+# PHMFactory
 
 <div align="center">
-  <img src="pic/PHM-Vibench.png" alt="PHM-Vibench 标志" width="280"/>
-
   <p>
     <a href="README.md">English</a> |
     <a href="README_CN.md"><strong>中文</strong></a>
   </p>
 
-  <p><strong>面向工业振动故障诊断实验的配置优先工作台。</strong></p>
+  <p><strong>面向工业 PHM 信号实验的配置优先工厂框架。</strong></p>
 
   <p>
     <img src="https://img.shields.io/badge/状态-alpha-orange" alt="状态：alpha"/>
     <img src="https://img.shields.io/badge/维护中%20demo-7-blue" alt="7 个维护中 demo"/>
-    <a href="https://github.com/PHMbench/PHM-Vibench/actions/workflows/core-quality-gates.yml"><img src="https://github.com/PHMbench/PHM-Vibench/actions/workflows/core-quality-gates.yml/badge.svg" alt="核心质量门禁"/></a>
+    <a href="https://github.com/PHMbench/phmfactory/actions/workflows/core-quality-gates.yml"><img src="https://github.com/PHMbench/phmfactory/actions/workflows/core-quality-gates.yml/badge.svg" alt="核心质量门禁"/></a>
     <img src="https://img.shields.io/badge/许可-Apache%202.0-green" alt="Apache 2.0 许可"/>
   </p>
 </div>
 
-PHM-Vibench 通过一个公开入口连接数据加载、模型构建、任务逻辑、训练和实验配置：
+PHMFactory 是 PHM-Vibench 在 v0.3 阶段的延续。它通过同一公开命令契约连接
+数据加载、模型构建、任务逻辑、训练、评估和实验配置：
 
 ```bash
 python main.py --config <yaml> [--override key=value ...]
+python -m phmfactory --config <yaml> [--override key=value ...]
+phmfactory --config <yaml> [--override key=value ...]
 ```
 
 项目仍处于 alpha 阶段。发布支持范围仅限
 [SUPPORTED_COMBINATIONS.md](SUPPORTED_COMBINATIONS.md) 中列出的维护配置。
-仓库中的其他文件、注册表条目、研究笔记和历史配置不应自动视为受支持能力。
+仓库中的其他文件、注册表条目、研究仓库和历史配置不应自动视为受支持能力。
 
 ## 运行离线示例
 
-安装环境后，运行仓库自带的 Dummy 配置：
+安装核心环境后，运行仓库自带的 Dummy 配置：
 
 ```bash
-git clone https://github.com/PHMbench/PHM-Vibench.git
-cd PHM-Vibench
-conda create -n phm-vibench python=3.10
-conda activate phm-vibench
+git clone https://github.com/PHMbench/phmfactory.git
+cd phmfactory
+conda create -n phmfactory python=3.10
+conda activate phmfactory
 python -m pip install -r requirements.txt
 
 python main.py --config configs/demo/00_smoke/dummy_dg.yaml \
@@ -44,14 +45,39 @@ python main.py --config configs/demo/00_smoke/dummy_dg.yaml \
   --override data.num_workers=0
 ```
 
-成功运行应正常退出、打印完成信息，并在 `results/demo/dummy_dg_smoke/`
-下写入输出。该命令验证软件链路，不代表基准性能。
+成功运行应正常退出并打印完成信息。该命令验证软件链路，不代表基准性能。
 
 详细安装、预期行为和故障排查：
 
 - [安装指南](docs/installation.md)
 - [快速开始](docs/quickstart.md)
 - [已知限制](KNOWN_LIMITATIONS.md)
+
+## CWRU 数据源快速示例
+
+PHMFactory 已定义预构建 CWRU demo 数据包契约：
+
+```text
+metadata.xlsx          必需
+RM_001_CWRU.h5         必需
+corpus.xlsx            可选
+```
+
+当 Hugging Face 和 ModelScope 均发布固定 revision、内容一致的数据包后，可运行：
+
+```bash
+python examples/cwru_quickstart.py --source huggingface
+```
+
+使用 ModelScope 时先安装对应的可选依赖：
+
+```bash
+python -m pip install -r phmfactory/data_sources/modelscope/requirements.txt
+python examples/cwru_quickstart.py --source modelscope
+```
+
+v0.3.0 在两个服务提供固定 revision、必需文件哈希一致，且 manifest 写入
+SHA-256 之前仍不得发布。详见 [CWRU demo 契约](docs/CWRU_DEMO_V0_3.md)。
 
 ## 当前维护范围
 
@@ -62,8 +88,8 @@ python main.py --config configs/demo/00_smoke/dummy_dg.yaml \
 - 小样本和广义小样本示例；
 - 边界明确的 HSE 预训练示例。
 
-只有 Dummy 示例完全离线。其他 demo 需要通过配置覆盖传入本地
-PHM-Vibench metadata 和原始数据。准确的模型、任务、数据和训练器组合见：
+Dummy 示例完全离线。其他 demo 需要本地兼容数据集或已经发布的数据源 bundle。
+准确的模型、任务、数据和训练器组合见：
 
 - [支持组件](SUPPORTED_COMPONENTS.md)
 - [支持组合](SUPPORTED_COMBINATIONS.md)
@@ -96,26 +122,29 @@ python -m scripts.config_inspect \
 ## 架构
 
 ```text
-main.py
-  └── 配置选择的 pipeline
-      ├── data factory
-      ├── model factory
-      ├── task factory
-      └── trainer factory
+main.py / python -m phmfactory / phmfactory
+  └── 公共配置解析器
+      └── 规范 Pipeline
+          ├── data factory
+          ├── model factory
+          ├── task factory
+          └── trainer factory
 ```
 
 主要目录：
 
+- `phmfactory/`：公共 Python 包、CLI、Pipeline 注册、配置解析和数据源适配；
 - `configs/`：base block、维护 demo、实验配置和配置注册表；
-- `src/data_factory/`：metadata、reader、dataset、sampler 与数据装配；
+- `src/data_factory/`：受保护的 metadata、reader、dataset、sampler 与数据装配；
 - `src/model_factory/`：模型家族、组件与模型构建；
 - `src/task_factory/`：任务、loss、metric 与任务注册表；
 - `src/trainer_factory/`：训练器构建和扩展；
 - `apps/streamlit/`：围绕同一 CLI 的可选浏览器工作区；
 - `test/`：维护中的 pytest 测试；
-- `docs/`：用户、开发、发布和历史文档。
+- `docs/`：用户、开发、发布和治理文档。
 
 添加数据集或模型时，应扩展现有 factory，不要在 `main.py` 中加入专用分支。
+`src/data_factory/reader/` 在 v0.3.0 中属于受保护核心，不因仓库清理而重组。
 
 ## 验证改动
 
@@ -127,14 +156,14 @@ git diff --exit-code docs/CONFIG_ATLAS.md
 python -m pytest test/ -q
 ```
 
-运行时或配置改动还应执行前面的离线冒烟命令。GitHub Actions 当前执行
-文档/配置一致性和聚焦的 UXFD 装配测试。证据术语和更聚焦的命令见
+运行时或配置改动还应执行前面的离线冒烟命令。GitHub Actions 负责文档/配置
+一致性、路径可移植性和聚焦运行契约。证据术语和更聚焦的命令见
 [测试指南](docs/testing.md)。
 
-## 文档
+## 文档与界面
 
 通过[文档索引](docs/index.md)查找安装、配置、数据、开发、测试、Streamlit、
-发布和历史材料。
+发布和迁移材料。
 
 可选 Web 界面：
 
@@ -145,6 +174,9 @@ streamlit run apps/streamlit/app.py
 
 其本地单 worker 边界见 [apps/streamlit/README.md](apps/streamlit/README.md)。
 
+v0.2 到 v0.3 的变化、兼容边界和发布阻塞项见
+[RELEASE_NOTES_v0.3.0.md](RELEASE_NOTES_v0.3.0.md)。
+
 ## 贡献与支持
 
 提交 Issue 或 Pull Request 前请阅读 [CONTRIBUTING_CN.md](CONTRIBUTING_CN.md)。
@@ -152,13 +184,13 @@ streamlit run apps/streamlit/app.py
 配置、override、环境和日志。社区参与遵循
 [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)。
 
-- Bug 与功能建议：[GitHub Issues](https://github.com/PHMbench/PHM-Vibench/issues)
+- Bug 与功能建议：[GitHub Issues](https://github.com/PHMbench/phmfactory/issues)
 - 安全问题：[SECURITY.md](SECURITY.md)
 - 开发流程：[docs/developer_guide.md](docs/developer_guide.md)
 
 ## 引用与许可
 
-PHM-Vibench 使用 [Apache License 2.0](LICENSE)。数据集和模型产物可能适用
+PHMFactory 使用 [Apache License 2.0](LICENSE)。数据集和模型产物可能适用
 原始来源的独立许可。
 
 软件引用元数据见 [CITATION.cff](CITATION.cff)。请引用实验所使用的准确 Git

--- a/RELEASE_NOTES_v0.3.0.md
+++ b/RELEASE_NOTES_v0.3.0.md
@@ -1,0 +1,263 @@
+# PHMFactory v0.3.0 Release Notes
+
+> Status: **draft release notes**. Final publication remains blocked by the pinned
+> dual-source CWRU bundle, final version change, repository rename, reviewed merge
+> order, and final artifact validation.
+
+## Overview
+
+PHMFactory v0.3.0 is the renamed and boundary-governed continuation of
+PHM-Vibench. The release focuses on a stable public entrypoint, reproducible
+configuration and data-provider contracts, repository ownership, and portability.
+It does not intentionally rewrite the established dataset readers, model algorithms,
+task logic, trainer behavior, signal shapes, channel ordering, or numerical paths.
+
+```text
+PHM-Vibench v0.2 release-candidate baseline
+                    ↓
+PHMFactory v0.3.0
+```
+
+## Public identity
+
+```text
+Project name:         PHMFactory
+GitHub repository:    PHMbench/phmfactory
+Python distribution:  phmfactory
+Python namespace:     phmfactory
+CLI command:          phmfactory
+```
+
+No `phm_factory`, `phm_vibench`, or `phmvibench` compatibility namespace is added.
+
+## Public entrypoints
+
+All supported command forms use the same parser and dispatcher:
+
+```bash
+python main.py --config <yaml> [--override key=value ...]
+python -m phmfactory --config <yaml> [--override key=value ...]
+phmfactory --config <yaml> [--override key=value ...]
+```
+
+`main.py` remains in the repository root as a thin compatibility dispatcher.
+`--config_path` remains a deprecated alias for `--config`.
+
+## Pipeline names
+
+The six Pipeline modules keep their numeric identity and use descriptive task names:
+
+| v0.2 name | v0.3 name |
+| --- | --- |
+| `Pipeline_01_default` | `Pipeline_01_Fault_Diagnosis` |
+| `Pipeline_02_pretrain_fewshot` | `Pipeline_02_Pretraining_Few_Shot` |
+| `Pipeline_03_multitask_pretrain_finetune` | `Pipeline_03_Multitask_Pretraining_Finetuning` |
+| `Pipeline_04_unified_metric` | `Pipeline_04_Unified_Evaluation` |
+| `Pipeline_05_default_w_explain` | `Pipeline_05_Explainable_Fault_Diagnosis` |
+| `Pipeline_06_generative` | `Pipeline_06_Generative_Modeling` |
+
+The files were renamed directly. Their protected contents were fingerprinted before
+and after the rename. Legacy configuration identifiers are accepted through explicit
+aliases, but direct imports of the old module filenames must be updated.
+
+## Configuration
+
+New integrations use:
+
+```python
+from phmfactory.config import resolve_config
+```
+
+The public resolver supports:
+
+- maintained preset names or YAML paths;
+- ordered `base_configs` composition;
+- typed, dotted `key=value` overrides;
+- canonical Pipeline resolution;
+- cycle and missing-source errors;
+- a plain-dictionary resolved result without loading the heavy training runtime.
+
+The established `src.configs` and utility configuration code remains available to the
+protected runtime. `configs/v0.0.9/` is retained while compatibility presets still
+reference it.
+
+## CWRU demo bundle
+
+The v0.3 provider-neutral bundle contract is:
+
+```text
+metadata.xlsx          required
+RM_001_CWRU.h5         required
+corpus.xlsx            optional
+```
+
+The files are joined by `Id`. The validator checks required files, metadata/HDF5 ID
+coverage, two-dimensional `(L, C)` signals, metadata length/channel aliases, optional
+corpus foreign keys, and cross-directory SHA-256 parity.
+
+Public API:
+
+```python
+from phmfactory.data_sources import (
+    compare_bundle_hashes,
+    download_bundle,
+    validate_bundle,
+)
+```
+
+CLI:
+
+```bash
+phmfactory data download --source huggingface
+phmfactory data download --source modelscope
+phmfactory data validate --path <bundle-dir>
+phmfactory data compare --left <hf-dir> --right <ms-dir>
+```
+
+The release is not ready until both providers publish the identical required files at
+immutable revisions and the manifest records their SHA-256 values. Pull-request tests
+remain offline and do not claim raw MAT reader validation.
+
+## Dependency ownership
+
+The root `requirements.txt` remains the core installation authority. Optional
+requirements are colocated with their subsystem:
+
+```text
+apps/streamlit/requirements.txt
+phmfactory/data_sources/modelscope/requirements.txt
+plot/requirements.txt
+test/requirements.txt
+```
+
+Subsystem requirement files are incremental. They do not include private SSH, local
+path, editable, or nested requirement references.
+
+## Streamlit
+
+The only maintained UI is:
+
+```bash
+streamlit run apps/streamlit/app.py
+```
+
+The duplicate `app/` package and root `streamlit_app.py` launcher were removed after
+exact archival. The maintained workspace invokes experiments through the public CLI
+and remains optional for core use.
+
+## Repository ownership
+
+The public upstream is restricted to maintained framework code, public APIs,
+configurations, tests, documentation, bounded examples, and governance evidence.
+
+Content removed after immutable preservation includes:
+
+- selected Agent and personal workflow assets through dedicated cleanup PRs;
+- `.archive/` and `dev/` workspaces;
+- tracked result-directory placeholders;
+- personal Rotor simulation and LQ-fix submodules;
+- duplicate legacy UI files;
+- lowercase case-colliding compatibility documents;
+- `docs/past/` and `docs/v0.1.0/` historical document trees.
+
+The eight remaining paper/research gitlinks are frozen until their destination
+repositories have content-level verification. The public framework must not depend on
+paper repositories, a personal fork, or Agent tooling.
+
+## Protected runtime
+
+The following remain protected compatibility surfaces in v0.3.0:
+
+```text
+src/data_factory/reader/
+src/data_factory/dataset_task/
+src/data_factory/samplers/
+src/data_factory/H5DataDict.py
+src/data_factory/data_factory.py
+src/model_factory/
+src/task_factory/
+src/trainer_factory/
+```
+
+Repository cleanup does not authorize reader or algorithm redesign. Existing reader
+signatures, selected channels, signal shapes, dtypes, parsing, and numerical behavior
+are preserved unless a separate evidence-backed bugfix states otherwise.
+
+## Breaking changes
+
+1. Import the new public package as `phmfactory`.
+2. Update direct imports of old Pipeline module filenames.
+3. Use `apps/streamlit/app.py`; the root Streamlit launcher is removed.
+4. Do not rely on case-only filename aliases.
+5. Treat paper, personal, Agent, generated, and historical workspaces as downstream or
+   archived content, not public framework dependencies.
+6. Use the final repository URL `https://github.com/PHMbench/phmfactory` after rename.
+
+## Migration examples
+
+### Python package
+
+```python
+# v0.3 public API
+import phmfactory
+from phmfactory.config import resolve_config
+```
+
+### Pipeline import
+
+```python
+# before
+from src.Pipeline_01_default import pipeline
+
+# v0.3
+from src.Pipeline_01_Fault_Diagnosis import pipeline
+```
+
+Prefer the public CLI over direct Pipeline imports.
+
+### Streamlit
+
+```bash
+# before
+streamlit run streamlit_app.py
+
+# v0.3
+streamlit run apps/streamlit/app.py
+```
+
+## Validation evidence
+
+The staged v0.3 PR stack records successful evidence for:
+
+- wheel and source-distribution construction;
+- clean public-package installation and CLI/module entrypoints;
+- documentation, configuration, and generated Atlas consistency;
+- offline Dummy smoke;
+- Pipeline 06 and UXFD focused contracts;
+- Streamlit tests on Ubuntu and Windows;
+- dependency ownership;
+- offline CWRU bundle validation and provider command construction;
+- case-insensitive path portability;
+- bounded archive and deletion scopes.
+
+## Remaining release blockers
+
+Before publishing v0.3.0:
+
+1. review and merge the complete staged PR graph in dependency order;
+2. merge the dedicated Agent-content cleanup branches or explicitly defer them;
+3. publish and pin the identical CWRU bundle on Hugging Face and ModelScope;
+4. populate the required SHA-256 values;
+5. finalize the optional `phm-data-factory` backend decision;
+6. change `0.3.0.dev0` to `0.3.0` only on the final release commit;
+7. rename the repository to `PHMbench/phmfactory` and verify redirects/checks;
+8. rerun all required gates under the final repository identity;
+9. build wheel and source distribution from the reviewed release commit;
+10. create the immutable `v0.3.0` tag and publish the release without moving the tag.
+
+## v0.2 provenance
+
+No final `v0.2.0` Git tag was published. The v0.2 changelog entry is explicitly a
+Release Candidate. The pre-v0.3 migration baseline and its interpretation are recorded
+in `docs/archive/audits/phmfactory-v0.2-provenance.md` rather than retroactively
+pretending a final release tag existed.

--- a/docs/PHMFACTORY_V0_3_RELEASE_READINESS.md
+++ b/docs/PHMFACTORY_V0_3_RELEASE_READINESS.md
@@ -1,6 +1,7 @@
 # PHMFactory v0.3 Release Readiness
 
-This page is the blocking checklist for the final PHMFactory v0.3 release. It is an audit contract, not a claim that the release is already ready.
+This page is the blocking checklist for the final PHMFactory v0.3 release. It is an
+audit contract, not a claim that the release is already ready.
 
 ## Current status
 
@@ -22,52 +23,81 @@ The release command must remain blocked while any finding exists:
 python tools/repo/check_release_readiness.py --mode release
 ```
 
-## Machine-checked blockers
+## Repository-resolved requirements
 
-The checker currently evaluates:
+The staged release-metadata change resolves the following repository-controlled
+requirements:
 
-1. `pyproject.toml` and `phmfactory.__version__` agree and equal `0.3.0`;
-2. the public README heading uses `PHMFactory`;
-3. `CITATION.cff` uses the PHMFactory title and final repository URL;
-4. `CHANGELOG.md` contains a v0.3.0 section;
-5. `RELEASE_NOTES_v0.3.0.md` exists;
-6. Hugging Face and ModelScope CWRU revisions are immutable rather than `main` or `master`;
-7. required CWRU bundle SHA-256 values are populated;
-8. v0.2 provenance has a visible resolution;
-9. no v0.3.0 tag already exists before the release gate passes;
-10. when running in GitHub Actions, the repository has the final `PHMbench/phmfactory` identity.
+```text
+README branding                         RESOLVED
+Chinese README branding                 RESOLVED
+CITATION title and final repository URL RESOLVED
+CHANGELOG v0.3.0 section                RESOLVED
+RELEASE_NOTES_v0.3.0.md                 RESOLVED
+v0.2 provenance                         RESOLVED WITHOUT FABRICATING A FINAL TAG
+```
+
+The v0.2 provenance record states that the earlier changelog was a Release Candidate,
+that no final `v0.2.0` tag existed, and that commit
+`a331769d4005018bc833534ecf4efeb5e8a5a78d` is the immutable pre-v0.3 migration
+baseline rather than a retroactive final release.
+
+## Remaining machine-checked blockers
+
+The release remains blocked by:
+
+1. `pyproject.toml` and `phmfactory.__version__` must change together from
+   `0.3.0.dev0` to exactly `0.3.0` on the final release commit;
+2. Hugging Face and ModelScope CWRU revisions must be immutable rather than `main` or
+   `master`;
+3. required CWRU `metadata.xlsx` and `RM_001_CWRU.h5` SHA-256 values must be populated;
+4. GitHub Actions must run under the final `PHMbench/phmfactory` repository identity;
+5. a `v0.3.0` tag must not exist before the release gate passes.
+
+The checker also continues to verify the resolved README, citation, changelog, release
+notes, version consistency, and v0.2 provenance requirements so they cannot regress.
 
 ## Human-reviewed blockers
 
 The following cannot be inferred safely from repository files alone:
 
 - all staged v0.3 PRs have been reviewed and merged in dependency order;
+- dedicated Agent-content cleanup PRs are either merged or explicitly deferred with a
+  documented ownership decision;
 - branch protection and required checks are configured for the final default branch;
-- public Hugging Face and ModelScope artifacts are available at the pinned immutable revisions;
+- public Hugging Face and ModelScope artifacts are available at the pinned immutable
+  revisions;
 - the two providers return byte-identical required bundle files;
-- the optional `phm-data-factory` backend decision has been finalized and its integration branch rebased without reintroducing legacy submodules;
+- the optional `phm-data-factory` backend decision has been finalized and its
+  integration branch rebased without reintroducing legacy submodules;
+- the eight paper/research gitlinks have verified destination coverage or an explicit
+  release deferral;
 - the GitHub repository rename and redirect behavior have been verified;
-- release notes accurately separate compatibility guarantees from experimental features;
-- the final wheel and source distribution were built from the tagged commit;
-- installation, CLI, module entrypoint, offline smoke, Pipeline 06, UXFD, Streamlit, dependency ownership, repository-layout, and CWRU gates all pass on the final release commit.
+- the final wheel and source distribution were built from the reviewed release commit;
+- installation, CLI, module entrypoint, offline smoke, Pipeline 06, UXFD, Streamlit,
+  dependency ownership, repository-layout, and CWRU gates all pass on the final
+  repository identity.
 
 ## Release order
 
 ```text
-1. merge the reviewed v0.3 PR stack in dependency order
-2. resolve the v0.2 provenance record
-3. publish and pin the dual-source CWRU bundle
-4. finalize repository branding and citation metadata
-5. change versions from 0.3.0.dev0 to 0.3.0
-6. create and validate RELEASE_NOTES_v0.3.0.md
-7. rename the GitHub repository to PHMbench/phmfactory
-8. rerun all required checks on the final repository identity
-9. build wheel and sdist from the final commit
-10. create tag v0.3.0 and publish the release
+1. review and merge the staged v0.3 PR graph in dependency order
+2. merge or explicitly defer the dedicated Agent and paper/submodule cleanup work
+3. publish the identical CWRU bundle to Hugging Face and ModelScope
+4. pin provider revisions and populate required SHA-256 values
+5. finalize the optional phm-data-factory backend decision
+6. rename the GitHub repository to PHMbench/phmfactory and verify redirects
+7. change versions from 0.3.0.dev0 to 0.3.0 on the final release commit
+8. rerun all required checks under the final repository identity
+9. build wheel and sdist from that reviewed commit
+10. create the immutable v0.3.0 tag and publish the release
 ```
 
-The repository rename, final version change, tag, and release publication must not occur before all blockers are cleared.
+The repository rename, final version change, tag, and release publication must not
+occur before their preceding blockers are cleared.
 
 ## Rollback
 
-Before tagging, revert the release-preparation commit or keep the repository at `0.3.0.dev0`. After tagging, use a corrective release rather than moving or recreating the published tag.
+Before tagging, revert the release-preparation commit or keep the repository at
+`0.3.0.dev0`. After tagging, publish a corrective release rather than moving,
+deleting, or recreating the published tag.

--- a/docs/archive/audits/phmfactory-v0.2-provenance.md
+++ b/docs/archive/audits/phmfactory-v0.2-provenance.md
@@ -1,0 +1,60 @@
+# PHMFactory v0.2 provenance resolution
+
+## Decision
+
+The repository does not contain a final `v0.2.0` Git tag. The maintained changelog
+entry is explicitly titled:
+
+```text
+v0.2.0 Release Candidate - 2026-07-11
+```
+
+PHMFactory does not retroactively create or reinterpret a final v0.2 release tag.
+Instead, the v0.3 migration records one immutable pre-migration runtime baseline:
+
+```text
+repository: PHMbench/PHM-Vibench
+baseline commit: a331769d4005018bc833534ecf4efeb5e8a5a78d
+baseline role: pre-v0.3 runtime and repository snapshot
+v0.2 status: release candidate, not a tagged final release
+```
+
+## Why this is sufficient provenance
+
+The baseline commit is the source used for the v0.3 reader, runtime, submodule,
+personal-path, and repository-boundary inventories. Protected runtime files were
+fingerprinted against this commit before cleanup and migration changes began.
+
+The record distinguishes three facts that must not be conflated:
+
+1. a v0.2.0 release-candidate changelog existed;
+2. no final `v0.2.0` Git tag was published;
+3. `a331769d4005018bc833534ecf4efeb5e8a5a78d` is the immutable pre-v0.3 migration
+   baseline, not a fabricated final release tag.
+
+## Migration interpretation
+
+Documentation may describe the transition as:
+
+```text
+PHM-Vibench v0.2 release-candidate baseline
+                    ->
+PHMFactory v0.3.0
+```
+
+It must not claim that `a331769...` was a tagged v0.2.0 final release.
+
+## Release-readiness marker
+
+```text
+provenance_status: resolved_without_final_tag
+baseline_sha: a331769d4005018bc833534ecf4efeb5e8a5a78d
+```
+
+The v0.3 release-readiness checker accepts this explicit record as the truthful
+alternative to a visible `v0.2*` tag.
+
+## Rollback
+
+Removing this record reopens the `V020_PROVENANCE_UNRESOLVED` release blocker. A final
+v0.2 tag must not be created after the fact merely to satisfy automation.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,12 @@ authors = [
 ]
 dynamic = ["dependencies"]
 
+[project.urls]
+Homepage = "https://github.com/PHMbench/phmfactory"
+Repository = "https://github.com/PHMbench/phmfactory"
+Issues = "https://github.com/PHMbench/phmfactory/issues"
+Documentation = "https://github.com/PHMbench/phmfactory/tree/main/docs"
+
 [project.scripts]
 phmfactory = "phmfactory.cli:main"
 

--- a/tools/repo/check_release_readiness.py
+++ b/tools/repo/check_release_readiness.py
@@ -7,7 +7,6 @@ import argparse
 import os
 import re
 import subprocess
-import sys
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Iterable
@@ -20,6 +19,9 @@ TARGET_VERSION = "0.3.0"
 TARGET_REPOSITORY = "PHMbench/phmfactory"
 REQUIRED_BUNDLE_HASHES = ("metadata", "signals")
 FLOATING_REVISIONS = {"main", "master", "latest", "develop", "development", ""}
+V020_PROVENANCE_PATH = Path("docs/archive/audits/phmfactory-v0.2-provenance.md")
+V020_BASELINE_SHA = "a331769d4005018bc833534ecf4efeb5e8a5a78d"
+V020_PROVENANCE_MARKER = "provenance_status: resolved_without_final_tag"
 
 
 @dataclass(frozen=True)
@@ -28,7 +30,7 @@ class Finding:
     detail: str
 
 
-def _read(path: str) -> str:
+def _read(path: str | Path) -> str:
     return (ROOT / path).read_text(encoding="utf-8")
 
 
@@ -51,6 +53,27 @@ def _git_tags() -> tuple[str, ...]:
         stdout=subprocess.PIPE,
     )
     return tuple(line.strip() for line in result.stdout.splitlines() if line.strip())
+
+
+def _v020_provenance_resolved(tags: tuple[str, ...]) -> tuple[bool, str]:
+    tagged = tuple(tag for tag in tags if tag.startswith("v0.2"))
+    if tagged:
+        return True, f"visible tags={tagged!r}"
+
+    path = ROOT / V020_PROVENANCE_PATH
+    if not path.is_file():
+        return False, f"no v0.2* tag and {V020_PROVENANCE_PATH} is absent"
+
+    text = path.read_text(encoding="utf-8")
+    required = (
+        V020_PROVENANCE_MARKER,
+        f"baseline_sha: {V020_BASELINE_SHA}",
+        "v0.2 status: release candidate, not a tagged final release",
+    )
+    missing = tuple(marker for marker in required if marker not in text)
+    if missing:
+        return False, f"{V020_PROVENANCE_PATH} is missing markers: {missing!r}"
+    return True, f"resolved by {V020_PROVENANCE_PATH}"
 
 
 def collect_findings() -> tuple[Finding, ...]:
@@ -126,10 +149,9 @@ def collect_findings() -> tuple[Finding, ...]:
             )
 
     tags = _git_tags()
-    if not any(tag.startswith("v0.2") for tag in tags):
-        findings.append(
-            Finding("V020_PROVENANCE_UNRESOLVED", "no visible v0.2* Git tag")
-        )
+    provenance_ok, provenance_detail = _v020_provenance_resolved(tags)
+    if not provenance_ok:
+        findings.append(Finding("V020_PROVENANCE_UNRESOLVED", provenance_detail))
     if any(tag in {"v0.3.0", "0.3.0"} for tag in tags):
         findings.append(
             Finding("V030_TAG_ALREADY_EXISTS", "release tag exists before readiness pass")


### PR DESCRIPTION
## What changed

This is PHMFactory v0.3 PR-12a. It resolves repository-controlled release metadata while deliberately keeping the release blocked on external data, repository identity, and final versioning.

### Branding and project metadata

- rebrands `README.md` and `README_CN.md` as PHMFactory;
- documents the three equivalent public entrypoints;
- updates clone, issue, badge, and citation URLs to `PHMbench/phmfactory`;
- removes the obsolete PHM-Vibench logo embed rather than presenting stale visual branding;
- adds final project URLs to `pyproject.toml` while retaining version `0.3.0.dev0`.

### Release documentation

- adds the complete `v0.3.0 - Unreleased` CHANGELOG section;
- adds `RELEASE_NOTES_v0.3.0.md` with migration, compatibility, data, validation, and blocker details;
- records the truthful v0.2 provenance in `docs/archive/audits/phmfactory-v0.2-provenance.md`;
- updates `CITATION.cff` to PHMFactory and the final repository URL;
- updates the release-readiness document to distinguish resolved repository metadata from unresolved external/finalization blockers.

### Provenance policy

No final `v0.2.0` tag existed. This PR does not fabricate one. The provenance record states:

```text
v0.2 status: release candidate, not a tagged final release
pre-v0.3 baseline: a331769d4005018bc833534ecf4efeb5e8a5a78d
provenance_status: resolved_without_final_tag
```

The readiness checker accepts either a real visible v0.2 tag or this explicit, marker-validated provenance record.

## Remaining blockers

The release intentionally remains blocked by:

```text
VERSION_NOT_FINAL
CWRU_REVISION_FLOATING
CWRU_HASH_MISSING
REPOSITORY_RENAME_PENDING
```

In the current development manifest, those produce six finding lines: one version, two provider revisions, two required hashes, and one repository identity.

This PR does not:

- change `0.3.0.dev0` to `0.3.0`;
- edit CWRU revisions or invent hashes;
- rename the GitHub repository;
- create a tag or release;
- change reader, Data Factory, model, task, trainer, Pipeline, configuration runtime, requirements ownership, Streamlit runtime, paper gitlinks, or archived workspaces.

## Changed files

```text
README.md
README_CN.md
CITATION.cff
CHANGELOG.md
RELEASE_NOTES_v0.3.0.md
pyproject.toml
docs/PHMFACTORY_V0_3_RELEASE_READINESS.md
docs/archive/audits/phmfactory-v0.2-provenance.md
tools/repo/check_release_readiness.py
.github/workflows/phmfactory-release-readiness.yml
```

## Validation contract

The readiness workflow must prove:

- English and Chinese README headings are PHMFactory;
- project URLs point to `PHMbench/phmfactory`;
- README, citation, changelog, release notes, and v0.2 provenance blockers are absent;
- version, CWRU pin/hash, and repository-rename blockers remain present;
- release mode still exits non-zero;
- layout and Core quality gates remain green.

## Base

```text
base: agent/v030-release-readiness-pr12
head: agent/v030-release-metadata-pr12a
```

PR #106 must remain immediately below this PR so the checker and blocking workflow are reviewed independently from the metadata changes.

## Rollback

A normal revert restores the previous branding and metadata. No version, tag, provider artifact, repository name, runtime implementation, or external state is changed.