### PR TITLE
docs(v0.3): draft changelog and migration guide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,104 @@
 # Changelog
 
+## v0.3.0 - Unreleased
+
+### Summary
+
+PHM-Vibench is being renamed to PHMFactory. v0.3.0 is a compatibility-first
+repository-boundary, public-interface, packaging, and reproducibility release.
+It does not intentionally rewrite the protected reader, model, task, trainer, or
+Pipeline algorithms.
+
+### Added
+
+- Public `phmfactory` Python package, module entrypoint, and console command.
+- Equivalent public entrypoints:
+  `python main.py`, `python -m phmfactory`, and `phmfactory`.
+- Public configuration resolver under `phmfactory.config`.
+- Descriptive canonical identifiers for Pipeline 01 through Pipeline 06.
+- Provider-neutral CWRU demo-bundle contract for Hugging Face and ModelScope.
+- Minimal non-interactive CWRU quickstart example.
+- Optional dependency ownership checks and subsystem requirement files.
+- Reader/runtime fingerprints and repository ownership inventories.
+- Case-insensitive repository-path guard for cross-platform checkout safety.
+- Release-readiness audit and blocking gate.
+- v0.2-to-v0.3 migration guide and draft v0.3 release notes.
+
+### Changed
+
+- Project public naming converges on PHMFactory and `phmfactory`.
+- Root `main.py` is retained as a thin public dispatcher.
+- The six Pipeline modules are renamed directly to descriptive task names without
+  algorithm changes or old-filename wrapper modules.
+- Maintained configurations use canonical Pipeline identifiers; legacy config
+  values resolve through explicit aliases and warnings.
+- Configuration path, composition, override, and Pipeline selection are exposed
+  through one lightweight public resolver.
+- Root `requirements.txt` remains the core dependency authority; optional
+  requirements live with Streamlit, ModelScope, plotting, and tests.
+- `apps/streamlit/` is the sole maintained web workspace and continues to invoke
+  experiments through the public CLI.
+- CWRU `corpus.xlsx` is optional for the fault-diagnosis quickstart.
+- Generated and personal workspaces are separated from the public framework only
+  after archive and integrity evidence.
+
+### Removed
+
+- Legacy duplicate `app/` workspace and root `streamlit_app.py` launcher.
+- Public Agent/vendor workspaces and personal development material after verified
+  preservation in the approved personal fork.
+- Personal Rotor and LQ-fix submodule gitlinks after complete fixed-commit tree
+  preservation.
+- Generated result/metric placeholder directories from the public source tree.
+- Case-colliding lowercase compatibility paths where canonical uppercase
+  authorities exist.
+
+### Preserved
+
+- `src/data_factory/reader/` path and dataset-specific reader implementations.
+- Established reader signatures, parsing, channel ordering, shapes, dtype
+  behavior, and numerical transforms unless a separately reviewed bugfix says
+  otherwise.
+- Existing `src.data_factory`, `src.model_factory`, `src.task_factory`,
+  `src.trainer_factory`, and Pipeline implementations as the v0.3 compatibility
+  runtime.
+- Root `configs/` and the five-block configuration model:
+  `environment / data / model / task / trainer`.
+- Fully offline `Dummy_Data` smoke validation.
+- Historical and paper material that has not yet satisfied content-level removal
+  evidence.
+
+### Compatibility and breaking changes
+
+- `--config_path` remains accepted, while `--config` is preferred.
+- Old Pipeline strings remain configuration aliases; direct imports of old
+  Pipeline module filenames must be updated.
+- No `phm_factory` or `phm_vibench` compatibility namespace is introduced.
+- New downstream integrations should use `phmfactory.*`; `src.*` remains an
+  internal compatibility path during v0.3.
+- The historical root Streamlit launcher is no longer available.
+
+### Data and reproducibility
+
+- The CWRU quickstart expects `metadata.xlsx` and `RM_001_CWRU.h5`; `corpus.xlsx`
+  is optional.
+- Bundle validation checks Id coverage and `(L, C)` signal shape against metadata.
+- Provider downloads are selective and do not occur inside readers or DataLoader
+  workers.
+- The final release requires immutable Hugging Face and ModelScope revisions,
+  populated SHA-256 values, and cross-provider core-file parity.
+
+### Release status
+
+v0.3.0 remains unreleased. Open blockers include final package versioning,
+PHMFactory README/citation branding, GitHub repository rename verification,
+CWRU provider pins and hashes, v0.2 provenance resolution, stacked-PR integration,
+final cross-platform/package/data gates, and creation of the final tag and release
+artifacts.
+
+See `MIGRATION_v0.2_to_v0.3.md`, `RELEASE_NOTES_v0.3.0.md`, and
+`docs/PHMFACTORY_V0_3_RELEASE_READINESS.md`.
+
 ## v0.2.0 Release Candidate - 2026-07-11
 
 ### Added
