### PR TITLE
release: defer optional backend to v0.3.1

### DIFF
--- a/.github/phmfactory-v0.3-submodules.allowlist.yml
+++ b/.github/phmfactory-v0.3-submodules.allowlist.yml
@@ -4,7 +4,7 @@ runtime_baseline_commit: a331769d4005018bc833534ecf4efeb5e8a5a78d
 
 allowed_submodules:
   - name: phm-data-factory
-    status: blocked_pending_org_transfer
+    status: deferred_to_v0.3.1
     optional: true
     path: packages/phm-data-factory
     target_url: https://github.com/PHMbench/phm-data-factory.git
@@ -13,6 +13,7 @@ allowed_submodules:
     license: Apache-2.0
     expected_owner: PHMbench
     approved_integration_pr: null
+    deferral_contract: docs/releases/v0.3.0-backend-deferral.yaml
     ownership_transfer:
       status: open
       source_issue_number: 5
@@ -52,7 +53,7 @@ legacy_entries:
     gitlink_commit: 2dd7dabe10c11a18e7a1d865ddcf70ba95f26ac7
     classification: paper
     allowlisted: false
-    action: migrate_then_remove
+    action: migrated_and_removed
   - path: paper/LQ_vibench_fix
     gitlink_commit: 1a15710fd532fad73c552704f48349576d843ee0
     classification: personal
@@ -62,34 +63,34 @@ legacy_entries:
     gitlink_commit: b385b07e82d6323a291d90e55a5ef4aff9336c0b
     classification: paper
     allowlisted: false
-    action: migrate_then_remove
+    action: migrated_and_removed
   - path: paper/UXFD_paper/Explainable_FD_Toolkit
     gitlink_commit: 379244dc8410eea0580714bc216c71074acba3a9
     classification: paper
     allowlisted: false
-    action: migrate_then_remove
+    action: migrated_and_removed
   - path: paper/UXFD_paper/LLM_Explainable_FD_Toolkit
     gitlink_commit: 08eb944dd9acdbbd6c69cf39f050854a936e9b78
     classification: paper
     allowlisted: false
-    action: migrate_then_remove
+    action: migrated_and_removed
   - path: paper/UXFD_paper/MOE_explainable
     gitlink_commit: 0da06ae366eeb66d852c144013af6925446615cb
     classification: paper
     allowlisted: false
-    action: migrate_then_remove
+    action: migrated_and_removed
   - path: paper/UXFD_paper/Neuralsymbolic_theory
     gitlink_commit: ad7dc2e2851f59d941e402e68fa3d3409b39c583
     classification: paper
     allowlisted: false
-    action: migrate_then_remove
+    action: migrated_and_removed
   - path: paper/UXFD_paper/Paper_fuzzy_XFD
     gitlink_commit: 1bedd533bd52e7ac2592d3a6f7aeffaf25a1014f
     classification: paper
     allowlisted: false
-    action: migrate_then_remove
+    action: migrated_and_removed
   - path: paper/UXFD_paper/TII_operator_attention
     gitlink_commit: 20f47bac5c02763e1f6b856c90ce32861025c003
     classification: paper
     allowlisted: false
-    action: migrate_then_remove
+    action: migrated_and_removed

--- a/.github/phmfactory-v0.3-submodules.allowlist.yml
+++ b/.github/phmfactory-v0.3-submodules.allowlist.yml
@@ -53,7 +53,7 @@ legacy_entries:
     gitlink_commit: 2dd7dabe10c11a18e7a1d865ddcf70ba95f26ac7
     classification: paper
     allowlisted: false
-    action: migrated_and_removed
+    action: migrate_then_remove
   - path: paper/LQ_vibench_fix
     gitlink_commit: 1a15710fd532fad73c552704f48349576d843ee0
     classification: personal
@@ -63,34 +63,34 @@ legacy_entries:
     gitlink_commit: b385b07e82d6323a291d90e55a5ef4aff9336c0b
     classification: paper
     allowlisted: false
-    action: migrated_and_removed
+    action: migrate_then_remove
   - path: paper/UXFD_paper/Explainable_FD_Toolkit
     gitlink_commit: 379244dc8410eea0580714bc216c71074acba3a9
     classification: paper
     allowlisted: false
-    action: migrated_and_removed
+    action: migrate_then_remove
   - path: paper/UXFD_paper/LLM_Explainable_FD_Toolkit
     gitlink_commit: 08eb944dd9acdbbd6c69cf39f050854a936e9b78
     classification: paper
     allowlisted: false
-    action: migrated_and_removed
+    action: migrate_then_remove
   - path: paper/UXFD_paper/MOE_explainable
     gitlink_commit: 0da06ae366eeb66d852c144013af6925446615cb
     classification: paper
     allowlisted: false
-    action: migrated_and_removed
+    action: migrate_then_remove
   - path: paper/UXFD_paper/Neuralsymbolic_theory
     gitlink_commit: ad7dc2e2851f59d941e402e68fa3d3409b39c583
     classification: paper
     allowlisted: false
-    action: migrated_and_removed
+    action: migrate_then_remove
   - path: paper/UXFD_paper/Paper_fuzzy_XFD
     gitlink_commit: 1bedd533bd52e7ac2592d3a6f7aeffaf25a1014f
     classification: paper
     allowlisted: false
-    action: migrated_and_removed
+    action: migrate_then_remove
   - path: paper/UXFD_paper/TII_operator_attention
     gitlink_commit: 20f47bac5c02763e1f6b856c90ce32861025c003
     classification: paper
     allowlisted: false
-    action: migrated_and_removed
+    action: migrate_then_remove

--- a/.github/workflows/phmfactory-release-readiness.yml
+++ b/.github/workflows/phmfactory-release-readiness.yml
@@ -15,6 +15,7 @@ on:
       - ".github/phmfactory-v0.3-submodules.allowlist.yml"
       - "docs/PHMFACTORY_V0_3_RELEASE_READINESS.md"
       - "docs/PHM_DATA_FACTORY_BACKEND_V0_3.md"
+      - "docs/releases/v0.3.0-backend-deferral.yaml"
       - "docs/releases/v0.2.0-rc-provenance.yaml"
       - "docs/releases/v0.2.0-rc-provenance.md"
       - "docs/index.md"
@@ -67,31 +68,29 @@ jobs:
           test/test_submodule_policy.py
 
       - name: Enforce deny-by-default submodule policy
-        run: python tools/repo/check_submodule_policy.py --mode policy
+        run: python tools/repo/check_submodule_policy.py --mode release
 
       - name: Record current blockers
         run: python tools/repo/check_release_readiness.py --mode audit | tee release-readiness.txt
 
-      - name: Require only the remaining pre-release blockers
+      - name: Require only the intentionally deferred pre-release blockers
         shell: bash
         run: |
           set -euo pipefail
           if python tools/repo/check_release_readiness.py --mode release; then
-            echo "Release mode unexpectedly passed before final release preparation." >&2
+            echo "Release mode unexpectedly passed before CWRU, rename, and final version preparation." >&2
             exit 1
           fi
 
-          for blocker in \
-            VERSION_NOT_FINAL \
-            CWRU_REVISION_FLOATING \
-            CWRU_HASH_MISSING \
-            PHM_DATA_FACTORY_BACKEND_PENDING \
-            REPOSITORY_RENAME_PENDING
-          do
-            grep -q "${blocker}" release-readiness.txt
-          done
+          grep -q 'PHMFactory v0.3 release readiness BLOCKED: 6 blocker(s)' release-readiness.txt
+          test "$(grep -c 'CWRU_REVISION_FLOATING' release-readiness.txt)" = 2
+          test "$(grep -c 'CWRU_HASH_MISSING' release-readiness.txt)" = 2
+          test "$(grep -c 'REPOSITORY_RENAME_PENDING' release-readiness.txt)" = 1
+          test "$(grep -c 'VERSION_NOT_FINAL' release-readiness.txt)" = 1
 
           for resolved in \
+            PHM_DATA_FACTORY_BACKEND_PENDING \
+            BACKEND_DEFERRAL_INVALID \
             LEGACY_SUBMODULES_REMAIN \
             README_BRAND_PENDING \
             CITATION_BRAND_PENDING \

--- a/.github/workflows/submodule-policy.yml
+++ b/.github/workflows/submodule-policy.yml
@@ -40,20 +40,18 @@ jobs:
       - name: Run focused policy tests
         run: python -m pytest -q test/test_submodule_policy.py
 
