### PR TITLE
docs(v0.3): track content-level paper gitlink migrations

### DIFF
--- a/.github/workflows/paper-migration-status.yml
+++ b/.github/workflows/paper-migration-status.yml
@@ -1,0 +1,62 @@
+name: Paper migration status
+
+on:
+  pull_request:
+    paths:
+      - ".github/phmfactory-v0.3-submodules.allowlist.yml"
+      - "docs/archive/audits/phmfactory-v0.3-paper-submodule-migration-status.yaml"
+      - "tools/repo/check_paper_migration_status.py"
+      - ".github/workflows/paper-migration-status.yml"
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  tracker:
+    name: Content-level paper migration contract
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          submodules: false
+
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+
+      - name: Install focused dependency
+        run: python -m pip install PyYAML
+
+      - name: Compile tracker checker
+        run: python -m py_compile tools/repo/check_paper_migration_status.py
+
+      - name: Validate structural tracker policy
+        run: python tools/repo/check_paper_migration_status.py --mode policy | tee paper-migration-policy.txt
+
+      - name: Require release mode to remain blocked
+        shell: bash
+        run: |
+          set -euo pipefail
+          if python tools/repo/check_paper_migration_status.py --mode release > paper-migration-release.txt; then
+            echo "Paper migration release policy unexpectedly passed." >&2
+            exit 1
+          fi
+          test "$(grep -c 'PAPER_MIGRATION_PENDING' paper-migration-release.txt)" = 8
+
+      - name: Upload migration evidence
+        uses: actions/upload-artifact@v4
+        with:
+          name: phmfactory-v030-paper-migration-status
+          path: |
+            paper-migration-policy.txt
+            paper-migration-release.txt
+          if-no-files-found: error

--- a/docs/archive/audits/phmfactory-v0.3-paper-submodule-migration-status.md
+++ b/docs/archive/audits/phmfactory-v0.3-paper-submodule-migration-status.md
@@ -1,0 +1,97 @@
+# PHMFactory v0.3 Paper Gitlink Migration Status
+
+## Policy
+
+A paper gitlink is removable only when its destination repository contains complete
+content-level evidence for the exact gitlink commit and the destination change has been
+reviewed or retained.
+
+Repository existence, a similar name, or a later working-tree snapshot is not enough.
+
+The machine-readable authority is:
+
+```text
+docs/archive/audits/phmfactory-v0.3-paper-submodule-migration-status.yaml
+```
+
+Validation commands:
+
+```bash
+python tools/repo/check_paper_migration_status.py --mode policy
+python tools/repo/check_paper_migration_status.py --mode release
+```
+
+Policy mode validates structure and evidence consistency. Release mode remains blocked
+until every paper has `safe_to_remove: true` under the review rules.
+
+## Current status
+
+| Paper | Source gitlink | Destination | Coverage | Target review | Safe to remove |
+| --- | --- | --- | ---: | --- | --- |
+| foundation metric | `2dd7dabe...` | unresolved | not started | not started | no |
+| P01 multimodal alignment | `b385b07e...` | `AI4Engineering-L/P01-UXFD-Multimodal-Alignment#2` | 89/89 | workflow approval required | no |
+| P02 XFD benchmark toolkit | `379244dc...` | `AI4Engineering-L/P02-XFD-Benchmark-Toolkit#2` | 163/163 | workflow approval required | no |
+| P03 evidence-grounded LLM XFD | `08eb944d...` | `AI4Engineering-L/P03-Evidence-Grounded-LLM-XFD#2` | 90/90 | workflow approval required | no |
+| P04 physics-informed MoE | `0da06ae3...` | `AI4Engineering-L/P04-Physics-Informed-MoE-XFD` | not started | not started | no |
+| P05 neuro-fuzzy safe XFD | `1bedd533...` | `AI4Engineering-L/P05-Neuro-Fuzzy-Safe-XFD` | not started | not started | no |
+| P06 neural-symbolic XFD | `ad7dc2e2...` | `AI4Engineering-L/P06-Verifiable-Neural-Symbolic-XFD` | not started | not started | no |
+| P07 operator attention | `20f47bac...` | `AI4Engineering-L/P07-XOAN-Operator-Attention` | not started | not started | no |
+
+## Completed content coverage
+
+### P01
+
+```text
+source blobs: 89
+snapshot exact: 68
+bounded overlay exact: 21
+uncovered: 0
+coverage manifest SHA-256:
+82cf569c2a900a9a5f0931a179cc2a5965ba48cf1f1101f407748e9721614780
+```
+
+### P02
+
+```text
+source blobs: 163
+snapshot exact: 142
+immutable archive exact: 21
+uncovered: 0
+coverage manifest SHA-256:
+05770099dfd98477b1eaca0a5a1f01db18595b763ef1b529f8f289c1ce61f3c0
+```
+
+### P03
+
+```text
+source blobs: 90
+snapshot exact: 81
+immutable archive exact: 9
+uncovered: 0
+coverage manifest SHA-256:
+9c34faa184756cb7a2db5d85ba3bbabac4a7116f21afbd82f3c95230641e3883
+```
+
+The archives and overlays are provenance-only. They do not promote legacy metrics,
+figures, checkpoints, or claims to verified PaperTrace evidence.
+
+## Current blocker
+
+The latest target heads returned `action_required` for their repository workflows, or
+require equivalent target-side human review. Therefore all three completed coverage
+items remain `safe_to_remove: false` and their PHMFactory gitlinks remain frozen.
+
+## Update rule
+
+Changing a paper to `safe_to_remove: true` requires all of:
+
+```text
+coverage_status: complete
+uncovered_count: 0
+target_review_status: target_ci_passed | target_reviewed | target_merged
+valid target repository, PR, head, source hash, and coverage hashes
+```
+
+The actual gitlink deletion must occur in a separate bounded PR that changes only the
+approved gitlink, its `.gitmodules` section, the tracker/allowlist state, and migration
+audit documentation.

