### PR TITLE
docs(branches): publish main/dev branch policy after canonical merge

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,19 @@ protected internal engine. The project remains in alpha; release support is limi
 the maintained configurations documented in
 [SUPPORTED_COMBINATIONS.md](SUPPORTED_COMBINATIONS.md).
 
+## Branch policy
+
+`main` is the user-facing stable branch and remains the default branch for cloning,
+documentation, and releases. `dev` is the integration and development branch. All
+routine feature, fix, documentation, test, CI, cleanup, and migration pull requests
+must target `dev`, and topic branches must start from the latest `dev`.
+
+Only an explicitly authorized release-promotion pull request (`dev` or
+`release/<version>` to `main`) or an emergency hotfix may target `main`. A hotfix
+must be synchronized back to `dev`. Both long-lived branches are pull-request-only;
+direct pushes are outside the maintained workflow. See
+[CONTRIBUTING.md](CONTRIBUTING.md) for the full contract.
+
 ## Run the offline example
 
 Install the core environment, then execute the repository-shipped Dummy configuration:

--- a/README_CN.md
+++ b/README_CN.md
@@ -32,6 +32,17 @@ PHMFactory 是 PHM-Vibench 的 v0.3 后继项目。v0.3 兼容性版本增加公
 项目仍处于 alpha 阶段；发布支持范围仅限
 [SUPPORTED_COMBINATIONS.md](SUPPORTED_COMBINATIONS.md) 中记录的维护配置。
 
+## 分支策略
+
+`main` 是面向用户的稳定分支，并继续作为 clone、用户文档和发布的默认分支；
+`dev` 是集成与开发分支。常规功能、修复、文档、测试、CI、清理和迁移 PR
+必须以 `dev` 为目标分支，topic branch 也必须从最新 `dev` 创建。
+
+只有明确授权的发布提升 PR（`dev` 或 `release/<version>` → `main`）或紧急
+hotfix 可以指向 `main`；hotfix 必须同步回 `dev`。两个长期分支都只能通过
+Pull Request 更新，不属于维护流程的直接 push 不应使用。完整规则见
+[CONTRIBUTING_CN.md](CONTRIBUTING_CN.md)。
+
 ## 运行离线示例
 
 安装核心环境后，运行仓库自带的 Dummy 配置：


### PR DESCRIPTION
## Objective

Resolve the only content conflict blocking the post-#127 `main → dev` synchronization by publishing the already-accepted branch-policy sections in the user-facing README files.

## Scope

```text
README.md
README_CN.md
```

Both files are based on current canonical `main`. The inserted branch-policy sections are byte-identical to the corresponding `dev` versions; all other README content remains the canonical #127 content.

## Contract

```text
main = stable/default/release branch
dev = routine integration/development branch
routine PRs target dev
release promotion and authorized hotfixes may target main
hotfixes must be synchronized back to dev
```

This PR does not modify runtime, tests, migration state, gitlinks, version, repository identity, tags, or releases.

## Validation

```text
python -m scripts.validate_docs
README.md content outside Branch policy unchanged
README_CN.md content outside 分支策略 unchanged
```
