### PR TITLE
chore(submodules): remove migrated P05 gitlink

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,6 @@
 [submodule "paper/2025-10_foundation_model_0_metric"]
 	path = paper/2025-10_foundation_model_0_metric
 	url = git@github.com:liq22/PHM-Vibench-Paper-2025-Metric.git
-[submodule "paper/UXFD_paper/Paper_fuzzy_XFD"]
-	path = paper/UXFD_paper/Paper_fuzzy_XFD
-	url = https://github.com/liq22/Paper_fuzzy_XFD.git
 [submodule "paper/UXFD_paper/Neuralsymbolic_theory"]
 	path = paper/UXFD_paper/Neuralsymbolic_theory
 	url = https://github.com/liq22/Neuralsymbolic_theory.git

--- a/docs/archive/audits/phmfactory-v0.3-p05-gitlink-removal.md
+++ b/docs/archive/audits/phmfactory-v0.3-p05-gitlink-removal.md
@@ -1,0 +1,60 @@
+# PHMFactory v0.3 P05 Gitlink Removal
+
+## Scope
+
+This bounded change removes only the migrated P05 parent-side gitlink:
+
+```text
+paper/UXFD_paper/Paper_fuzzy_XFD
+```
+
+It does not modify the accepted P05 destination repository, scientific claims, runtime code, configuration semantics, package version, repository identity, tags, or releases.
+
+## Source authority
+
+```yaml
+parent_repository: PHMbench/PHM-Vibench
+source_path: paper/UXFD_paper/Paper_fuzzy_XFD
+source_gitlink_commit: 1bedd533bd52e7ac2592d3a6f7aeffaf25a1014f
+```
+
+## Accepted destination evidence
+
+```yaml
+target_repository: AI4Engineering-L/P05-Neuro-Fuzzy-Safe-XFD
+target_pr: 2
+target_validated_head: bad91311b343638d3f1a929691899dffc024ace7
+target_merge_commit: c2b6238f422fb2b4d6229146db2c016b2051f69e
+source_blob_count: 53
+uncovered_count: 0
+coverage_manifest_sha256: 5094bff21ad30dd7d5bffa519edf6cbcc3781544199bda5e06e419825ab13337
+source_archive_sha256: be0efbcf96c7cceb00a00283c03db42af6c3495a37c2212737658dfeb1de0e55
+```
+
+The canonical migration tracker records `coverage_status: complete`, `target_review_status: target_merged`, and `safe_to_remove: true` for P05.
+
+## Tree change
+
+```text
+.gitmodules: remove the P05 section
+mode-160000 entry: remove the exact P05 gitlink
+other paper gitlinks: unchanged
+Foundation gitlink: unchanged
+```
+
+## Validation contract
+
+The pull request must prove:
+
+```text
+P05 path is absent from .gitmodules
+P05 mode-160000 entry is absent from the Git tree
+remaining P06-P07 and Foundation gitlinks retain exact commits
+submodule policy passes in policy mode
+release mode remains blocked
+core package and offline smoke remain unchanged
+```
+
+## Rollback
+
+Before merge, reset or delete the topic branch. After merge, revert the bounded removal commit to restore the exact `.gitmodules` section and gitlink commit. The original P05 content remains independently preserved in the accepted destination repository, its provenance archive, and immutable Git history.


### PR DESCRIPTION
## Objective

Remove exactly one legacy parent-side paper gitlink after accepted destination migration evidence:

```text
paper/UXFD_paper/Paper_fuzzy_XFD
```

## Source and destination authority

```yaml
source_gitlink: 1bedd533bd52e7ac2592d3a6f7aeffaf25a1014f
target_repository: AI4Engineering-L/P05-Neuro-Fuzzy-Safe-XFD
target_pr: 2
target_merge_commit: c2b6238f422fb2b4d6229146db2c016b2051f69e
source_blobs: 53
uncovered: 0
tracker_safe_to_remove: true
```

## Changes

```text
.gitmodules
paper/UXFD_paper/Paper_fuzzy_XFD (mode-160000 removal)
docs/archive/audits/phmfactory-v0.3-p05-gitlink-removal.md
```

No other paper or Foundation gitlink is modified.

## Validation required

- P05 is absent from `.gitmodules` and from the Git tree;
- remaining P06-P07 and Foundation gitlinks retain exact commits;
- Submodule policy, release readiness, repository layout, and Core quality gates pass;
- release mode remains blocked by legitimate remaining blockers.

## Boundaries

```text
no reader/Data Factory/model/task/trainer/Pipeline change
no scientific claim promotion
no Foundation removal
no backend integration
no CWRU pin/hash change
no rename/version/tag/release
```

This PR removes one gitlink only. P06-P07 removals require separate PRs.