### PR TITLE
feat(generative): rebuild population-aware CFM for v0.3

### DIFF
--- a/.github/workflows/pipeline06-cfm-quality-gates.yml
+++ b/.github/workflows/pipeline06-cfm-quality-gates.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths:
       - "src/Pipeline_06_Generative_Modeling.py"
+      - "src/config_schema/**"
       - "src/model_factory/generative_model/**"
       - "src/task_factory/Components/generative/**"
       - "src/task_factory/task/generative/**"
@@ -17,6 +18,7 @@ on:
       - main
     paths:
       - "src/Pipeline_06_Generative_Modeling.py"
+      - "src/config_schema/**"
       - "src/model_factory/generative_model/**"
       - "src/task_factory/Components/generative/**"
       - "src/task_factory/task/generative/**"
@@ -73,18 +75,22 @@ jobs:
         run: |
           python -m py_compile \
             src/Pipeline_06_Generative_Modeling.py \
+            src/config_schema/models.py \
             src/model_factory/generative_model/condition_encoder.py \
             src/model_factory/generative_model/film.py \
             src/model_factory/generative_model/phm_cfm_mlp1d.py \
             src/task_factory/Components/generative/flow_matching.py \
             src/task_factory/Components/generative/euler_ode.py \
+            src/task_factory/Components/generative/population.py \
             src/task_factory/task/generative/conditional_flow_matching.py \
             test/generative/test_pipeline06_import.py \
             test/generative/test_pipeline06_preflight.py \
             test/generative/test_pipeline06_dispatch.py \
             test/generative/test_cfm_core_contract.py \
             test/generative/test_cfm_dtype_contract.py \
-            test/generative/test_cfm_factory_contract.py
+            test/generative/test_cfm_factory_contract.py \
+            test/generative/test_g3_evidence_contract.py \
+            test/generative/test_population_cfm.py
 
       - name: Inspect exploratory CFM configuration
         shell: bash
@@ -95,6 +101,11 @@ jobs:
             --dump targets \
             --format yaml \
             2>&1 | tee pipeline06-cfm-config-inspect.log
+          python -m scripts.config_inspect \
+            --config configs/experiments/generative/dummy_generative_cfm_population.yaml \
+            --dump targets \
+            --format yaml \
+            2>&1 | tee -a pipeline06-cfm-config-inspect.log
 
       - name: Record focused environment
         run: python -m pip freeze > pipeline06-cfm-environment.txt
@@ -110,6 +121,8 @@ jobs:
             test/generative/test_cfm_core_contract.py \
             test/generative/test_cfm_dtype_contract.py \
             test/generative/test_cfm_factory_contract.py \
+            test/generative/test_g3_evidence_contract.py \
+            test/generative/test_population_cfm.py \
             2>&1 | tee pipeline06-cfm-pytest.log
 
       - name: Upload focused diagnostics

--- a/configs/base/task/generative_cfm.yaml
+++ b/configs/base/task/generative_cfm.yaml
@@ -7,6 +7,14 @@ task:
   optimizer: "adamw"
   t_eps: 0.001
 
+  population_regularization:
+    enabled: false
+    weight: 0.1
+    dependency: "pearson_correlation"
+    estimator: "biased"
+    rbf_bandwidths: [0.1, 0.5, 1.0, 2.0]
+    same_time_per_batch: true
+
   generative:
     mode: "train"
     source_split: "train"

--- a/configs/experiments/generative/README.md
+++ b/configs/experiments/generative/README.md
@@ -24,3 +24,13 @@ and maintained tests, and green post-merge CI.
 
 `sanity_ok` is functional smoke evidence. It is not benchmark-performance or
 scientific-validity evidence.
+
+Available CFM contracts:
+
+- `dummy_generative_cfm.yaml` keeps the baseline velocity-MSE objective;
+- `dummy_generative_cfm_population.yaml` adds a same-time population-correlation
+  MMD regularizer.
+
+The population variant is a PHM CFM adaptation, not a full PaD-TS or DDPM
+implementation. Its population dependency metric is emitted only when the
+regularizer is enabled and remains exploratory evidence.

--- a/configs/experiments/generative/dummy_generative_cfm_population.yaml
+++ b/configs/experiments/generative/dummy_generative_cfm_population.yaml
@@ -1,0 +1,61 @@
+# Experimental population-aware CFM adaptation on repository Dummy_Data.
+# This is not a full PaD-TS/DDPM implementation and carries no benchmark claim.
+pipeline: "Pipeline_06_Generative_Modeling"
+
+base_configs:
+  environment: "configs/base/environment/base.yaml"
+  data: "configs/base/data/base_cross_domain.yaml"
+  model: "configs/base/model/generative_cfm.yaml"
+  task: "configs/base/task/generative_cfm.yaml"
+  trainer: "configs/base/trainer/default_single_gpu.yaml"
+
+environment:
+  project: "experiment_dummy_population_aware_cfm"
+  seed: 0
+  iterations: 1
+  output_dir: "results/experiments/dummy_population_aware_cfm"
+  notes: "Population correlation MMD adaptation; exploratory offline evidence only."
+  wandb: false
+  swanlab: false
+
+data:
+  data_dir: "data"
+  metadata_file: "metadata_dummy.csv"
+  batch_size: 2
+  num_workers: 0
+  train_ratio: 0.8
+  val_ratio: 0.2
+  test_ratio: 0.0
+  normalization: "standardization"
+  window_size: 128
+  stride: 16
+  num_window: 4
+  dtype: "float32"
+  pin_memory: false
+
+model:
+  hidden_dim: 32
+  condition_dim: 16
+
+task:
+  target_system_id: null
+  population_regularization:
+    enabled: true
+    weight: 0.1
+    dependency: "pearson_correlation"
+    estimator: "biased"
+    rbf_bandwidths: [0.1, 0.5, 1.0, 2.0]
+    same_time_per_batch: true
+  generative:
+    mode: "train"
+    synthetic_dataset_id: "dummy_population_aware_cfm"
+    validity_status: "exploratory"
+
+trainer:
+  monitor: "val_loss"
+  num_epochs: 1
+  gpus: 1
+  device: "cpu"
+  early_stopping: false
+  log_every_n_steps: 1
+  save_top_k: 1

