### PR TITLE
feat(data): add governed phm-data-factory v0.3.1 backend

### DIFF
--- a/.github/phmfactory-v0.3-submodules.allowlist.yml
+++ b/.github/phmfactory-v0.3-submodules.allowlist.yml
@@ -4,21 +4,28 @@ runtime_baseline_commit: a331769d4005018bc833534ecf4efeb5e8a5a78d
 
 allowed_submodules:
   - name: phm-data-factory
-    status: deferred_to_v0.3.1
+    status: approved
     optional: true
     path: packages/phm-data-factory
     target_url: https://github.com/PHMbench/phm-data-factory.git
-    reviewed_source_tree_commit: 5580fafec2ea5615f6d3276d95e1e5a948cc0f13
-    pinned_commit: null
+    reviewed_source_tree_commit: 16180b5fd9ca31d79fe65efd29b11439c1e54186
+    pinned_commit: 16180b5fd9ca31d79fe65efd29b11439c1e54186
+    release_tag: v0.2.0
+    package_version: 0.2.0
+    api_schema_version: 1.0.0
+    capability_schema_version: 1.0.0
     license: Apache-2.0
     expected_owner: PHMbench
-    approved_integration_pr: null
-    deferral_contract: docs/releases/v0.3.0-backend-deferral.yaml
+    approved_integration_pr: 148
+    v0.3.0_deferral_contract: docs/releases/v0.3.0-backend-deferral.yaml
     ownership_transfer:
-      status: open
+      status: completed
       source_issue_number: 5
       target_repository: PHMbench/phm-data-factory
-    baseline_consumers: []
+    baseline_consumers:
+      - src/data_factory/phm_data_factory.py
+      - src/data_factory/standalone.py
+      - src/data_factory/__init__.py
     permitted_new_consumers:
       - src/data_factory/phm_data_factory.py
       - src/data_factory/standalone.py

--- a/.github/workflows/phm-data-factory-backend.yml
+++ b/.github/workflows/phm-data-factory-backend.yml
@@ -1,0 +1,108 @@
+name: phm-data-factory backend
+
+on:
+  pull_request:
+    paths:
+      - ".gitmodules"
+      - "packages/phm-data-factory"
+      - ".github/phmfactory-v0.3-submodules.allowlist.yml"
+      - ".github/workflows/phm-data-factory-backend.yml"
+      - "src/config_schema/models.py"
+      - "src/configs/config_utils.py"
+      - "src/data_factory/__init__.py"
+      - "src/data_factory/phm_data_factory.py"
+      - "src/data_factory/standalone.py"
+      - "scripts/validate_docs.py"
+      - "tools/repo/check_submodule_policy.py"
+      - "test/test_phm_data_factory_backend.py"
+      - "test/test_submodule_policy.py"
+      - "test/test_validate_docs_scope.py"
+  push:
+    branches:
+      - dev
+      - main
+    paths:
+      - ".gitmodules"
+      - "packages/phm-data-factory"
+      - ".github/phmfactory-v0.3-submodules.allowlist.yml"
+      - ".github/workflows/phm-data-factory-backend.yml"
+      - "src/config_schema/models.py"
+      - "src/configs/config_utils.py"
+      - "src/data_factory/**"
+      - "scripts/validate_docs.py"
+      - "tools/repo/check_submodule_policy.py"
+      - "test/test_phm_data_factory_backend.py"
+      - "test/test_submodule_policy.py"
+      - "test/test_validate_docs_scope.py"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: phm-data-factory-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  backend-contract:
+    name: Exact optional backend contract
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    env:
+      PYTHONDONTWRITEBYTECODE: "1"
+      MPLCONFIGDIR: /tmp/phmfactory-matplotlib
+
+    steps:
+      - name: Check out exact provider gitlink
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          submodules: recursive
+
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+          cache: pip
+
+      - name: Install focused runtime
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install --index-url https://download.pytorch.org/whl/cpu "torch==2.6.0"
+          python -m pip install "pytest>=7" "pydantic>=2.0" "PyYAML>=6.0" "pytorch-lightning>=1.5"
+          python -m pip install -e "packages/phm-data-factory[legacy,yaml]"
+
+      - name: Verify provider identity
+        run: |
+          test "$(git -C packages/phm-data-factory rev-parse HEAD)" = "16180b5fd9ca31d79fe65efd29b11439c1e54186"
+          python - <<'PY'
+          from pathlib import Path
+          import phm_data_factory
+
+          expected = (Path.cwd() / "packages/phm-data-factory/src").resolve()
+          origin = Path(phm_data_factory.__file__).resolve()
+          assert expected in origin.parents, (expected, origin)
+          assert phm_data_factory.__version__ == "0.2.0"
+          manifest = phm_data_factory.agent_contract_manifest()
+          assert manifest["api_schema_version"] == "1.0.0"
+          assert manifest["capability_schema_version"] == "1.0.0"
+          PY
+
+      - name: Validate governed gitlink
+        run: python tools/repo/check_submodule_policy.py --mode release
+
+      - name: Compile adapter surface
+        run: >-
+          python -m py_compile
+          src/data_factory/standalone.py
+          src/data_factory/phm_data_factory.py
+          src/data_factory/__init__.py
+          src/config_schema/models.py
+          src/configs/config_utils.py
+
+      - name: Run focused contracts
+        run: >-
+          python -m pytest -q
+          test/test_phm_data_factory_backend.py
+          test/test_submodule_policy.py
+          test/test_validate_docs_scope.py

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "packages/phm-data-factory"]
+	path = packages/phm-data-factory
+	url = https://github.com/PHMbench/phm-data-factory.git

--- a/KNOWN_LIMITATIONS.md
+++ b/KNOWN_LIMITATIONS.md
@@ -13,6 +13,10 @@
 - Only the dummy smoke demo is offline and repo-shipped.
 - Non-dummy demos require local PHM-Vibench metadata/raw data and may need a
   machine-specific `data.data_dir` override.
