### PR TITLE
docs(v0.3): update canonical submodule governance state

### DIFF
--- a/.github/phmfactory-v0.3-submodules.allowlist.yml
+++ b/.github/phmfactory-v0.3-submodules.allowlist.yml
@@ -1,9 +1,11 @@
-schema_version: 1
+schema_version: 2
 policy: deny_by_default
-runtime_baseline_commit: a331769d4005018bc833534ecf4efeb5e8a5a78d
-allowed_submodules:
+frozen_baseline_commit: a331769d4005018bc833534ecf4efeb5e8a5a78d
+current_migration_parent: 3d098efc11943b1f5ef477ccdf93a10ef27d6911
+
+candidate_submodules:
   - name: phm-data-factory
-    status: candidate_not_in_frozen_baseline
+    status: blocked_pending_provider_merge_and_consumer_rebase
     optional: true
     path: packages/phm-data-factory
     url: https://github.com/liq22/P01-phm-data-factory.git
@@ -11,66 +13,80 @@ allowed_submodules:
     license: Apache-2.0
     owner: liq22
     proposed_by: PHMbench/PHM-Vibench#82
-    baseline_consumers: []
-    proposed_consumers:
-      - src/data_factory/phm_data_factory.py
-      - src/data_factory/standalone.py
-      - src/data_factory/data_factory.py
-      - src/data_factory/__init__.py
+    provider_review: liq22/P01-phm-data-factory#4
+    current_in_gitmodules: false
     required_conditions:
+      - provider_review_merged_or_commit_explicitly_accepted
+      - consumer_change_rebased_on_clean_v0_3_chain
       - public_https_url
       - immutable_reviewed_commit
       - compatible_explicit_license
-      - core_install_and_dummy_smoke_work_without_initialization
+      - submodule_uninitialized_core_install_passes
+      - submodule_uninitialized_dummy_smoke_passes
       - no_paper_personal_or_agent_runtime_dependency
-legacy_entries:
-  - path: "data/Rotor_simulation"
+      - focused_backend_tests_pass
+      - full_core_quality_gates_pass
+
+removed_legacy_entries:
+  - path: data/Rotor_simulation
     gitlink_commit: d46d089c5a086965dda5555734692114bc347437
     classification: personal
-    allowlisted: false
-    action: migrate_then_remove
-  - path: "paper/2025-10_foundation_model_0_metric"
-    gitlink_commit: 2dd7dabe10c11a18e7a1d865ddcf70ba95f26ac7
-    classification: paper
-    allowlisted: false
-    action: migrate_then_remove
-  - path: "paper/LQ_vibench_fix"
+    status: removed_after_private_archive_verification
+    removal_review: PHMbench/PHM-Vibench#103
+    private_archive: upstream-archive/phmfactory-v0.3.0/personal-submodules/data/Rotor_simulation
+  - path: paper/LQ_vibench_fix
     gitlink_commit: 1a15710fd532fad73c552704f48349576d843ee0
     classification: personal
-    allowlisted: false
-    action: migrate_then_remove
-  - path: "paper/UXFD_paper/1D-2D_fusion_explainable"
+    status: removed_after_private_archive_verification
+    removal_review: PHMbench/PHM-Vibench#103
+    private_archive: upstream-archive/phmfactory-v0.3.0/personal-submodules/paper/LQ_vibench_fix
+
+frozen_legacy_entries:
+  - path: paper/2025-10_foundation_model_0_metric
+    url: git@github.com:liq22/PHM-Vibench-Paper-2025-Metric.git
+    gitlink_commit: 2dd7dabe10c11a18e7a1d865ddcf70ba95f26ac7
+    classification: paper
+    status: frozen_pending_content_level_destination_verification
+  - path: paper/UXFD_paper/1D-2D_fusion_explainable
+    url: https://github.com/liq22/1D-2D_fusion_explainable.git
     gitlink_commit: b385b07e82d6323a291d90e55a5ef4aff9336c0b
     classification: paper