--- a/src/Pipeline_06_Generative_Modeling.py
+++ b/src/Pipeline_06_Generative_Modeling.py
@@ -31,6 +31,18 @@ def _get_attr(value: Any, key: str, default: Any = None) -> Any:
     return getattr(value, key, default)
 
 
+def _population_rbf_bandwidths(args_task: Any) -> tuple[float, ...] | None:
+    population_cfg = _get_attr(args_task, "population_regularization", None)
+    if not bool(_get_attr(population_cfg, "enabled", False)):
+        return None
+    values = _get_attr(
+        population_cfg,
+        "rbf_bandwidths",
+        (0.1, 0.5, 1.0, 2.0),
+    )
+    return tuple(float(value) for value in values)
+
+
 def _validate_required_sections(configs: Any) -> None:
     """Reject incomplete five-block configurations before factory dispatch."""
 
@@ -504,10 +516,13 @@ def _write_metrics_csv(path: Path, metrics: dict[str, Any]) -> str:
     from src.utils.generative_evidence import sha256_file
 
     path.parent.mkdir(parents=True, exist_ok=True)
+    method_required = list(metrics.get("summary", {}).get("required_for_method", []))
+    metric_names = list(REQUIRED_METRICS)
+    metric_names.extend(name for name in method_required if name not in metric_names)
     with path.open("w", encoding="utf-8", newline="") as handle:
         writer = csv.DictWriter(handle, fieldnames=["metric", "value", "status", "reason"])
         writer.writeheader()
-        for name in REQUIRED_METRICS:
+        for name in metric_names:
             result = metrics[name]
             writer.writerow(
                 {
@@ -687,6 +702,7 @@ def _run_sample_stage(args: Any, configs: Any, iteration: int) -> Any:
             channels,
             max_samples=num_samples,
         )
+        population_bandwidths = _population_rbf_bandwidths(args_task)
         leakage_bundle = evaluate_smoke_metrics(
             real,
             samples,
@@ -694,6 +710,7 @@ def _run_sample_stage(args: Any, configs: Any, iteration: int) -> Any:
             fake_labels=condition["fault_label"].detach().cpu(),
             real_domains=real_domains,
             fake_domains=condition["domain_id"].detach().cpu(),
+            population_rbf_bandwidths=population_bandwidths,
         )
         config_evidence, generated_protocol = _write_run_contracts(
             run_path, configs, args, args_task
@@ -715,7 +732,9 @@ def _run_sample_stage(args: Any, configs: Any, iteration: int) -> Any:
             synthetic_dataset_id=str(
                 _get_attr(gen_cfg, "synthetic_dataset_id", f"{name}-iter-{iteration}")
             ),
-            method_id="conditional_flow_matching",
+            method_id=str(
+                getattr(task, "method_id", "conditional_flow_matching")
+            ),
             model_type=str(args_model.type),
             model_name=str(args_model.name),
             loss_id=str(getattr(task, "loss_id", "conditional_flow_matching")),
@@ -746,6 +765,15 @@ def _run_sample_stage(args: Any, configs: Any, iteration: int) -> Any:
                 name: leakage_bundle[name]
                 for name in ("nearest_neighbor_leakage_l2", "duplicate_rate")
             },
+            population_metrics=(
+                {
+                    "population_dependency_mmd": leakage_bundle[
+                        "population_dependency_mmd"
+                    ]
+                }
+                if population_bandwidths is not None
+                else None
+            ),
             sampler_metadata=dict(getattr(task, "sampler_metadata", lambda: {})()),
             scientific_status=str(_get_attr(gen_cfg, "validity_status", "exploratory")),
         )
@@ -811,6 +839,24 @@ def _run_eval_stage(args: Any, configs: Any, iteration: int) -> Any:
             )
         )
         synthetic_manifest, synthetic_manifest_hash = load_hashed_json(manifest_path)
+        population_bandwidths = _population_rbf_bandwidths(args_task)
+        expected_method_id = (
+            "population_aware_cfm"
+            if population_bandwidths is not None
+            else "conditional_flow_matching"
+        )
+        manifest_method_id = str(
+            _get_attr(
+                _get_attr(synthetic_manifest, "method", {}),
+                "method_id",
+                "",
+            )
+        )
+        if manifest_method_id != expected_method_id:
+            raise ValueError(
+                "evaluation config population mode does not match the synthetic "
+                f"manifest: expected {expected_method_id!r}, got {manifest_method_id!r}"
+            )
         expected_samples_hash = _get_attr(
             _get_attr(synthetic_manifest, "generated_artifact", {}),
             "sha256",
@@ -867,6 +913,7 @@ def _run_eval_stage(args: Any, configs: Any, iteration: int) -> Any:
             training_wall_clock_seconds=(
                 float(training_wall_clock) if training_wall_clock is not None else None
             ),
+            population_rbf_bandwidths=population_bandwidths,
         )
         metrics_path = run_path / "generative_eval_metrics.csv"
         metrics_hash = _write_metrics_csv(metrics_path, metrics)

--- a/src/config_schema/__init__.py
+++ b/src/config_schema/__init__.py
@@ -1,11 +1,19 @@
-from .models import DataConfig, EnvironmentConfig, ExperimentConfig, ModelConfig, TaskConfig, TrainerConfig
+from .models import (
+    DataConfig,
+    EnvironmentConfig,
+    ExperimentConfig,
+    ModelConfig,
+    PopulationRegularizationConfig,
+    TaskConfig,
+    TrainerConfig,
+)
 
 __all__ = [
     "EnvironmentConfig",
     "DataConfig",
     "ModelConfig",
+    "PopulationRegularizationConfig",
     "TaskConfig",
     "TrainerConfig",
     "ExperimentConfig",
 ]
-

--- a/src/config_schema/models.py
+++ b/src/config_schema/models.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import math
 from typing import Any, Dict, List, Literal, Optional
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
@@ -50,7 +51,45 @@ class ModelConfig(BaseModel):
         return self
 
 