-      - name: Require only backend integration to remain blocked
+      - name: Require release-mode submodule policy to pass
+        run: python tools/repo/check_submodule_policy.py --mode release | tee submodule-release.txt
+
+      - name: Require zero submodule release blockers
         shell: bash
         run: |
           set -euo pipefail
-          if python tools/repo/check_submodule_policy.py --mode release > submodule-release.txt; then
-            echo "Submodule release policy unexpectedly passed before backend resolution." >&2
+          grep -q '0 release blocker(s)' submodule-release.txt
+          if grep -Eq 'PHM_DATA_FACTORY_BACKEND_PENDING|LEGACY_SUBMODULE_REMAINS|BACKEND_DEFERRAL_(MISSING|INVALID|CONFLICT)' submodule-release.txt; then
+            echo "Resolved submodule blocker returned." >&2
             exit 1
           fi
-          grep -q 'PHM_DATA_FACTORY_BACKEND_PENDING' submodule-release.txt
-          if grep -q 'LEGACY_SUBMODULE_REMAINS' submodule-release.txt; then
-            echo "Legacy submodule blocker returned after all gitlinks were removed." >&2
-            exit 1
-          fi
-          test "$(grep -c 'release-blocker' submodule-release.txt)" = 1
 
       - name: Upload policy evidence
         uses: actions/upload-artifact@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ PHM-Vibench is being renamed to **PHMFactory**. This entry records the release d
   submodule policy, and paper-migration tracking.
 - Explicit v0.2.0 release-candidate provenance anchored to
   `a331769d4005018bc833534ecf4efeb5e8a5a78d`.
+- Machine-readable `phm-data-factory` v0.3.0 exclusion and v0.3.1 deferral contract.
 
 ### Changed
 
@@ -35,6 +36,8 @@ PHM-Vibench is being renamed to **PHMFactory**. This entry records the release d
 - CWRU requires `metadata.xlsx` and `RM_001_CWRU.h5`; `corpus.xlsx` is optional for the
   fault-diagnosis quickstart.
 - The mature `src.*` runtime remains in place behind the public façade.
+- Optional `phm-data-factory` integration is deferred to v0.3.1; v0.3.0 contains no
+  backend gitlink, runtime import, support claim, or live-IoTDB claim.
 
 ### Removed or migrated
 
@@ -43,6 +46,9 @@ PHM-Vibench is being renamed to **PHMFactory**. This entry records the release d
 - Tracked `results/` and `metrics_reports/` placeholders.
 - Personal `data/Rotor_simulation` and `paper/LQ_vibench_fix` gitlinks after complete
   fixed-commit preservation.
+- P01–P09 paper/research gitlinks after destination-level fixed-SHA preservation,
+  accepted Foundation partitioning, and machine-verifiable migration tracking.
+- `.gitmodules` after the final migrated gitlink was removed.
 - Case-colliding lowercase authority files.
 - Historical `docs/past/` and `docs/v0.1.0/` trees after provenance preservation.
 
@@ -60,18 +66,18 @@ PHM-Vibench is being renamed to **PHMFactory**. This entry records the release d
 
 ### Release status
 
-v0.3.0 is not publishable while these machine-checked conditions remain:
+The paper/submodule migration and optional-backend decisions are complete. v0.3.0 remains
+unpublishable only while these machine-checked conditions remain:
 
 ```text
 2 x CWRU_HASH_MISSING
 2 x CWRU_REVISION_FLOATING
-1 x LEGACY_SUBMODULES_REMAIN
-1 x PHM_DATA_FACTORY_BACKEND_PENDING
 1 x REPOSITORY_RENAME_PENDING
 1 x VERSION_NOT_FINAL
 ```
 
-The package remains `0.3.0.dev0`; no final tag or release is authorized.
+The package remains `0.3.0.dev0`; no final tag or release is authorized. The version is
+changed to `0.3.0` only in the final promotion after CWRU and repository identity are ready.
 
 ## v0.2.0 Release Candidate - 2026-07-11
 

--- a/RELEASE_NOTES_v0.3.0.md
+++ b/RELEASE_NOTES_v0.3.0.md
@@ -84,16 +84,33 @@ required files have matching SHA-256 values.
 - `apps/streamlit/app.py` is the only maintained web entrypoint.
 - The old `app/` prototype and root `streamlit_app.py` were archived and removed.
 
-### Repository boundary
+### Repository boundary and paper migration
 
 The public repository no longer carries root/hidden Agent workspaces, `.archive/`,
-`dev/`, tracked result placeholders, or the two personal Rotor/LQ-fix gitlinks. Historical
-and removed material remains recoverable from immutable Git history and the approved
-archive, which is not a runtime, build, test, data, or release dependency.
+`dev/`, tracked result placeholders, or legacy personal/paper gitlinks. P01–P09 content
+was resolved through fixed-SHA destination evidence; the Foundation tree was partitioned
+into accepted P08/P09 imports and provenance/reference classes. All legacy mode-160000
+entries and the now-empty `.gitmodules` file are removed.
 
-One optional `phm-data-factory` backend may be integrated later only under the governed
-organization-owned target and an immutable gitlink. Eight paper/research gitlinks remain
-frozen until their content-level migration trackers permit removal.
+### Optional backend decision
+
+`phm-data-factory` is deferred to v0.3.1. It is not part of the v0.3.0 runtime, package,
+submodule tree, supported component set, or release blocker.
+
+The v0.3.0 contract requires:
+
+```text
+backend gitlink absent
+runtime import absent
+silent fallback forbidden
+core runtime independent
+backend integration/support/live-IoTDB claims false
+```
+
+The machine-readable authority is
+`docs/releases/v0.3.0-backend-deferral.yaml`. A future v0.3.1 integration still requires
+an organization-owned public repository, compatible license, immutable reviewed commit,
+bounded adapter PR, and proof that core paths pass without backend initialization.
 
 ## Preserved compatibility boundary
 
@@ -148,24 +165,32 @@ or a universal compatibility claim.
 
 ## Remaining release blockers
 
-The strict release gate currently reports:
+The strict release gate now expects exactly:
 
 ```text
 2 x CWRU_HASH_MISSING
 2 x CWRU_REVISION_FLOATING
-1 x LEGACY_SUBMODULES_REMAIN
-1 x PHM_DATA_FACTORY_BACKEND_PENDING
 1 x REPOSITORY_RENAME_PENDING
 1 x VERSION_NOT_FINAL
 ```
 
-Until those conditions are cleared:
+Resolved conditions that must not return include:
+
+```text
+PHM_DATA_FACTORY_BACKEND_PENDING
+LEGACY_SUBMODULES_REMAIN
+UNKNOWN_SUBMODULES_PRESENT
+```
+
+Until the remaining conditions are cleared:
 
 - the version remains `0.3.0.dev0`;
 - the repository remains `PHMbench/PHM-Vibench`;
 - no `v0.3.0` tag, GitHub Release, wheel, or sdist publication is authorized;
-- no paper gitlink may be removed unless its tracker says `safe_to_remove: true`;
 - no CWRU online parity claim may be made.
+
+The final version switch to `0.3.0` belongs in the last promotion step after CWRU and
+repository identity are ready; it is not performed early merely to suppress the version gate.
 
 Audit commands:
 
@@ -174,4 +199,4 @@ python tools/repo/check_release_readiness.py --mode audit
 python tools/repo/check_release_readiness.py --mode release
 ```
 
-The second command must remain non-zero until all release blockers are resolved.
+The second command must remain non-zero until all final release blockers are resolved.

--- a/docs/PHMFACTORY_V0_3_RELEASE_READINESS.md
+++ b/docs/PHMFACTORY_V0_3_RELEASE_READINESS.md
@@ -1,119 +1,151 @@
 # PHMFactory v0.3 Release Readiness
 
-This page is the blocking checklist for the final PHMFactory v0.3 release. It is an audit contract, not a claim that the release is already ready.
+This document is the blocking contract for the final PHMFactory v0.3.0 release. It records the current tree, not an assertion that publication is already authorized.
 
 ## Current status
 
 ```text
 status: BLOCKED
 release target: v0.3.0