-    allowlisted: false
-    action: migrate_then_remove
-  - path: "paper/UXFD_paper/Explainable_FD_Toolkit"
+    status: frozen_pending_content_level_destination_verification
+  - path: paper/UXFD_paper/Explainable_FD_Toolkit
+    url: https://github.com/liq22/Explainable_FD_Toolkit.git
     gitlink_commit: 379244dc8410eea0580714bc216c71074acba3a9
     classification: paper
-    allowlisted: false
-    action: migrate_then_remove
-  - path: "paper/UXFD_paper/LLM_Explainable_FD_Toolkit"
+    status: frozen_pending_content_level_destination_verification
+  - path: paper/UXFD_paper/LLM_Explainable_FD_Toolkit
+    url: https://github.com/liq22/LLM_Explainable_FD_Toolkit.git
     gitlink_commit: 08eb944dd9acdbbd6c69cf39f050854a936e9b78
     classification: paper
-    allowlisted: false
-    action: migrate_then_remove
-  - path: "paper/UXFD_paper/MOE_explainable"
+    status: frozen_pending_content_level_destination_verification
+  - path: paper/UXFD_paper/MOE_explainable
+    url: https://github.com/liq22/MOE_explainable.git
     gitlink_commit: 0da06ae366eeb66d852c144013af6925446615cb
     classification: paper
-    allowlisted: false
-    action: migrate_then_remove
-  - path: "paper/UXFD_paper/Neuralsymbolic_theory"
-    gitlink_commit: ad7dc2e2851f59d941e402e68fa3d3409b39c583
-    classification: paper
-    allowlisted: false
-    action: migrate_then_remove
-  - path: "paper/UXFD_paper/Paper_fuzzy_XFD"
+    status: frozen_pending_content_level_destination_verification
+  - path: paper/UXFD_paper/Paper_fuzzy_XFD
+    url: https://github.com/liq22/Paper_fuzzy_XFD.git
     gitlink_commit: 1bedd533bd52e7ac2592d3a6f7aeffaf25a1014f
     classification: paper
-    allowlisted: false
-    action: migrate_then_remove
-  - path: "paper/UXFD_paper/TII_operator_attention"
+    status: frozen_pending_content_level_destination_verification
+  - path: paper/UXFD_paper/Neuralsymbolic_theory
+    url: https://github.com/liq22/Neuralsymbolic_theory.git
+    gitlink_commit: ad7dc2e2851f59d941e402e68fa3d3409b39c583
+    classification: paper
+    status: frozen_pending_content_level_destination_verification
+  - path: paper/UXFD_paper/TII_operator_attention
+    url: git@github.com:liq22/TII_operator_attention.git
     gitlink_commit: 20f47bac5c02763e1f6b856c90ce32861025c003
     classification: paper
-    allowlisted: false
-    action: migrate_then_remove
+    status: frozen_pending_content_level_destination_verification
+
+release_rules:
+  - no_unknown_gitlinks
+  - no_personal_workspace_gitlinks
+  - no_agent_tool_gitlinks
+  - frozen_paper_gitlinks_must_not_be_treated_as_framework_dependencies
+  - candidate_backend_must_not_be_present_until_status_is_active
+  - active_backend_must_remain_optional_and_pinned