-TaskType = Literal["DG", "CDDG", "FS", "GFS", "pretrain", "Default_task"]
+TaskType = Literal[
+    "DG",
+    "CDDG",
+    "FS",
+    "GFS",
+    "pretrain",
+    "Default_task",
+    "generative",
+]
+
+
+class PopulationRegularizationConfig(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    enabled: bool = False
+    weight: float = Field(0.1, gt=0.0)
+    dependency: Literal["pearson_correlation"] = "pearson_correlation"
+    estimator: Literal["biased"] = "biased"
+    rbf_bandwidths: List[float] = Field(
+        default_factory=lambda: [0.1, 0.5, 1.0, 2.0]
+    )
+    same_time_per_batch: bool = True
+
+    @model_validator(mode="after")
+    def _check_population_contract(self) -> "PopulationRegularizationConfig":
+        if not math.isfinite(self.weight):
+            raise ValueError("task.population_regularization.weight must be finite")
+        if not self.rbf_bandwidths or any(
+            not math.isfinite(value) or value <= 0.0
+            for value in self.rbf_bandwidths
+        ):
+            raise ValueError(
+                "task.population_regularization.rbf_bandwidths must be finite and positive"
+            )
+        if self.enabled and not self.same_time_per_batch:
+            raise ValueError(
+                "enabled population regularization requires same_time_per_batch=true"
+            )
+        return self
 
 
 class TaskConfig(BaseModel):
@@ -60,6 +99,7 @@ class TaskConfig(BaseModel):
     name: str = Field(..., description="Task name under task.type.")
 
     target_system_id: Optional[List[int]] = None
+    population_regularization: Optional[PopulationRegularizationConfig] = None
 
     @model_validator(mode="after")
     def _check_target_system_id(self) -> "TaskConfig":
@@ -97,4 +137,22 @@ class ExperimentConfig(BaseModel):
     def _basic_coupling_checks(self) -> "ExperimentConfig":
         if self.pipeline and not self.pipeline.startswith("Pipeline_"):
             raise ValueError("pipeline should be a src/Pipeline_*.py module name")
+        population = self.task.population_regularization
+        if population is not None and population.enabled:
+            if (
+                self.task.type != "generative"
+                or self.task.name != "conditional_flow_matching"
+            ):
+                raise ValueError(
+                    "population_regularization is supported only by "
+                    "conditional_flow_matching"
+                )
+            if int(getattr(self.model, "in_channels", 0)) < 2:
+                raise ValueError(
+                    "population_regularization requires model.in_channels >= 2"
+                )
+            if self.data.batch_size is None or self.data.batch_size < 2:
+                raise ValueError(
+                    "population_regularization requires data.batch_size >= 2"
+                )
         return self

--- a/src/task_factory/Components/generative/__init__.py
+++ b/src/task_factory/Components/generative/__init__.py
@@ -9,15 +9,23 @@ from .normalization import (
     load_normalization_evidence,
     write_normalization_evidence,
 )
+from .population import (
+    PopulationCorrelationMMD,
+    multi_rbf_mmd,
+    pearson_correlation_vectors,
+)
 
 __all__ = [
     "ConditionalFlowMatchingLoss",
+    "PopulationCorrelationMMD",
     "REQUIRED_METRICS",
     "build_evaluation_manifest",
     "build_normalization_evidence",
     "build_synthetic_manifest",
     "evaluate_smoke_metrics",
     "load_normalization_evidence",
+    "multi_rbf_mmd",
+    "pearson_correlation_vectors",
     "sample_euler_ode",
     "write_normalization_evidence",
 ]

--- a/src/task_factory/Components/generative/manifests.py
+++ b/src/task_factory/Components/generative/manifests.py
@@ -43,6 +43,7 @@ def build_synthetic_manifest(
     data_evidence: dict[str, str],
     generated_evidence: dict[str, str],
     leakage_metrics: dict[str, Any],
+    population_metrics: dict[str, Any] | None = None,
     sampler_metadata: dict[str, Any] | None = None,
     scientific_status: str = "exploratory",
 ) -> dict[str, Any]:
@@ -91,6 +92,12 @@ def build_synthetic_manifest(
         leakage_metrics.get(name, {}).get("status") == "ok"
         for name in ("nearest_neighbor_leakage_l2", "duplicate_rate")
     )
+    population_required = method_id == "population_aware_cfm"
+    population_metrics = dict(population_metrics or {})
+    population_ok = (
+        population_metrics.get("population_dependency_mmd", {}).get("status")
+        == "ok"
+    )
 
     evidence = {
         "strict_checkpoint": checkpoint_ok,
@@ -104,9 +111,11 @@ def build_synthetic_manifest(
         "condition_counts": bool(condition_counts),
         "leakage_metrics": leakage_ok,
     }
+    if population_required:
+        evidence["population_metrics"] = population_ok
     missing = [name for name, passed in evidence.items() if not passed]
 
-    return {
+    manifest = {
         "schema_version": "0.2.1",
         "created_at": datetime.now(timezone.utc).isoformat(),
         "synthetic_dataset_id": synthetic_dataset_id,
@@ -151,6 +160,9 @@ def build_synthetic_manifest(
             "paper_ready": False,
         },
     }
+    if population_required:
+        manifest["population"] = population_metrics
+    return manifest
 
 
 def build_evaluation_manifest(
@@ -172,9 +184,16 @@ def build_evaluation_manifest(
             "test-reference evaluation is not eligible in the maintained smoke contract"
         )
 
+    method_required_metrics = list(
+        metrics.get("summary", {}).get("required_for_method", [])
+    )
+    metric_names = list(REQUIRED_METRICS)
+    metric_names.extend(
+        name for name in method_required_metrics if name not in metric_names
+    )
     statuses = {
         name: str(metrics.get(name, {}).get("status", "missing"))
-        for name in REQUIRED_METRICS
+        for name in metric_names
     }
     missing_status = [
         name for name, status in statuses.items() if status == "missing"
@@ -206,7 +225,7 @@ def build_evaluation_manifest(
     )
     paper_smoke_metric_eligible = runtime_smoke_eligible and not not_computable
 
-    return {
+    manifest = {
         "schema_version": "0.2.1",
         "created_at": datetime.now(timezone.utc).isoformat(),
         "generated_artifact": {
@@ -249,3 +268,8 @@ def build_evaluation_manifest(
             ),
         },
     }
+    if method_required_metrics:
+        manifest["metric_summary"][
+            "required_for_method"
+        ] = method_required_metrics
+    return manifest

--- a/src/task_factory/Components/generative/metrics.py
+++ b/src/task_factory/Components/generative/metrics.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
 import math
+from collections.abc import Sequence
 from typing import Any, Callable
 
 import torch
+
+from .population import PopulationCorrelationMMD
 
 
 REQUIRED_METRICS = (
@@ -16,6 +19,8 @@ REQUIRED_METRICS = (
     "fid_like_embedding_distance",
     "training_wall_clock_seconds",
 )
+
+POPULATION_DEPENDENCY_METRIC = "population_dependency_mmd"
 
 
 def _metric_result(
@@ -222,6 +227,7 @@ def evaluate_smoke_metrics(
     fake_domains: torch.Tensor | None = None,
     duplicate_threshold: float = 1e-6,
     training_wall_clock_seconds: float | None = None,
+    population_rbf_bandwidths: Sequence[float] | None = None,
 ) -> dict[str, Any]:
     """Compute the eight required structured Pipeline 06 smoke metrics."""
 
@@ -239,6 +245,17 @@ def evaluate_smoke_metrics(
             lambda: _spectral_distance(real_tensor, fake_tensor)
         ),
     }
+    method_required_metrics: list[str] = []
+    if population_rbf_bandwidths is not None:
+        metrics[POPULATION_DEPENDENCY_METRIC] = _safe_metric(
+            lambda: float(
+                PopulationCorrelationMMD(population_rbf_bandwidths)(
+                    real_tensor,
+                    fake_tensor,
+                ).item()
+            )
+        )
+        method_required_metrics.append(POPULATION_DEPENDENCY_METRIC)
 
     if any(
         value is None
@@ -318,4 +335,9 @@ def evaluate_smoke_metrics(
             metrics[name]["status"] == "failed" for name in REQUIRED_METRICS
         ),
     }
+    if method_required_metrics:
+        metrics["summary"]["required_for_method"] = method_required_metrics
+        metrics["summary"]["method_required_ok"] = all(
+            metrics[name]["status"] == "ok" for name in method_required_metrics
+        )
     return metrics

--- a/src/task_factory/Components/generative/population.py
+++ b/src/task_factory/Components/generative/population.py
@@ -1,0 +1,106 @@
+"""Population-level dependency regularization for multichannel windows."""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Sequence
+
+import torch
+import torch.nn as nn
+
+
+def _parse_bandwidths(bandwidths: Sequence[float]) -> tuple[float, ...]:
+    parsed = tuple(float(value) for value in bandwidths)
+    if not parsed or any(not math.isfinite(value) or value <= 0.0 for value in parsed):
+        raise ValueError(
+            "population RBF bandwidths must be non-empty, finite, and positive"
+        )
+    return parsed
+
+
+def pearson_correlation_vectors(
+    windows: torch.Tensor,
+    eps: float = 1e-8,
+) -> torch.Tensor:
+    """Return upper-triangle channel correlations for each ``[N,C,L]`` window."""
+
+    tensor = torch.as_tensor(windows)
+    parsed_eps = float(eps)
+    if not math.isfinite(parsed_eps) or parsed_eps <= 0.0:
+        raise ValueError("population correlation eps must be finite and positive")
+    if tensor.ndim != 3:
+        raise ValueError(
+            f"population windows must be [N,C,L], got {tuple(tensor.shape)}"
+        )
+    if tensor.shape[0] < 2:
+        raise ValueError("population regularization requires batch_size >= 2")
+    if tensor.shape[1] < 2:
+        raise ValueError("population regularization requires at least two channels")
+    if tensor.shape[2] < 2:
+        raise ValueError("population regularization requires window length >= 2")
+    if not torch.isfinite(tensor).all():
+        raise ValueError("population windows contain NaN/Inf")
+
+    centered = tensor - tensor.mean(dim=2, keepdim=True)
+    norms = centered.square().sum(dim=2, keepdim=True).sqrt().clamp_min(parsed_eps)
+    normalized = centered / norms
+    correlations = torch.einsum("ncl,ndl->ncd", normalized, normalized)
+    indices = torch.triu_indices(
+        tensor.shape[1],
+        tensor.shape[1],
+        offset=1,
+        device=tensor.device,
+    )
+    return correlations[:, indices[0], indices[1]]
+
+
+def multi_rbf_mmd(
+    real_features: torch.Tensor,
+    fake_features: torch.Tensor,
+    bandwidths: Sequence[float],
+) -> torch.Tensor:
+    """Return biased multi-kernel RBF MMD squared for two feature populations."""
+
+    real = torch.as_tensor(real_features)
+    fake = torch.as_tensor(fake_features, device=real.device, dtype=real.dtype)
+    parsed_bandwidths = _parse_bandwidths(bandwidths)
+    if real.ndim != 2 or fake.ndim != 2:
+        raise ValueError("MMD features must both be [N,D]")
+    if real.shape[0] < 2 or fake.shape[0] < 2:
+        raise ValueError("population MMD requires at least two real and fake samples")
+    if real.shape[1] != fake.shape[1]:
+        raise ValueError("real and fake population feature dimensions must match")
+    if not torch.isfinite(real).all() or not torch.isfinite(fake).all():
+        raise ValueError("population MMD features contain NaN/Inf")
+
+    def kernel(left: torch.Tensor, right: torch.Tensor) -> torch.Tensor:
+        squared_distance = torch.cdist(left, right).square()
+        values = [
+            torch.exp(-squared_distance / (2.0 * bandwidth * bandwidth))
+            for bandwidth in parsed_bandwidths
+        ]
+        return torch.stack(values).mean(dim=0)
+
+    value = kernel(real, real).mean() + kernel(fake, fake).mean()
+    value = value - 2.0 * kernel(real, fake).mean()
+    if not torch.isfinite(value):
+        raise ValueError("population MMD returned NaN/Inf")
+    return value.clamp_min(0.0)
+
+
+class PopulationCorrelationMMD(nn.Module):
+    """Compare distributions of within-window channel correlations."""
+
+    def __init__(self, bandwidths: Sequence[float], eps: float = 1e-8):
+        super().__init__()
+        self.bandwidths = _parse_bandwidths(bandwidths)
+        self.eps = float(eps)
+        if not math.isfinite(self.eps) or self.eps <= 0.0:
+            raise ValueError("population correlation eps must be finite and positive")
+
+    def forward(self, real: torch.Tensor, fake: torch.Tensor) -> torch.Tensor:
+        return multi_rbf_mmd(
+            pearson_correlation_vectors(real, eps=self.eps),
+            pearson_correlation_vectors(fake, eps=self.eps),
+            self.bandwidths,
+        )

--- a/src/task_factory/task/generative/README.md
+++ b/src/task_factory/task/generative/README.md
@@ -1,0 +1,33 @@
+# Generative Tasks
+
+`conditional_flow_matching.py` implements the exploratory Pipeline 06 path
+`x_t=(1-t)z+t*x_1` with velocity target `x_1-z`. The default configuration uses
+velocity MSE only.
+
+## Population-aware CFM
+
+The optional population regularizer compares distributions of upper-triangle
+Pearson channel-correlation vectors with biased multi-kernel RBF MMD:
+
+```yaml
+task:
+  population_regularization:
+    enabled: true
+    weight: 0.1
+    dependency: pearson_correlation
+    estimator: biased
+    rbf_bandwidths: [0.1, 0.5, 1.0, 2.0]
+    same_time_per_batch: true
+```
+
+Enabled runs require at least two samples and two channels. One flow time is
+shared by the batch, and the clean estimate is reconstructed as
+`x_t + (1-t) * predicted_velocity` before the population loss is evaluated.
+
+The task logs velocity MSE, population MMD, and their weighted combined loss.
+Sample/eval evidence uses the configured RBF bandwidths and requires an `ok`
+population dependency metric. Disabled runs keep the baseline metrics and
+manifest contracts unchanged.
+
+This is an exploratory CFM adaptation, not a benchmark-valid or paper-ready
+claim.

--- a/src/task_factory/task/generative/conditional_flow_matching.py
+++ b/src/task_factory/task/generative/conditional_flow_matching.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import math
 from collections.abc import Mapping
 from typing import Any
 
@@ -9,6 +10,7 @@ import torch.nn as nn
 
 from src.task_factory.Components.generative import (
     ConditionalFlowMatchingLoss,
+    PopulationCorrelationMMD,
     sample_euler_ode,
 )
 
@@ -22,6 +24,12 @@ def _flatten_values(value: Any) -> list[Any]:
             flattened.extend(_flatten_values(item))
         return flattened
     return [value]
+
+
+def _get_value(value: Any, key: str, default: Any = None) -> Any:
+    if isinstance(value, Mapping):
+        return value.get(key, default)
+    return getattr(value, key, default)
 
 
 class ConditionalFlowMatchingTask(pl.LightningModule):
@@ -46,10 +54,55 @@ class ConditionalFlowMatchingTask(pl.LightningModule):
         self.args_environment = args_environment
         self.metadata = metadata
         self.loss_id = "conditional_flow_matching"
+        self.method_id = "conditional_flow_matching"
         self.sampler_id = "euler_ode"
         self.loss_fn = ConditionalFlowMatchingLoss(
             eps=float(getattr(args_task, "t_eps", 1e-3))
         )
+        population = _get_value(args_task, "population_regularization", None)
+        self.population_regularization_enabled = bool(
+            _get_value(population, "enabled", False)
+        )
+        self.population_weight = 0.0
+        self.population_rbf_bandwidths: tuple[float, ...] = ()
+        self.population_loss: PopulationCorrelationMMD | None = None
+        if self.population_regularization_enabled:
+            dependency = str(
+                _get_value(population, "dependency", "pearson_correlation")
+            )
+            estimator = str(_get_value(population, "estimator", "biased"))
+            same_time = bool(
+                _get_value(population, "same_time_per_batch", True)
+            )
+            self.population_weight = float(_get_value(population, "weight", 0.1))
+            bandwidths = _get_value(
+                population,
+                "rbf_bandwidths",
+                (0.1, 0.5, 1.0, 2.0),
+            )
+            if dependency != "pearson_correlation":
+                raise ValueError(
+                    "population_regularization.dependency must be pearson_correlation"
+                )
+            if estimator != "biased":
+                raise ValueError(
+                    "population_regularization.estimator must be biased"
+                )
+            if not same_time:
+                raise ValueError(
+                    "population_regularization requires same_time_per_batch=true"
+                )
+            if (
+                not math.isfinite(self.population_weight)
+                or self.population_weight <= 0.0
+            ):
+                raise ValueError(
+                    "population_regularization.weight must be finite and positive"
+                )
+            self.population_loss = PopulationCorrelationMMD(bandwidths)
+            self.population_rbf_bandwidths = self.population_loss.bandwidths
+            self.method_id = "population_aware_cfm"
+            self.loss_id = "conditional_flow_matching+population_correlation_mmd"
         self.save_hyperparameters(
             {
                 "task_type": getattr(args_task, "type", "generative"),
@@ -71,6 +124,13 @@ class ConditionalFlowMatchingTask(pl.LightningModule):
                 "lr": float(getattr(args_task, "lr", 1e-4)),
                 "weight_decay": float(
                     getattr(args_task, "weight_decay", 1e-4)
+                ),
+                "population_regularization_enabled": (
+                    self.population_regularization_enabled
+                ),
+                "population_weight": self.population_weight,
+                "population_rbf_bandwidths": list(
+                    self.population_rbf_bandwidths
                 ),
             }
         )
@@ -192,15 +252,28 @@ class ConditionalFlowMatchingTask(pl.LightningModule):
         x1 = self._to_ncl(batch["x"])
         condition = self._extract_condition(batch, x1.shape[0])
         noise = torch.randn_like(x1)
+        time_batch_size = (
+            1 if self.population_regularization_enabled else x1.shape[0]
+        )
         t = self.loss_fn.sample_t(
-            x1.shape[0],
+            time_batch_size,
             x1.device,
             dtype=x1.dtype,
         )
+        if self.population_regularization_enabled:
+            t = t.expand(x1.shape[0]).clone()
         x_t = self.loss_fn.sample_xt(x1, noise, t)
         predicted_velocity = self.forward(x_t, t, condition)
         loss_values = self.loss_fn(predicted_velocity, x1, noise, t)
         loss = loss_values["loss"]
+        population_mmd = None
+        if self.population_regularization_enabled:
+            if self.population_loss is None:
+                raise RuntimeError("population regularization is missing its loss module")
+            t_view = t.to(device=x1.device, dtype=x1.dtype).view(-1, 1, 1)
+            predicted_clean = x_t + (1.0 - t_view) * predicted_velocity
+            population_mmd = self.population_loss(x1, predicted_clean)
+            loss = loss + self.population_weight * population_mmd
         self.log(
             f"{stage}_loss",
             loss,
@@ -219,6 +292,16 @@ class ConditionalFlowMatchingTask(pl.LightningModule):
             logger=True,
             batch_size=x1.shape[0],
         )
+        if population_mmd is not None:
+            self.log(
+                f"{stage}_population_correlation_mmd",
+                population_mmd,
+                on_step=(stage == "train"),
+                on_epoch=True,
+                prog_bar=False,
+                logger=True,
+                batch_size=x1.shape[0],
+            )
         return loss
 
     def training_step(

--- a/test/generative/test_g3_evidence_contract.py
+++ b/test/generative/test_g3_evidence_contract.py
@@ -7,7 +7,11 @@ import pytest
 import torch
 import torch.nn as nn
 
-from src.task_factory.Components.generative.manifests import build_synthetic_manifest
+from src.task_factory.Components.generative import (
+    REQUIRED_METRICS,
+    build_evaluation_manifest,
+    build_synthetic_manifest,
+)
 from src.task_factory.Components.generative.normalization import (
     build_normalization_evidence,
     load_normalization_evidence,
@@ -84,6 +88,92 @@ def test_docs_only_manifest_remains_non_promotional() -> None:
     assert manifest["validity"]["scientific_status"] == "docs-only"
     assert manifest["validity"]["benchmark_valid"] is False
     assert manifest["validity"]["paper_ready"] is False
+
+
+def test_baseline_manifest_does_not_add_population_evidence() -> None:
+    manifest = build_synthetic_manifest(**_synthetic_manifest_kwargs())
+
+    assert "population" not in manifest
+    assert "population_metrics" not in manifest["validity"]["evidence"]
+
+
+def test_population_manifest_requires_and_persists_population_metric() -> None:
+    kwargs = _synthetic_manifest_kwargs()
+    kwargs["method_id"] = "population_aware_cfm"
+    kwargs["population_metrics"] = {
+        "population_dependency_mmd": {
+            "value": 0.1,
+            "status": "ok",
+            "reason": "",
+        }
+    }
+
+    manifest = build_synthetic_manifest(**kwargs)
+
+    assert manifest["population"]["population_dependency_mmd"]["value"] == 0.1
+    assert manifest["validity"]["evidence"]["population_metrics"] is True
+    assert manifest["validity"]["runtime_smoke_eligible"] is True
+
+
+def test_population_manifest_downgrades_missing_population_metric() -> None:
+    kwargs = _synthetic_manifest_kwargs()
+    kwargs["method_id"] = "population_aware_cfm"
+
+    manifest = build_synthetic_manifest(**kwargs)
+
+    assert manifest["validity"]["runtime_smoke_eligible"] is False
+    assert "population_metrics" in manifest["validity"]["missing_evidence"]
+
+
+def _evaluation_metrics(population_status: str = "ok") -> dict:
+    metrics = {
+        name: {"value": 0.1, "status": "ok", "reason": ""}
+        for name in REQUIRED_METRICS
+    }
+    metrics["population_dependency_mmd"] = {
+        "value": 0.2 if population_status == "ok" else None,
+        "status": population_status,
+        "reason": "" if population_status == "ok" else "population metric failed",
+    }
+    metrics["summary"] = {
+        "required": list(REQUIRED_METRICS),
+        "required_for_method": ["population_dependency_mmd"],
+    }
+    return metrics
+
+
+def _evaluation_manifest(metrics: dict) -> dict:
+    return build_evaluation_manifest(
+        generated_path="samples.pt",
+        generated_sha256="samples-sha",
+        synthetic_manifest_path="synthetic.json",
+        synthetic_manifest_sha256="manifest-sha",
+        metrics_path="metrics.csv",
+        metrics_sha256="metrics-sha",
+        reference_split="train",
+        metrics=metrics,
+        training_wall_clock_seconds=1.0,
+        sampling_wall_clock_seconds=0.5,
+    )
+
+
+def test_evaluation_manifest_requires_population_metric_for_method() -> None:
+    manifest = _evaluation_manifest(_evaluation_metrics())
+
+    assert manifest["metric_statuses"]["population_dependency_mmd"] == "ok"
+    assert manifest["metric_summary"]["required_for_method"] == [
+        "population_dependency_mmd"
+    ]
+    assert manifest["promotion"]["runtime_smoke_eligible"] is True
+
+
+def test_evaluation_manifest_blocks_failed_population_metric() -> None:
+    manifest = _evaluation_manifest(_evaluation_metrics("failed"))
+
+    assert manifest["promotion"]["runtime_smoke_eligible"] is False
+    assert "population_dependency_mmd" in manifest["metric_summary"][
+        "failed_metrics"
+    ]
 
 
 @pytest.mark.parametrize("missing_key", ["protocol_evidence", "generated_evidence"])

--- a/test/generative/test_population_cfm.py
+++ b/test/generative/test_population_cfm.py
@@ -1,0 +1,279 @@
+from __future__ import annotations
+
+import copy
+import csv
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+import torch
+import torch.nn as nn
+from pydantic import ValidationError
+
+import src.Pipeline_06_Generative_Modeling as pipeline06
+from src.config_schema import ExperimentConfig, PopulationRegularizationConfig
+from src.model_factory.generative_model.phm_cfm_mlp1d import Model
+from src.task_factory.Components.generative import (
+    PopulationCorrelationMMD,
+    evaluate_smoke_metrics,
+    multi_rbf_mmd,
+    pearson_correlation_vectors,
+)
+from src.task_factory.task.generative.conditional_flow_matching import (
+    ConditionalFlowMatchingTask,
+)
+
+
+METADATA = {
+    1: {"Label": 0, "Domain_id": 0},
+    2: {"Label": 1, "Domain_id": 1},
+}
+
+
+def test_population_features_and_mmd_contract() -> None:
+    torch.manual_seed(0)
+    real = torch.randn(4, 3, 32)
+    fake = torch.randn(4, 3, 32, requires_grad=True)
+    real_features = pearson_correlation_vectors(real)
+    fake_features = pearson_correlation_vectors(fake)
+
+    assert real_features.shape == (4, 3)
+    forward = multi_rbf_mmd(real_features, fake_features, [0.1, 0.5, 1.0])
+    reverse = multi_rbf_mmd(fake_features, real_features, [0.1, 0.5, 1.0])
+    assert forward.item() >= 0.0
+    torch.testing.assert_close(forward, reverse)
+    forward.backward()
+    assert fake.grad is not None
+    assert torch.isfinite(fake.grad).all()
+
+
+def test_population_mmd_is_zero_for_identical_windows() -> None:
+    windows = torch.randn(4, 2, 16)
+    value = PopulationCorrelationMMD([0.1, 0.5, 1.0, 2.0])(windows, windows)
+    assert value.item() == pytest.approx(0.0, abs=1e-7)
+
+
+@pytest.mark.parametrize("shape", [(1, 2, 16), (2, 1, 16), (2, 2, 1)])
+def test_population_features_reject_insufficient_population(shape) -> None:
+    with pytest.raises(ValueError, match="requires"):
+        pearson_correlation_vectors(torch.randn(*shape))
+
+
+def test_population_features_reject_nonfinite_values() -> None:
+    windows = torch.randn(2, 2, 16)
+    windows[0, 0, 0] = float("nan")
+
+    with pytest.raises(ValueError, match="NaN/Inf"):
+        pearson_correlation_vectors(windows)
+
+
+@pytest.mark.parametrize("bandwidths", [[], [0.0], [float("inf")]])
+def test_population_mmd_rejects_invalid_bandwidths(bandwidths) -> None:
+    with pytest.raises(ValueError, match="bandwidths"):
+        PopulationCorrelationMMD(bandwidths)
+
+
+class _RecordingModel(nn.Module):
+    def __init__(self, model: nn.Module):
+        super().__init__()
+        self.model = model
+        self.last_t = None
+
+    def forward(self, x, t, condition):
+        self.last_t = t.detach().clone()
+        return self.model(x, t, condition)
+
+
+def _model_args() -> SimpleNamespace:
+    return SimpleNamespace(
+        type="generative_model",
+        name="phm_cfm_mlp1d",
+        in_channels=2,
+        hidden_dim=16,
+        condition_dim=8,
+        num_fault_classes=2,
+        num_domains=2,
+    )
+
+
+def _task(
+    population_enabled: bool,
+    *,
+    population_weight: float = 0.1,
+) -> tuple[ConditionalFlowMatchingTask, _RecordingModel]:
+    model_args = _model_args()
+    recording = _RecordingModel(Model(model_args, METADATA))
+    task_args = SimpleNamespace(
+        type="generative",
+        name="conditional_flow_matching",
+        lr=1e-4,
+        weight_decay=1e-4,
+        optimizer="adamw",
+        t_eps=1e-3,
+        population_regularization=SimpleNamespace(
+            enabled=population_enabled,
+            weight=population_weight,
+            dependency="pearson_correlation",
+            estimator="biased",
+            rbf_bandwidths=[0.1, 0.5, 1.0, 2.0],
+            same_time_per_batch=True,
+        ),
+    )
+    task = ConditionalFlowMatchingTask(
+        network=recording,
+        args_data=SimpleNamespace(normalization="standardization"),
+        args_model=model_args,
+        args_task=task_args,
+        args_trainer=SimpleNamespace(),
+        args_environment=SimpleNamespace(),
+        metadata=METADATA,
+    )
+    return task, recording
+
+
+def test_population_cfm_uses_shared_time_and_combined_loss() -> None:
+    task, recording = _task(True)
+    logged = {}
+    task.log = lambda name, value, **kwargs: logged.setdefault(name, value)
+    loss = task.training_step(
+        {
+            "x": torch.randn(3, 32, 2),
+            "y": torch.tensor([0, 1, 0]),
+            "file_id": torch.tensor([1, 2, 1]),
+        }
+    )
+
+    assert task.method_id == "population_aware_cfm"
+    assert task.loss_id == "conditional_flow_matching+population_correlation_mmd"
+    assert torch.unique(recording.last_t).numel() == 1
+    torch.testing.assert_close(
+        loss,
+        logged["train_mse_v"]
+        + task.population_weight * logged["train_population_correlation_mmd"],
+    )
+    loss.backward()
+    assert next(recording.model.parameters()).grad is not None
+
+
+def test_disabled_population_keeps_baseline_task_contract() -> None:
+    task, _ = _task(False)
+
+    assert task.method_id == "conditional_flow_matching"
+    assert task.loss_id == "conditional_flow_matching"
+    assert task.population_loss is None
+
+
+@pytest.mark.parametrize("weight", [0.0, float("nan"), float("inf")])
+def test_population_task_rejects_invalid_runtime_weight(weight: float) -> None:
+    with pytest.raises(ValueError, match="finite and positive"):
+        _task(True, population_weight=weight)
+
+
+def test_population_metric_is_absent_for_baseline() -> None:
+    metrics = evaluate_smoke_metrics(torch.randn(3, 2, 16), torch.randn(3, 2, 16))
+
+    assert "population_dependency_mmd" not in metrics
+    assert "required_for_method" not in metrics["summary"]
+
+
+def test_population_metric_uses_requested_bandwidths() -> None:
+    torch.manual_seed(7)
+    real = torch.randn(3, 2, 16)
+    fake = torch.randn(3, 2, 16)
+    expected = PopulationCorrelationMMD([7.0])(real, fake).item()
+
+    metrics = evaluate_smoke_metrics(
+        real,
+        fake,
+        population_rbf_bandwidths=[7.0],
+    )
+
+    assert metrics["population_dependency_mmd"]["value"] == pytest.approx(expected)
+    assert metrics["summary"]["required_for_method"] == ["population_dependency_mmd"]
+    assert metrics["summary"]["method_required_ok"] is True
+
+
+def test_pipeline_population_bandwidths_are_enabled_only() -> None:
+    disabled = SimpleNamespace(population_regularization=SimpleNamespace(enabled=False))
+    enabled = {
+        "population_regularization": {
+            "enabled": True,
+            "rbf_bandwidths": [0.25, 0.75],
+        }
+    }
+
+    assert pipeline06._population_rbf_bandwidths(disabled) is None
+    assert pipeline06._population_rbf_bandwidths(enabled) == (0.25, 0.75)
+
+
+def test_population_metric_is_written_to_csv(tmp_path: Path) -> None:
+    metrics = evaluate_smoke_metrics(
+        torch.randn(3, 2, 16),
+        torch.randn(3, 2, 16),
+        population_rbf_bandwidths=[0.5],
+    )
+    path = tmp_path / "metrics.csv"
+
+    pipeline06._write_metrics_csv(path, metrics)
+
+    with path.open(encoding="utf-8", newline="") as handle:
+        names = [row["metric"] for row in csv.DictReader(handle)]
+    assert names[-1] == "population_dependency_mmd"
+
+
+def _experiment_config() -> dict:
+    return {
+        "pipeline": "Pipeline_06_Generative_Modeling",
+        "environment": {
+            "project": "population-contract",
+            "output_dir": "results/test-population-contract",
+        },
+        "data": {
+            "data_dir": "data",
+            "metadata_file": "metadata_dummy.csv",
+            "batch_size": 2,
+        },
+        "model": {
+            "type": "generative_model",
+            "name": "phm_cfm_mlp1d",
+            "in_channels": 2,
+        },
+        "task": {
+            "type": "generative",
+            "name": "conditional_flow_matching",
+            "population_regularization": {"enabled": True},
+        },
+        "trainer": {"name": "Default_trainer"},
+    }
+
+
+def test_population_config_accepts_valid_contract() -> None:
+    validated = ExperimentConfig.model_validate(_experiment_config())
+
+    assert validated.task.population_regularization.enabled is True
+
+
+@pytest.mark.parametrize(
+    ("section", "field", "value", "message"),
+    [
+        ("data", "batch_size", 1, "data.batch_size >= 2"),
+        ("model", "in_channels", 1, "model.in_channels >= 2"),
+        ("task", "name", "other", "only by conditional_flow_matching"),
+    ],
+)
+def test_population_config_rejects_invalid_coupling(
+    section: str,
+    field: str,
+    value,
+    message: str,
+) -> None:
+    config = copy.deepcopy(_experiment_config())
+    config[section][field] = value
+
+    with pytest.raises(ValidationError, match=message):
+        ExperimentConfig.model_validate(config)
+
+
+def test_population_config_rejects_invalid_numeric_contract() -> None:
+    with pytest.raises(ValidationError, match="finite and positive"):
+        PopulationRegularizationConfig(rbf_bandwidths=[float("inf")])


### PR DESCRIPTION
## Summary

Rebuilds the population-aware Conditional Flow Matching experiment on the v0.3 PHMFactory topology and supersedes closed PR #79.

- add an opt-in same-time Pearson-correlation MMD regularizer for multichannel CFM
- keep baseline CFM behavior and evidence unchanged when the regularizer is disabled
- emit `population_dependency_mmd` only for population-aware runs and require it in method-specific manifests
- add strict schema/runtime validation for batch size, channel count, finite positive weights/bandwidths, dependency type, estimator, and shared flow time
- add an exploratory Dummy_Data config, method documentation, focused tests, and Pipeline 06 CI coverage

## Implementation notes

The population feature for each `[N,C,L]` window is the upper triangle of its within-window Pearson channel-correlation matrix. Training compares real and reconstructed-clean feature populations with biased multi-kernel RBF MMD:

`loss = velocity_mse + weight * population_correlation_mmd`

A single flow time is shared across the batch when the regularizer is enabled. This is a focused PHM CFM adaptation, not a full PaD-TS/DDPM implementation.

## Evidence

- commit: `0095606fc7442a8582f88b54f47c9fbddbf0d413`
- `python -m pytest -q test/generative/`: 76 passed
- `python -m scripts.validate_configs`: 7/7 passed
- `python -m scripts.validate_docs`: 100 files passed
- config inspection passed for baseline and population-aware configs
- config Atlas regeneration produced no diff
- remaining suite excluding the environment-blocked entrypoint module: 245 passed, 1 skipped
- standard full-suite collection is locally blocked because an installed third-party `examples` package shadows this repository's namespace-only `examples/`; this is unrelated to the patch

### CPU train → sample → eval

Repository Dummy_Data, seed 0, CPU:

- all ledger stages: `completed`
- strict checkpoint SHA-256: `1be9fc9d43fc1f48fe4996bc71e3d833d7442634b14066059f6a5bd2c84e8f7f`
- normalization: `source_split=train`, `scope=per_channel`, SHA-256 `6f92228981009ff49e3d4bbfca05a49f26c72bdec786ce52d255a0402708b106`
- samples SHA-256: `ac8b6895fe156a50c428fb6bba47e7d618a2500170a94dd7fd7fec923caaf5b5`
- population dependency MMD: status `ok`
- evaluation: 8 metrics `ok`, 1 `not_computable`, 0 failed, 0 missing
- runtime smoke eligible: true

## Scientific boundary

This PR remains intentionally exploratory:

- no GPU evidence
- no repeated-seed dispersion
- no benchmark-valid claim
- `sanity_ok=false`
- `paper_smoke_metric_eligible=false` because downstream classifier utility is not computable with the single-class smoke sample
- `paper_ready=false`

Target branch is `dev` in accordance with the v0.3 branch policy.