-repository target: PHMbench/phmfactory
+current repository: PHMbench/PHM-Vibench
+target repository: PHMbench/phmfactory
+package version: 0.3.0.dev0
 ```
 
-Run the audit with:
-
-```bash
-python tools/repo/check_release_readiness.py --mode audit
-```
-
-The release command must remain blocked while any finding exists:
-
-```bash
-python tools/repo/check_release_readiness.py --mode release
-```
-
-Submodule policy can be inspected independently:
+Audit commands:
 
 ```bash
 python tools/repo/check_submodule_policy.py --mode policy
 python tools/repo/check_submodule_policy.py --mode release
+python tools/repo/check_release_readiness.py --mode audit
+python tools/repo/check_release_readiness.py --mode release
 ```
 
-## Machine-checked blockers
+The submodule release policy must now pass. The overall release command remains non-zero while any final release finding exists.
 
-The checker currently evaluates:
+## Resolved release areas
 
-1. `pyproject.toml` and `phmfactory.__version__` agree and equal `0.3.0`;
-2. the public README heading uses `PHMFactory`;
-3. `CITATION.cff` uses the PHMFactory title and final repository URL;
-4. `CHANGELOG.md` contains a v0.3.0 section;
-5. `RELEASE_NOTES_v0.3.0.md` exists;
-6. Hugging Face and ModelScope CWRU revisions are immutable rather than `main` or `master`;
-7. required CWRU bundle SHA-256 values are populated;
-8. the governed `phm-data-factory` backend is organization-owned, approved, pinned, and present at the exact gitlink;
-9. all legacy paper/research submodules have completed content-level migration and are absent from `.gitmodules`;
-10. v0.2 provenance is resolved either by a visible historical tag or by the exact approved release-candidate provenance record;
-11. no v0.3.0 tag already exists before the release gate passes;
-12. when running in GitHub Actions, the repository has the final `PHMbench/phmfactory` identity.
-
-## Resolved staged records
-
-The staged v0.3 chain now includes:
+The following areas are complete and must not return as blockers:
 
 - PHMFactory README and citation branding;
-- a v0.3 changelog section and draft release notes;
-- an explicit v0.2.0 release-candidate provenance authority at
-  `docs/releases/v0.2.0-rc-provenance.yaml`;
-- the immutable v0.2 runtime baseline commit
-  `a331769d4005018bc833534ecf4efeb5e8a5a78d`;
-- an explicit decision not to create a retroactive final v0.2.0 tag;
-- a deny-by-default submodule allowlist with one neutral organization-owned backend target;
-- an explicit decision not to merge the old personal-URL backend integration directly.
+- public `phmfactory` package, CLI, configuration resolver, and canonical Pipeline names;
+- explicit v0.2.0 release-candidate provenance anchored to `a331769d4005018bc833534ecf4efeb5e8a5a78d`;
+- P01–P09 content-level migration evidence;
+- Foundation 257-path partition with zero unassigned paths;
+- removal of every legacy mode-160000 paper, personal, and research gitlink;
+- removal of `.gitmodules` after the last gitlink was deleted;
+- deny-by-default submodule policy with zero submodule release blockers;
+- formal deferral of optional `phm-data-factory` integration to v0.3.1.
 
-These records are only effective after their stacked PRs are reviewed and merged.
-
-## Current submodule state
-
-The `phm-data-factory` source tree has a reviewed Apache-2.0 commit, but its neutral
-organization-owned repository transfer has not completed. The allowlist therefore
-uses:
+The backend decision authority is:
 
 ```text
-status: blocked_pending_org_transfer
-path: packages/phm-data-factory
-target: https://github.com/PHMbench/phm-data-factory.git
+docs/releases/v0.3.0-backend-deferral.yaml
 ```
 
-The remaining paper gitlinks are still frozen because destination repository names
-alone do not prove content coverage. Both conditions remain release blockers.
+A valid deferral means the backend is absent, optional, not imported by the v0.3.0 runtime, not claimed as supported, and not release-blocking.
+
+## Remaining machine-checked blockers
+
+The expected current finding set is exactly:
+
+```text
+2 x CWRU_REVISION_FLOATING
+2 x CWRU_HASH_MISSING
+1 x REPOSITORY_RENAME_PENDING
+1 x VERSION_NOT_FINAL
+```
+
+Total expected findings:
+
+```text
+6
+```
+
+No other finding is authorized. In particular, these must remain absent:
+
+```text
+PHM_DATA_FACTORY_BACKEND_PENDING
+BACKEND_DEFERRAL_INVALID
+LEGACY_SUBMODULES_REMAIN
+UNKNOWN_SUBMODULES_PRESENT
+README_BRAND_PENDING
+CITATION_BRAND_PENDING
+CITATION_REPOSITORY_PENDING
+V020_PROVENANCE_UNRESOLVED
+```
+
+## Meaning of the remaining blockers
+
+### CWRU immutable publication
+
+Both Hugging Face and ModelScope currently use floating revisions, and the logical `metadata` and `signals` SHA-256 values are not pinned. This is intentionally deferred from the present change set.
+
+Release requires:
+
+```text
+immutable provider revisions
+metadata SHA-256
+signals SHA-256
+byte-identical required files across providers
+```
+
+### Repository identity
+
+GitHub still reports `PHMbench/PHM-Vibench`. The final release identity is `PHMbench/phmfactory`. The rename is intentionally deferred from the present change set.
+
+### Final version
+
+`pyproject.toml` and `phmfactory.__version__` must remain `0.3.0.dev0` until the CWRU and repository-identity gates are ready. The final promotion PR changes both to `0.3.0` exactly once, after the other release blockers are cleared.
+
+`VERSION_NOT_FINAL` is therefore a finalization gate, not a request to publish final metadata early.
+
+## Backend boundary
+
+`phm-data-factory` is deferred to v0.3.1 and must not be added to the v0.3.0 tree.
+
+For v0.3.0:
+
+```text
+backend gitlink: absent
+runtime import: forbidden
+silent fallback: forbidden
+core dependency: false
+release blocker: false
+support claim: false
+```
+
+A future v0.3.1 integration still requires an organization-owned public repository, compatible license, immutable reviewed commit, bounded adapter PR, explicit missing-backend failure, and proof that core paths pass without backend initialization.
 
 See [PHM_DATA_FACTORY_BACKEND_V0_3.md](PHM_DATA_FACTORY_BACKEND_V0_3.md).
 
-## Human-reviewed blockers
-
-The following cannot be inferred safely from repository files alone:
-
-- all staged v0.3 PRs have been reviewed and merged in dependency order;
-- branch protection and required checks are configured for the final default branch;
-- public Hugging Face and ModelScope artifacts are available at the pinned immutable revisions;
-- the two providers return byte-identical required bundle files;
-- the backend organization transfer preserves the reviewed source tree or has verified replacement-tree parity;
-- the final backend adapter remains optional and does not modify protected Data Factory behavior;
-- every legacy paper gitlink has destination-level source/config/result verification;
-- the GitHub repository rename and redirect behavior have been verified;
-- release notes accurately separate compatibility guarantees from experimental features;
-- the final wheel and source distribution were built from the tagged commit;
-- installation, CLI, module entrypoint, offline smoke, Pipeline 06, UXFD, Streamlit, dependency ownership, repository-layout, submodule-policy, and CWRU gates all pass on the final release commit.
-
-## Release order
+## Final release order
 
 ```text