--- a/docs/archive/audits/phmfactory-v0.3-paper-submodule-migration-status.yaml
+++ b/docs/archive/audits/phmfactory-v0.3-paper-submodule-migration-status.yaml
@@ -1,0 +1,104 @@
+schema_version: 1
+source_repository: PHMbench/PHM-Vibench
+release_target: v0.3.0
+policy: content_level_destination_evidence_required
+
+papers:
+  - paper_id: foundation-metric
+    source_path: paper/2025-10_foundation_model_0_metric
+    source_commit: 2dd7dabe10c11a18e7a1d865ddcf70ba95f26ac7
+    target_repository: null
+    target_pr: null
+    coverage_status: not_started
+    target_review_status: not_started
+    safe_to_remove: false
+
+  - paper_id: P01
+    source_path: paper/UXFD_paper/1D-2D_fusion_explainable
+    source_repository: liq22/1D-2D_fusion_explainable
+    source_commit: b385b07e82d6323a291d90e55a5ef4aff9336c0b
+    source_blob_count: 89
+    target_repository: AI4Engineering-L/P01-UXFD-Multimodal-Alignment
+    target_branch: migration/verify-phmfactory-gitlink-b385
+    target_head: 9b895a4a3fbf5faaa4152f9fe3096104d583ee87
+    target_pr: 2
+    snapshot_exact_count: 68
+    archive_or_overlay_exact_count: 21
+    uncovered_count: 0
+    coverage_manifest_sha256: 82cf569c2a900a9a5f0931a179cc2a5965ba48cf1f1101f407748e9721614780
+    source_archive_sha256: c498b48144524174e7054efc1451c52c72c51c0bc5603a0c35f0b358f5bfcb51
+    coverage_status: complete
+    target_review_status: workflow_approval_required
+    safe_to_remove: false
+
+  - paper_id: P02
+    source_path: paper/UXFD_paper/Explainable_FD_Toolkit
+    source_repository: liq22/Explainable_FD_Toolkit
+    source_commit: 379244dc8410eea0580714bc216c71074acba3a9
+    source_blob_count: 163
+    target_repository: AI4Engineering-L/P02-XFD-Benchmark-Toolkit
+    target_branch: migration/verify-phmfactory-gitlink-379244
+    target_head: 47d256ff923685d2f84b1f07004b459f86a79b63
+    target_pr: 2
+    snapshot_exact_count: 142
+    archive_or_overlay_exact_count: 21
+    uncovered_count: 0
+    coverage_manifest_sha256: 05770099dfd98477b1eaca0a5a1f01db18595b763ef1b529f8f289c1ce61f3c0
+    source_archive_sha256: f6adc63df49697b1f50f6e5f99325c968c97acc8ded60efb3c4fbbb183a1a633
+    coverage_status: complete
+    target_review_status: workflow_approval_required
+    safe_to_remove: false
+
+  - paper_id: P03
+    source_path: paper/UXFD_paper/LLM_Explainable_FD_Toolkit
+    source_repository: liq22/LLM_Explainable_FD_Toolkit
+    source_commit: 08eb944dd9acdbbd6c69cf39f050854a936e9b78
+    source_blob_count: 90
+    target_repository: AI4Engineering-L/P03-Evidence-Grounded-LLM-XFD
+    target_branch: migration/verify-phmfactory-gitlink-08eb94
+    target_head: 31e0f9f1c66839648af9315895f67a35cce98bff
+    target_pr: 2
+    snapshot_exact_count: 81
+    archive_or_overlay_exact_count: 9
+    uncovered_count: 0
+    coverage_manifest_sha256: 9c34faa184756cb7a2db5d85ba3bbabac4a7116f21afbd82f3c95230641e3883
+    source_archive_sha256: 6db015b3505435cef73632f9e6e15cbf3fdf4c67d9fb47c38cc0d7ebdb6e366c
+    coverage_status: complete
+    target_review_status: workflow_approval_required
+    safe_to_remove: false
+
+  - paper_id: P04
+    source_path: paper/UXFD_paper/MOE_explainable
+    source_commit: 0da06ae366eeb66d852c144013af6925446615cb
+    target_repository: AI4Engineering-L/P04-Physics-Informed-MoE-XFD
+    target_pr: null
+    coverage_status: not_started
+    target_review_status: not_started
+    safe_to_remove: false
+
+  - paper_id: P05
+    source_path: paper/UXFD_paper/Paper_fuzzy_XFD
+    source_commit: 1bedd533bd52e7ac2592d3a6f7aeffaf25a1014f
+    target_repository: AI4Engineering-L/P05-Neuro-Fuzzy-Safe-XFD
+    target_pr: null
+    coverage_status: not_started
+    target_review_status: not_started
+    safe_to_remove: false
+
+  - paper_id: P06
+    source_path: paper/UXFD_paper/Neuralsymbolic_theory
+    source_commit: ad7dc2e2851f59d941e402e68fa3d3409b39c583
+    target_repository: AI4Engineering-L/P06-Verifiable-Neural-Symbolic-XFD
+    target_pr: null
+    coverage_status: not_started
+    target_review_status: not_started
+    safe_to_remove: false
+
+  - paper_id: P07
+    source_path: paper/UXFD_paper/TII_operator_attention
+    source_commit: 20f47bac5c02763e1f6b856c90ce32861025c003
+    target_repository: AI4Engineering-L/P07-XOAN-Operator-Attention
+    target_pr: null
+    coverage_status: not_started
+    target_review_status: not_started
+    safe_to_remove: false