@@ -33,4 +132,3 @@
   `SUPPORTED_COMBINATIONS.md`.
 - The evidence is functional smoke and contract evidence, not a performance
   benchmark.
-

--- a/MIGRATION_v0.2_to_v0.3.md
+++ b/MIGRATION_v0.2_to_v0.3.md
@@ -1,0 +1,221 @@
+# Migrating from PHM-Vibench v0.2 to PHMFactory v0.3
+
+> Status: draft for the unreleased v0.3.0 migration stack.
+>
+> This guide does not announce a release. Package version finalization, immutable
+> CWRU provider revisions and hashes, the GitHub repository rename, and the v0.3.0
+> tag remain separately gated.
+
+## 1. Naming
+
+| Surface | v0.2 | v0.3 |
+| --- | --- | --- |
+| Project display name | PHM-Vibench | PHMFactory |
+| Python distribution | repository-only workflow | `phmfactory` |
+| Python namespace | internal `src.*` modules | `phmfactory` public package |
+| CLI | `python main.py` | `python main.py`, `python -m phmfactory`, `phmfactory` |
+| Planned GitHub repository | `PHMbench/PHM-Vibench` | `PHMbench/phmfactory` after the governed rename |
+
+The public namespace is exactly:
+
+```python
+import phmfactory
+```
+
+No `phm_factory` or `phm_vibench` compatibility namespace is introduced.
+
+## 2. Installation
+
+Core runtime and the default Hugging Face CWRU provider:
+
+```bash
+python -m pip install -r requirements.txt
+```
+
+Optional ModelScope provider:
+
+```bash
+python -m pip install -r phmfactory/data_sources/modelscope/requirements.txt
+```
+
+Optional Streamlit workspace:
+
+```bash
+python -m pip install -r apps/streamlit/requirements.txt
+```
+
+Development tests:
+
+```bash
+python -m pip install -r test/requirements.txt
+```
+
+Optional requirement files contain subsystem-specific increments. Install the
+root requirements first.
+
+## 3. Public entrypoints
+
+The following forms share one parser and dispatcher:
+
+```bash
+python main.py --config configs/demo/00_smoke/dummy_dg.yaml
+python -m phmfactory --config configs/demo/00_smoke/dummy_dg.yaml
+phmfactory --config configs/demo/00_smoke/dummy_dg.yaml
+```
+
+`--config` is preferred. `--config_path` remains accepted for compatibility.
+
+The root `main.py` remains a supported thin public dispatcher.
+
+## 4. Pipeline names
+
+The Pipeline modules are renamed directly. No old-filename wrapper modules are
+provided.
+
+| v0.2 identifier/module | v0.3 canonical identifier/module |
+| --- | --- |
+| `Pipeline_01_default` | `Pipeline_01_Fault_Diagnosis` |
+| `Pipeline_02_pretrain_fewshot` | `Pipeline_02_Pretraining_Few_Shot` |
+| `Pipeline_03_multitask_pretrain_finetune` | `Pipeline_03_Multitask_Pretraining_Finetuning` |
+| `Pipeline_04_unified_metric` | `Pipeline_04_Unified_Evaluation` |
+| `Pipeline_05_default_w_explain` | `Pipeline_05_Explainable_Fault_Diagnosis` |
+| `Pipeline_06_generative` | `Pipeline_06_Generative_Modeling` |
+
+Maintained configuration values are migrated to the canonical identifiers.
+Legacy configuration strings are resolved through explicit aliases and emit a
+warning. Direct Python imports of old module filenames must be changed:
+
+```python
+# v0.2
+from src.Pipeline_01_default import pipeline
+
+# v0.3
+from src.Pipeline_01_Fault_Diagnosis import pipeline
+```
+
+Pipeline algorithms, seeds, data splits, metric semantics, and checkpoint
+formats are not intentionally changed by the rename.
+
+## 5. Configuration API
+
+New integrations should resolve configurations through:
+
+```python
+from phmfactory.config import resolve_config
+
+resolved = resolve_config(
+    "configs/demo/00_smoke/dummy_dg.yaml",
+    overrides=("trainer.num_epochs=1", "data.num_workers=0"),
+)
+```
+
+The public resolver handles maintained aliases, ordered `base_configs`, typed
+CLI overrides, Pipeline canonicalization, cycle detection, and missing-source
+errors.
+
+The established internal configuration implementations remain available as the
+v0.3 compatibility engine. Their physical consolidation is not part of this
+release.
+
+## 6. CWRU demo data
+
+The v0.3 CWRU bundle contract is:
+
+```text
+metadata.xlsx       required
+RM_001_CWRU.h5      required
+corpus.xlsx         optional
+```
+
+The files join on `Id`. The prebuilt HDF5 signal for each selected sample is a
+2-D `(L, C)` array and is validated against metadata length and channel aliases.
+
+Commands:
+
+```bash
+python main.py data download --source huggingface
+python main.py data download --source modelscope
+python main.py data validate --path <bundle-dir>
+python main.py data compare --left <hf-dir> --right <modelscope-dir>
+```
+
+Minimal example:
+
+```bash
+python examples/cwru_quickstart.py --source huggingface
+```
+
+The v0.3.0 release requires immutable provider revisions and populated SHA-256
+values. Development branch names and empty hashes are not release evidence.
+
+## 7. Streamlit workspace
+
+The historical duplicate UI paths are removed after exact preservation outside
+the public framework:
+
+```text
+app/
+streamlit_app.py
+```
+
+The only maintained web entrypoint is:
+
+```bash
+streamlit run apps/streamlit/app.py
+```
+
+The UI remains an optional adapter around the public CLI. It is not a second
+training framework and does not directly call Pipeline functions.
+
+## 8. Runtime-core preservation
+
+The mature runtime remains under `src/` during v0.3. In particular,
+`src/data_factory/reader/` is not moved or mechanically rewritten.
+
+The migration does not intentionally change reader signatures, signal parsing,
+channel order, array shape, dtype behavior, or numerical transforms.
+
+New downstream integrations should prefer `phmfactory.*`; direct `src.*`
+imports are compatibility paths and are not the long-term public API.
+
+## 9. Repository ownership boundary
+
+Paper repositories, personal forks, and third-party projects may depend on
+PHMFactory. PHMFactory must not require those downstream repositories at
+runtime, build time, test time, data time, or release time.
+
+Agent workspaces, personal development material, paper-specific results, and
+personal submodules are moved out of public upstream only after destination and
+integrity verification.
+
+A governed optional `phm-data-factory` backend is the sole proposed submodule
+exception. Its final inclusion is a separate reviewed decision.
+
+## 10. Output and historical material
+
+Generated outputs are not sources of truth. Configuration remains under
+`configs/`; run artifacts belong in configured output directories and should
+not be committed as framework source.
+
+Historical directories are not automatically deleted merely because they are
+old. Removal requires zero maintained references plus provenance and archive
+evidence.
+
+## 11. Validation before adopting v0.3
+
+At minimum, run:
+
+```bash
+python -m scripts.validate_docs
+python -m scripts.validate_configs
+python -m scripts.gen_config_atlas
+git diff --exit-code docs/CONFIG_ATLAS.md
+python -m pytest test/ -q
+python main.py --config configs/demo/00_smoke/dummy_dg.yaml \
+  --override trainer.num_epochs=1 \
+  --override data.num_workers=0
+```
+
+For packaging changes, also build and install the wheel in a clean environment.
+For a release, run both pinned CWRU provider downloads and verify core-file hash
+parity.