-1. merge the reviewed v0.3 PR stack in dependency order
-2. retain the approved v0.2 release-candidate provenance record
-3. transfer and integrate the organization-owned phm-data-factory backend
-4. complete content-level migration of the remaining paper gitlinks
-5. publish and pin the dual-source CWRU bundle
-6. finalize repository branding and citation metadata
-7. change versions from 0.3.0.dev0 to 0.3.0
-8. validate RELEASE_NOTES_v0.3.0.md against the final tree
-9. rename the GitHub repository to PHMbench/phmfactory
-10. rerun all required checks on the final repository identity
-11. build wheel and sdist from the final commit
-12. create tag v0.3.0 and publish the release
+1. keep the merged migration and backend-deferral authorities unchanged
+2. publish and verify the dual-source immutable CWRU bundle
+3. update the CWRU manifest with immutable revisions and logical-key SHA-256 values
+4. rerun release-readiness and confirm only rename/version remain
+5. prepare the final promotion PR
+6. rename the GitHub repository to PHMbench/phmfactory
+7. change 0.3.0.dev0 to 0.3.0 in package metadata
+8. update changelog and release-note status from pre-release to final
+9. run full CI, wheel/sdist build, clean installation, CLI and smoke validation
+10. require release-readiness PASS with 0 blockers
+11. create tag v0.3.0 and publish the release
 ```
 
-The repository rename, final version change, tag, and release publication must not occur before all blockers are cleared.
+## Human review required before tagging
+
+The final tagged commit still requires confirmation that:
+
+- branch protection and required checks are correct for the final repository identity;
+- Hugging Face and ModelScope expose the exact immutable bundle revisions;
+- required CWRU files are byte-identical across providers;
+- release notes accurately separate maintained software behavior from experimental or deferred components;
+- wheel and source distribution are built from the exact tagged commit;
+- clean installation, CLI entrypoints, offline Dummy smoke, Pipeline 06, UXFD, Streamlit, dependency ownership, repository layout, submodule policy, and CWRU validation all pass.
 
 ## Rollback
 
-Before tagging, revert the release-preparation commit or keep the repository at `0.3.0.dev0`. After tagging, use a corrective release rather than moving or recreating the published tag.
+Before tagging, revert the final promotion commit or retain `0.3.0.dev0`. After publication, do not move or recreate the tag; issue a corrective release instead.

--- a/docs/PHM_DATA_FACTORY_BACKEND_V0_3.md
+++ b/docs/PHM_DATA_FACTORY_BACKEND_V0_3.md
@@ -1,76 +1,88 @@
-# PHMFactory v0.3 `phm-data-factory` Backend Contract
+# PHMFactory v0.3 `phm-data-factory` Backend Decision
 
-## Decision
+## Final v0.3.0 decision
 
-PHMFactory v0.3 permits exactly one optional Git submodule exception:
+`phm-data-factory` is **deferred to v0.3.1**. It is not included in, required by, or release-blocking for PHMFactory v0.3.0.
 
 ```text
-path: packages/phm-data-factory
-repository target: https://github.com/PHMbench/phm-data-factory.git
-license: Apache-2.0
-status: blocked_pending_org_transfer
+v0.3.0 status: deferred_to_v0.3.1
+included in v0.3.0: false
+required for core runtime: false
+backend gitlink allowed in v0.3.0: false
+runtime import allowed in v0.3.0: false
 ```
 
-The backend is intended to remain available as an experimental, opt-in data access
-adapter. It is not part of the default Dummy or CWRU software path.
-
 The machine-readable authority is:
+
+```text
+docs/releases/v0.3.0-backend-deferral.yaml
+```
+
+The deny-by-default candidate record remains in:
 
 ```text
 .github/phmfactory-v0.3-submodules.allowlist.yml
 ```
 
-## Current blocker
+This preserves the future integration contract without advertising an unavailable backend as part of v0.3.0.
 
-The reviewed backend source tree is currently available only under a personal-account
-repository. No PHMbench- or AI4Engineering-L-owned repository was found during the
-v0.3 review.
+## Why deferral is the correct v0.3 boundary
 
-The reviewed source tree commit is:
+The reviewed backend source tree exists at:
 
 ```text
 5580fafec2ea5615f6d3276d95e1e5a948cc0f13
 ```
 
-The source package identifies itself as:
+but a final organization-owned, immutable target integration has not been accepted. Integrating it now would mix repository transfer, optional dependency packaging, adapter behavior, runtime boundaries, and release promotion in one late-stage change.
+
+The core v0.3 paths do not require this component:
 
 ```text
-distribution: phm-data-factory
-version:      0.2.0
-license:      Apache-2.0
+import phmfactory
+python main.py --help
+python -m phmfactory --help
+phmfactory --help
+repo-shipped Dummy_Data smoke
+provider-neutral CWRU bundle interface
+core wheel build and clean installation
 ```
 
-Before integration, the repository must be transferred or content-verified into the
-organization-owned target URL. PHMFactory does not add a personal-account URL to its
-final `.gitmodules` file.
+Deferral therefore reduces release risk without removing a validated future path.
 
-## Why PR #82 is not merged directly
+## v0.3.0 repository contract
 
-The earlier experimental PR is useful implementation evidence, but it is not the final
-v0.3 integration because it:
+For v0.3.0 all of the following are required:
 
-1. points `.gitmodules` at a personal-account repository;
-2. is based on the old pre-cleanup repository topology;
-3. would reintroduce historical `.gitmodules` context when rebased mechanically;
-4. modifies protected `src/data_factory/data_factory.py` lifecycle behavior;
-5. mutates `sys.path` to import an uninstalled submodule checkout;
-6. combines ownership transfer, schema changes, runtime adapter code, documentation,
-   and base-factory lifecycle changes in one PR.
+- `.gitmodules` is absent unless another separately approved submodule exists;
+- `packages/phm-data-factory` is not a gitlink;
+- no placeholder commit or branch-tracking entry is permitted;
+- no personal-account URL or private SSH dependency is permitted;
+- core code does not import the backend;
+- selecting an unavailable backend must fail explicitly rather than silently falling back;
+- no statement may claim backend integration, support, live IoTDB support, or performance evidence.
 
-The final integration must be rebuilt as a bounded PR on the current PHMFactory v0.3
-stack.
+A valid deferral is non-blocking in both:
 
-## Required ownership migration
+```bash
+python tools/repo/check_submodule_policy.py --mode release
+python tools/repo/check_release_readiness.py --mode release
+```
 
-The backend repository must satisfy:
+The second command remains blocked by unrelated release conditions until they are resolved.
+
+## v0.3.1 entry gate
+
+A future integration must satisfy all of the following before the allowlist can move to `approved`:
 
 ```text
-public organization-owned HTTPS URL
-Apache-2.0 license
+organization-owned public HTTPS repository
+compatible explicit Apache-2.0 license
 immutable reviewed commit
-no personal path or credential
-no private SSH dependency
-no paper or Agent runtime dependency
+bounded adapter PR
+no protected runtime rewrite
+explicit missing-backend error
+core CLI, wheel, Dummy and CWRU paths pass without backend initialization
 ```
 
 Preferred target:
@@ -79,36 +91,29 @@ Preferred target:
 https://github.com/PHMbench/phm-data-factory.git
 ```
 
-The reviewed source commit may remain reachable after a normal GitHub transfer. If the
-backend is recreated instead, the replacement commit must have explicit tree-content
-parity evidence.
+If the repository is recreated instead of transferred, the replacement commit requires explicit tree-content parity evidence.
 
-## Final integration scope
+## Allowed future integration surface
 
-A compliant backend integration PR may change only the minimum required surface:
+A bounded v0.3.1 integration may review changes to:
 
 ```text
 .gitmodules
-packages/phm-data-factory                 gitlink
+packages/phm-data-factory
 .github/phmfactory-v0.3-submodules.allowlist.yml
-src/data_factory/phm_data_factory.py      isolated registered adapter
-src/data_factory/standalone.py            optional import boundary
-src/data_factory/__init__.py               explicit export/registration
-src/config_schema/models.py               conditional backend fields
-src/configs/config_utils.py                compatibility validation
-scripts/validate_docs.py                   submodule traversal exclusion
+src/data_factory/phm_data_factory.py
+src/data_factory/standalone.py
+src/data_factory/__init__.py
+src/config_schema/models.py
+src/configs/config_utils.py
+scripts/validate_docs.py
 test/test_phm_data_factory_backend.py
 test/test_validate_docs_scope.py
 docs/PHM_DATA_FACTORY_BACKEND_V0_3.md
 KNOWN_LIMITATIONS.md
 ```
 
-The exact changed-file list must be reviewed again after rebasing. Inclusion in this
-list is permission to review, not permission to change behavior arbitrarily.
-
-## Protected paths
-
-The backend integration must not modify:
+The following remain protected and require a separate compatibility PR if a real defect is found:
 
 ```text
 src/data_factory/data_factory.py
@@ -121,108 +126,26 @@ src/trainer_factory/**
 src/Pipeline_*.py
 ```
 
-If a real defect requires changing a protected path, that change must be separated into
-a dedicated compatibility PR with before/after runtime evidence.
+## Import and failure contract for v0.3.1
 
-## Import contract
+The future adapter may lazily import an installed `phm_data_factory` package only when explicitly selected. It must not mutate `sys.path`, initialize a submodule automatically, or silently fall back to the existing backend.
 
