### PR TITLE
build(v0.3): add release-readiness blocking gate

### DIFF
--- a/.github/workflows/phmfactory-release-readiness.yml
+++ b/.github/workflows/phmfactory-release-readiness.yml
@@ -1,0 +1,68 @@
+name: PHMFactory release readiness
+
+on:
+  pull_request:
+    paths:
+      - "pyproject.toml"
+      - "phmfactory/__init__.py"
+      - "README.md"
+      - "CITATION.cff"
+      - "CHANGELOG.md"
+      - "RELEASE_NOTES_v0.3.0.md"
+      - "phmfactory/data_sources/manifests/cwru-demo-v1.yaml"
+      - "docs/PHMFACTORY_V0_3_RELEASE_READINESS.md"
+      - "tools/repo/check_release_readiness.py"
+      - ".github/workflows/phmfactory-release-readiness.yml"
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  readiness-audit:
+    name: Audit v0.3 release blockers
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Check out repository with tags
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+
+      - name: Install audit dependency
+        run: python -m pip install PyYAML
+
+      - name: Compile release checker
+        run: python -m py_compile tools/repo/check_release_readiness.py
+
+      - name: Record current blockers
+        run: python tools/repo/check_release_readiness.py --mode audit | tee release-readiness.txt
+
+      - name: Require the pre-release gate to remain blocked
+        shell: bash
+        run: |
+          set -euo pipefail
+          if python tools/repo/check_release_readiness.py --mode release; then
+            echo "Release mode unexpectedly passed before final release preparation." >&2
+            exit 1
+          fi
+          grep -q 'VERSION_NOT_FINAL' release-readiness.txt
+          grep -q 'README_BRAND_PENDING' release-readiness.txt
+          grep -q 'CWRU_REVISION_FLOATING' release-readiness.txt
+          grep -q 'CWRU_HASH_MISSING' release-readiness.txt
+
+      - name: Upload readiness report
+        uses: actions/upload-artifact@v4
+        with:
+          name: phmfactory-v030-release-readiness
+          path: release-readiness.txt
+          if-no-files-found: error

--- a/docs/PHMFACTORY_V0_3_RELEASE_READINESS.md
+++ b/docs/PHMFACTORY_V0_3_RELEASE_READINESS.md
@@ -1,0 +1,73 @@
+# PHMFactory v0.3 Release Readiness
+
+This page is the blocking checklist for the final PHMFactory v0.3 release. It is an audit contract, not a claim that the release is already ready.
+
+## Current status
+
+```text
+status: BLOCKED
+release target: v0.3.0
+repository target: PHMbench/phmfactory
+```
+
+Run the audit with:
+
+```bash
+python tools/repo/check_release_readiness.py --mode audit
+```
+
+The release command must remain blocked while any finding exists:
+
+```bash
+python tools/repo/check_release_readiness.py --mode release
+```
+
+## Machine-checked blockers
+
+The checker currently evaluates:
+
+1. `pyproject.toml` and `phmfactory.__version__` agree and equal `0.3.0`;
+2. the public README heading uses `PHMFactory`;
+3. `CITATION.cff` uses the PHMFactory title and final repository URL;
+4. `CHANGELOG.md` contains a v0.3.0 section;
+5. `RELEASE_NOTES_v0.3.0.md` exists;
+6. Hugging Face and ModelScope CWRU revisions are immutable rather than `main` or `master`;
+7. required CWRU bundle SHA-256 values are populated;
+8. v0.2 provenance has a visible resolution;
+9. no v0.3.0 tag already exists before the release gate passes;
+10. when running in GitHub Actions, the repository has the final `PHMbench/phmfactory` identity.
+
+## Human-reviewed blockers
+
+The following cannot be inferred safely from repository files alone:
+
+- all staged v0.3 PRs have been reviewed and merged in dependency order;
+- branch protection and required checks are configured for the final default branch;
+- public Hugging Face and ModelScope artifacts are available at the pinned immutable revisions;
+- the two providers return byte-identical required bundle files;
+- the optional `phm-data-factory` backend decision has been finalized and its integration branch rebased without reintroducing legacy submodules;
+- the GitHub repository rename and redirect behavior have been verified;
+- release notes accurately separate compatibility guarantees from experimental features;
+- the final wheel and source distribution were built from the tagged commit;
+- installation, CLI, module entrypoint, offline smoke, Pipeline 06, UXFD, Streamlit, dependency ownership, repository-layout, and CWRU gates all pass on the final release commit.
+
+## Release order
+
+```text
+1. merge the reviewed v0.3 PR stack in dependency order
+2. resolve the v0.2 provenance record
+3. publish and pin the dual-source CWRU bundle
+4. finalize repository branding and citation metadata
+5. change versions from 0.3.0.dev0 to 0.3.0
+6. create and validate RELEASE_NOTES_v0.3.0.md
+7. rename the GitHub repository to PHMbench/phmfactory
+8. rerun all required checks on the final repository identity
+9. build wheel and sdist from the final commit
+10. create tag v0.3.0 and publish the release
+```
+
+The repository rename, final version change, tag, and release publication must not occur before all blockers are cleared.
+
+## Rollback
+
+Before tagging, revert the release-preparation commit or keep the repository at `0.3.0.dev0`. After tagging, use a corrective release rather than moving or recreating the published tag.