--- a/RELEASE_NOTES_v0.3.0.md
+++ b/RELEASE_NOTES_v0.3.0.md
@@ -1,0 +1,188 @@
+# PHMFactory v0.3.0 Release Notes
+
+> **Draft — unreleased.**
+>
+> This document describes the intended v0.3.0 release surface. It is not release
+> evidence and must not be used to infer that the package, repository rename,
+> public data pins, tag, or artifacts have been published.
+
+## Release purpose
+
+v0.3.0 changes PHM-Vibench into PHMFactory as a public, configuration-first PHM
+framework while preserving the established runtime core.
+
+The release is primarily about:
+
+- repository ownership boundaries;
+- one public package and CLI;
+- descriptive Pipeline names;
+- one public configuration resolver;
+- a bounded dual-provider CWRU demo contract;
+- optional dependency ownership;
+- removal of duplicate UI and non-framework workspaces;
+- repository portability and release governance.
+
+It is not a wholesale reader, model, task, trainer, or Pipeline-algorithm rewrite.
+
+## Public interface
+
+The distribution, import namespace, and executable are all named `phmfactory`:
+
+```python
+import phmfactory
+```
+
+```bash
+python main.py --config <yaml>
+python -m phmfactory --config <yaml>
+phmfactory --config <yaml>
+```
+
+All three command forms use the same parser and dispatcher. Root `main.py`
+remains supported.
+
+## Pipeline names
+
+The six established Pipeline files use descriptive canonical names:
+
+```text
+Pipeline_01_Fault_Diagnosis
+Pipeline_02_Pretraining_Few_Shot
+Pipeline_03_Multitask_Pretraining_Finetuning
+Pipeline_04_Unified_Evaluation
+Pipeline_05_Explainable_Fault_Diagnosis
+Pipeline_06_Generative_Modeling
+```
+
+Legacy configuration identifiers remain explicit aliases. Direct imports of
+old module filenames are a breaking change because no six-file wrapper layer is
+introduced.
+
+## Configuration
+
+`phmfactory.config.resolve_config()` is the public configuration entrypoint. It
+provides:
+
+- maintained preset and YAML-path resolution;
+- ordered recursive `base_configs` composition;
+- typed dotted overrides;
+- canonical Pipeline selection;
+- cycle and missing-source errors;
+- resolved path and override provenance.
+
+The mature internal configuration implementation remains in place for v0.3
+compatibility. Physical internal consolidation is deferred.
+
+## Data and CWRU quickstart
+
+The maintained CWRU demo bundle contains:
+
+```text
+metadata.xlsx       required
+RM_001_CWRU.h5      required
+corpus.xlsx         optional
+```
+
+Provider adapters selectively download only the declared files from Hugging
+Face or ModelScope, verify the bundle, and pass a local directory to the
+established Data Factory.
+
+The release does not claim new raw-MAT reader validation. The prebuilt HDF5 path
+and fully offline `Dummy_Data` smoke are separate validation surfaces.
+
+## Dependency ownership
+
+The root `requirements.txt` remains the core installation authority. Optional
+increments live with the subsystem that owns them, including:
+
+```text
+apps/streamlit/requirements.txt
+phmfactory/data_sources/modelscope/requirements.txt
+plot/requirements.txt
+test/requirements.txt
+```
+
+This prevents Streamlit, ModelScope, test, and plotting dependencies from being
+silently treated as mandatory core packages.
+
+## UI consolidation
+
+The maintained optional web workspace is:
+
+```text
+apps/streamlit/
+```
+
+The legacy duplicate `app/` tree and root `streamlit_app.py` launcher are removed
+after exact preservation outside the public framework. The maintained UI calls
+the public CLI and does not become a second training implementation.
+
+## Repository ownership cleanup
+
+Personal Agent tooling, development scratchpads, generated result placeholders,
+personal submodules, and historical duplicate paths are moved or removed only
+after archive and integrity evidence.
+
+Paper submodules are not removed merely because similarly named destination
+repositories exist. Each requires content-level mapping and review.
+
+The framework has no runtime, build, test, data, or release dependency on the
+personal archive or paper repositories.
+
+## Cross-platform repository layout
+
+Case-colliding compatibility paths are removed in favor of canonical spellings,
+and a repository-layout gate rejects future case-insensitive path collisions.
+This protects Windows and default macOS checkouts.
+
+## Preserved runtime boundary
+
+v0.3 preserves the mature runtime under `src/`, including the existing dataset
+reader path:
+
+```text
+src/data_factory/reader/
+```
+
+The migration does not intentionally change:
+
+- reader parsing or signatures;
+- channel order, shape, or dtype;
+- model/task/trainer algorithms;
+- data splits or seeds;
+- metrics or checkpoint formats.
+
+## Breaking changes
+
+- Project and public Python naming converges on PHMFactory / `phmfactory`.
+- Direct imports of the six old Pipeline module filenames must be updated.
+- The duplicate root Streamlit launcher and historical `app/` package are removed.
+- Personal, Agent, and paper/result workspaces are no longer public framework
+  runtime surfaces.
+- Case-colliding lowercase compatibility files are removed.
+
+## Migration guide
+
+See [MIGRATION_v0.2_to_v0.3.md](MIGRATION_v0.2_to_v0.3.md).
+
+## Release blockers still open
+
+v0.3.0 must not be released until all of the following are resolved:
+
+1. package and module versions are finalized from `0.3.0.dev0` to `0.3.0`;
+2. README and citation metadata use final PHMFactory branding and repository identity;
+3. the GitHub repository rename and redirect are verified;
+4. Hugging Face and ModelScope bundle revisions are immutable;
+5. required CWRU bundle SHA-256 values are populated and cross-provider parity passes;
+6. v0.2 release/RC provenance is explicitly resolved;
+7. the stacked PR sequence is reviewed and integrated in dependency order;
+8. final wheel, source distribution, cross-platform imports, offline smoke, and
+   provider release gates pass;
+9. the governed optional `phm-data-factory` backend disposition is recorded;
+10. the v0.3.0 tag and release artifacts are created only from the approved final commit.
+
+## Evidence boundary
+
+Passing unit, contract, or one-epoch smoke tests demonstrates software wiring. It
+does not establish benchmark superiority, universal component compatibility,
+or permission to redistribute external datasets.