-The adapter may import the installed `phm_data_factory` package lazily when
-`data.factory_name: phm_data` is selected.
-
-It must not:
-
-- prepend the submodule source directory to `sys.path`;
-- import the optional backend during ordinary `phmfactory --help`;
-- initialize the submodule automatically;
-- silently fall back to the existing HDF5 backend;
-- catch and hide an unavailable-backend error.
-
-Expected failure when the backend is selected but unavailable:
+Expected unavailable-backend behavior:
 
 ```text
 phm-data-factory is optional and is not installed.
-Initialize packages/phm-data-factory and install the required backend extra.
+Install the approved backend and its required extra before selecting data.factory_name: phm_data.
 ```
 
-## Optionality contract
+## Claim boundary
 
-All of the following must pass with the submodule uninitialized and the backend package
-absent:
+For v0.3.0:
 
 ```text
-import phmfactory
-python main.py --help
-python -m phmfactory --help
-phmfactory --help
-fully offline Dummy_Data smoke
-Hugging Face CWRU bundle validation and quickstart
-core wheel build and clean installation
+backend_integrated: false
+backend_supported: false
+live_iotdb_supported: false
+performance_claim_authorized: false
 ```
 
-Backend-focused CI may initialize and install the exact gitlink separately.
-
-## Configuration contract
-
-The experimental selection remains explicit:
-
-```yaml
-data:
-  factory_name: phm_data
-  phm_data_config: path/to/backend.yaml
-  dataset_name: CWRU
-```
-
-Rules:
-
-- `phm_data_config` is required when `factory_name == phm_data`;
-- existing `data_dir` and `metadata_file` requirements remain unchanged for the
-  default backend;
-- there is no implicit provider or storage fallback;
-- the backend does not redefine task filtering, splits, windowing, normalization,
-  Dataset/DataLoader behavior, task logic, or trainer logic.
-
-## Submodule policy
-
-`tools/repo/check_submodule_policy.py` enforces:
-
-- one allowlisted backend candidate;
-- exact organization-owned target URL and path;
-- no branch tracking;
-- exact immutable gitlink after approval;
-- no unknown new submodules;
-- no return of already removed personal gitlinks;
-- exact tracking of still-frozen legacy paper gitlinks;
-- release blocking while legacy paper gitlinks remain or the backend is not approved
-  and integrated.
-
-Policy mode permits the known migration state while rejecting structural drift:
-
-```bash
-python tools/repo/check_submodule_policy.py --mode policy
-```
-
-Release mode is strict:
-
-```bash
-python tools/repo/check_submodule_policy.py --mode release
-```
-
-## Maturity and support
-
-Initial status:
-
-```text
-experimental
-synthetic contract evidence only
-no maintained real-data performance claim
-no live-IoTDB support claim
-not part of the supported demo matrix
-```
-
-The backend can move to a supported status only through separate evidence and
-`SUPPORTED_COMPONENTS.md` / `SUPPORTED_COMBINATIONS.md` review.
-
-## Rollback
-
-The final integration must be removable by reverting one bounded PR. Existing default
-backends and maintained demos must remain unchanged when that PR is reverted.
+These boundaries are release facts, not temporary documentation language. Changing them requires new implementation and validation evidence in v0.3.1 or later.

--- a/docs/releases/v0.3.0-backend-deferral.yaml
+++ b/docs/releases/v0.3.0-backend-deferral.yaml
@@ -1,0 +1,45 @@
+schema_version: 1
+release: 0.3.0
+component: phm-data-factory
+
+decision:
+  status: deferred_to_v0.3.1
+  included_in_v0.3.0: false
+  required_for_core: false
+  release_blocking_for_v0.3.0: false
+  target_release: 0.3.1
+
+ownership:
+  target_repository: PHMbench/phm-data-factory
+  organization_owned_required: true
+  immutable_pin_required: true
+  personal_repository_url_forbidden: true
+
+v0.3.0_repository_state:
+  gitlink_required: false
+  gitlink_present_allowed: false
+  placeholder_gitlink_allowed: false
+  branch_tracking_allowed: false
+  runtime_import_allowed: false
+
+behavior_without_backend:
+  public_cli_works: true
+  dummy_smoke_works: true
+  cwru_bundle_interface_works: true
+  silent_fallback_allowed: false
+  explicit_selection_error_required: true
+
+v0.3.1_entry_gate:
+  - organization_owned_public_https_repository
+  - compatible_explicit_license
+  - immutable_reviewed_commit
+  - bounded_adapter_pr
+  - no_protected_runtime_rewrite
+  - explicit_missing_backend_error
+  - core_paths_pass_without_backend
+
+claim_boundary:
+  backend_integrated: false
+  backend_supported: false
+  live_iotdb_supported: false
+  performance_claim_authorized: false

--- a/test/test_submodule_policy.py
+++ b/test/test_submodule_policy.py
@@ -13,13 +13,14 @@ sys.modules[SPEC.name] = policy
 SPEC.loader.exec_module(policy)
 
 
-def test_repository_policy_has_no_structural_errors() -> None:
-    findings = policy.collect_findings()
-    structural = [finding for finding in findings if not finding.release_only]
-    assert structural == []
-    codes = {finding.code for finding in findings}
-    assert "PHM_DATA_FACTORY_BACKEND_PENDING" in codes
-    assert "LEGACY_SUBMODULE_REMAINS" not in codes
+def test_repository_policy_has_no_findings() -> None:
+    assert policy.collect_findings() == ()
+
+
+def test_invalid_deferral_is_rejected() -> None:
+    errors = policy._deferral_errors({})
+    assert errors
+    assert any("decision.status" in error for error in errors)
 
 
 def test_unknown_submodule_is_rejected(monkeypatch) -> None:
@@ -58,11 +59,30 @@ def test_personal_backend_url_is_not_allowlisted(monkeypatch) -> None:
     changed = dict(allowlist)
     changed["allowed_submodules"] = [candidate]
     monkeypatch.setattr(policy, "_load_allowlist", lambda: changed)
-    monkeypatch.setattr(policy, "_configured_submodules", lambda: {})
-    monkeypatch.setattr(policy, "_gitlinks", lambda: {})
 
     findings = policy.collect_findings()
     assert any(finding.code == "BACKEND_URL_INVALID" for finding in findings)
+
+
+def test_deferred_backend_must_be_absent(monkeypatch) -> None:
+    monkeypatch.setattr(
+        policy,
+        "_configured_submodules",
+        lambda: {
+            policy.TARGET_BACKEND_PATH: {
+                "url": policy.TARGET_BACKEND_URL,
+                "branch": "",
+            }
+        },
+    )
+    monkeypatch.setattr(
+        policy,
+        "_gitlinks",
+        lambda: {policy.TARGET_BACKEND_PATH: "a" * 40},
+    )
+
+    findings = policy.collect_findings()
+    assert any(finding.code == "BACKEND_PRESENT_BEFORE_APPROVAL" for finding in findings)
 
 
 def test_approved_backend_requires_exact_gitlink(monkeypatch) -> None:

--- a/tools/repo/check_release_readiness.py
+++ b/tools/repo/check_release_readiness.py
@@ -26,6 +26,7 @@ FLOATING_REVISIONS = {"main", "master", "latest", "develop", "development", ""}
 SHA40 = re.compile(r"[0-9a-f]{40}")
 V020_PROVENANCE_PATH = "docs/releases/v0.2.0-rc-provenance.yaml"
 SUBMODULE_ALLOWLIST_PATH = ".github/phmfactory-v0.3-submodules.allowlist.yml"