+- The optional `phm_data` adapter is contract-tested with a synthetic local
+  HDF5 fixture. PHMFactory has not validated a maintained real-data demo,
+  live-IoTDB run, throughput target, or PHM accuracy result through this
+  backend.
 - Maintained validation uses the `LQ_signal` conda environment. Base Python may
   lack required packages such as `pytorch_lightning`.
 
@@ -31,4 +35,3 @@
 - Dataset adapter fallback to `Default_dataset` remains a behavior to inspect
   carefully when adding new task names.
 - Unknown pipeline, model, and task values are expected to fail explicitly.
-

--- a/README.md
+++ b/README.md
@@ -97,6 +97,23 @@ The final v0.3 release remains blocked until both public providers use immutable
 revisions and byte-identical required-file SHA-256 values. See
 [docs/CWRU_DEMO_V0_3.md](docs/CWRU_DEMO_V0_3.md).
 
+## Optional shared data backend (v0.3.1)
+
+PHMFactory can explicitly select the organization-owned
+[`phm-data-factory`](https://github.com/PHMbench/phm-data-factory) v0.2.0
+backend while retaining PHMFactory's existing splits, windowing, datasets, and
+loaders. The backend is optional and never initializes itself or replaces the
+default factory silently.
+
+```bash
+git submodule update --init packages/phm-data-factory
+python -m pip install -e 'packages/phm-data-factory[legacy,yaml]'
+```
+
+Then set `data.factory_name: phm_data` and provide `data.phm_data_config`.
+See the [governed backend contract](docs/PHM_DATA_FACTORY_BACKEND_V0_3.md) for
+the exact pin, configuration example, failure behavior, and evidence limits.
+
 ## Maintained surface
 
 The maintained demo surface covers:
@@ -106,6 +123,8 @@ The maintained demo surface covers:
 - few-shot and generalized few-shot examples;
 - bounded HSE pretraining examples;
 - an optional Streamlit workspace around the same public CLI.
+- an opt-in `phm-data-factory` v0.2.0 training backend for dense continuous
+  signals, outside the default install and maintained performance matrix.
 
 Files, registry entries, research notes, and historical configurations outside the
 maintained surface are not automatically supported. The exact model, task, data, and

--- a/docs/PHM_DATA_FACTORY_BACKEND_V0_3.md
+++ b/docs/PHM_DATA_FACTORY_BACKEND_V0_3.md
@@ -26,6 +26,32 @@ The deny-by-default candidate record remains in:
 
 This preserves the future integration contract without advertising an unavailable backend as part of v0.3.0.
 
+## v0.3.1 integration authority
+
+The v0.3.0 deferral remains a historical release fact. The bounded v0.3.1
+integration is now authorized against one public, immutable provider release:
+
+```text
+integration status: implementation_in_review
+provider repository: https://github.com/PHMbench/phm-data-factory.git
+provider release: v0.2.0
+provider commit: 16180b5fd9ca31d79fe65efd29b11439c1e54186
+provider package: phm-data-factory 0.2.0
+provider API schema: 1.0.0
+provider capability schema: 1.0.0
+license: Apache-2.0
+```
+
+The provider repository is organization-owned and public, its `v0.2.0` tag
+peels to the reviewed merge commit above, and its release publishes a wheel,
+source archive, and checksums. This satisfies the ownership, licensing, and
+immutable-source entry gates; the remaining gates belong to the bounded
+PHMFactory adapter PR and its validation.
+
+This authority does not make the backend part of the default installation and
+does not authorize claims about real-dataset accuracy, throughput, live IoTDB
+operation inside PHMFactory, or additional signal modalities.
+
 ## Why deferral is the correct v0.3 boundary
 
 The reviewed backend source tree exists at:

--- a/docs/PHM_DATA_FACTORY_BACKEND_V0_3.md
+++ b/docs/PHM_DATA_FACTORY_BACKEND_V0_3.md
@@ -32,7 +32,7 @@ The v0.3.0 deferral remains a historical release fact. The bounded v0.3.1
 integration is now authorized against one public, immutable provider release:
 
 ```text
-integration status: implementation_in_review
+integration status: draft_pr_148
 provider repository: https://github.com/PHMbench/phm-data-factory.git
 provider release: v0.2.0
 provider commit: 16180b5fd9ca31d79fe65efd29b11439c1e54186
@@ -47,6 +47,9 @@ peels to the reviewed merge commit above, and its release publishes a wheel,
 source archive, and checksums. This satisfies the ownership, licensing, and
 immutable-source entry gates; the remaining gates belong to the bounded
 PHMFactory adapter PR and its validation.
+
+The bounded implementation is tracked in
+[PHM-Vibench PR #148](https://github.com/PHMbench/PHM-Vibench/pull/148).
 
 This authority does not make the backend part of the default installation and
 does not authorize claims about real-dataset accuracy, throughput, live IoTDB
@@ -127,16 +130,20 @@ A bounded v0.3.1 integration may review changes to:
 .gitmodules
 packages/phm-data-factory
 .github/phmfactory-v0.3-submodules.allowlist.yml
+.github/workflows/phm-data-factory-backend.yml
 src/data_factory/phm_data_factory.py
 src/data_factory/standalone.py
 src/data_factory/__init__.py
 src/config_schema/models.py
 src/configs/config_utils.py
 scripts/validate_docs.py
+tools/repo/check_submodule_policy.py
 test/test_phm_data_factory_backend.py
+test/test_submodule_policy.py
 test/test_validate_docs_scope.py
 docs/PHM_DATA_FACTORY_BACKEND_V0_3.md
 KNOWN_LIMITATIONS.md
+README.md
 ```
 
 The following remain protected and require a separate compatibility PR if a real defect is found:
@@ -152,9 +159,35 @@ src/trainer_factory/**
 src/Pipeline_*.py
 ```
 
-## Import and failure contract for v0.3.1
+## Configuration and import contract for v0.3.1
 
-The future adapter may lazily import an installed `phm_data_factory` package only when explicitly selected. It must not mutate `sys.path`, initialize a submodule automatically, or silently fall back to the existing backend.
+The adapter lazily imports the installed `phm_data_factory` package only when
+explicitly selected. It does not mutate `sys.path`, initialize a submodule
+automatically, or silently fall back to the existing backend.
+
+Initialize and install the exact optional provider explicitly:
+
+```bash
+git submodule update --init packages/phm-data-factory
+python -m pip install -e 'packages/phm-data-factory[legacy,yaml]'
+```
+
+Select it in a PHMFactory configuration:
+
+```yaml
+data:
+  factory_name: phm_data
+  phm_data_config: configs/data/phm-data.yaml
+  dataset_name: CWRU
+  batch_size: 32
+  num_workers: 4
+```
+
+`phm_data_config` is resolved from the process working directory and is passed
+to provider `connect()`. The adapter consumes trusted typed metadata through
+`metadata_frame("phm_vibench_v1")` and dense arrays through `read_signal()`.
+PHMFactory continues to own filtering, splits, windowing, normalization,
+Dataset/DataLoader construction, tasks, models, and trainers.
 
 Expected unavailable-backend behavior:
 
@@ -175,3 +208,14 @@ performance_claim_authorized: false
 ```
 
 These boundaries are release facts, not temporary documentation language. Changing them requires new implementation and validation evidence in v0.3.1 or later.
+
+For the v0.3.1 integration under review:
+
+```text
+optional_adapter_implemented: true
+default_install_requires_backend: false
+silent_fallback_allowed: false
+protected_runtime_rewritten: false
+real_dataset_or_performance_claim_authorized: false
+live_iotdb_claim_authorized: false
+```

--- a/scripts/validate_docs.py
+++ b/scripts/validate_docs.py
@@ -6,6 +6,7 @@ links resolve and that per-directory AI docs defer shared content to README.md.
 
 from __future__ import annotations
 
+import configparser
 import re
 import sys
 from dataclasses import dataclass
@@ -27,7 +28,25 @@ SKIP_TOP_DIRS = {
 SKIP_DIR_NAMES = {"__pycache__"}
 
 
-def is_skipped_path(rel: Path) -> bool:
+def configured_submodule_paths(repo_root: Path) -> tuple[Path, ...]:
+    gitmodules = repo_root / ".gitmodules"
+    if not gitmodules.is_file():
+        return ()
+    parser = configparser.ConfigParser(interpolation=None, strict=True)
+    parser.read(gitmodules, encoding="utf-8")
+    paths: list[Path] = []
+    for section in parser.sections():
+        if not section.startswith('submodule "'):
+            continue
+        value = parser.get(section, "path", fallback="").strip()
+        if value:
+            paths.append(Path(value))
+    return tuple(paths)
+
+
+def is_skipped_path(rel: Path, submodule_paths: tuple[Path, ...] = ()) -> bool:
+    if any(rel == path or path in rel.parents for path in submodule_paths):
+        return True
     if rel.parts and rel.parts[0] in SKIP_TOP_DIRS:
         return True
     if len(rel.parts) >= 2 and rel.parts[:2] == (".claude", "handoffs"):
@@ -51,6 +70,7 @@ class Issue:
 
 
 def iter_doc_files(repo_root: Path) -> Iterable[Path]:
+    submodule_paths = configured_submodule_paths(repo_root)
     patterns = [
         "README.md",
         "CLAUDE.md",
@@ -61,7 +81,7 @@ def iter_doc_files(repo_root: Path) -> Iterable[Path]:
     for pattern in patterns:
         for path in repo_root.rglob(pattern):
             rel = path.relative_to(repo_root)
-            if is_skipped_path(rel):
+            if is_skipped_path(rel, submodule_paths):
                 continue
             yield path
 
@@ -107,10 +127,11 @@ def first_n_lines(path: Path, n: int = 40) -> str:
 
 def check_ai_docs_point_to_readme(repo_root: Path) -> list[Issue]:
     issues: list[Issue] = []
+    submodule_paths = configured_submodule_paths(repo_root)
     for doc_name in ["CLAUDE.md", "AGENTS.md", "GEMINI.md"]:
         for path in repo_root.rglob(doc_name):
             rel = path.relative_to(repo_root)
-            if is_skipped_path(rel):
+            if is_skipped_path(rel, submodule_paths):
                 continue
             readme = path.parent / "README.md"
             if not readme.exists():

--- a/src/config_schema/models.py
+++ b/src/config_schema/models.py
@@ -25,10 +25,33 @@ class EnvironmentConfig(BaseModel):
 class DataConfig(BaseModel):
     model_config = ConfigDict(extra="allow")
 
-    data_dir: str = Field(..., description="Dataset root dir containing metadata and processed files.")
-    metadata_file: str = Field(..., description="Metadata filename relative to data_dir (xlsx/csv).")
+    factory_name: str = Field("default", description="Registered data-factory name.")
+    data_dir: Optional[str] = Field(
+        None, description="Dataset root dir containing metadata and processed files."
+    )
+    metadata_file: Optional[str] = Field(
+        None, description="Metadata filename relative to data_dir (xlsx/csv)."
+    )
+    phm_data_config: Optional[str] = Field(
+        None,
+        description="Configuration path for the optional phm-data-factory backend.",
+    )
+    dataset_name: Optional[str] = None
     batch_size: Optional[int] = Field(None, ge=1)
     num_workers: Optional[int] = Field(None, ge=0)
+
+    @model_validator(mode="after")
+    def _check_factory_fields(self) -> "DataConfig":
+        if self.factory_name == "phm_data":
+            if not self.phm_data_config:
+                raise ValueError(
+                    "data.factory_name=phm_data requires data.phm_data_config"
+                )
+        elif not self.data_dir or not self.metadata_file:
+            raise ValueError(
+                "data.data_dir and data.metadata_file are required for legacy factories"
+            )
+        return self
 
 
 class ModelConfig(BaseModel):

--- a/src/configs/config_utils.py
+++ b/src/configs/config_utils.py
@@ -274,7 +274,7 @@ def _validate_config_wrapper(config: ConfigWrapper) -> None:
         ValueError: 缺少必需字段时
     """
     required_sections = {
-        'data': ['data_dir', 'metadata_file'],
+        'data': [],
         'model': ['name', 'type'],
         'task': ['name', 'type']
     }
@@ -290,6 +290,17 @@ def _validate_config_wrapper(config: ConfigWrapper) -> None:
         for field in fields:
             if not hasattr(section_obj, field):
                 raise ValueError(f"缺少必需字段: {section}.{field}")
+
+    data = config.data
+    if getattr(data, 'factory_name', 'default') == 'phm_data':
+        if not getattr(data, 'phm_data_config', None):
+            raise ValueError(
+                "data.factory_name=phm_data requires data.phm_data_config"
+            )
+    else:
+        for field in ('data_dir', 'metadata_file'):
+            if not getattr(data, field, None):
+                raise ValueError(f"缺少必需字段: data.{field}")
 
     # 扩展验证：对比学习配置验证
     _validate_contrastive_config(config)
@@ -431,7 +442,16 @@ def makedir(path):
 
 def build_experiment_name(configs) -> str:
     """Compose an experiment name from configuration sections."""
-    dataset_name = configs.data.metadata_file
+    dataset_name = getattr(configs.data, "dataset_name", None)
+    if not dataset_name:
+        source = getattr(configs.data, "metadata_file", None) or getattr(
+            configs.data, "phm_data_config", None
+        )
+        dataset_name = (
+            Path(str(source)).stem
+            if isinstance(source, (str, Path))
+            else "phm_data"
+        )
     model_name = configs.model.name
     task_name = f"{configs.task.type}{configs.task.name}"
     timestamp = datetime.now().strftime("%d_%H%M%S")

--- a/src/data_factory/__init__.py
+++ b/src/data_factory/__init__.py
@@ -9,6 +9,8 @@ from .data_factory import (
 )
 from .dataset_task.Dataset_cluster import IdIncludedDataset
 from .id_data_factory import id_data_factory
+from .phm_data_factory import PHMDataFactory
+from .standalone import build_data_repository
 
 
 
@@ -58,9 +60,11 @@ def build_data(args_data: Any, args_task: Any) -> Any:
 # public exports
 __all__ = [
     "build_data",
+    "build_data_repository",
     "resolve_data_factory_class",
     "register_data_factory",
     "DATA_FACTORY_REGISTRY",
     "IdIncludedDataset",
     "id_data_factory",
+    "PHMDataFactory",
 ]

--- a/src/data_factory/phm_data_factory.py
+++ b/src/data_factory/phm_data_factory.py
@@ -1,0 +1,76 @@
+"""PHMFactory training adapter backed by ``phm-data-factory`` v0.2."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator, Mapping, Sequence
+from typing import Any
+
+import numpy as np
+
+from .data_factory import data_factory, register_data_factory
+from .data_utils import MetadataAccessor
+from .standalone import build_data_repository
+
+
+class RepositorySignalMapping(Mapping[Any, np.ndarray]):
+    """Read dense arrays lazily through the provider's stable training API."""
+
+    def __init__(self, repository: Any, sample_ids: Sequence[Any]):
+        self._repository = repository
+        self._sample_ids = tuple(sample_ids)
+
+    def __getitem__(self, sample_id: Any) -> np.ndarray:
+        return np.asarray(self._repository.read_signal(sample_id))
+
+    def __iter__(self) -> Iterator[Any]:
+        return iter(self._sample_ids)
+
+    def __len__(self) -> int:
+        return len(self._sample_ids)
+
+
+@register_data_factory("phm_data")
+class PHMDataFactory(data_factory):
+    """Reuse PHMFactory splits and loaders over the optional provider."""
+
+    def __init__(self, args_data: Any, args_task: Any):
+        self._repository: Any | None = None
+        self._closed = False
+        try:
+            super().__init__(args_data, args_task)
+        except BaseException:
+            self.close()
+            raise
+
+    def _init_metadata(self, args_data: Any) -> MetadataAccessor:
+        self._repository = build_data_repository(args_data)
+        frame = self._repository.metadata_frame("phm_vibench_v1")
+        if "Id" not in frame.columns:
+            raise ValueError("phm-data-factory metadata profile has no Id column")
+        return MetadataAccessor(frame, key_column="Id")
+
+    def _init_data(self, args_data: Any, **_: Any) -> RepositorySignalMapping:
+        del args_data
+        if self._repository is None:
+            raise RuntimeError("phm-data-factory repository was not initialized")
+        target_metadata = self.search_dataset_id()
+        return RepositorySignalMapping(self._repository, target_metadata.keys())
+
+    def close(self) -> None:
+        if self._closed:
+            return
+        self._closed = True
+        if self._repository is not None:
+            self._repository.close()
+
+    def __enter__(self) -> "PHMDataFactory":
+        return self
+
+    def __exit__(self, exc_type: Any, exc_value: Any, traceback: Any) -> None:
+        self.close()
+
+    def __del__(self) -> None:
+        try:
+            self.close()
+        except Exception:
+            pass

--- a/src/data_factory/standalone.py
+++ b/src/data_factory/standalone.py
@@ -1,0 +1,63 @@
+"""Configuration bridge for the optional ``phm-data-factory`` backend."""
+
+from __future__ import annotations
+
+import importlib
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+
+EXPECTED_PROVIDER_VERSION = "0.2.0"
+MISSING_BACKEND_MESSAGE = (
+    "phm-data-factory is optional and is not installed. "
+    "Install the approved backend and its required extra before selecting "
+    "data.factory_name: phm_data."
+)
+
+
+def _value(config: Any, name: str, default: Any = None) -> Any:
+    if isinstance(config, Mapping):
+        return config.get(name, default)
+    return getattr(config, name, default)
+
+
+def _load_provider() -> Any:
+    """Import the installed provider without changing import resolution."""
+
+    try:
+        provider = importlib.import_module("phm_data_factory")
+    except ModuleNotFoundError as exc:
+        if exc.name != "phm_data_factory":
+            raise
+        raise ModuleNotFoundError(MISSING_BACKEND_MESSAGE) from exc
+
+    version = getattr(provider, "__version__", None)
+    if version != EXPECTED_PROVIDER_VERSION:
+        raise RuntimeError(
+            "PHMFactory requires phm-data-factory 0.2.0 for the phm_data "
+            f"backend; imported version {version!r}."
+        )
+    if not callable(getattr(provider, "connect", None)):
+        raise RuntimeError("Installed phm-data-factory has no callable connect API.")
+    return provider
+
+
+def _configured_backend(args_data: Any) -> Mapping[str, Any] | Path:
+    configured = _value(args_data, "phm_data_config")
+    if not configured:
+        raise ValueError(
+            "data.factory_name=phm_data requires data.phm_data_config"
+        )
+    if isinstance(configured, Mapping):
+        return dict(configured)
+    if not isinstance(configured, (str, Path)):
+        raise TypeError("data.phm_data_config must be a path or mapping")
+    return Path(configured).expanduser().resolve()
+
+
+def build_data_repository(args_data: Any) -> Any:
+    """Open the explicitly configured provider; never select a fallback."""
+
+    configured = _configured_backend(args_data)
+    return _load_provider().connect(configured)

--- a/test/test_phm_data_factory_backend.py
+++ b/test/test_phm_data_factory_backend.py
@@ -1,0 +1,232 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import h5py
+import numpy as np
+import pandas as pd
+import pytest
+
+from src.config_schema.models import DataConfig
+from src.configs.config_utils import build_experiment_name, load_config
+from src.data_factory import build_data, build_data_repository
+from src.data_factory import standalone
+from src.data_factory.data_factory import data_factory
+
+
+def _missing_module(name: str) -> ModuleNotFoundError:
+    return ModuleNotFoundError(f"No module named {name!r}", name=name)
+
+
+def _backend_config(tmp_path: Path) -> Path:
+    pd.DataFrame(
+        [
+            {
+                "Id": 1,
+                "Dataset_id": 7,
+                "Name": "fixture",
+                "Visiable": 1,
+                "Label": 2,
+                "Domain_id": 3,
+                "Sample_lenth": 8,
+                "Channel": 1,
+            }
+        ]
+    ).to_csv(tmp_path / "metadata.csv", index=False)
+    with h5py.File(tmp_path / "cache.h5", "w") as handle:
+        handle.create_dataset("1", data=np.arange(8, dtype=np.float64)[:, None])
+    config = tmp_path / "phm-data.yaml"
+    config.write_text(
+        "backend: local\n"
+        f"metadata_path: {tmp_path / 'metadata.csv'}\n"
+        f"signal_path: {tmp_path / 'cache.h5'}\n",
+        encoding="utf-8",
+    )
+    return config
+
+
+def _end_to_end_backend_config(tmp_path: Path) -> Path:
+    pd.DataFrame(
+        [
+            {
+                "Id": sample_id,
+                "Dataset_id": 7,
+                "Name": "fixture",
+                "Visiable": 1,
+                "Label": label,
+                "Domain_id": domain,
+                "Sample_lenth": 16,
+                "Channel": 1,
+            }
+            for sample_id, label, domain in ((1, 0, 0), (2, 1, 1))
+        ]
+    ).to_csv(tmp_path / "metadata-e2e.csv", index=False)
+    with h5py.File(tmp_path / "signals-e2e.h5", "w") as handle:
+        handle.create_dataset("1", data=np.arange(16, dtype=np.float64)[:, None])
+        handle.create_dataset("2", data=np.arange(16, 32, dtype=np.float64)[:, None])
+    config = tmp_path / "phm-data-e2e.yaml"
+    config.write_text(
+        "backend: local\n"
+        f"metadata_path: {tmp_path / 'metadata-e2e.csv'}\n"
+        f"signal_path: {tmp_path / 'signals-e2e.h5'}\n",
+        encoding="utf-8",
+    )
+    return config
+
+
+def test_data_config_requires_factory_specific_fields() -> None:
+    DataConfig(factory_name="phm_data", phm_data_config="backend.yaml")
+    DataConfig(data_dir="data", metadata_file="metadata.csv")
+    with pytest.raises(ValueError, match="phm_data_config"):
+        DataConfig(factory_name="phm_data")
+    with pytest.raises(ValueError, match="data.data_dir"):
+        DataConfig()
+
+
+def test_legacy_config_loader_applies_same_conditional_contract() -> None:
+    common: dict[str, Any] = {
+        "model": {"name": "model", "type": "MLP"},
+        "task": {"name": "classification", "type": "DG"},
+    }
+    config = load_config(
+        {
+            **common,
+            "data": {
+                "factory_name": "phm_data",
+                "phm_data_config": "config/provider.yaml",
+            },
+        }
+    )
+    assert config.data.phm_data_config == "config/provider.yaml"
+    assert build_experiment_name(config).startswith("provider/")
+
+    with pytest.raises(ValueError, match="phm_data_config"):
+        load_config({**common, "data": {"factory_name": "phm_data"}})
+    with pytest.raises(ValueError, match="data.data_dir"):
+        load_config({**common, "data": {"factory_name": "default"}})
+
+
+def test_missing_backend_is_explicit_and_does_not_change_sys_path(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    before = tuple(sys.path)
+
+    def missing(_: str) -> Any:
+        raise _missing_module("phm_data_factory")
+
+    monkeypatch.setattr(standalone.importlib, "import_module", missing)
+    with pytest.raises(ModuleNotFoundError, match="optional and is not installed"):
+        build_data_repository(
+            SimpleNamespace(factory_name="phm_data", phm_data_config="backend.yaml")
+        )
+    assert tuple(sys.path) == before
+
+
+def test_provider_dependency_import_error_is_not_misreported(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def missing_dependency(_: str) -> Any:
+        raise _missing_module("provider_dependency")
+
+    monkeypatch.setattr(
+        standalone.importlib, "import_module", missing_dependency
+    )
+    with pytest.raises(ModuleNotFoundError) as raised:
+        build_data_repository(
+            SimpleNamespace(factory_name="phm_data", phm_data_config="backend.yaml")
+        )
+    assert raised.value.name == "provider_dependency"
+
+
+def test_wrong_provider_version_fails_closed(monkeypatch: pytest.MonkeyPatch) -> None:
+    provider = SimpleNamespace(__version__="0.3.0", connect=lambda _: object())
+    monkeypatch.setattr(
+        standalone.importlib, "import_module", lambda _: provider
+    )
+    with pytest.raises(RuntimeError, match="requires phm-data-factory 0.2.0"):
+        build_data_repository(
+            SimpleNamespace(factory_name="phm_data", phm_data_config="backend.yaml")
+        )
+
+
+def test_registered_factory_uses_exact_provider_training_contract(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    provider = pytest.importorskip("phm_data_factory")
+    assert provider.__version__ == "0.2.0"
+    manifest = provider.agent_contract_manifest()
+    assert manifest["api_schema_version"] == "1.0.0"
+    assert manifest["capability_schema_version"] == "1.0.0"
+    config = _backend_config(tmp_path)
+    monkeypatch.setattr(
+        data_factory, "_init_dataset", lambda self: ("train", "val", "test")
+    )
+    monkeypatch.setattr(
+        data_factory, "_init_dataloader", lambda self: ("tl", "vl", "xl")
+    )
+    args_data = SimpleNamespace(
+        factory_name="phm_data", phm_data_config=str(config), num_workers=0
+    )
+
+    factory = build_data(args_data, SimpleNamespace(name="Default", type="DG"))
+    try:
+        assert factory.metadata["1"]["Dataset_id"] == 7
+        assert factory.metadata["1"]["Label"] == 2
+        np.testing.assert_array_equal(factory.data["1"][:, 0], np.arange(8))
+    finally:
+        factory.close()
+        factory.close()
+    assert factory._closed is True
+
+
+def test_provider_backend_reaches_existing_datasets_and_loaders(tmp_path: Path) -> None:
+    provider = pytest.importorskip("phm_data_factory")
+    assert provider.__version__ == "0.2.0"
+    args_data = SimpleNamespace(
+        factory_name="phm_data",
+        phm_data_config=str(_end_to_end_backend_config(tmp_path)),
+        num_workers=0,
+        batch_size=1,
+        window_size=4,
+        stride=1,
+        train_ratio=0.5,
+        num_window=2,
+        dtype="float32",
+        normalization="none",
+    )
+    args_task = SimpleNamespace(
+        name="classification",
+        type="DG",
+        target_system_id=[7],
+        source_domain_id=[0],
+        target_domain_id=[1],
+    )
+
+    with build_data(args_data, args_task) as factory:
+        train_batch = next(iter(factory.train_loader))
+        test_batch = next(iter(factory.test_loader))
+        assert tuple(train_batch["x"].shape) == (1, 4, 1)
+        assert tuple(test_batch["x"].shape) == (1, 4, 1)
+        assert train_batch["y"].tolist() == [0]
+        assert test_batch["y"].tolist() == [1]
+
+
+def test_backend_config_is_required_before_import(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    called = False
+
+    def unexpected_import(_: str) -> Any:
+        nonlocal called
+        called = True
+        raise AssertionError("provider import must not run")
+
+    monkeypatch.setattr(
+        standalone.importlib, "import_module", unexpected_import
+    )
+    with pytest.raises(ValueError, match="phm_data_config"):
+        build_data_repository(SimpleNamespace(factory_name="phm_data"))
+    assert called is False

--- a/test/test_submodule_policy.py
+++ b/test/test_submodule_policy.py
@@ -52,6 +52,19 @@ def test_unconfigured_raw_gitlink_is_rejected(monkeypatch) -> None:
     )
 
 
+def test_gitlinks_reads_the_staged_index(monkeypatch) -> None:
+    output = (
+        "100644 " + "1" * 40 + " 0\tREADME.md\n"
+        "160000 " + "2" * 40 + " 0\tpackages/provider\n"
+    )
+    monkeypatch.setattr(
+        policy.subprocess,
+        "run",
+        lambda *args, **kwargs: type("Result", (), {"stdout": output})(),
+    )
+    assert policy._gitlinks() == {"packages/provider": "2" * 40}
+
+
 def test_personal_backend_url_is_not_allowlisted(monkeypatch) -> None:
     allowlist = policy._load_allowlist()
     candidate = dict(allowlist["allowed_submodules"][0])
@@ -65,6 +78,12 @@ def test_personal_backend_url_is_not_allowlisted(monkeypatch) -> None:
 
 
 def test_deferred_backend_must_be_absent(monkeypatch) -> None:
+    allowlist = policy._load_allowlist()
+    candidate = dict(allowlist["allowed_submodules"][0])
+    candidate.update(status="deferred_to_v0.3.1", pinned_commit=None)
+    changed = dict(allowlist)
+    changed["allowed_submodules"] = [candidate]
+    monkeypatch.setattr(policy, "_load_allowlist", lambda: changed)
     monkeypatch.setattr(
         policy,
         "_configured_submodules",
@@ -88,7 +107,11 @@ def test_deferred_backend_must_be_absent(monkeypatch) -> None:
 def test_approved_backend_requires_exact_gitlink(monkeypatch) -> None:
     allowlist = policy._load_allowlist()
     candidate = dict(allowlist["allowed_submodules"][0])
-    candidate.update(status="approved", pinned_commit="b" * 40)
+    candidate.update(
+        status="approved",
+        reviewed_source_tree_commit=policy.TARGET_BACKEND_COMMIT,
+        pinned_commit=policy.TARGET_BACKEND_COMMIT,
+    )
     changed = dict(allowlist)
     changed["allowed_submodules"] = [candidate]
     monkeypatch.setattr(policy, "_load_allowlist", lambda: changed)
@@ -110,3 +133,23 @@ def test_approved_backend_requires_exact_gitlink(monkeypatch) -> None:
 
     findings = policy.collect_findings()
     assert any(finding.code == "BACKEND_GITLINK_MISMATCH" for finding in findings)
+
+
+def test_approved_backend_requires_released_commit(monkeypatch) -> None:
+    allowlist = policy._load_allowlist()
+    candidate = dict(allowlist["allowed_submodules"][0])
+    candidate.update(
+        status="approved",
+        reviewed_source_tree_commit="b" * 40,
+        pinned_commit="b" * 40,
+    )
+    changed = dict(allowlist)
+    changed["allowed_submodules"] = [candidate]
+    monkeypatch.setattr(policy, "_load_allowlist", lambda: changed)
+    monkeypatch.setattr(policy, "_configured_submodules", lambda: {})
+    monkeypatch.setattr(policy, "_gitlinks", lambda: {})
+
+    findings = policy.collect_findings()
+    codes = {finding.code for finding in findings}
+    assert "BACKEND_REVIEWED_COMMIT_INVALID" in codes
+    assert "BACKEND_PIN_INVALID" in codes

--- a/test/test_validate_docs_scope.py
+++ b/test/test_validate_docs_scope.py
@@ -24,3 +24,21 @@ def test_validate_docs_skips_local_agent_and_obsidian_dirs(tmp_path) -> None:
     scanned = {path.relative_to(tmp_path).as_posix() for path in iter_doc_files(tmp_path)}
 
     assert scanned == {"README.md", ".claude/README.md"}
+
+
+def test_validate_docs_skips_initialized_git_submodules(tmp_path) -> None:
+    (tmp_path / "README.md").write_text("# Root\n", encoding="utf-8")
+    (tmp_path / ".gitmodules").write_text(
+        '[submodule "provider"]\n'
+        "\tpath = packages/provider\n"
+        "\turl = https://example.invalid/provider.git\n",
+        encoding="utf-8",
+    )
+    provider = tmp_path / "packages" / "provider"
+    provider.mkdir(parents=True)
+    (provider / "README.md").write_text("[broken](missing.md)\n", encoding="utf-8")
+    (provider / "AGENTS.md").write_text("# External instructions\n", encoding="utf-8")
+
+    scanned = {path.relative_to(tmp_path).as_posix() for path in iter_doc_files(tmp_path)}
+
+    assert scanned == {"README.md"}

--- a/tools/repo/check_submodule_policy.py
+++ b/tools/repo/check_submodule_policy.py
@@ -21,6 +21,8 @@ DEFERRAL_PATH = ROOT / "docs/releases/v0.3.0-backend-deferral.yaml"
 GITMODULES_PATH = ROOT / ".gitmodules"
 TARGET_BACKEND_PATH = "packages/phm-data-factory"
 TARGET_BACKEND_URL = "https://github.com/PHMbench/phm-data-factory.git"
+TARGET_BACKEND_COMMIT = "16180b5fd9ca31d79fe65efd29b11439c1e54186"
+TARGET_INTEGRATION_PR = 148
 SHA40 = re.compile(r"[0-9a-f]{40}")
 DEFERRED_STATUS = "deferred_to_v0.3.1"
 APPROVED_STATUS = "approved"
@@ -70,7 +72,7 @@ def _configured_submodules() -> dict[str, dict[str, str]]:
 
 def _gitlinks() -> dict[str, str]:
     result = subprocess.run(
-        ["git", "ls-tree", "-r", "HEAD"],
+        ["git", "ls-files", "--stage"],
         cwd=ROOT,
         check=True,
         text=True,
@@ -82,8 +84,8 @@ def _gitlinks() -> dict[str, str]:
             continue
         metadata, path = line.split("\t", 1)
         fields = metadata.split()
-        if len(fields) == 3 and fields[0] == "160000" and fields[1] == "commit":
-            gitlinks[path] = fields[2]
+        if len(fields) == 3 and fields[0] == "160000" and fields[2] == "0":
+            gitlinks[path] = fields[1]
     return gitlinks
 
 
@@ -215,16 +217,56 @@ def collect_findings() -> tuple[Finding, ...]:
     if status not in {DEFERRED_STATUS, APPROVED_STATUS}:
         findings.append(Finding("BACKEND_STATUS_INVALID", f"unsupported status: {status!r}"))
 
+    if status == APPROVED_STATUS:
+        expected_release = {
+            "release_tag": "v0.2.0",
+            "package_version": "0.2.0",
+            "api_schema_version": "1.0.0",
+            "capability_schema_version": "1.0.0",
+            "approved_integration_pr": TARGET_INTEGRATION_PR,
+        }
+        for field, expected in expected_release.items():
+            actual = candidate.get(field)
+            if actual != expected:
+                findings.append(
+                    Finding(
+                        "BACKEND_RELEASE_AUTHORITY_INVALID",
+                        f"{field}={actual!r}, expected {expected!r}",
+                    )
+                )
+        ownership = candidate.get("ownership_transfer") or {}
+        if not isinstance(ownership, dict) or ownership.get("status") != "completed":
+            findings.append(
+                Finding(
+                    "BACKEND_OWNERSHIP_TRANSFER_INCOMPLETE",
+                    "ownership_transfer.status must be completed",
+                )
+            )
+
     reviewed = str(candidate.get("reviewed_source_tree_commit") or "")
     if not SHA40.fullmatch(reviewed):
         findings.append(
             Finding("BACKEND_REVIEWED_COMMIT_INVALID", "reviewed source tree commit is not 40 hex")
+        )
+    elif status == APPROVED_STATUS and reviewed != TARGET_BACKEND_COMMIT:
+        findings.append(
+            Finding(
+                "BACKEND_REVIEWED_COMMIT_INVALID",
+                f"reviewed commit must be released commit {TARGET_BACKEND_COMMIT}",
+            )
         )
 
     pinned = str(candidate.get("pinned_commit") or "")
     if status == APPROVED_STATUS and not SHA40.fullmatch(pinned):
         findings.append(
             Finding("BACKEND_PIN_MISSING", "approved backend requires a 40-hex pinned_commit")
+        )
+    elif status == APPROVED_STATUS and pinned != TARGET_BACKEND_COMMIT:
+        findings.append(
+            Finding(
+                "BACKEND_PIN_INVALID",
+                f"pinned commit must be released commit {TARGET_BACKEND_COMMIT}",
+            )
         )
     if status != APPROVED_STATUS and pinned:
         findings.append(
@@ -237,13 +279,17 @@ def collect_findings() -> tuple[Finding, ...]:
         else:
             for error in _deferral_errors(_load_deferral()):
                 findings.append(Finding("BACKEND_DEFERRAL_INVALID", error))
-    elif status == APPROVED_STATUS and DEFERRAL_PATH.is_file():
-        findings.append(
-            Finding(
-                "BACKEND_DEFERRAL_CONFLICT",
-                "approved backend cannot retain the v0.3.0 exclusion contract",
+    elif status == APPROVED_STATUS:
+        if not DEFERRAL_PATH.is_file():
+            findings.append(
+                Finding(
+                    "BACKEND_HISTORICAL_DEFERRAL_MISSING",
+                    str(DEFERRAL_PATH.relative_to(ROOT)),
+                )
             )
-        )
+        else:
+            for error in _deferral_errors(_load_deferral()):
+                findings.append(Finding("BACKEND_HISTORICAL_DEFERRAL_INVALID", error))
 
     legacy_items = allowlist.get("legacy_entries") or []
     legacy: dict[str, dict[str, Any]] = {}


### PR DESCRIPTION
## Scope

This PR implements the bounded PHMFactory v0.3.1 integration for the public optional provider `PHMbench/phm-data-factory`.

- pins provider release `v0.2.0` at exact merge commit `16180b5fd9ca31d79fe65efd29b11439c1e54186`;
- adds explicit `factory_name: phm_data` selection using trusted `metadata_frame("phm_vibench_v1")` and dense `read_signal()`;
- preserves PHMFactory-owned filtering, splits, windowing, normalization, Dataset/DataLoader, tasks, models, and trainers;
- requires an explicitly installed provider and `phm_data_config`;
- fails closed on a missing/wrong-version provider;
- performs no `sys.path` mutation, submodule initialization, or silent fallback;
- retains the immutable v0.3.0 deferral record as historical release evidence while approving PR #148 for v0.3.1.

## Exact dependency authority

- repository: `https://github.com/PHMbench/phm-data-factory.git`
- gitlink/reviewed commit: `16180b5fd9ca31d79fe65efd29b11439c1e54186`
- tag/package: `v0.2.0` / `0.2.0`
- API and capability schemas: `1.0.0`
- license: Apache-2.0
- submodule checkout: clean and detached

## Non-goals / protected paths

No changes to `src/data_factory/data_factory.py`, readers, dataset-task implementations, samplers, models, tasks, trainers, or Pipeline semantics.

This PR makes no real-dataset accuracy, throughput, live-IoTDB-in-PHMFactory, multimodal, or paper-result claim. The provider's separate synthetic live-IoTDB acceptance is not promoted into PHMFactory runtime evidence.

## Local validation

Environment: conda `LQ_signal`, base `dev@921b6f7485798eb20cc8323da9078003474eb541`.

- full maintained suite: **242 passed, 1 skipped**;
- focused adapter contract: **8 passed**, including provider → existing filtering → window Dataset → DataLoader;
- submodule policy tests: **9 passed**;
- documentation: 99 maintained files passed before artifact build; final clean-checkout validation is repeated by CI;
- maintained configs: **7/7 passed**;
- exact submodule release policy: **PASS, 0 blockers**;
- protected runtime diff: empty;
- root and module CLI help: pass;
- repo-shipped Dummy end-to-end train/test: pass with output redirected to `/tmp`;
- wheel: `pip wheel --no-deps --no-build-isolation` passed; clean installed-wheel CLI/import smoke passed and importing `src.data_factory` did not load `phm_data_factory`.

The direct `python -m build` command could not run because PyPA `build` is not installed in `LQ_signal`; no dependency was installed solely to hide that environment limitation. Wheel construction succeeded through pip's PEP 517 path.

Release-readiness audit retains exactly the five pre-existing blockers (two missing CWRU hashes, two floating CWRU provider revisions, and `0.3.0.dev0`); it has no backend blocker.

## Risk and rollback

Risk is contained to explicit `factory_name: phm_data` selection. Existing factory names retain their original required fields and behavior. Rollback is the removal of the adapter registration, exact gitlink, and approved allowlist entry; no data migration or protected-runtime rewrite is involved.