### PR TITLE
chore(submodules): remove migrated P04 gitlink

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,6 @@
 [submodule "paper/2025-10_foundation_model_0_metric"]
 	path = paper/2025-10_foundation_model_0_metric
 	url = git@github.com:liq22/PHM-Vibench-Paper-2025-Metric.git
-[submodule "paper/UXFD_paper/MOE_explainable"]
-	path = paper/UXFD_paper/MOE_explainable
-	url = https://github.com/liq22/MOE_explainable.git
 [submodule "paper/UXFD_paper/Paper_fuzzy_XFD"]
 	path = paper/UXFD_paper/Paper_fuzzy_XFD
 	url = https://github.com/liq22/Paper_fuzzy_XFD.git

--- a/docs/archive/audits/phmfactory-v0.3-p04-gitlink-removal.md
+++ b/docs/archive/audits/phmfactory-v0.3-p04-gitlink-removal.md
@@ -1,0 +1,60 @@
+# PHMFactory v0.3 P04 Gitlink Removal
+
+## Scope
+
+This bounded change removes only the migrated P04 parent-side gitlink:
+
+```text
+paper/UXFD_paper/MOE_explainable
+```
+
+It does not modify the accepted P04 destination repository, scientific claims, runtime code, configuration semantics, package version, repository identity, tags, or releases.
+
+## Source authority
+
+```yaml
+parent_repository: PHMbench/PHM-Vibench
+source_path: paper/UXFD_paper/MOE_explainable
+source_gitlink_commit: 0da06ae366eeb66d852c144013af6925446615cb
+```
+
+## Accepted destination evidence
+
+```yaml
+target_repository: AI4Engineering-L/P04-Physics-Informed-MoE-XFD
+target_pr: 2
+target_validated_head: bca10311e4d25145b5a7d18e491c1af639b7eca8
+target_merge_commit: b983481ce02645c1e9044b98ad2528168c07ad28
+source_blob_count: 48
+uncovered_count: 0
+coverage_manifest_sha256: 95cbebba433e8965344cce955b5d28230485a82afbb8cafa8946fb0c8d0e329a
+source_archive_sha256: 8d143549375271a795462c37b0b3b103148315754e97d52683e1506193e10339
+```
+
+The canonical migration tracker records `coverage_status: complete`, `target_review_status: target_merged`, and `safe_to_remove: true` for P04.
+
+## Tree change
+
+```text
+.gitmodules: remove the P04 section
+mode-160000 entry: remove the exact P04 gitlink
+other paper gitlinks: unchanged
+Foundation gitlink: unchanged
+```
+
+## Validation contract
+
+The pull request must prove:
+
+```text
+P04 path is absent from .gitmodules
+P04 mode-160000 entry is absent from the Git tree
+remaining P05-P07 and Foundation gitlinks retain exact commits
+submodule policy passes in policy mode
+release mode remains blocked
+core package and offline smoke remain unchanged
+```
+
+## Rollback
+
+Before merge, reset or delete the topic branch. After merge, revert the bounded removal commit to restore the exact `.gitmodules` section and gitlink commit. The original P04 content remains independently preserved in the accepted destination repository, its provenance archive, and immutable Git history.


### PR DESCRIPTION
## Objective

Remove exactly one legacy parent-side paper gitlink after accepted destination migration evidence:

```text
paper/UXFD_paper/MOE_explainable
```

## Source and destination authority

```yaml
source_gitlink: 0da06ae366eeb66d852c144013af6925446615cb
target_repository: AI4Engineering-L/P04-Physics-Informed-MoE-XFD
target_pr: 2
target_merge_commit: b983481ce02645c1e9044b98ad2528168c07ad28
source_blobs: 48
uncovered: 0
tracker_safe_to_remove: true
```

## Changes

```text
.gitmodules
paper/UXFD_paper/MOE_explainable (mode-160000 removal)
docs/archive/audits/phmfactory-v0.3-p04-gitlink-removal.md
```

No other paper or Foundation gitlink is modified.

## Validation required

- P04 is absent from `.gitmodules` and from the Git tree;
- remaining P05-P07 and Foundation gitlinks retain exact commits;
- Submodule policy, release readiness, repository layout, and Core quality gates pass;
- release mode remains blocked by legitimate remaining blockers.

## Boundaries

```text
no reader/Data Factory/model/task/trainer/Pipeline change
no scientific claim promotion
no Foundation removal
no backend integration
no CWRU pin/hash change
no rename/version/tag/release
```

This PR removes one gitlink only. P05-P07 removals require separate PRs.