+BACKEND_DEFERRAL_PATH = "docs/releases/v0.3.0-backend-deferral.yaml"
 V020_BASELINE_COMMIT = "a331769d4005018bc833534ecf4efeb5e8a5a78d"
 V020_EXPECTED_PROVENANCE: dict[str, Any] = {
     "project_name": "PHM-Vibench",
@@ -36,6 +37,7 @@ V020_EXPECTED_PROVENANCE: dict[str, Any] = {
     "tag_present": False,
     "superseded_by": "v0.3.0",
 }
+DEFERRED_STATUS = "deferred_to_v0.3.1"
 
 
 @dataclass(frozen=True)
@@ -116,84 +118,122 @@ def _configured_submodules() -> dict[str, dict[str, str]]:
     return configured
 
 
+def _yaml_mapping(path: str) -> dict[str, Any]:
+    payload = yaml.safe_load(_read(path)) or {}
+    if not isinstance(payload, dict):
+        raise ValueError(f"{path} must contain a YAML mapping")
+    return payload
+
+
 def _v020_provenance_error() -> str:
     path = ROOT / V020_PROVENANCE_PATH
     if not path.is_file():
         return f"no visible v0.2* Git tag and {V020_PROVENANCE_PATH} is absent"
-
-    try:
-        payload = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
-    except (OSError, yaml.YAMLError) as exc:
-        return f"could not parse {V020_PROVENANCE_PATH}: {exc}"
-
-    if not isinstance(payload, dict):
-        return f"{V020_PROVENANCE_PATH} must contain a YAML mapping"
-
+    payload = _yaml_mapping(V020_PROVENANCE_PATH)
     mismatches = []
     for key, expected in V020_EXPECTED_PROVENANCE.items():
         actual = payload.get(key)
         if actual != expected:
             mismatches.append(f"{key}={actual!r}, expected {expected!r}")
-    if mismatches:
-        return "; ".join(mismatches)
-    return ""
+    return "; ".join(mismatches)
+
+
+def _backend_deferral_error(payload: dict[str, Any]) -> str:
+    decision = payload.get("decision") or {}
+    ownership = payload.get("ownership") or {}
+    state = payload.get("v0.3.0_repository_state") or {}
+    behavior = payload.get("behavior_without_backend") or {}
+    claims = payload.get("claim_boundary") or {}
+    checks = {
+        "schema_version": (payload.get("schema_version"), 1),
+        "release": (str(payload.get("release") or ""), "0.3.0"),
+        "component": (payload.get("component"), "phm-data-factory"),
+        "decision.status": (decision.get("status"), DEFERRED_STATUS),
+        "decision.included_in_v0.3.0": (decision.get("included_in_v0.3.0"), False),
+        "decision.required_for_core": (decision.get("required_for_core"), False),
+        "decision.release_blocking_for_v0.3.0": (
+            decision.get("release_blocking_for_v0.3.0"),
+            False,
+        ),
+        "decision.target_release": (str(decision.get("target_release") or ""), "0.3.1"),
+        "ownership.target_repository": (
+            ownership.get("target_repository"),
+            "PHMbench/phm-data-factory",
+        ),
+        "ownership.organization_owned_required": (
+            ownership.get("organization_owned_required"),
+            True,
+        ),
+        "ownership.immutable_pin_required": (
+            ownership.get("immutable_pin_required"),
+            True,
+        ),
+        "ownership.personal_repository_url_forbidden": (
+            ownership.get("personal_repository_url_forbidden"),
+            True,
+        ),
+        "v0.3.0_repository_state.gitlink_present_allowed": (
+            state.get("gitlink_present_allowed"),
+            False,
+        ),
+        "v0.3.0_repository_state.runtime_import_allowed": (
+            state.get("runtime_import_allowed"),
+            False,
+        ),
+        "behavior_without_backend.silent_fallback_allowed": (
+            behavior.get("silent_fallback_allowed"),
+            False,
+        ),
+        "behavior_without_backend.explicit_selection_error_required": (
+            behavior.get("explicit_selection_error_required"),
+            True,
+        ),
+        "claim_boundary.backend_integrated": (claims.get("backend_integrated"), False),
+        "claim_boundary.backend_supported": (claims.get("backend_supported"), False),
+        "claim_boundary.live_iotdb_supported": (claims.get("live_iotdb_supported"), False),
+        "claim_boundary.performance_claim_authorized": (
+            claims.get("performance_claim_authorized"),
+            False,
+        ),
+    }
+    mismatches = [
+        f"{field}={actual!r}, expected {expected!r}"
+        for field, (actual, expected) in checks.items()
+        if actual != expected
+    ]
+    return "; ".join(mismatches)
 
 
 def _submodule_findings() -> tuple[Finding, ...]:
     findings: list[Finding] = []
-    try:
-        allowlist = yaml.safe_load(_read(SUBMODULE_ALLOWLIST_PATH)) or {}
-    except (OSError, yaml.YAMLError) as exc:
-        return (Finding("SUBMODULE_POLICY_INVALID", str(exc)),)
-    if not isinstance(allowlist, dict):
-        return (Finding("SUBMODULE_POLICY_INVALID", "allowlist is not a mapping"),)
-
+    allowlist = _yaml_mapping(SUBMODULE_ALLOWLIST_PATH)
     allowed = allowlist.get("allowed_submodules") or []
     candidate = allowed[0] if isinstance(allowed, list) and len(allowed) == 1 else {}
     if not isinstance(candidate, dict):
         candidate = {}
+
     status = str(candidate.get("status") or "")
     target_url = str(candidate.get("target_url") or "")
     pinned_commit = str(candidate.get("pinned_commit") or "")
-
     configured = _configured_submodules()
     gitlinks = _gitlinks()
+
     raw_unknown = sorted(set(gitlinks) - set(configured))
     if raw_unknown:
         findings.append(Finding("UNKNOWN_SUBMODULES_PRESENT", ", ".join(raw_unknown)))
-
-    backend = configured.get(TARGET_BACKEND_PATH)
-    backend_ready = (
-        status == "approved"
-        and target_url == TARGET_BACKEND_URL
-        and re.fullmatch(r"[0-9a-f]{40}", pinned_commit) is not None
-        and backend is not None
-        and backend.get("url") == TARGET_BACKEND_URL
-        and not backend.get("branch")
-        and _gitlink(TARGET_BACKEND_PATH) == pinned_commit
-    )
-    if not backend_ready:
-        findings.append(
-            Finding(
-                "PHM_DATA_FACTORY_BACKEND_PENDING",
-                f"status={status!r}, configured={backend is not None}, target_url={target_url!r}",
-            )
-        )
 
     legacy_items = allowlist.get("legacy_entries") or []
     legacy_paths = {
         str(item.get("path"))
         for item in legacy_items
-        if isinstance(item, dict)
-        and item.get("path")
-        and item.get("action") == "migrate_then_remove"
+        if isinstance(item, dict) and item.get("path")
     }
     remaining = sorted(path for path in configured if path in legacy_paths)
     if remaining:
         findings.append(
             Finding(
                 "LEGACY_SUBMODULES_REMAIN",
-                f"{len(remaining)} legacy paper gitlink(s): {', '.join(remaining)}",
+                f"{len(remaining)} legacy gitlink(s): {', '.join(remaining)}",
             )
         )
 
@@ -201,9 +241,50 @@ def _submodule_findings() -> tuple[Finding, ...]:
         path for path in configured if path != TARGET_BACKEND_PATH and path not in legacy_paths
     )
     if unknown:
-        findings.append(
-            Finding("UNKNOWN_SUBMODULES_PRESENT", ", ".join(unknown))
+        findings.append(Finding("UNKNOWN_SUBMODULES_PRESENT", ", ".join(unknown)))
+
+    backend = configured.get(TARGET_BACKEND_PATH)
+    if status == DEFERRED_STATUS:
+        if not (ROOT / BACKEND_DEFERRAL_PATH).is_file():
+            findings.append(
+                Finding("BACKEND_DEFERRAL_INVALID", f"{BACKEND_DEFERRAL_PATH} is absent")
+            )
+        else:
+            error = _backend_deferral_error(_yaml_mapping(BACKEND_DEFERRAL_PATH))
+            if error:
+                findings.append(Finding("BACKEND_DEFERRAL_INVALID", error))
+        if backend is not None or _gitlink(TARGET_BACKEND_PATH):
+            findings.append(
+                Finding(
+                    "BACKEND_DEFERRAL_INVALID",
+                    "v0.3.0 deferral requires no configured backend or gitlink",
+                )
+            )
+        if pinned_commit:
+            findings.append(
+                Finding("BACKEND_DEFERRAL_INVALID", "deferred backend must not set pinned_commit")
+            )
+        if target_url != TARGET_BACKEND_URL:
+            findings.append(
+                Finding("BACKEND_DEFERRAL_INVALID", f"target_url={target_url!r}")
+            )
+    else:
+        backend_ready = (
+            status == "approved"
+            and target_url == TARGET_BACKEND_URL
+            and SHA40.fullmatch(pinned_commit) is not None
+            and backend is not None
+            and backend.get("url") == TARGET_BACKEND_URL
+            and not backend.get("branch")
+            and _gitlink(TARGET_BACKEND_PATH) == pinned_commit
         )
+        if not backend_ready:
+            findings.append(
+                Finding(
+                    "PHM_DATA_FACTORY_BACKEND_PENDING",
+                    f"status={status!r}, configured={backend is not None}, target_url={target_url!r}",
+                )
+            )
 
     return tuple(findings)
 
@@ -214,11 +295,9 @@ def collect_findings() -> tuple[Finding, ...]:
     pyproject = _read("pyproject.toml")
     package_init = _read("phmfactory/__init__.py")
     readme = _read("README.md")
-    citation = yaml.safe_load(_read("CITATION.cff")) or {}
+    citation = _yaml_mapping("CITATION.cff")
     changelog = _read("CHANGELOG.md")
-    manifest = yaml.safe_load(
-        _read("phmfactory/data_sources/manifests/cwru-demo-v1.yaml")
-    ) or {}
+    manifest = _yaml_mapping("phmfactory/data_sources/manifests/cwru-demo-v1.yaml")
 
     project_version = _toml_version(pyproject)
     package_version = _python_version(package_init)
@@ -241,9 +320,7 @@ def collect_findings() -> tuple[Finding, ...]:
         findings.append(Finding("README_BRAND_PENDING", "README heading is not PHMFactory"))
 
     if citation.get("title") != "PHMFactory":
-        findings.append(
-            Finding("CITATION_BRAND_PENDING", f"title={citation.get('title')!r}")
-        )
+        findings.append(Finding("CITATION_BRAND_PENDING", f"title={citation.get('title')!r}"))
     expected_url = f"https://github.com/{TARGET_REPOSITORY}"
     for field in ("repository-code", "url"):
         if citation.get(field) != expected_url:
@@ -265,7 +342,9 @@ def collect_findings() -> tuple[Finding, ...]:
     release_pin_required = manifest.get("release_pin_required") is True
     for provider_name, provider in sorted(providers.items()):
         revision = str((provider or {}).get("revision") or "")
-        if (release_pin_required and not _is_immutable_revision(revision)) or revision.casefold() in FLOATING_REVISIONS:
+        if (
+            release_pin_required and not _is_immutable_revision(revision)
+        ) or revision.casefold() in FLOATING_REVISIONS:
             findings.append(
                 Finding(
                     "CWRU_REVISION_FLOATING",
@@ -303,9 +382,7 @@ def collect_findings() -> tuple[Finding, ...]:
         if provenance_error:
             findings.append(Finding("V020_PROVENANCE_UNRESOLVED", provenance_error))
     if any(tag in {"v0.3.0", "0.3.0"} for tag in tags):
-        findings.append(
-            Finding("V030_TAG_ALREADY_EXISTS", "release tag exists before readiness pass")
-        )
+        findings.append(Finding("V030_TAG_ALREADY_EXISTS", "release tag exists before readiness pass"))
 
     repository = os.environ.get("GITHUB_REPOSITORY", "")
     if repository and repository != TARGET_REPOSITORY:
@@ -336,7 +413,13 @@ def main() -> int:
 
     try:
         findings = collect_findings()
-    except (OSError, configparser.Error, yaml.YAMLError, subprocess.CalledProcessError) as exc:
+    except (
+        OSError,
+        ValueError,
+        configparser.Error,
+        yaml.YAMLError,
+        subprocess.CalledProcessError,
+    ) as exc:
         print(f"Release readiness ERROR: {exc}", file=sys.stderr)
         return 1
 

--- a/tools/repo/check_submodule_policy.py
+++ b/tools/repo/check_submodule_policy.py
@@ -258,10 +258,6 @@ def collect_findings() -> tuple[Finding, ...]:
             if path in legacy:
                 findings.append(Finding("LEGACY_ENTRY_DUPLICATE", path))
             legacy[path] = item
-            if item.get("action") != "migrated_and_removed":
-                findings.append(
-                    Finding("LEGACY_ENTRY_STATUS_STALE", f"{path}: action={item.get('action')!r}")
-                )
 
     configured = _configured_submodules()
     gitlinks = _gitlinks()

--- a/tools/repo/check_submodule_policy.py
+++ b/tools/repo/check_submodule_policy.py
@@ -17,10 +17,13 @@ import yaml
 
 ROOT = Path(__file__).resolve().parents[2]
 ALLOWLIST_PATH = ROOT / ".github/phmfactory-v0.3-submodules.allowlist.yml"
+DEFERRAL_PATH = ROOT / "docs/releases/v0.3.0-backend-deferral.yaml"
 GITMODULES_PATH = ROOT / ".gitmodules"
 TARGET_BACKEND_PATH = "packages/phm-data-factory"
 TARGET_BACKEND_URL = "https://github.com/PHMbench/phm-data-factory.git"
 SHA40 = re.compile(r"[0-9a-f]{40}")
+DEFERRED_STATUS = "deferred_to_v0.3.1"
+APPROVED_STATUS = "approved"
 
 
 @dataclass(frozen=True)
@@ -30,11 +33,19 @@ class Finding:
     release_only: bool = False
 
 
-def _load_allowlist() -> dict[str, Any]:
-    payload = yaml.safe_load(ALLOWLIST_PATH.read_text(encoding="utf-8")) or {}
+def _load_yaml(path: Path, label: str) -> dict[str, Any]:
+    payload = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
     if not isinstance(payload, dict):
-        raise ValueError("submodule allowlist must contain a YAML mapping")
+        raise ValueError(f"{label} must contain a YAML mapping")
     return payload
+
+
+def _load_allowlist() -> dict[str, Any]:
+    return _load_yaml(ALLOWLIST_PATH, "submodule allowlist")
+
+
+def _load_deferral() -> dict[str, Any]:
+    return _load_yaml(DEFERRAL_PATH, "backend deferral contract")
 
 
 def _configured_submodules() -> dict[str, dict[str, str]]:
@@ -76,8 +87,94 @@ def _gitlinks() -> dict[str, str]:
     return gitlinks
 
 
-def _gitlink(path: str) -> str:
-    return _gitlinks().get(path, "")
+def _deferral_errors(payload: dict[str, Any]) -> tuple[str, ...]:
+    errors: list[str] = []
+    decision = payload.get("decision") or {}
+    ownership = payload.get("ownership") or {}
+    state = payload.get("v0.3.0_repository_state") or {}
+    behavior = payload.get("behavior_without_backend") or {}
+    claims = payload.get("claim_boundary") or {}
+
+    exact = {
+        "schema_version": (payload.get("schema_version"), 1),
+        "release": (str(payload.get("release") or ""), "0.3.0"),
+        "component": (payload.get("component"), "phm-data-factory"),
+        "decision.status": (decision.get("status"), DEFERRED_STATUS),
+        "decision.included_in_v0.3.0": (decision.get("included_in_v0.3.0"), False),
+        "decision.required_for_core": (decision.get("required_for_core"), False),
+        "decision.release_blocking_for_v0.3.0": (
+            decision.get("release_blocking_for_v0.3.0"),
+            False,
+        ),
+        "decision.target_release": (str(decision.get("target_release") or ""), "0.3.1"),
+        "ownership.target_repository": (
+            ownership.get("target_repository"),
+            "PHMbench/phm-data-factory",
+        ),
+        "ownership.organization_owned_required": (
+            ownership.get("organization_owned_required"),
+            True,
+        ),
+        "ownership.immutable_pin_required": (
+            ownership.get("immutable_pin_required"),
+            True,
+        ),
+        "ownership.personal_repository_url_forbidden": (
+            ownership.get("personal_repository_url_forbidden"),
+            True,
+        ),
+        "v0.3.0_repository_state.gitlink_required": (state.get("gitlink_required"), False),
+        "v0.3.0_repository_state.gitlink_present_allowed": (
+            state.get("gitlink_present_allowed"),
+            False,
+        ),
+        "v0.3.0_repository_state.placeholder_gitlink_allowed": (
+            state.get("placeholder_gitlink_allowed"),
+            False,
+        ),
+        "v0.3.0_repository_state.branch_tracking_allowed": (
+            state.get("branch_tracking_allowed"),
+            False,
+        ),
+        "v0.3.0_repository_state.runtime_import_allowed": (
+            state.get("runtime_import_allowed"),
+            False,
+        ),
+        "behavior_without_backend.public_cli_works": (behavior.get("public_cli_works"), True),
+        "behavior_without_backend.dummy_smoke_works": (behavior.get("dummy_smoke_works"), True),
+        "behavior_without_backend.silent_fallback_allowed": (
+            behavior.get("silent_fallback_allowed"),
+            False,
+        ),
+        "behavior_without_backend.explicit_selection_error_required": (
+            behavior.get("explicit_selection_error_required"),
+            True,
+        ),
+        "claim_boundary.backend_integrated": (claims.get("backend_integrated"), False),
+        "claim_boundary.backend_supported": (claims.get("backend_supported"), False),
+        "claim_boundary.live_iotdb_supported": (claims.get("live_iotdb_supported"), False),
+        "claim_boundary.performance_claim_authorized": (
+            claims.get("performance_claim_authorized"),
+            False,
+        ),
+    }
+    for field, (actual, expected) in exact.items():
+        if actual != expected:
+            errors.append(f"{field}={actual!r}, expected {expected!r}")
+
+    gates = payload.get("v0.3.1_entry_gate") or []
+    required_gates = {
+        "organization_owned_public_https_repository",
+        "compatible_explicit_license",
+        "immutable_reviewed_commit",
+        "bounded_adapter_pr",
+        "no_protected_runtime_rewrite",
+        "explicit_missing_backend_error",
+        "core_paths_pass_without_backend",
+    }
+    if not isinstance(gates, list) or set(gates) != required_gates:
+        errors.append("v0.3.1_entry_gate must contain the exact approved gate set")
+    return tuple(errors)
 
 
 def collect_findings() -> tuple[Finding, ...]:
@@ -115,7 +212,7 @@ def collect_findings() -> tuple[Finding, ...]:
         findings.append(Finding("BACKEND_LICENSE_INVALID", "license must be Apache-2.0"))
 
     status = str(candidate.get("status") or "")
-    if status not in {"blocked_pending_org_transfer", "approved"}:
+    if status not in {DEFERRED_STATUS, APPROVED_STATUS}:
         findings.append(Finding("BACKEND_STATUS_INVALID", f"unsupported status: {status!r}"))
 
     reviewed = str(candidate.get("reviewed_source_tree_commit") or "")
@@ -125,13 +222,27 @@ def collect_findings() -> tuple[Finding, ...]:
         )
 
     pinned = str(candidate.get("pinned_commit") or "")
-    if status == "approved" and not SHA40.fullmatch(pinned):
+    if status == APPROVED_STATUS and not SHA40.fullmatch(pinned):
         findings.append(
             Finding("BACKEND_PIN_MISSING", "approved backend requires a 40-hex pinned_commit")
         )
-    if status != "approved" and pinned:
+    if status != APPROVED_STATUS and pinned:
         findings.append(
-            Finding("BACKEND_PIN_PREMATURE", "blocked backend must not advertise a final pinned_commit")
+            Finding("BACKEND_PIN_PREMATURE", "deferred backend must not advertise a final pin")
+        )
+
+    if status == DEFERRED_STATUS:
+        if not DEFERRAL_PATH.is_file():
+            findings.append(Finding("BACKEND_DEFERRAL_MISSING", str(DEFERRAL_PATH.relative_to(ROOT))))
+        else:
+            for error in _deferral_errors(_load_deferral()):
+                findings.append(Finding("BACKEND_DEFERRAL_INVALID", error))
+    elif status == APPROVED_STATUS and DEFERRAL_PATH.is_file():
+        findings.append(
+            Finding(
+                "BACKEND_DEFERRAL_CONFLICT",
+                "approved backend cannot retain the v0.3.0 exclusion contract",
+            )
         )
 
     legacy_items = allowlist.get("legacy_entries") or []
@@ -147,6 +258,10 @@ def collect_findings() -> tuple[Finding, ...]:
             if path in legacy:
                 findings.append(Finding("LEGACY_ENTRY_DUPLICATE", path))
             legacy[path] = item
+            if item.get("action") != "migrated_and_removed":
+                findings.append(
+                    Finding("LEGACY_ENTRY_STATUS_STALE", f"{path}: action={item.get('action')!r}")
+                )
 
     configured = _configured_submodules()
     gitlinks = _gitlinks()
@@ -159,11 +274,11 @@ def collect_findings() -> tuple[Finding, ...]:
             findings.append(Finding("CONFIGURED_SUBMODULE_GITLINK_MISSING", path))
             continue
         if path == TARGET_BACKEND_PATH:
-            if status != "approved":
+            if status != APPROVED_STATUS:
                 findings.append(
                     Finding(
                         "BACKEND_PRESENT_BEFORE_APPROVAL",
-                        "backend gitlink exists while allowlist status is not approved",
+                        "backend gitlink exists while v0.3.0 defers integration",
                     )
                 )
             if entry["url"] != TARGET_BACKEND_URL:
@@ -183,42 +298,16 @@ def collect_findings() -> tuple[Finding, ...]:
                 )
             continue
 
-        item = legacy.get(path)
-        if item is None:
+        if path in legacy:
+            findings.append(Finding("REMOVED_LEGACY_SUBMODULE_RETURNED", path))
+        else:
             findings.append(Finding("UNKNOWN_SUBMODULE", path))
-            continue
-        expected = str(item.get("gitlink_commit") or "")
-        if gitlink != expected:
-            findings.append(
-                Finding(
-                    "LEGACY_GITLINK_DRIFT",
-                    f"{path}: gitlink={gitlink!r}, expected={expected!r}",
-                )
-            )
-        findings.append(
-            Finding("LEGACY_SUBMODULE_REMAINS", path, release_only=True)
-        )
 
-    for path, item in sorted(legacy.items()):
-        action = str(item.get("action") or "")
-        if action == "migrated_and_removed" and path in configured:
-            findings.append(
-                Finding("REMOVED_LEGACY_SUBMODULE_RETURNED", path)
-            )
-
-    if TARGET_BACKEND_PATH not in configured:
+    if status == APPROVED_STATUS and TARGET_BACKEND_PATH not in configured:
         findings.append(
             Finding(
                 "PHM_DATA_FACTORY_BACKEND_PENDING",
-                f"{status}: organization-owned backend gitlink is not integrated",
-                release_only=True,
-            )
-        )
-    elif status != "approved":
-        findings.append(
-            Finding(
-                "PHM_DATA_FACTORY_BACKEND_PENDING",
-                f"backend status is {status!r}",
+                "approved backend is missing its exact configured gitlink",
                 release_only=True,
             )
         )
@@ -233,7 +322,13 @@ def main() -> int:
 
     try:
         findings = collect_findings()
-    except (OSError, ValueError, configparser.Error, yaml.YAMLError) as exc:
+    except (
+        OSError,
+        ValueError,
+        configparser.Error,
+        yaml.YAMLError,
+        subprocess.CalledProcessError,
+    ) as exc:
         print(f"Submodule policy ERROR: {exc}", file=sys.stderr)
         return 1
 


### PR DESCRIPTION
## Objective

Resolve the last independently actionable v0.3.0 release blocker while leaving CWRU publication and repository rename untouched.

```text
phm-data-factory included in v0.3.0: false
required by core runtime: false
release-blocking for v0.3.0: false
target release: v0.3.1
```

## Machine-readable authority

```text
docs/releases/v0.3.0-backend-deferral.yaml
```

The contract requires no backend gitlink, no runtime import, no personal URL, no branch tracking, no silent fallback, and no backend/support/live-IoTDB/performance claim in v0.3.0.

## Changes

- mark the optional backend `deferred_to_v0.3.1` in the deny-by-default allowlist;
- preserve `migrate_then_remove` as the paper tracker classification while requiring all corresponding gitlinks to remain absent;
- make valid deferral pass submodule policy in both policy and release modes;
- make missing/invalid/conflicting deferral evidence fail closed;
- update release-readiness so backend and legacy gitlinks no longer appear as blockers;
- require the current blocker set to be exactly 6 findings:
  - 2 CWRU floating revisions;
  - 2 CWRU missing hashes;
  - repository rename pending;
  - final version pending;
- refresh changelog, release notes, backend contract, and release-readiness documentation.

## Explicitly unchanged

```text
CWRU revisions and hashes
GitHub repository name
pyproject/package version (remains 0.3.0.dev0)
tag and publication state
runtime/model/task/trainer/Pipeline behavior
```

The final version is intentionally not changed early; it belongs in the final promotion after CWRU and repository identity are ready.

## Focused validation

```text
submodule policy mode: PASS, 0 blockers
submodule release mode: PASS, 0 blockers
related tests: 15 passed
expected release-readiness findings: 6
backend/legacy findings: 0
paper tracker pending papers: 0
```