--- a/docs/archive/audits/phmfactory-v0.3-submodule-inventory.md
+++ b/docs/archive/audits/phmfactory-v0.3-submodule-inventory.md
@@ -1,0 +1,140 @@
+# PHMFactory v0.3 submodule inventory and governance state
+
+## Purpose
+
+This audit separates three distinct states that must not be conflated:
+
+```text
+removed personal workspaces
+frozen paper/research gitlinks
+candidate framework backend
+```
+
+A repository name, existing GitHub destination, or historical gitlink is not by itself
+sufficient evidence that a submodule belongs in the public PHMFactory runtime.
+
+## Frozen baseline
+
+The immutable repository baseline contained ten configured submodules:
+
+```text
+source commit: a331769d4005018bc833534ecf4efeb5e8a5a78d
+configured paths: 10
+gitlinks:        10
+```
+
+Classification at that baseline:
+
+```text
+personal workspaces: 2
+paper workspaces:    8
+framework backends:  0
+```
+
+The original `.gitmodules`, URLs, branch metadata, and all ten gitlink commits are
+preserved in the approved personal-fork archive.
+
+## Personal workspaces already removed
+
+The following gitlinks were removed only after their full external commit trees were
+reconstructed and verified in the personal fork:
+
+| Former upstream path | Fixed external commit | Preserved blobs | Status |
+| --- | --- | ---: | --- |
+| `data/Rotor_simulation` | `d46d089c5a086965dda5555734692114bc347437` | 41 | removed by canonical PR #103 |
+| `paper/LQ_vibench_fix` | `1a15710fd532fad73c552704f48349576d843ee0` | 152 | removed by canonical PR #103 |
+
+Neither path is permitted to return through a later rebase or `.gitmodules` conflict
+resolution.
+
+## Current frozen paper gitlinks
+
+The current migration chain retains eight paper/research gitlinks:
+
+| Path | Fixed gitlink | State |
+| --- | --- | --- |
+| `paper/2025-10_foundation_model_0_metric` | `2dd7dabe10c11a18e7a1d865ddcf70ba95f26ac7` | frozen |
+| `paper/UXFD_paper/1D-2D_fusion_explainable` | `b385b07e82d6323a291d90e55a5ef4aff9336c0b` | frozen |
+| `paper/UXFD_paper/Explainable_FD_Toolkit` | `379244dc8410eea0580714bc216c71074acba3a9` | frozen |
+| `paper/UXFD_paper/LLM_Explainable_FD_Toolkit` | `08eb944dd9acdbbd6c69cf39f050854a936e9b78` | frozen |
+| `paper/UXFD_paper/MOE_explainable` | `0da06ae366eeb66d852c144013af6925446615cb` | frozen |
+| `paper/UXFD_paper/Paper_fuzzy_XFD` | `1bedd533bd52e7ac2592d3a6f7aeffaf25a1014f` | frozen |
+| `paper/UXFD_paper/Neuralsymbolic_theory` | `ad7dc2e2851f59d941e402e68fa3d3409b39c583` | frozen |
+| `paper/UXFD_paper/TII_operator_attention` | `20f47bac5c02763e1f6b856c90ce32861025c003` | frozen |
+
+`frozen` means:
+
+- the gitlink is retained to avoid data or research loss;
+- PHMFactory does not import it, package it, or require it for tests or release;
+- it is not an approved framework dependency;
+- deletion requires destination mapping plus content-level or hash-level coverage;
+- existence of an `AI4Engineering-L` repository with a similar name is not enough.
+
+## Candidate `phm-data-factory` backend
+
+PR #82 proposes the only framework-submodule exception candidate:
+
+```text
+path:       packages/phm-data-factory
+repository: https://github.com/liq22/P01-phm-data-factory.git
+commit:     5580fafec2ea5615f6d3276d95e1e5a948cc0f13
+license:    Apache-2.0
+optional:   true
+```
+
+Current state:
+
+```text
+provider PR: liq22/P01-phm-data-factory#4 — Draft, unmerged
+consumer PR: PHMbench/PHM-Vibench#82 — Draft, based on the old main baseline
+present in current .gitmodules: no
+```
+
+Therefore the candidate is **not yet approved or active**. It must not be inserted by
+blindly merging or rebasing the old `.gitmodules` patch, because that could restore the
+removed personal entries or conflict with the eight frozen paper entries.
+
+Before activation, all of the following must hold:
+
+1. the provider commit is explicitly accepted or its provider review is merged;
+2. the consumer integration is rebased onto the clean v0.3 chain;
+3. `.gitmodules` adds only `packages/phm-data-factory` and changes no frozen entry;
+4. the URL is public HTTPS and the gitlink is the reviewed full commit;
+5. the provider remains optional;
+6. uninitialized-submodule core installation, CLI, Dummy smoke, and CWRU quickstart pass;
+7. focused backend and configuration tests pass;
+8. no paper, personal fork, or Agent runtime dependency is introduced.
+
+## Policy authority
+
+The machine-readable state is:
+
+```text
+.github/phmfactory-v0.3-submodules.allowlist.yml
+```
+
+Its policy is deny-by-default. It records:
+
+- the two verified removals;
+- the eight frozen paper entries;
+- the single blocked backend candidate;
+- release conditions for any transition to active status.
+
+## Scope of this PR
+
+This audit and policy update do not modify:
+
+```text
+.gitmodules
+any gitlink
+src/data_factory/**
+provider code
+reader code
+Pipeline code
+configuration behavior
+```
+
+## Rollback
+
+A normal revert restores the previous policy document. It does not alter submodule
+content or Git history.


