### PR TITLE
[Superseded] docs(release): defer optional backend to v0.3.1

### DIFF
--- a/docs/releases/v0.3.0-backend-deferral.yaml
+++ b/docs/releases/v0.3.0-backend-deferral.yaml
@@ -1,0 +1,45 @@
+schema_version: 1
+release: 0.3.0
+component: phm-data-factory
+
+decision:
+  status: deferred_to_v0.3.1
+  included_in_v0.3.0: false
+  required_for_core: false
+  release_blocking_for_v0.3.0: false
+  target_release: 0.3.1
+
+ownership:
+  target_repository: PHMbench/phm-data-factory
+  organization_owned_required: true
+  immutable_pin_required: true
+  personal_repository_url_forbidden: true
+
+v0.3.0_repository_state:
+  gitlink_required: false
+  gitlink_present_allowed: false
+  placeholder_gitlink_allowed: false
+  branch_tracking_allowed: false
+  runtime_import_allowed: false
+
+behavior_without_backend:
+  public_cli_works: true
+  dummy_smoke_works: true
+  cwru_bundle_interface_works: true
+  silent_fallback_allowed: false
+  explicit_selection_error_required: true
+
+v0.3.1_entry_gate:
+  - organization_owned_public_https_repository
+  - compatible_explicit_license
+  - immutable_reviewed_commit
+  - bounded_adapter_pr
+  - no_protected_runtime_rewrite
+  - explicit_missing_backend_error
+  - core_paths_pass_without_backend
+
+claim_boundary:
+  backend_integrated: false
+  backend_supported: false
+  live_iotdb_supported: false
+  performance_claim_authorized: false


### PR DESCRIPTION
## Objective

Make the existing architectural decision machine-verifiable:

```text
phm-data-factory is not included in PHMFactory v0.3.0
phm-data-factory is not required by the core runtime
integration is deferred to v0.3.1
```

## New authority

```text
docs/releases/v0.3.0-backend-deferral.yaml
```

The contract forbids a personal URL, placeholder gitlink, branch tracking, runtime import and silent fallback in v0.3.0. A future v0.3.1 integration still requires an organization-owned repository, immutable pin and bounded adapter PR.

## Required follow-up in this PR

Synchronize the submodule allowlist, submodule policy checker, release-readiness checker, workflows/tests and `docs/PHM_DATA_FACTORY_BACKEND_V0_3.md` so a valid deferral is non-blocking for v0.3.0 while an invalid or missing deferral contract fails explicitly.

## Non-goals

```text
no backend gitlink
no adapter implementation
no protected runtime change
no personal repository reference
no claim that the backend is integrated or supported
no CWRU hash/revision, rename, version, tag or release action
```
