### PR TITLE
refactor(runtime): add fail-closed execution envelope

### DIFF
--- a/.github/workflows/phmfactory-public-package.yml
+++ b/.github/workflows/phmfactory-public-package.yml
@@ -16,6 +16,8 @@ on:
       - "test/test_phmfactory_entrypoints.py"
       - "test/test_phmfactory_config_resolver.py"
       - "test/test_pipeline_name_migration.py"
+      - "test/test_runtime_control_plane.py"
+      - "test/test_runtime_execution.py"
       - ".github/workflows/phmfactory-public-package.yml"
   push:
     branches:
@@ -34,6 +36,8 @@ on:
       - "test/test_phmfactory_entrypoints.py"
       - "test/test_phmfactory_config_resolver.py"
       - "test/test_pipeline_name_migration.py"
+      - "test/test_runtime_control_plane.py"
+      - "test/test_runtime_execution.py"
       - ".github/workflows/phmfactory-public-package.yml"
   workflow_dispatch:
 
@@ -64,11 +68,14 @@ jobs:
         run: >-
           python -m py_compile
           phmfactory/*.py
+          phmfactory/runtime/*.py
           src/configs/config_utils.py
           main.py
           test/test_phmfactory_entrypoints.py
           test/test_phmfactory_config_resolver.py
           test/test_pipeline_name_migration.py
+          test/test_runtime_control_plane.py
+          test/test_runtime_execution.py
 
       - name: Run focused public API tests
         run: >-
@@ -77,6 +84,8 @@ jobs:
           test/test_phmfactory_entrypoints.py
           test/test_phmfactory_config_resolver.py
           test/test_pipeline_name_migration.py
+          test/test_runtime_control_plane.py
+          test/test_runtime_execution.py
 
       - name: Upload focused pytest diagnostics
         if: always()
@@ -105,6 +114,9 @@ jobs:
               "phmfactory/cli.py",
               "phmfactory/config.py",
               "phmfactory/pipelines.py",
+              "phmfactory/runtime/__init__.py",
+              "phmfactory/runtime/spec.py",
+              "phmfactory/runtime/execution.py",
               "src/__init__.py",
               "src/configs/config_utils.py",
               "configs/__init__.py",
@@ -129,7 +141,7 @@ jobs:
           python -m venv /tmp/phmfactory-wheel
           /tmp/phmfactory-wheel/bin/python -m pip install --no-deps dist/*.whl
           /tmp/phmfactory-wheel/bin/python -m pip install PyYAML
-          /tmp/phmfactory-wheel/bin/python -c "import phmfactory, phmfactory.config, src; print(phmfactory.__version__)"
+          /tmp/phmfactory-wheel/bin/python -c "import phmfactory, phmfactory.config, phmfactory.runtime, src; print(phmfactory.__version__)"
           /tmp/phmfactory-wheel/bin/phmfactory --help
           /tmp/phmfactory-wheel/bin/python -m phmfactory --help
           cd /tmp

--- a/docs/developer_runtime_control_plane.md
+++ b/docs/developer_runtime_control_plane.md
@@ -7,15 +7,26 @@ imported:
 config or preset + CLI overrides
   -> phmfactory.config.resolve_config
   -> phmfactory.runtime.CompiledRunSpec
+  -> phmfactory.runtime.ExecutionEnvelope
   -> canonical Pipeline adapter
   -> protected src runtime
 ```
 
-`CompiledRunSpec` is the hand-off boundary for the ongoing runtime consolidation. It
-contains the fully composed configuration, canonical Pipeline identifier, explicit
-overrides, and a deterministic semantic SHA-256. Its hash excludes the absolute
-installation path, so an identical packaged preset has the same identity outside a
-repository checkout.
+`CompiledRunSpec` contains the fully composed configuration, canonical Pipeline
+identifier, explicit overrides, and a deterministic semantic SHA-256. Its hash excludes
+the absolute installation path, so an identical packaged preset has the same identity
+outside a repository checkout.
+
+`ExecutionEnvelope` is the public invocation boundary. It records pending, running,
+succeeded, or failed state and rejects ambiguous outcomes. A Pipeline module must expose
+a callable `pipeline(args)` and a successful invocation must return an explicit result.
+Returning `None`, omitting the entrypoint, or attempting to execute the same envelope
+twice is a contract error. Exceptions retain their original traceback while the envelope
+records the failure type and message for the later run-attestation writer.
+
+The public CLI prints the completion message only after the envelope reaches
+`succeeded`. A failed Pipeline therefore produces a non-zero process outcome rather than
+`print + return` followed by apparent success.
 
 Protected Pipeline code must consume `compiled_run_spec.runtime_config()` instead of
 reparsing the source YAML or automatically discovering machine-local files. Until a
@@ -53,7 +64,7 @@ The following invariants govern later refactors:
 2. local configuration is an explicit input;
 3. the selected Pipeline and executed configuration share one contract;
 4. runtime code receives a mutable copy and cannot mutate the compiled contract;
-5. missing sections, invalid iterations, invalid factory results, and execution failures
-   raise rather than printing success;
+5. missing sections, invalid iterations, invalid factory results, `None` Pipeline
+   results, and execution failures raise rather than printing success;
 6. data and logging resources are closed through a shared `finally` boundary;
-7. successful runs must produce a mandatory minimal attestation.
+7. successful and failed runs must produce a mandatory minimal attestation.

--- a/phmfactory/cli.py
+++ b/phmfactory/cli.py
@@ -10,7 +10,7 @@ from typing import Any
 
 from phmfactory.config import DEFAULT_CONFIG, resolve_config
 from phmfactory.pipelines import pipeline_module_name
-from phmfactory.runtime import CompiledRunSpec
+from phmfactory.runtime import CompiledRunSpec, ExecutionEnvelope
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -95,7 +95,7 @@ def _resolve_pipeline(args: argparse.Namespace, config_path: str) -> str:
 
 
 def run(args: argparse.Namespace) -> Any:
-    """Dispatch a parsed argument namespace to the protected runtime."""
+    """Compile and execute one Pipeline through the fail-closed public boundary."""
     requested_config = _resolve_config_path(args)
     resolved = resolve_config(requested_config, override_values=args.override)
     compiled = CompiledRunSpec.compile(resolved)
@@ -110,10 +110,11 @@ def run(args: argparse.Namespace) -> Any:
     args.resolved_config_data = compiled.runtime_config()
     args.run_spec_sha256 = compiled.sha256
 
-    pipeline_module = importlib.import_module(
-        pipeline_module_name(resolved.pipeline, warn=False)
-    )
-    result = pipeline_module.pipeline(args)
+    module_name = pipeline_module_name(resolved.pipeline, warn=False)
+    envelope = ExecutionEnvelope(spec=compiled, pipeline_module=module_name)
+    args.execution_envelope = envelope
+    pipeline_module = importlib.import_module(module_name)
+    result = envelope.execute(pipeline_module, args)
     print("完成所有实验！")
     return result
 

--- a/phmfactory/runtime/__init__.py
+++ b/phmfactory/runtime/__init__.py
@@ -1,5 +1,15 @@
 """Public runtime-control contracts for PHMFactory."""
 
+from phmfactory.runtime.execution import (
+    ExecutionEnvelope,
+    ExecutionStatus,
+    PipelineContractError,
+)
 from phmfactory.runtime.spec import CompiledRunSpec
 
-__all__ = ["CompiledRunSpec"]
+__all__ = [
+    "CompiledRunSpec",
+    "ExecutionEnvelope",
+    "ExecutionStatus",
+    "PipelineContractError",
+]

--- a/phmfactory/runtime/execution.py
+++ b/phmfactory/runtime/execution.py
@@ -1,0 +1,96 @@
+"""Fail-closed execution boundary for public PHMFactory entrypoints."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from enum import Enum
+from types import ModuleType
+from typing import Any, Callable
+
+from phmfactory.runtime.spec import CompiledRunSpec
+
+
+class ExecutionStatus(str, Enum):
+    """Finite states for one public Pipeline invocation."""
+
+    PENDING = "pending"
+    RUNNING = "running"
+    SUCCEEDED = "succeeded"
+    FAILED = "failed"
+
+
+class PipelineContractError(RuntimeError):
+    """Raised when a Pipeline module violates the public execution contract."""
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+@dataclass
+class ExecutionEnvelope:
+    """Record and enforce the lifecycle of one compiled Pipeline invocation."""
+
+    spec: CompiledRunSpec
+    pipeline_module: str
+    schema_version: int = 1
+    status: ExecutionStatus = ExecutionStatus.PENDING
+    started_at: str | None = None
+    finished_at: str | None = None
+    error_type: str | None = None
+    error_message: str | None = None
+
+    def _fail(self, error: BaseException) -> None:
+        self.status = ExecutionStatus.FAILED
+        self.finished_at = _utc_now()
+        self.error_type = type(error).__name__
+        self.error_message = str(error)
+
+    def execute(self, module: ModuleType | Any, args: Any) -> Any:
+        """Execute exactly once and reject missing or ambiguous success results."""
+
+        if self.status is not ExecutionStatus.PENDING:
+            raise PipelineContractError(
+                f"execution envelope cannot run from status {self.status.value!r}"
+            )
+
+        entrypoint: Callable[[Any], Any] | None = getattr(module, "pipeline", None)
+        if not callable(entrypoint):
+            error = PipelineContractError(
+                f"Pipeline module {self.pipeline_module!r} has no callable pipeline(args)"
+            )
+            self._fail(error)
+            raise error
+
+        self.status = ExecutionStatus.RUNNING
+        self.started_at = _utc_now()
+        try:
+            result = entrypoint(args)
+            if result is None:
+                raise PipelineContractError(
+                    f"Pipeline {self.spec.pipeline!r} returned None; "
+                    "successful Pipelines must return an explicit result"
+                )
+        except BaseException as error:
+            self._fail(error)
+            raise
+
+        self.status = ExecutionStatus.SUCCEEDED
+        self.finished_at = _utc_now()
+        return result
+
+    def as_dict(self) -> dict[str, Any]:
+        """Return the minimal state needed by the later run-attestation writer."""
+
+        return {
+            "schema_version": self.schema_version,
+            "run_spec_sha256": self.spec.sha256,
+            "pipeline": self.spec.pipeline,
+            "pipeline_module": self.pipeline_module,
+            "status": self.status.value,
+            "started_at": self.started_at,
+            "finished_at": self.finished_at,
+            "error_type": self.error_type,
+            "error_message": self.error_message,
+        }

--- a/test/test_phmfactory_entrypoints.py
+++ b/test/test_phmfactory_entrypoints.py
@@ -105,9 +105,10 @@ def test_run_passes_maintained_preset_path_to_runtime(
 ) -> None:
     observed: dict[str, object] = {}
 
-    def pipeline(args: argparse.Namespace) -> None:
+    def pipeline(args: argparse.Namespace) -> bool:
         observed["requested_config"] = args.requested_config
         observed["config_path"] = args.config_path
+        return True
 
     monkeypatch.setattr(
         cli.importlib,
@@ -121,7 +122,7 @@ def test_run_passes_maintained_preset_path_to_runtime(
         override=None,
     )
 
-    cli.run(args)
+    assert cli.run(args) is True
 
     assert observed["requested_config"] == preset
     assert Path(str(observed["config_path"])) == resolve_config_path(preset)

--- a/test/test_runtime_execution.py
+++ b/test/test_runtime_execution.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from phmfactory import cli
+from phmfactory.config import ResolvedConfig
+from phmfactory.runtime import (
+    CompiledRunSpec,
+    ExecutionEnvelope,
+    ExecutionStatus,
+    PipelineContractError,
+)
+
+
+def _spec() -> CompiledRunSpec:
+    return CompiledRunSpec.compile(
+        ResolvedConfig(
+            requested="smoke",
+            path=Path("/tmp/smoke.yaml"),
+            data={"pipeline": "Pipeline_01_Fault_Diagnosis"},
+            pipeline="Pipeline_01_Fault_Diagnosis",
+            overrides={},
+        )
+    )
+
+
+def test_envelope_records_success() -> None:
+    envelope = ExecutionEnvelope(
+        spec=_spec(),
+        pipeline_module="src.Pipeline_01_Fault_Diagnosis",
+    )
+    result = envelope.execute(SimpleNamespace(pipeline=lambda args: ["ok"]), object())
+
+    assert result == ["ok"]
+    assert envelope.status is ExecutionStatus.SUCCEEDED
+    assert envelope.started_at is not None
+    assert envelope.finished_at is not None
+    assert envelope.error_type is None
+    assert envelope.as_dict()["run_spec_sha256"] == envelope.spec.sha256
+
+
+def test_envelope_rejects_none_as_ambiguous_success() -> None:
+    envelope = ExecutionEnvelope(spec=_spec(), pipeline_module="src.invalid")
+
+    with pytest.raises(PipelineContractError, match="returned None"):
+        envelope.execute(SimpleNamespace(pipeline=lambda args: None), object())
+
+    assert envelope.status is ExecutionStatus.FAILED
+    assert envelope.error_type == "PipelineContractError"
+    assert envelope.finished_at is not None
+
+
+def test_envelope_rejects_missing_entrypoint() -> None:
+    envelope = ExecutionEnvelope(spec=_spec(), pipeline_module="src.invalid")
+
+    with pytest.raises(PipelineContractError, match="no callable pipeline"):
+        envelope.execute(SimpleNamespace(), object())
+
+    assert envelope.status is ExecutionStatus.FAILED
+
+
+def test_envelope_records_and_reraises_pipeline_error() -> None:
+    envelope = ExecutionEnvelope(spec=_spec(), pipeline_module="src.invalid")
+
+    def fail(args):
+        raise ValueError("invalid training state")
+
+    with pytest.raises(ValueError, match="invalid training state"):
+        envelope.execute(SimpleNamespace(pipeline=fail), object())
+
+    assert envelope.status is ExecutionStatus.FAILED
+    assert envelope.error_type == "ValueError"
+    assert envelope.error_message == "invalid training state"
+
+
+def test_envelope_cannot_execute_twice() -> None:
+    envelope = ExecutionEnvelope(spec=_spec(), pipeline_module="src.valid")
+    envelope.execute(SimpleNamespace(pipeline=lambda args: True), object())
+
+    with pytest.raises(PipelineContractError, match="cannot run from status"):
+        envelope.execute(SimpleNamespace(pipeline=lambda args: True), object())
+
+
+def test_cli_does_not_print_completion_when_pipeline_returns_none(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    resolved = ResolvedConfig(
+        requested="broken",
+        path=Path("/tmp/broken.yaml"),
+        data={"pipeline": "Pipeline_01_Fault_Diagnosis"},
+        pipeline="Pipeline_01_Fault_Diagnosis",
+        overrides={},
+    )
+    monkeypatch.setattr(cli, "resolve_config", lambda *args, **kwargs: resolved)
+    monkeypatch.setattr(
+        cli.importlib,
+        "import_module",
+        lambda name: SimpleNamespace(pipeline=lambda args: None),
+    )
+
+    args = argparse.Namespace(
+        config="broken",
+        config_path=None,
+        notes="",
+        override=None,
+    )
+    with pytest.raises(PipelineContractError):
+        cli.run(args)
+
+    assert "完成所有实验" not in capsys.readouterr().out
+    assert args.execution_envelope.status is ExecutionStatus.FAILED


### PR DESCRIPTION
## Objective

Ensure the public PHMFactory CLI cannot report success when a Pipeline has not produced an explicit successful result.

## Changes

- add `ExecutionEnvelope`, `ExecutionStatus`, and `PipelineContractError`;
- execute the canonical Pipeline through pending/running/succeeded/failed states;
- reject missing entrypoints, `None` results, and accidental second execution;
- record failure type/message while preserving the original traceback;
- attach the envelope for the next run-attestation PR;
- print completion only after `succeeded`;
- extend source, wheel-content, clean-install, and checkout-outside dispatch gates.

## Boundaries

```text
no Pipeline/reader/model/task/trainer algorithm change
no data split, metric, or checkpoint change
no CWRU revision/hash change
no repository rename/version/tag/release change
```

## Validation

```text
PHMFactory public package and focused execution tests: success
wheel contents and clean installation: success
checkout-outside wheel dispatch: success
Core quality gates and Dummy smoke: success
CWRU bundle contract: success
Repository layout: success
Submodule policy: success
```