--- a/tools/repo/check_release_readiness.py
+++ b/tools/repo/check_release_readiness.py
@@ -1,0 +1,172 @@
+#!/usr/bin/env python3
+"""Audit PHMFactory v0.3 release readiness without mutating repository state."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable
+
+import yaml
+
+
+ROOT = Path(__file__).resolve().parents[2]
+TARGET_VERSION = "0.3.0"
+TARGET_REPOSITORY = "PHMbench/phmfactory"
+REQUIRED_BUNDLE_HASHES = ("metadata", "signals")
+FLOATING_REVISIONS = {"main", "master", "latest", "develop", "development", ""}
+
+
+@dataclass(frozen=True)
+class Finding:
+    code: str
+    detail: str
+
+
+def _read(path: str) -> str:
+    return (ROOT / path).read_text(encoding="utf-8")
+
+
+def _toml_version(text: str) -> str:
+    match = re.search(r'^version\s*=\s*"([^"]+)"', text, flags=re.MULTILINE)
+    return match.group(1) if match else ""
+
+
+def _python_version(text: str) -> str:
+    match = re.search(r'^__version__\s*=\s*"([^"]+)"', text, flags=re.MULTILINE)
+    return match.group(1) if match else ""
+
+
+def _git_tags() -> tuple[str, ...]:
+    result = subprocess.run(
+        ["git", "tag", "--list"],
+        cwd=ROOT,
+        check=True,
+        text=True,
+        stdout=subprocess.PIPE,
+    )
+    return tuple(line.strip() for line in result.stdout.splitlines() if line.strip())
+
+
+def collect_findings() -> tuple[Finding, ...]:
+    findings: list[Finding] = []
+
+    pyproject = _read("pyproject.toml")
+    package_init = _read("phmfactory/__init__.py")
+    readme = _read("README.md")
+    citation = yaml.safe_load(_read("CITATION.cff")) or {}
+    changelog = _read("CHANGELOG.md")
+    manifest = yaml.safe_load(
+        _read("phmfactory/data_sources/manifests/cwru-demo-v1.yaml")
+    ) or {}
+
+    project_version = _toml_version(pyproject)
+    package_version = _python_version(package_init)
+    if project_version != package_version:
+        findings.append(
+            Finding(
+                "VERSION_MISMATCH",
+                f"pyproject={project_version!r}, package={package_version!r}",
+            )
+        )
+    if project_version != TARGET_VERSION:
+        findings.append(
+            Finding(
+                "VERSION_NOT_FINAL",
+                f"expected {TARGET_VERSION!r}, found {project_version!r}",
+            )
+        )
+
+    if not readme.startswith("# PHMFactory\n"):
+        findings.append(Finding("README_BRAND_PENDING", "README heading is not PHMFactory"))
+
+    if citation.get("title") != "PHMFactory":
+        findings.append(
+            Finding("CITATION_BRAND_PENDING", f"title={citation.get('title')!r}")
+        )
+    expected_url = f"https://github.com/{TARGET_REPOSITORY}"
+    for field in ("repository-code", "url"):
+        if citation.get(field) != expected_url:
+            findings.append(
+                Finding(
+                    "CITATION_REPOSITORY_PENDING",
+                    f"{field}={citation.get(field)!r}, expected {expected_url!r}",
+                )
+            )
+
+    if not re.search(r"^##\s+v?0\.3\.0\b", changelog, flags=re.MULTILINE):
+        findings.append(Finding("CHANGELOG_V030_MISSING", "no v0.3.0 section"))
+    if not (ROOT / "RELEASE_NOTES_v0.3.0.md").is_file():
+        findings.append(
+            Finding("RELEASE_NOTES_V030_MISSING", "RELEASE_NOTES_v0.3.0.md absent")
+        )
+
+    providers = manifest.get("providers") or {}
+    for provider_name, provider in sorted(providers.items()):
+        revision = str((provider or {}).get("revision") or "")
+        if revision.casefold() in FLOATING_REVISIONS:
+            findings.append(
+                Finding(
+                    "CWRU_REVISION_FLOATING",
+                    f"{provider_name} revision={revision!r}",
+                )
+            )
+
+    expected_hashes = manifest.get("expected_sha256") or {}
+    for key in REQUIRED_BUNDLE_HASHES:
+        value = str(expected_hashes.get(key) or "")
+        if not re.fullmatch(r"[0-9a-f]{64}", value):
+            findings.append(
+                Finding("CWRU_HASH_MISSING", f"expected_sha256.{key} is not pinned")
+            )
+
+    tags = _git_tags()
+    if not any(tag.startswith("v0.2") for tag in tags):
+        findings.append(
+            Finding("V020_PROVENANCE_UNRESOLVED", "no visible v0.2* Git tag")
+        )
+    if any(tag in {"v0.3.0", "0.3.0"} for tag in tags):
+        findings.append(
+            Finding("V030_TAG_ALREADY_EXISTS", "release tag exists before readiness pass")
+        )
+
+    repository = os.environ.get("GITHUB_REPOSITORY", "")
+    if repository and repository != TARGET_REPOSITORY:
+        findings.append(
+            Finding(
+                "REPOSITORY_RENAME_PENDING",
+                f"current={repository!r}, expected={TARGET_REPOSITORY!r}",
+            )
+        )
+
+    return tuple(sorted(findings, key=lambda item: (item.code, item.detail)))
+
+
+def _print_findings(findings: Iterable[Finding]) -> None:
+    findings = tuple(findings)
+    if not findings:
+        print("PHMFactory v0.3 release readiness PASS: 0 blockers")
+        return
+    print(f"PHMFactory v0.3 release readiness BLOCKED: {len(findings)} blocker(s)")
+    for finding in findings:
+        print(f"- {finding.code}: {finding.detail}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--mode", choices=("audit", "release"), default="audit")
+    args = parser.parse_args()
+
+    findings = collect_findings()
+    _print_findings(findings)
+    if args.mode == "release" and findings:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## What changed

This refreshed canonical PHMFactory v0.3 PR-12 readiness branch replaces PR #106. Unlike the earlier retarget-only PR, this branch is physically based on the final PR-11b tree, so the repository-layout contract is inherited rather than reintroduced through stale ancestry.

It adds exactly:

```text
.github/workflows/phmfactory-release-readiness.yml
docs/PHMFACTORY_V0_3_RELEASE_READINESS.md
tools/repo/check_release_readiness.py
```

The checker supports:

```bash
python tools/repo/check_release_readiness.py --mode audit
python tools/repo/check_release_readiness.py --mode release
```

Audit mode reports blockers without mutation. Release mode exits non-zero until all machine-checked blockers are cleared.

## Physical ancestry correction

```text
base: agent/v030-historical-docs-pr11b-final
base SHA: 1c079079ee0776b2a5b6e60772c85b130c931e30
head: agent/v030-release-readiness-pr12-final
head SHA: 19748c93fb4716a5314cdaf38317b39a84da0cd7
```

This corrects the prior situation where changing a PR base did not rewrite the head branch ancestry. No layout exception or guard weakening is used.

## Non-actions

This PR does not change package version, branding, CWRU revisions or hashes, repository name, tags, releases, protected runtime, requirements ownership, Streamlit, paper gitlinks, or archived workspaces.

## Validation required

```text
PHMFactory release readiness
Repository layout
Core quality gates
```

The release-readiness workflow must prove that audit mode succeeds and release mode remains blocked.

## Rollback

A normal revert removes the checker, document, and workflow without changing runtime or external state.