### PR DESCRIPTION
## What changed

This is a non-destructive PHMFactory v0.3 release-documentation stage layered on the release-readiness gate.

It adds or updates only:

```text
CHANGELOG.md
MIGRATION_v0.2_to_v0.3.md
RELEASE_NOTES_v0.3.0.md
```

The documents record the actual v0.3 migration surface: `phmfactory` public naming, three equivalent CLI entrypoints, direct descriptive Pipeline renames, one public config resolver, the CWRU bundle contract, requirements ownership, Streamlit consolidation, runtime preservation, repository ownership boundaries, and breaking-change guidance.

## Deliberately unresolved

This PR does not make the release ready. It does not:

- change `0.3.0.dev0` to `0.3.0`;
- rename the GitHub repository;
- rewrite README or final citation repository URLs;
- create or move a Git tag;
- publish a GitHub release, wheel, or source distribution;
- replace floating CWRU revisions or populate provider hashes;
- claim online Hugging Face / ModelScope parity;
- resolve the v0.2 release-candidate provenance;
- alter the optional `phm-data-factory` backend decision.

Both new documents are explicitly marked draft/unreleased, and the changelog retains the existing v0.2.0 Release Candidate record unchanged.

## Protected boundary

No change to readers, Data Factory behavior, model/task/trainer implementations, Pipeline algorithms, maintained configs, CWRU implementation, requirements, Streamlit runtime, paper gitlinks, submodules, or historical directories.

## Base

```text
base: agent/v030-release-readiness-pr12
head: agent/v030-release-docs-pr12b
```

## Validation required

```text
PHMFactory release readiness audit
Repository layout / case-insensitive path contract
Core documentation and configuration contracts
Markdown links and whitespace
```

Release mode must remain blocked after this PR because version, repository identity, CWRU pins/hashes, v0.2 provenance, and final publication gates remain open.

## Rollback

A normal revert removes the two draft documents and restores the previous changelog. No runtime, data, repository identity, or release state is changed.