### PR DESCRIPTION
## What changed

This is the bounded PHMFactory v0.3 PR-10B submodule-governance update.

It changes only:

```text
.github/phmfactory-v0.3-submodules.allowlist.yml
docs/archive/audits/phmfactory-v0.3-submodule-inventory.md
```

No `.gitmodules` entry, gitlink, runtime file, provider code, configuration behavior, or dependency is changed.

## Canonical state

Frozen baseline:

```text
configured submodules: 10
personal workspaces:    2
paper workspaces:       8
framework backends:     0
```

Current v0.3 migration state:

```text
personal gitlinks removed after full private-tree verification: 2
paper gitlinks retained frozen:                                8
active framework submodules:                                   0
blocked framework candidate:                                   1
```

The two verified removals are:

```text
data/Rotor_simulation@d46d089c5a086965dda5555734692114bc347437
paper/LQ_vibench_fix@1a15710fd532fad73c552704f48349576d843ee0
```

They were removed through canonical PR #103 and must not return through a later rebase.

## Frozen paper entries

Eight paper/research gitlinks remain because content-level destination verification is incomplete. `frozen` means they are retained for provenance and loss prevention, but are not imported, packaged, tested, or treated as PHMFactory framework dependencies.

No paper gitlink is removed by this PR.

## `phm-data-factory` candidate

The only permitted backend candidate remains:

```text
path:       packages/phm-data-factory
repository: https://github.com/liq22/P01-phm-data-factory.git
commit:     5580fafec2ea5615f6d3276d95e1e5a948cc0f13
license:    Apache-2.0
optional:   true
```

It is recorded as:

```text
blocked_pending_provider_merge_and_consumer_rebase
```

because:

```text
liq22/P01-phm-data-factory#4 is Draft and unmerged
PHMbench/PHM-Vibench#82 is Draft and based on the old main baseline
candidate is not present in current .gitmodules
```

The old `.gitmodules` patch must not be merged blindly. A clean consumer PR must add only the reviewed public-HTTPS backend gitlink and prove that core install, CLI, Dummy smoke, and CWRU quickstart work when the optional submodule is not initialized.

## Policy changes

The machine-readable policy now distinguishes:

```text
candidate_submodules
removed_legacy_entries
frozen_legacy_entries
release_rules
```

The policy remains deny-by-default.

## Protected boundary

No change to readers, Data Factory, models, tasks, trainers, Pipelines, maintained configs, CWRU providers, requirements, Streamlit, `.gitmodules`, or gitlink state.

## Base

```text
base: agent/v030-reader-doc-neutralization-pr03b
base SHA: 3d098efc11943b1f5ef477ccdf93a10ef27d6911
head: agent/v030-submodule-governance-pr10b
head SHA: 8c1be3eb619f18c3d5e8ef51f1599a3aaeec4829
```

## Validation

Required before review or merge:

```text
documentation validation
maintained configuration validation
configuration Atlas parity
whitespace validation
changed-file inspection: exactly two governance documents
```

## Rollback

A normal revert restores the previous policy and removes the new audit. No submodule state is altered.