--- a/tools/repo/check_paper_migration_status.py
+++ b/tools/repo/check_paper_migration_status.py
@@ -1,0 +1,166 @@
+#!/usr/bin/env python3
+"""Validate content-level migration status for PHMFactory paper gitlinks."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+
+ROOT = Path(__file__).resolve().parents[2]
+TRACKER = ROOT / "docs/archive/audits/phmfactory-v0.3-paper-submodule-migration-status.yaml"
+ALLOWLIST = ROOT / ".github/phmfactory-v0.3-submodules.allowlist.yml"
+SHA40 = re.compile(r"[0-9a-f]{40}")
+SHA64 = re.compile(r"[0-9a-f]{64}")
+REVIEWED_STATUSES = {"target_ci_passed", "target_reviewed", "target_merged"}
+
+
+@dataclass(frozen=True)
+class Finding:
+    code: str
+    detail: str
+    release_only: bool = False
+
+
+def _load(path: Path) -> dict[str, Any]:
+    payload = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+    if not isinstance(payload, dict):
+        raise ValueError(f"{path} must contain a YAML mapping")
+    return payload
+
+
+def collect_findings() -> tuple[Finding, ...]:
+    tracker = _load(TRACKER)
+    allowlist = _load(ALLOWLIST)
+    findings: list[Finding] = []
+
+    papers = tracker.get("papers") or []
+    if not isinstance(papers, list) or len(papers) != 8:
+        findings.append(Finding("PAPER_COUNT_INVALID", "tracker must contain exactly 8 papers"))
+        papers = papers if isinstance(papers, list) else []
+
+    tracked: dict[str, dict[str, Any]] = {}
+    for item in papers:
+        if not isinstance(item, dict):
+            findings.append(Finding("PAPER_ENTRY_INVALID", repr(item)))
+            continue
+        path = str(item.get("source_path") or "")
+        if not path:
+            findings.append(Finding("PAPER_SOURCE_PATH_MISSING", repr(item)))
+            continue
+        if path in tracked:
+            findings.append(Finding("PAPER_SOURCE_PATH_DUPLICATE", path))
+        tracked[path] = item
+
+    legacy_items = allowlist.get("legacy_entries") or []
+    expected = {
+        str(item.get("path")): str(item.get("gitlink_commit"))
+        for item in legacy_items
+        if isinstance(item, dict)
+        and item.get("path")
+        and item.get("action") == "migrate_then_remove"
+    }
+    if set(tracked) != set(expected):
+        missing = sorted(set(expected) - set(tracked))
+        extra = sorted(set(tracked) - set(expected))
+        findings.append(
+            Finding(
+                "PAPER_TRACKER_PATH_DRIFT",
+                f"missing={missing}, extra={extra}",
+            )
+        )
+
+    for path, item in sorted(tracked.items()):
+        source_commit = str(item.get("source_commit") or "")
+        if source_commit != expected.get(path):
+            findings.append(
+                Finding(
+                    "PAPER_SOURCE_COMMIT_MISMATCH",
+                    f"{path}: {source_commit!r} != {expected.get(path)!r}",
+                )
+            )
+        elif not SHA40.fullmatch(source_commit):
+            findings.append(Finding("PAPER_SOURCE_COMMIT_INVALID", path))
+
+        coverage = str(item.get("coverage_status") or "")
+        review = str(item.get("target_review_status") or "")
+        safe = item.get("safe_to_remove") is True
+
+        if coverage == "complete":
+            source_count = item.get("source_blob_count")
+            snapshot_count = item.get("snapshot_exact_count")
+            archive_count = item.get("archive_or_overlay_exact_count")
+            uncovered = item.get("uncovered_count")
+            if not all(
+                isinstance(value, int)
+                for value in (source_count, snapshot_count, archive_count, uncovered)
+            ):
+                findings.append(Finding("PAPER_COVERAGE_COUNTS_INVALID", path))
+            elif snapshot_count + archive_count + uncovered != source_count:
+                findings.append(Finding("PAPER_COVERAGE_SUM_INVALID", path))
+            if uncovered != 0:
+                findings.append(Finding("PAPER_COVERAGE_INCOMPLETE", path))
+            for key in ("coverage_manifest_sha256", "source_archive_sha256"):
+                if not SHA64.fullmatch(str(item.get(key) or "")):
+                    findings.append(Finding("PAPER_COVERAGE_HASH_INVALID", f"{path}: {key}"))
+            if not item.get("target_repository") or not item.get("target_pr"):
+                findings.append(Finding("PAPER_TARGET_EVIDENCE_MISSING", path))
+            if not SHA40.fullmatch(str(item.get("target_head") or "")):
+                findings.append(Finding("PAPER_TARGET_HEAD_INVALID", path))
+        elif coverage not in {"not_started", "in_progress"}:
+            findings.append(Finding("PAPER_COVERAGE_STATUS_INVALID", f"{path}: {coverage!r}"))
+
+        removable = coverage == "complete" and review in REVIEWED_STATUSES
+        if safe and not removable:
+            findings.append(
+                Finding("PAPER_PREMATURE_SAFE_TO_REMOVE", f"{path}: review={review!r}")
+            )
+        if safe and item.get("uncovered_count") != 0:
+            findings.append(Finding("PAPER_SAFE_WITH_UNCOVERED_BLOBS", path))
+        if not safe:
+            findings.append(
+                Finding(
+                    "PAPER_MIGRATION_PENDING",
+                    f"{path}: coverage={coverage}, review={review}",
+                    release_only=True,
+                )
+            )
+
+    return tuple(sorted(findings, key=lambda item: (item.release_only, item.code, item.detail)))
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--mode", choices=("policy", "release"), default="policy")
+    args = parser.parse_args()
+
+    try:
+        findings = collect_findings()
+    except (OSError, ValueError, yaml.YAMLError) as exc:
+        print(f"Paper migration tracker ERROR: {exc}", file=sys.stderr)
+        return 1
+
+    for finding in findings:
+        kind = "release-blocker" if finding.release_only else "policy-error"
+        print(f"- {kind} {finding.code}: {finding.detail}")
+
+    active = findings if args.mode == "release" else tuple(
+        finding for finding in findings if not finding.release_only
+    )
+    if active:
+        print(f"Paper migration tracker FAIL: {len(active)} active finding(s)", file=sys.stderr)
+        return 1
+
+    pending = sum(finding.release_only for finding in findings)
+    print(f"Paper migration tracker PASS: structural contract valid, {pending} pending paper(s)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## What changed

This PR adds a machine-readable and human-readable migration tracker for all eight remaining paper/research gitlinks.

```text
docs/archive/audits/phmfactory-v0.3-paper-submodule-migration-status.yaml
docs/archive/audits/phmfactory-v0.3-paper-submodule-migration-status.md
tools/repo/check_paper_migration_status.py
.github/workflows/paper-migration-status.yml
```

## Removal rule

A paper gitlink is not removable merely because a similarly named destination repository exists. The tracker requires:

```text
exact source gitlink commit
complete source blob count
zero uncovered blobs
destination repository and PR
target head
coverage/archive hashes
target CI/review/merge status
safe_to_remove: true
```

## Current evidence

Completed content coverage:

| Paper | Coverage | Target PR | Current blocker |
| --- | ---: | --- | --- |
| P01 | 89/89 | `AI4Engineering-L/P01-UXFD-Multimodal-Alignment#2` | workflow approval / target review |
| P02 | 163/163 | `AI4Engineering-L/P02-XFD-Benchmark-Toolkit#2` | workflow approval / target review |
| P03 | 90/90 | `AI4Engineering-L/P03-Evidence-Grounded-LLM-XFD#2` | workflow approval / target review |

P04-P07 and the foundation-model metric gitlink remain `not_started`.

All eight entries remain:

```text
safe_to_remove: false
```

No public gitlink is deleted in this PR.

## Validation behavior

```bash
python tools/repo/check_paper_migration_status.py --mode policy
```

must pass the structural/evidence contract.

```bash
python tools/repo/check_paper_migration_status.py --mode release
```

must remain blocked with exactly eight `PAPER_MIGRATION_PENDING` findings on this branch.

## Protected boundary

No change to `.gitmodules`, gitlinks, reader, Data Factory, model, task, trainer, Pipeline, config, CWRU, requirements, Streamlit, package version, repository name, or external paper content.

## Base

```text
base: agent/v030-phm-data-backend-governance-pr12d
base SHA: bc43654b32c4b939ca5a9f4037c3b03a30edcf69
head: agent/v030-paper-migration-tracker-pr12e
```

## Rollback

A normal revert removes only the tracker, checker, workflow, and summary. It does not alter any source or destination repository.