### PR TITLE
ci: enforce auditable main/dev PR bases

### DIFF
--- a/.github/workflows/pr-base-policy.yml
+++ b/.github/workflows/pr-base-policy.yml
@@ -1,0 +1,34 @@
+name: Pull request base policy
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened, edited, labeled, unlabeled]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  policy:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Check out trusted base branch policy
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+          persist-credentials: false
+
+      - name: Evaluate auditable main/dev topology
+        env:
+          BASE_BRANCH: ${{ github.event.pull_request.base.ref }}
+          HEAD_BRANCH: ${{ github.event.pull_request.head.ref }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          LABELS_JSON: ${{ toJSON(github.event.pull_request.labels.*.name) }}
+        run: |
+          python tools/repo/check_pr_base_policy.py \
+            --base "$BASE_BRANCH" \
+            --head "$HEAD_BRANCH" \
+            --number "$PR_NUMBER" \
+            --labels-json "$LABELS_JSON"

--- a/.github/workflows/pr-base-policy.yml
+++ b/.github/workflows/pr-base-policy.yml
@@ -24,11 +24,15 @@ jobs:
         env:
           BASE_BRANCH: ${{ github.event.pull_request.base.ref }}
           HEAD_BRANCH: ${{ github.event.pull_request.head.ref }}
+          BASE_REPOSITORY: ${{ github.event.pull_request.base.repo.full_name }}
+          HEAD_REPOSITORY: ${{ github.event.pull_request.head.repo.full_name }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           LABELS_JSON: ${{ toJSON(github.event.pull_request.labels.*.name) }}
         run: |
           python tools/repo/check_pr_base_policy.py \
             --base "$BASE_BRANCH" \
             --head "$HEAD_BRANCH" \
+            --base-repo "$BASE_REPOSITORY" \
+            --head-repo "$HEAD_REPOSITORY" \
             --number "$PR_NUMBER" \
             --labels-json "$LABELS_JSON"

--- a/test/test_pr_base_policy.py
+++ b/test/test_pr_base_policy.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+import pytest
+
+from tools.repo.check_pr_base_policy import (
+    HOTFIX_LABEL,
+    MAIN_SYNC_LABEL,
+    RELEASE_LABEL,
+    evaluate_pr_base,
+)
+
+
+@pytest.mark.parametrize(
+    "head",
+    (
+        "feat/new-capability",
+        "fix/one-defect",
+        "docs/one-authority",
+        "test/one-contract",
+        "ci/one-gate",
+        "cleanup/one-ledger",
+        "migration/one-source-sha",
+        "research/one-protocol",
+    ),
+)
+def test_routine_topics_target_dev(head: str) -> None:
+    decision = evaluate_pr_base(base="dev", head=head, number=200)
+    assert decision.allowed is True
+    assert decision.code == "routine-dev-pr"
+
+
+def test_routine_topic_cannot_target_main() -> None:
+    decision = evaluate_pr_base(base="main", head="feat/new-capability", number=200)
+    assert decision.allowed is False
+    assert decision.code == "routine-pr-targets-main"
+
+
+def test_release_promotion_requires_maintainer_label() -> None:
+    denied = evaluate_pr_base(base="main", head="dev", number=201)
+    assert denied.allowed is False
+
+    allowed = evaluate_pr_base(
+        base="main",
+        head="dev",
+        number=201,
+        labels=[RELEASE_LABEL],
+    )
+    assert allowed.allowed is True
+    assert allowed.code == "release-promotion"
+
+
+def test_hotfix_requires_authorization_label() -> None:
+    denied = evaluate_pr_base(base="main", head="hotfix/cve", number=202)
+    assert denied.allowed is False
+
+    allowed = evaluate_pr_base(
+        base="main",
+        head="hotfix/cve",
+        number=202,
+        labels=[HOTFIX_LABEL],
+    )
+    assert allowed.allowed is True
+    assert allowed.code == "emergency-hotfix"
+
+
+def test_transition_pr_127_is_narrowly_scoped() -> None:
+    allowed = evaluate_pr_base(
+        base="main",
+        head="agent/v030-canonical-integration-r2",
+        number=127,
+    )
+    assert allowed.allowed is True
+    assert allowed.code == "transition-pr-127"
+
+    wrong_number = evaluate_pr_base(
+        base="main",
+        head="agent/v030-canonical-integration-r2",
+        number=128,
+    )
+    assert wrong_number.allowed is False
+
+    wrong_head = evaluate_pr_base(base="main", head="other", number=127)
+    assert wrong_head.allowed is False
+
+
+def test_main_to_dev_sync_requires_label() -> None:
+    denied = evaluate_pr_base(base="dev", head="main", number=203)
+    assert denied.allowed is False
+
+    allowed = evaluate_pr_base(
+        base="dev",
+        head="main",
+        number=203,
+        labels=[MAIN_SYNC_LABEL],
+    )
+    assert allowed.allowed is True
+    assert allowed.code == "main-to-dev-sync"

--- a/test/test_pr_base_policy.py
+++ b/test/test_pr_base_policy.py
@@ -3,11 +3,33 @@ from __future__ import annotations
 import pytest
 
 from tools.repo.check_pr_base_policy import (
+    CANONICAL_REPOSITORY,
     HOTFIX_LABEL,
     MAIN_SYNC_LABEL,
     RELEASE_LABEL,
     evaluate_pr_base,
 )
+
+FORK_REPOSITORY = "attacker/PHM-Vibench"
+
+
+def decide(
+    *,
+    base: str,
+    head: str,
+    number: int,
+    labels=(),
+    base_repo: str = CANONICAL_REPOSITORY,
+    head_repo: str = CANONICAL_REPOSITORY,
+):
+    return evaluate_pr_base(
+        base=base,
+        head=head,
+        base_repo=base_repo,
+        head_repo=head_repo,
+        number=number,
+        labels=labels,
+    )
 
 
 @pytest.mark.parametrize(
@@ -24,22 +46,45 @@ from tools.repo.check_pr_base_policy import (
     ),
 )
 def test_routine_topics_target_dev(head: str) -> None:
-    decision = evaluate_pr_base(base="dev", head=head, number=200)
+    decision = decide(base="dev", head=head, number=200)
     assert decision.allowed is True
     assert decision.code == "routine-dev-pr"
 
 
+def test_ordinary_fork_topic_can_target_dev() -> None:
+    decision = decide(
+        base="dev",
+        head="fix/external-contribution",
+        head_repo=FORK_REPOSITORY,
+        number=200,
+    )
+    assert decision.allowed is True
+    assert decision.code == "routine-dev-pr"
+
+
+def test_managed_base_must_belong_to_canonical_repository() -> None:
+    decision = decide(
+        base="dev",
+        head="fix/external-contribution",
+        base_repo=FORK_REPOSITORY,
+        head_repo=FORK_REPOSITORY,
+        number=200,
+    )
+    assert decision.allowed is False
+    assert decision.code == "unexpected-base-repository"
+
+
 def test_routine_topic_cannot_target_main() -> None:
-    decision = evaluate_pr_base(base="main", head="feat/new-capability", number=200)
+    decision = decide(base="main", head="feat/new-capability", number=200)
     assert decision.allowed is False
     assert decision.code == "routine-pr-targets-main"
 
 
-def test_release_promotion_requires_maintainer_label() -> None:
-    denied = evaluate_pr_base(base="main", head="dev", number=201)
+def test_release_promotion_requires_maintainer_label_and_same_repo() -> None:
+    denied = decide(base="main", head="dev", number=201)
     assert denied.allowed is False
 
-    allowed = evaluate_pr_base(
+    allowed = decide(
         base="main",
         head="dev",
         number=201,
@@ -48,12 +93,34 @@ def test_release_promotion_requires_maintainer_label() -> None:
     assert allowed.allowed is True
     assert allowed.code == "release-promotion"
 
+    fork = decide(
+        base="main",
+        head="dev",
+        head_repo=FORK_REPOSITORY,
+        number=201,
+        labels=[RELEASE_LABEL],
+    )
+    assert fork.allowed is False
 
-def test_hotfix_requires_authorization_label() -> None:
-    denied = evaluate_pr_base(base="main", head="hotfix/cve", number=202)
+
+@pytest.mark.parametrize("head", ("dev", "release/v0.3.0"))
+def test_fork_cannot_impersonate_release_source(head: str) -> None:
+    decision = decide(
+        base="main",
+        head=head,
+        head_repo=FORK_REPOSITORY,
+        number=204,
+        labels=[RELEASE_LABEL],
+    )
+    assert decision.allowed is False
+    assert decision.code == "routine-pr-targets-main"
+
+
+def test_hotfix_requires_authorization_label_and_same_repo() -> None:
+    denied = decide(base="main", head="hotfix/cve", number=202)
     assert denied.allowed is False
 
-    allowed = evaluate_pr_base(
+    allowed = decide(
         base="main",
         head="hotfix/cve",
         number=202,
@@ -62,9 +129,18 @@ def test_hotfix_requires_authorization_label() -> None:
     assert allowed.allowed is True
     assert allowed.code == "emergency-hotfix"
 
+    fork = decide(
+        base="main",
+        head="hotfix/cve",
+        head_repo=FORK_REPOSITORY,
+        number=202,
+        labels=[HOTFIX_LABEL],
+    )
+    assert fork.allowed is False
 
-def test_transition_pr_127_is_narrowly_scoped() -> None:
-    allowed = evaluate_pr_base(
+
+def test_transition_pr_127_is_narrowly_scoped_to_same_repo() -> None:
+    allowed = decide(
         base="main",
         head="agent/v030-canonical-integration-r2",
         number=127,
@@ -72,22 +148,30 @@ def test_transition_pr_127_is_narrowly_scoped() -> None:
     assert allowed.allowed is True
     assert allowed.code == "transition-pr-127"
 
-    wrong_number = evaluate_pr_base(
+    wrong_number = decide(
         base="main",
         head="agent/v030-canonical-integration-r2",
         number=128,
     )
     assert wrong_number.allowed is False
 
-    wrong_head = evaluate_pr_base(base="main", head="other", number=127)
+    wrong_head = decide(base="main", head="other", number=127)
     assert wrong_head.allowed is False
 
+    fork = decide(
+        base="main",
+        head="agent/v030-canonical-integration-r2",
+        head_repo=FORK_REPOSITORY,
+        number=127,
+    )
+    assert fork.allowed is False
 
-def test_main_to_dev_sync_requires_label() -> None:
-    denied = evaluate_pr_base(base="dev", head="main", number=203)
+
+def test_main_to_dev_sync_requires_label_and_same_repo() -> None:
+    denied = decide(base="dev", head="main", number=203)
     assert denied.allowed is False
 
-    allowed = evaluate_pr_base(
+    allowed = decide(
         base="dev",
         head="main",
         number=203,
@@ -95,3 +179,13 @@ def test_main_to_dev_sync_requires_label() -> None:
     )
     assert allowed.allowed is True
     assert allowed.code == "main-to-dev-sync"
+
+    fork = decide(
+        base="dev",
+        head="main",
+        head_repo=FORK_REPOSITORY,
+        number=203,
+        labels=[MAIN_SYNC_LABEL],
+    )
+    assert fork.allowed is False
+    assert fork.code == "unsupported-dev-source"

--- a/tools/repo/check_pr_base_policy.py
+++ b/tools/repo/check_pr_base_policy.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+"""Enforce the documented main/dev pull-request topology.
+
+The policy is deliberately independent of GitHub branch-name inference for
+privileged main-branch operations: release promotions and emergency hotfixes
+also require maintainer-controlled labels.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from dataclasses import dataclass
+from typing import Iterable, Sequence
+
+RELEASE_LABEL = "release-promotion-approved"
+HOTFIX_LABEL = "emergency-hotfix-approved"
+MAIN_SYNC_LABEL = "main-sync-approved"
+TRANSITION_PR = 127
+DEV_PREFIXES = (
+    "feat/",
+    "fix/",
+    "docs/",
+    "test/",
+    "ci/",
+    "cleanup/",
+    "migration/",
+    "research/",
+    "release/",
+)
+
+
+@dataclass(frozen=True)
+class PolicyDecision:
+    allowed: bool
+    code: str
+    message: str
+
+
+def _normalise_labels(labels: Iterable[str]) -> frozenset[str]:
+    return frozenset(str(label).strip() for label in labels if str(label).strip())
+
+
+def evaluate_pr_base(
+    *,
+    base: str,
+    head: str,
+    number: int,
+    labels: Iterable[str] = (),
+) -> PolicyDecision:
+    """Return one deterministic decision for the supplied PR topology."""
+
+    base = str(base).strip()
+    head = str(head).strip()
+    label_set = _normalise_labels(labels)
+
+    if base == "main":
+        if number == TRANSITION_PR and head == "agent/v030-canonical-integration-r2":
+            return PolicyDecision(
+                True,
+                "transition-pr-127",
+                "Canonical v0.3 PR #127 is the sole documented transition exception.",
+            )
+        if (head == "dev" or head.startswith("release/")) and RELEASE_LABEL in label_set:
+            return PolicyDecision(
+                True,
+                "release-promotion",
+                "Authorized release promotion into main.",
+            )
+        if head.startswith("hotfix/") and HOTFIX_LABEL in label_set:
+            return PolicyDecision(
+                True,
+                "emergency-hotfix",
+                "Authorized emergency hotfix; a back-sync PR to dev is required.",
+            )
+        return PolicyDecision(
+            False,
+            "routine-pr-targets-main",
+            "Routine work must target dev. Main accepts only labelled release promotions, "
+            "labelled emergency hotfixes, and transition PR #127.",
+        )
+
+    if base == "dev":
+        if head == "main" and MAIN_SYNC_LABEL in label_set:
+            return PolicyDecision(
+                True,
+                "main-to-dev-sync",
+                "Authorized synchronization of the post-release main ancestry into dev.",
+            )
+        if any(head.startswith(prefix) for prefix in DEV_PREFIXES):
+            return PolicyDecision(True, "routine-dev-pr", "Routine topic PR correctly targets dev.")
+        return PolicyDecision(
+            False,
+            "unsupported-dev-source",
+            "Dev accepts focused topic branches or a labelled main-to-dev synchronization PR.",
+        )
+
+    return PolicyDecision(
+        True,
+        "unmanaged-base",
+        f"Base branch {base!r} is outside the main/dev governance workflow.",
+    )
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--base", required=True)
+    parser.add_argument("--head", required=True)
+    parser.add_argument("--number", required=True, type=int)
+    parser.add_argument(
+        "--labels-json",
+        default="[]",
+        help="JSON array containing pull-request label names.",
+    )
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = build_parser().parse_args(list(argv) if argv is not None else None)
+    try:
+        labels = json.loads(args.labels_json)
+    except json.JSONDecodeError as exc:
+        raise SystemExit(f"labels-json must be valid JSON: {exc}") from exc
+    if not isinstance(labels, list) or not all(isinstance(label, str) for label in labels):
+        raise SystemExit("labels-json must be a JSON array of strings")
+
+    decision = evaluate_pr_base(
+        base=args.base,
+        head=args.head,
+        number=args.number,
+        labels=labels,
+    )
+    status = "ALLOW" if decision.allowed else "DENY"
+    print(f"{status} [{decision.code}] {decision.message}")
+    return 0 if decision.allowed else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/repo/check_pr_base_policy.py
+++ b/tools/repo/check_pr_base_policy.py
@@ -1,9 +1,10 @@
 #!/usr/bin/env python3
 """Enforce the documented main/dev pull-request topology.
 
-The policy is deliberately independent of GitHub branch-name inference for
-privileged main-branch operations: release promotions and emergency hotfixes
-also require maintainer-controlled labels.
+Privileged operations require both an auditable maintainer-controlled label and
+canonical repository identity. A fork may contribute an ordinary topic branch to
+``dev``, but it cannot impersonate this repository's long-lived branches merely by
+using the same branch name.
 """
 
 from __future__ import annotations
@@ -13,6 +14,7 @@ import json
 from dataclasses import dataclass
 from typing import Iterable, Sequence
 
+CANONICAL_REPOSITORY = "PHMbench/PHM-Vibench"
 RELEASE_LABEL = "release-promotion-approved"
 HOTFIX_LABEL = "emergency-hotfix-approved"
 MAIN_SYNC_LABEL = "main-sync-approved"
@@ -45,6 +47,8 @@ def evaluate_pr_base(
     *,
     base: str,
     head: str,
+    base_repo: str,
+    head_repo: str,
     number: int,
     labels: Iterable[str] = (),
 ) -> PolicyDecision:
@@ -52,47 +56,79 @@ def evaluate_pr_base(
 
     base = str(base).strip()
     head = str(head).strip()
+    base_repo = str(base_repo).strip()
+    head_repo = str(head_repo).strip()
     label_set = _normalise_labels(labels)
+    base_is_canonical = base_repo == CANONICAL_REPOSITORY
+    same_canonical_repository = base_is_canonical and head_repo == CANONICAL_REPOSITORY
+
+    if base in {"main", "dev"} and not base_is_canonical:
+        return PolicyDecision(
+            False,
+            "unexpected-base-repository",
+            f"Managed base {base!r} must belong to {CANONICAL_REPOSITORY}.",
+        )
 
     if base == "main":
-        if number == TRANSITION_PR and head == "agent/v030-canonical-integration-r2":
+        if (
+            number == TRANSITION_PR
+            and head == "agent/v030-canonical-integration-r2"
+            and same_canonical_repository
+        ):
             return PolicyDecision(
                 True,
                 "transition-pr-127",
                 "Canonical v0.3 PR #127 is the sole documented transition exception.",
             )
-        if (head == "dev" or head.startswith("release/")) and RELEASE_LABEL in label_set:
+        if (
+            (head == "dev" or head.startswith("release/"))
+            and RELEASE_LABEL in label_set
+            and same_canonical_repository
+        ):
             return PolicyDecision(
                 True,
                 "release-promotion",
-                "Authorized release promotion into main.",
+                "Authorized same-repository release promotion into main.",
             )
-        if head.startswith("hotfix/") and HOTFIX_LABEL in label_set:
+        if (
+            head.startswith("hotfix/")
+            and HOTFIX_LABEL in label_set
+            and same_canonical_repository
+        ):
             return PolicyDecision(
                 True,
                 "emergency-hotfix",
-                "Authorized emergency hotfix; a back-sync PR to dev is required.",
+                "Authorized same-repository emergency hotfix; a back-sync PR to dev is required.",
             )
         return PolicyDecision(
             False,
             "routine-pr-targets-main",
-            "Routine work must target dev. Main accepts only labelled release promotions, "
-            "labelled emergency hotfixes, and transition PR #127.",
+            "Routine work must target dev. Main accepts only labelled same-repository "
+            "release promotions, labelled same-repository emergency hotfixes, and the "
+            "exact transition PR #127.",
         )
 
     if base == "dev":
-        if head == "main" and MAIN_SYNC_LABEL in label_set:
+        if (
+            head == "main"
+            and MAIN_SYNC_LABEL in label_set
+            and same_canonical_repository
+        ):
             return PolicyDecision(
                 True,
                 "main-to-dev-sync",
-                "Authorized synchronization of the post-release main ancestry into dev.",
+                "Authorized same-repository synchronization of main ancestry into dev.",
             )
         if any(head.startswith(prefix) for prefix in DEV_PREFIXES):
-            return PolicyDecision(True, "routine-dev-pr", "Routine topic PR correctly targets dev.")
+            return PolicyDecision(
+                True,
+                "routine-dev-pr",
+                "Routine topic PR correctly targets dev; fork topic branches are permitted.",
+            )
         return PolicyDecision(
             False,
             "unsupported-dev-source",
-            "Dev accepts focused topic branches or a labelled main-to-dev synchronization PR.",
+            "Dev accepts focused topic branches or a labelled same-repository main-to-dev sync.",
         )
 
     return PolicyDecision(
@@ -106,6 +142,8 @@ def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--base", required=True)
     parser.add_argument("--head", required=True)
+    parser.add_argument("--base-repo", required=True)
+    parser.add_argument("--head-repo", required=True)
     parser.add_argument("--number", required=True, type=int)
     parser.add_argument(
         "--labels-json",
@@ -127,6 +165,8 @@ def main(argv: Sequence[str] | None = None) -> int:
     decision = evaluate_pr_base(
         base=args.base,
         head=args.head,
+        base_repo=args.base_repo,
+        head_repo=args.head_repo,
         number=args.number,
         labels=labels,
     )


### PR DESCRIPTION
## Objective

Implement the automatable portion of Issue #129 without changing repository settings:

```text
main = user-facing stable/release branch
dev  = routine integration/development branch
```

## Policy

- routine `feat/fix/docs/test/ci/cleanup/migration/research/*` PRs target `dev`;
- `dev` or `release/*` may target `main` only with `release-promotion-approved`;
- `hotfix/*` may target `main` only with `emergency-hotfix-approved`;
- `main -> dev` synchronization requires `main-sync-approved`;
- canonical PR #127 is the only unlabelled transition exception, and only from its exact head branch.

Branch name alone does not authorize a privileged operation.

## Implementation

```text
.github/workflows/pr-base-policy.yml
tools/repo/check_pr_base_policy.py
test/test_pr_base_policy.py
```

`pull_request_target` checks out the trusted base SHA and never executes code from an untrusted PR head. Permissions are read-only.

## Validation

The pure decision function covers routine dev PRs, rejected routine main PRs, labelled release promotion, labelled hotfix, labelled main-to-dev sync, and the narrowly scoped #127 exception.

## Remaining administrator gate

This PR cannot configure GitHub branch protection/rulesets through the available connector. Issue #129 remains open for:

- required PRs and maintainer review on `main` and `dev`;
- required status checks;
- disabled force pushes and deletion.

## Non-goals

```text
no runtime or submodule change
no direct branch settings mutation
no merge of #127
no version, rename, tag, or release
```
