### PR TITLE
chore(submodules): remove final Foundation gitlink

### DIFF
--- a/.github/workflows/phmfactory-release-readiness.yml
+++ b/.github/workflows/phmfactory-release-readiness.yml
@@ -86,13 +86,13 @@ jobs:
             CWRU_REVISION_FLOATING \
             CWRU_HASH_MISSING \
             PHM_DATA_FACTORY_BACKEND_PENDING \
-            LEGACY_SUBMODULES_REMAIN \
             REPOSITORY_RENAME_PENDING
           do
             grep -q "${blocker}" release-readiness.txt
           done
 
           for resolved in \
+            LEGACY_SUBMODULES_REMAIN \
             README_BRAND_PENDING \
             CITATION_BRAND_PENDING \
             CITATION_REPOSITORY_PENDING \

--- a/.github/workflows/submodule-policy.yml
+++ b/.github/workflows/submodule-policy.yml
@@ -40,16 +40,20 @@ jobs:
       - name: Run focused policy tests
         run: python -m pytest -q test/test_submodule_policy.py
 
-      - name: Require release mode to remain blocked
+      - name: Require only backend integration to remain blocked
         shell: bash
         run: |
           set -euo pipefail
           if python tools/repo/check_submodule_policy.py --mode release > submodule-release.txt; then
-            echo "Submodule release policy unexpectedly passed." >&2
+            echo "Submodule release policy unexpectedly passed before backend resolution." >&2
             exit 1
           fi
           grep -q 'PHM_DATA_FACTORY_BACKEND_PENDING' submodule-release.txt
-          grep -q 'LEGACY_SUBMODULE_REMAINS' submodule-release.txt
+          if grep -q 'LEGACY_SUBMODULE_REMAINS' submodule-release.txt; then
+            echo "Legacy submodule blocker returned after all gitlinks were removed." >&2
+            exit 1
+          fi
+          test "$(grep -c 'release-blocker' submodule-release.txt)" = 1
 
       - name: Upload policy evidence
         uses: actions/upload-artifact@v4

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "paper/2025-10_foundation_model_0_metric"]
-	path = paper/2025-10_foundation_model_0_metric
-	url = git@github.com:liq22/PHM-Vibench-Paper-2025-Metric.git

--- a/docs/archive/audits/phmfactory-v0.3-foundation-gitlink-removal.md
+++ b/docs/archive/audits/phmfactory-v0.3-foundation-gitlink-removal.md
@@ -1,0 +1,60 @@
+# PHMFactory v0.3 Foundation Gitlink Removal
+
+## Scope
+
+This bounded change removes the final legacy gitlink:
+
+```text
+paper/2025-10_foundation_model_0_metric
+```
+
+Because no configured submodules remain, `.gitmodules` is removed as an empty authority file.
+
+## Source authority
+
+```yaml
+source_repository: liq22/PHM-Vibench-Paper-2025-Metric
+source_commit: 2dd7dabe10c11a18e7a1d865ddcf70ba95f26ac7
+source_paths: 257
+unique_git_blob_oids: 243
+```
+
+## Accepted evidence
+
+```yaml
+partition_program_merge: 8ff9e6a776230111888b0ecb719f26fdaf4283f0
+partition_manifest_sha256: d0ee37b6d1d3d6704042c59c1d16dcca0a9f70bf454b6c14c901db8e4acedf5c
+p08_target_merge: 476246e0a8fe6b513e1a33638cca6dd999ae1d06
+p09_target_merge: 9374427e09491cbab281c4167db5bf3539d7ac92
+unassigned_paths: 0
+cross_authority_overlap: 0
+paper_migration_pending: 0
+tracker_safe_to_remove: true
+```
+
+## Tree change
+
+```text
+.gitmodules: removed
+paper/2025-10_foundation_model_0_metric: mode-160000 entry removed
+all regular runtime/package/config files: unchanged
+```
+
+## Validation contract
+
+The pull request must prove:
+
+```text
+zero mode-160000 entries
+no .gitmodules file
+paper migration release mode passes with zero pending papers
+submodule policy passes in policy mode
+release readiness no longer reports LEGACY_SUBMODULES_REMAIN
+repository layout and Core quality gates pass
+```
+
+Remaining release blockers such as CWRU immutable revisions/hashes, backend decision, repository rename and final version remain independent and are not changed here.
+
+## Rollback
+
+A normal revert restores the exact `.gitmodules` content and Foundation gitlink commit. The original content remains preserved in the fixed source commit, the accepted partition manifest and the merged P08/P09 provenance imports.

--- a/test/test_submodule_policy.py
+++ b/test/test_submodule_policy.py
@@ -19,7 +19,7 @@ def test_repository_policy_has_no_structural_errors() -> None:
     assert structural == []
     codes = {finding.code for finding in findings}
     assert "PHM_DATA_FACTORY_BACKEND_PENDING" in codes
-    assert "LEGACY_SUBMODULE_REMAINS" in codes
+    assert "LEGACY_SUBMODULE_REMAINS" not in codes
 
 
 def test_unknown_submodule_is_rejected(monkeypatch) -> None:
@@ -36,7 +36,6 @@ def test_unknown_submodule_is_rejected(monkeypatch) -> None:
     )
 
 
-
 def test_unconfigured_raw_gitlink_is_rejected(monkeypatch) -> None:
     monkeypatch.setattr(policy, "_configured_submodules", lambda: {})
     monkeypatch.setattr(
@@ -50,6 +49,7 @@ def test_unconfigured_raw_gitlink_is_rejected(monkeypatch) -> None:
         and finding.detail == "arbitrary/raw-gitlink"
         for finding in findings
     )
+
 
 def test_personal_backend_url_is_not_allowlisted(monkeypatch) -> None:
     allowlist = policy._load_allowlist()


### PR DESCRIPTION
## Objective

Remove the final legacy parent-side gitlink after the Foundation partition and both fixed-SHA target imports were accepted.

```text
paper/2025-10_foundation_model_0_metric
```

Because no configured submodules remain, `.gitmodules` is removed.

## Accepted authority

```yaml
source_commit: 2dd7dabe10c11a18e7a1d865ddcf70ba95f26ac7
partition_program_merge: 8ff9e6a776230111888b0ecb719f26fdaf4283f0
partition_manifest_sha256: d0ee37b6d1d3d6704042c59c1d16dcca0a9f70bf454b6c14c901db8e4acedf5c
p08_target_merge: 476246e0a8fe6b513e1a33638cca6dd999ae1d06
p09_target_merge: 9374427e09491cbab281c4167db5bf3539d7ac92
tracker_pending_papers: 0
tracker_safe_to_remove: true
```

## Changes

```text
.gitmodules: removed
paper/2025-10_foundation_model_0_metric: mode-160000 entry removed
docs/archive/audits/phmfactory-v0.3-foundation-gitlink-removal.md: added
```

## Validation required

- zero mode-160000 entries;
- `.gitmodules` absent;
- paper migration release mode passes with zero pending papers;
- submodule policy passes in policy mode;
- release readiness no longer reports `LEGACY_SUBMODULES_REMAIN`;
- Core quality gates and repository layout pass.

## Boundaries

```text
no runtime/config/model/task/trainer/Pipeline change
no backend/CWRU/version/rename/tag/release change
```

This PR only removes the last migrated gitlink. It does not assert that all other release blockers are resolved.