### PR TITLE
feat(runtime): add mandatory atomic run attestation

### DIFF
--- a/.github/workflows/phmfactory-public-package.yml
+++ b/.github/workflows/phmfactory-public-package.yml
@@ -18,6 +18,7 @@ on:
       - "test/test_pipeline_name_migration.py"
       - "test/test_runtime_control_plane.py"
       - "test/test_runtime_execution.py"
+      - "test/test_runtime_attestation.py"
       - ".github/workflows/phmfactory-public-package.yml"
   push:
     branches:
@@ -38,6 +39,7 @@ on:
       - "test/test_pipeline_name_migration.py"
       - "test/test_runtime_control_plane.py"
       - "test/test_runtime_execution.py"
+      - "test/test_runtime_attestation.py"
       - ".github/workflows/phmfactory-public-package.yml"
   workflow_dispatch:
 
@@ -76,6 +78,7 @@ jobs:
           test/test_pipeline_name_migration.py
           test/test_runtime_control_plane.py
           test/test_runtime_execution.py
+          test/test_runtime_attestation.py
 
       - name: Run focused public API tests
         run: >-
@@ -86,6 +89,7 @@ jobs:
           test/test_pipeline_name_migration.py
           test/test_runtime_control_plane.py
           test/test_runtime_execution.py
+          test/test_runtime_attestation.py
 
       - name: Upload focused pytest diagnostics
         if: always()
@@ -117,6 +121,7 @@ jobs:
               "phmfactory/runtime/__init__.py",
               "phmfactory/runtime/spec.py",
               "phmfactory/runtime/execution.py",
+              "phmfactory/runtime/attestation.py",
               "src/__init__.py",
               "src/configs/config_utils.py",
               "configs/__init__.py",
@@ -146,6 +151,7 @@ jobs:
           /tmp/phmfactory-wheel/bin/python -m phmfactory --help
           cd /tmp
           /tmp/phmfactory-wheel/bin/python - <<'PY'
+          import json
           from pathlib import Path
           from types import SimpleNamespace
           from unittest.mock import patch
@@ -180,4 +186,10 @@ jobs:
 
           with patch.object(cli.importlib, "import_module", side_effect=fake_import):
               assert cli.main(["--config", "smoke"]) == "wheel-dispatch-pass"
+
+          manifests = list(Path("/tmp/results").rglob("run_manifest.json"))
+          assert len(manifests) == 1, manifests
+          payload = json.loads(manifests[0].read_text(encoding="utf-8"))
+          assert payload["status"] == "succeeded"
+          assert payload["run_spec"]["pipeline"] == "Pipeline_01_Fault_Diagnosis"
           PY

--- a/docs/developer_runtime_control_plane.md
+++ b/docs/developer_runtime_control_plane.md
@@ -8,8 +8,10 @@ config or preset + CLI overrides
   -> phmfactory.config.resolve_config
   -> phmfactory.runtime.CompiledRunSpec
   -> phmfactory.runtime.ExecutionEnvelope
+  -> phmfactory.runtime.RunAttestation (pending)
   -> canonical Pipeline adapter
   -> protected src runtime
+  -> RunAttestation (succeeded or failed)
 ```
 
 `CompiledRunSpec` contains the fully composed configuration, canonical Pipeline
@@ -22,11 +24,35 @@ succeeded, or failed state and rejects ambiguous outcomes. A Pipeline module mus
 a callable `pipeline(args)` and a successful invocation must return an explicit result.
 Returning `None`, omitting the entrypoint, or attempting to execute the same envelope
 twice is a contract error. Exceptions retain their original traceback while the envelope
-records the failure type and message for the later run-attestation writer.
+records the failure stage, type, and message.
 
 The public CLI prints the completion message only after the envelope reaches
 `succeeded`. A failed Pipeline therefore produces a non-zero process outcome rather than
 `print + return` followed by apparent success.
+
+## Mandatory invocation manifest
+
+After configuration compilation and before Pipeline import, the CLI creates:
+
+```text
+<environment.output_dir>/.phmfactory/runs/<run_id>/run_manifest.json
+```
+
+The first atomic version has `status: pending`. The same path is atomically replaced with
+`succeeded` or `failed` after execution. Each manifest contains the run ID, run-spec hash,
+canonical Pipeline and module, config source, explicit overrides, code revision when
+available, Python/platform summary, execution timestamps, and structured failure data.
+
+Manifest writes use a same-directory temporary file, flush and `fsync`, followed by
+`os.replace`. If the pending manifest cannot be created, the Pipeline is not imported. If
+the final succeeded manifest cannot be written, the public invocation fails and no
+completion message is printed. This makes the minimum attestation mandatory rather than
+best effort.
+
+The first schema intentionally keeps `data`, `protocol`, `seed`, and `environment`
+evidence as nested extension points. Pipeline-specific evidence such as the Pipeline 06
+stage ledger or UXFD explainability artifacts should be referenced from this manifest in
+later bounded PRs; they must not create another top-level run identity.
 
 Protected Pipeline code must consume `compiled_run_spec.runtime_config()` instead of
 reparsing the source YAML or automatically discovering machine-local files. Until a
@@ -67,4 +93,5 @@ The following invariants govern later refactors:
 5. missing sections, invalid iterations, invalid factory results, `None` Pipeline
    results, and execution failures raise rather than printing success;
 6. data and logging resources are closed through a shared `finally` boundary;
-7. successful and failed runs must produce a mandatory minimal attestation.
+7. every compiled invocation creates one mandatory minimal attestation;
+8. Pipeline-specific evidence extends the invocation manifest instead of redefining it.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -41,14 +41,20 @@ A successful smoke run should:
 
 - exit with status code `0`;
 - complete the config → data → model → task → trainer path;
-- print the repository completion message;
+- print `run_manifest=<path>` followed by the completion message;
 - create run output beneath `results/demo/dummy_dg_smoke/`;
+- create one invocation manifest below
+  `results/demo/dummy_dg_smoke/.phmfactory/runs/<run_id>/run_manifest.json`;
 - require no external dataset download.
+
+The invocation manifest is created with `status: pending` before Pipeline import and is
+atomically updated to `succeeded` or `failed`. A run is not considered successful when
+the final manifest cannot be written.
 
 Inspect the output tree without assuming a fixed experiment subdirectory name:
 
 ```bash
-find results/demo/dummy_dg_smoke -maxdepth 4 -type f | sort
+find results/demo/dummy_dg_smoke -maxdepth 6 -type f | sort
 ```
 
 Runtime outputs are evidence for the exact commit, configuration, overrides, data,
@@ -72,7 +78,8 @@ before requesting review for runtime or configuration changes. See the
 ## 5. Run a maintained demo with local data
 
 Only the dummy demo is fully offline. For another maintained configuration, pass
-local data paths as overrides instead of editing the tracked YAML:
+local data paths as explicit overrides instead of editing tracked YAML or relying on
+machine-local auto-discovery:
 
 ```bash
 python main.py --config configs/demo/01_cross_domain/cwru_dg.yaml \
@@ -110,8 +117,15 @@ surface; report unconditional optional imports as dependency-boundary bugs.
 ### A data or metadata path does not exist
 
 Return to the offline dummy config to verify the software environment. For local
-data, use `data.data_dir` and `data.metadata_file` overrides or
-`configs/local/local.yaml`.
+data, use explicit `data.data_dir` and `data.metadata_file` overrides or create a
+reviewable experiment YAML under `configs/experiments/`.
+
+### The run fails before training starts
+
+Open the printed or expected manifest path below
+`<environment.output_dir>/.phmfactory/runs/`. A failed manifest records the stage,
+exception type, and message. Configuration compilation failures that cannot determine a
+valid `environment.output_dir` fail before a manifest can be created.
 
 ### CUDA initialization fails
 

--- a/phmfactory/cli.py
+++ b/phmfactory/cli.py
@@ -10,7 +10,12 @@ from typing import Any
 
 from phmfactory.config import DEFAULT_CONFIG, resolve_config
 from phmfactory.pipelines import pipeline_module_name
-from phmfactory.runtime import CompiledRunSpec, ExecutionEnvelope
+from phmfactory.runtime import (
+    AttestationWriteError,
+    CompiledRunSpec,
+    ExecutionEnvelope,
+    RunAttestation,
+)
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -94,8 +99,19 @@ def _resolve_pipeline(args: argparse.Namespace, config_path: str) -> str:
     ).pipeline
 
 
+def _write_failed_attestation(
+    attestation: RunAttestation,
+    envelope: ExecutionEnvelope,
+    original_error: BaseException,
+) -> None:
+    try:
+        attestation.write(envelope)
+    except AttestationWriteError as write_error:
+        raise write_error from original_error
+
+
 def run(args: argparse.Namespace) -> Any:
-    """Compile and execute one Pipeline through the fail-closed public boundary."""
+    """Compile, attest, and execute one Pipeline through the public boundary."""
     requested_config = _resolve_config_path(args)
     resolved = resolve_config(requested_config, override_values=args.override)
     compiled = CompiledRunSpec.compile(resolved)
@@ -113,8 +129,37 @@ def run(args: argparse.Namespace) -> Any:
     module_name = pipeline_module_name(resolved.pipeline, warn=False)
     envelope = ExecutionEnvelope(spec=compiled, pipeline_module=module_name)
     args.execution_envelope = envelope
-    pipeline_module = importlib.import_module(module_name)
-    result = envelope.execute(pipeline_module, args)
+
+    try:
+        attestation = RunAttestation.prepare(compiled, module_name, envelope)
+    except BaseException as error:
+        envelope.record_failure(error, stage="attestation_prepare")
+        raise
+
+    args.run_attestation = attestation
+    args.run_id = attestation.run_id
+    args.run_manifest_path = str(attestation.manifest_path)
+
+    try:
+        pipeline_module = importlib.import_module(module_name)
+    except BaseException as error:
+        envelope.record_failure(error, stage="import")
+        _write_failed_attestation(attestation, envelope, error)
+        raise
+
+    try:
+        result = envelope.execute(pipeline_module, args)
+    except BaseException as error:
+        _write_failed_attestation(attestation, envelope, error)
+        raise
+
+    try:
+        attestation.write(envelope)
+    except AttestationWriteError as error:
+        envelope.record_failure(error, stage="attestation_finalize")
+        raise
+
+    print(f"run_manifest={attestation.manifest_path}")
     print("完成所有实验！")
     return result
 

--- a/phmfactory/runtime/__init__.py
+++ b/phmfactory/runtime/__init__.py
@@ -1,5 +1,10 @@
 """Public runtime-control contracts for PHMFactory."""
 
+from phmfactory.runtime.attestation import (
+    AttestationError,
+    AttestationWriteError,
+    RunAttestation,
+)
 from phmfactory.runtime.execution import (
     ExecutionEnvelope,
     ExecutionStatus,
@@ -8,8 +13,11 @@ from phmfactory.runtime.execution import (
 from phmfactory.runtime.spec import CompiledRunSpec
 
 __all__ = [
+    "AttestationError",
+    "AttestationWriteError",
     "CompiledRunSpec",
     "ExecutionEnvelope",
     "ExecutionStatus",
     "PipelineContractError",
+    "RunAttestation",
 ]

--- a/phmfactory/runtime/attestation.py
+++ b/phmfactory/runtime/attestation.py
@@ -1,0 +1,163 @@
+"""Mandatory minimal run attestation for public PHMFactory executions."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+import json
+import os
+from pathlib import Path
+import platform
+import subprocess
+import sys
+from typing import Any, Mapping
+from uuid import uuid4
+
+from phmfactory.runtime.execution import ExecutionEnvelope
+from phmfactory.runtime.spec import CompiledRunSpec
+
+
+class AttestationError(RuntimeError):
+    """Base error for the mandatory run-attestation contract."""
+
+
+class AttestationWriteError(AttestationError):
+    """Raised when a run manifest cannot be written atomically."""
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _new_run_id(spec: CompiledRunSpec) -> str:
+    stamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%S%fZ")
+    return f"{stamp}-{spec.sha256[:12]}-{uuid4().hex[:8]}"
+
+
+def _output_root(spec: CompiledRunSpec, *, cwd: Path | None = None) -> Path:
+    environment = spec.config.get("environment")
+    if not isinstance(environment, Mapping):
+        raise AttestationError("compiled config must contain an environment mapping")
+    output_dir = environment.get("output_dir")
+    if not isinstance(output_dir, str) or not output_dir.strip():
+        raise AttestationError(
+            "environment.output_dir is required for mandatory run attestation"
+        )
+    root = Path(output_dir).expanduser()
+    if not root.is_absolute():
+        root = (cwd or Path.cwd()) / root
+    return root.resolve()
+
+
+def _code_revision() -> dict[str, str | None]:
+    github_sha = os.environ.get("GITHUB_SHA", "").strip()
+    if github_sha:
+        return {"value": github_sha, "source": "GITHUB_SHA"}
+    try:
+        completed = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except (OSError, subprocess.CalledProcessError):
+        return {"value": None, "source": "unavailable"}
+    revision = completed.stdout.strip()
+    return {"value": revision or None, "source": "git"}
+
+
+def _atomic_json_write(path: Path, payload: Mapping[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_name(f".{path.name}.{uuid4().hex}.tmp")
+    try:
+        with temporary.open("x", encoding="utf-8") as handle:
+            json.dump(payload, handle, indent=2, ensure_ascii=False, sort_keys=True)
+            handle.write("\n")
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temporary, path)
+    except (OSError, TypeError, ValueError) as error:
+        try:
+            temporary.unlink(missing_ok=True)
+        except OSError:
+            pass
+        raise AttestationWriteError(f"could not write run manifest {path}: {error}") from error
+
+
+@dataclass(frozen=True)
+class RunAttestation:
+    """Location and immutable identity of one invocation-level run manifest."""
+
+    spec: CompiledRunSpec
+    pipeline_module: str
+    run_id: str
+    manifest_path: Path
+    created_at: str
+
+    @classmethod
+    def prepare(
+        cls,
+        spec: CompiledRunSpec,
+        pipeline_module: str,
+        envelope: ExecutionEnvelope,
+        *,
+        cwd: Path | None = None,
+    ) -> "RunAttestation":
+        """Create a pending manifest before importing or executing the Pipeline."""
+
+        run_id = _new_run_id(spec)
+        root = _output_root(spec, cwd=cwd)
+        attestation = cls(
+            spec=spec,
+            pipeline_module=pipeline_module,
+            run_id=run_id,
+            manifest_path=root / ".phmfactory" / "runs" / run_id / "run_manifest.json",
+            created_at=_utc_now(),
+        )
+        attestation.write(envelope)
+        return attestation
+
+    def payload(self, envelope: ExecutionEnvelope) -> dict[str, Any]:
+        """Build the single invocation-level evidence document."""
+
+        return {
+            "schema_version": 1,
+            "run_id": self.run_id,
+            "status": envelope.status.value,
+            "created_at": self.created_at,
+            "run_spec": {
+                "sha256": self.spec.sha256,
+                "pipeline": self.spec.pipeline,
+                "pipeline_module": self.pipeline_module,
+                "requested_config": self.spec.requested_config,
+                "resolved_config_path": self.spec.resolved_config_path,
+                "overrides": self.spec.overrides,
+            },
+            "execution": envelope.as_dict(),
+            "code": {"revision": _code_revision()},
+            "environment": {
+                "python": sys.version.split()[0],
+                "platform": platform.platform(),
+            },
+            "failure": (
+                {
+                    "stage": envelope.failure_stage,
+                    "type": envelope.error_type,
+                    "message": envelope.error_message,
+                }
+                if envelope.status.value == "failed"
+                else None
+            ),
+            "artifacts": [],
+            "evidence": {
+                "data": {},
+                "protocol": {},
+                "seed": {},
+                "environment": {},
+            },
+        }
+
+    def write(self, envelope: ExecutionEnvelope) -> None:
+        """Atomically replace the manifest with the current envelope state."""
+
+        _atomic_json_write(self.manifest_path, self.payload(envelope))

--- a/phmfactory/runtime/execution.py
+++ b/phmfactory/runtime/execution.py
@@ -38,12 +38,18 @@ class ExecutionEnvelope:
     status: ExecutionStatus = ExecutionStatus.PENDING
     started_at: str | None = None
     finished_at: str | None = None
+    failure_stage: str | None = None
     error_type: str | None = None
     error_message: str | None = None
 
-    def _fail(self, error: BaseException) -> None:
+    def record_failure(self, error: BaseException, *, stage: str) -> None:
+        """Record one terminal failure while retaining the original exception."""
+
+        if self.status is ExecutionStatus.FAILED:
+            return
         self.status = ExecutionStatus.FAILED
         self.finished_at = _utc_now()
+        self.failure_stage = stage
         self.error_type = type(error).__name__
         self.error_message = str(error)
 
@@ -60,7 +66,7 @@ class ExecutionEnvelope:
             error = PipelineContractError(
                 f"Pipeline module {self.pipeline_module!r} has no callable pipeline(args)"
             )
-            self._fail(error)
+            self.record_failure(error, stage="contract")
             raise error
 
         self.status = ExecutionStatus.RUNNING
@@ -73,7 +79,7 @@ class ExecutionEnvelope:
                     "successful Pipelines must return an explicit result"
                 )
         except BaseException as error:
-            self._fail(error)
+            self.record_failure(error, stage="pipeline")
             raise
 
         self.status = ExecutionStatus.SUCCEEDED
@@ -81,7 +87,7 @@ class ExecutionEnvelope:
         return result
 
     def as_dict(self) -> dict[str, Any]:
-        """Return the minimal state needed by the later run-attestation writer."""
+        """Return the minimal state consumed by the run-attestation writer."""
 
         return {
             "schema_version": self.schema_version,
@@ -91,6 +97,7 @@ class ExecutionEnvelope:
             "status": self.status.value,
             "started_at": self.started_at,
             "finished_at": self.finished_at,
+            "failure_stage": self.failure_stage,
             "error_type": self.error_type,
             "error_message": self.error_message,
         }

--- a/test/test_phmfactory_entrypoints.py
+++ b/test/test_phmfactory_entrypoints.py
@@ -42,6 +42,7 @@ def test_config_takes_precedence_over_legacy_alias() -> None:
 
 
 def test_run_dispatches_resolved_canonical_module(
+    tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     observed: dict[str, object] = {}
@@ -66,8 +67,11 @@ def test_run_dispatches_resolved_canonical_module(
         assert override_values == ["pipeline=Pipeline_04_unified_metric"]
         return ResolvedConfig(
             requested=source,
-            path=Path("/tmp/missing.yaml"),
-            data={"pipeline": "Pipeline_04_Unified_Evaluation"},
+            path=tmp_path / "missing.yaml",
+            data={
+                "pipeline": "Pipeline_04_Unified_Evaluation",
+                "environment": {"output_dir": str(tmp_path / "runs")},
+            },
             pipeline="Pipeline_04_Unified_Evaluation",
             overrides={"pipeline": "Pipeline_04_unified_metric"},
         )
@@ -86,21 +90,26 @@ def test_run_dispatches_resolved_canonical_module(
     resolved_data = observed.pop("resolved_config_data")
     run_spec_sha256 = observed.pop("run_spec_sha256")
     assert compiled.pipeline == "Pipeline_04_Unified_Evaluation"
-    assert resolved_data == {"pipeline": "Pipeline_04_Unified_Evaluation"}
+    assert resolved_data == {
+        "pipeline": "Pipeline_04_Unified_Evaluation",
+        "environment": {"output_dir": str(tmp_path / "runs")},
+    }
     assert run_spec_sha256 == compiled.sha256
     assert observed == {
         "module": "src.Pipeline_04_Unified_Evaluation",
         "requested_config": "missing.yaml",
-        "config_path": "/tmp/missing.yaml",
-        "resolved_config_path": "/tmp/missing.yaml",
+        "config_path": str(tmp_path / "missing.yaml"),
+        "resolved_config_path": str(tmp_path / "missing.yaml"),
         "resolved_pipeline": "Pipeline_04_Unified_Evaluation",
         "notes": "entrypoint-parity",
     }
+    assert Path(args.run_manifest_path).is_file()
 
 
 @pytest.mark.parametrize("preset", tuple(sorted(MAINTAINED_PRESETS)))
 def test_run_passes_maintained_preset_path_to_runtime(
     preset: str,
+    tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     observed: dict[str, object] = {}
@@ -119,13 +128,14 @@ def test_run_passes_maintained_preset_path_to_runtime(
         config=preset,
         config_path=None,
         notes="",
-        override=None,
+        override=[f"environment.output_dir={tmp_path / 'runs'}"],
     )
 
     assert cli.run(args) is True
 
     assert observed["requested_config"] == preset
     assert Path(str(observed["config_path"])) == resolve_config_path(preset)
+    assert Path(args.run_manifest_path).is_file()
 
 
 def test_cwru_quickstart_uses_one_lightning_device_for_cpu(
@@ -219,3 +229,4 @@ def test_run_dispatches_packaged_base_configs_outside_checkout(
         "task": "classification",
         "trainer": "cpu",
     }
+    assert Path(args.run_manifest_path).is_file()

--- a/test/test_runtime_attestation.py
+++ b/test/test_runtime_attestation.py
@@ -1,0 +1,157 @@
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from phmfactory import cli
+from phmfactory.config import ResolvedConfig
+from phmfactory.runtime import (
+    AttestationError,
+    AttestationWriteError,
+    CompiledRunSpec,
+    ExecutionEnvelope,
+    ExecutionStatus,
+    RunAttestation,
+)
+from phmfactory.runtime import attestation as attestation_module
+
+
+def _resolved(tmp_path: Path) -> ResolvedConfig:
+    return ResolvedConfig(
+        requested="smoke",
+        path=tmp_path / "smoke.yaml",
+        data={
+            "pipeline": "Pipeline_01_Fault_Diagnosis",
+            "environment": {"output_dir": str(tmp_path / "outputs")},
+        },
+        pipeline="Pipeline_01_Fault_Diagnosis",
+        overrides={},
+    )
+
+
+def _load(path: Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def test_prepare_writes_pending_manifest_atomically(tmp_path: Path) -> None:
+    spec = CompiledRunSpec.compile(_resolved(tmp_path))
+    envelope = ExecutionEnvelope(spec=spec, pipeline_module="src.pipeline")
+    attestation = RunAttestation.prepare(spec, "src.pipeline", envelope)
+
+    payload = _load(attestation.manifest_path)
+    assert payload["status"] == "pending"
+    assert payload["run_spec"]["sha256"] == spec.sha256
+    assert payload["failure"] is None
+    assert not list(attestation.manifest_path.parent.glob("*.tmp"))
+
+
+def test_success_replaces_pending_manifest(tmp_path: Path) -> None:
+    spec = CompiledRunSpec.compile(_resolved(tmp_path))
+    envelope = ExecutionEnvelope(spec=spec, pipeline_module="src.pipeline")
+    attestation = RunAttestation.prepare(spec, "src.pipeline", envelope)
+    envelope.execute(SimpleNamespace(pipeline=lambda args: {"metric": 1.0}), object())
+    attestation.write(envelope)
+
+    payload = _load(attestation.manifest_path)
+    assert payload["status"] == "succeeded"
+    assert payload["execution"]["status"] == "succeeded"
+    assert payload["execution"]["finished_at"] is not None
+
+
+def test_failure_manifest_preserves_stage_and_error(tmp_path: Path) -> None:
+    spec = CompiledRunSpec.compile(_resolved(tmp_path))
+    envelope = ExecutionEnvelope(spec=spec, pipeline_module="src.pipeline")
+    attestation = RunAttestation.prepare(spec, "src.pipeline", envelope)
+
+    def fail(args):
+        raise RuntimeError("training failed")
+
+    with pytest.raises(RuntimeError, match="training failed"):
+        envelope.execute(SimpleNamespace(pipeline=fail), object())
+    attestation.write(envelope)
+
+    payload = _load(attestation.manifest_path)
+    assert payload["status"] == "failed"
+    assert payload["failure"] == {
+        "stage": "pipeline",
+        "type": "RuntimeError",
+        "message": "training failed",
+    }
+
+
+def test_missing_output_dir_blocks_before_execution(tmp_path: Path) -> None:
+    resolved = _resolved(tmp_path)
+    resolved.data["environment"] = {}
+    spec = CompiledRunSpec.compile(resolved)
+    envelope = ExecutionEnvelope(spec=spec, pipeline_module="src.pipeline")
+
+    with pytest.raises(AttestationError, match="environment.output_dir"):
+        RunAttestation.prepare(spec, "src.pipeline", envelope)
+
+
+def test_failed_atomic_replace_leaves_previous_manifest_valid(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    spec = CompiledRunSpec.compile(_resolved(tmp_path))
+    envelope = ExecutionEnvelope(spec=spec, pipeline_module="src.pipeline")
+    attestation = RunAttestation.prepare(spec, "src.pipeline", envelope)
+    before = _load(attestation.manifest_path)
+    envelope.execute(SimpleNamespace(pipeline=lambda args: True), object())
+
+    monkeypatch.setattr(
+        attestation_module.os,
+        "replace",
+        lambda *args: (_ for _ in ()).throw(OSError("replace denied")),
+    )
+    with pytest.raises(AttestationWriteError, match="replace denied"):
+        attestation.write(envelope)
+
+    assert _load(attestation.manifest_path) == before
+
+
+def test_cli_writes_success_manifest(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    resolved = _resolved(tmp_path)
+    monkeypatch.setattr(cli, "resolve_config", lambda *args, **kwargs: resolved)
+    monkeypatch.setattr(
+        cli.importlib,
+        "import_module",
+        lambda name: SimpleNamespace(pipeline=lambda args: ["ok"]),
+    )
+    args = argparse.Namespace(config="smoke", config_path=None, notes="", override=None)
+
+    assert cli.run(args) == ["ok"]
+    payload = _load(Path(args.run_manifest_path))
+    assert payload["run_id"] == args.run_id
+    assert payload["status"] == "succeeded"
+    assert args.execution_envelope.status is ExecutionStatus.SUCCEEDED
+
+
+def test_cli_writes_failed_manifest_and_reraises(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    resolved = _resolved(tmp_path)
+    monkeypatch.setattr(cli, "resolve_config", lambda *args, **kwargs: resolved)
+
+    def fail(args):
+        raise ValueError("bad pipeline")
+
+    monkeypatch.setattr(
+        cli.importlib,
+        "import_module",
+        lambda name: SimpleNamespace(pipeline=fail),
+    )
+    args = argparse.Namespace(config="smoke", config_path=None, notes="", override=None)
+
+    with pytest.raises(ValueError, match="bad pipeline"):
+        cli.run(args)
+
+    payload = _load(Path(args.run_manifest_path))
+    assert payload["status"] == "failed"
+    assert payload["failure"]["stage"] == "pipeline"
+    assert payload["failure"]["type"] == "ValueError"

--- a/test/test_runtime_execution.py
+++ b/test/test_runtime_execution.py
@@ -50,6 +50,7 @@ def test_envelope_rejects_none_as_ambiguous_success() -> None:
         envelope.execute(SimpleNamespace(pipeline=lambda args: None), object())
 
     assert envelope.status is ExecutionStatus.FAILED
+    assert envelope.failure_stage == "pipeline"
     assert envelope.error_type == "PipelineContractError"
     assert envelope.finished_at is not None
 
@@ -61,6 +62,7 @@ def test_envelope_rejects_missing_entrypoint() -> None:
         envelope.execute(SimpleNamespace(), object())
 
     assert envelope.status is ExecutionStatus.FAILED
+    assert envelope.failure_stage == "contract"
 
 
 def test_envelope_records_and_reraises_pipeline_error() -> None:
@@ -73,6 +75,7 @@ def test_envelope_records_and_reraises_pipeline_error() -> None:
         envelope.execute(SimpleNamespace(pipeline=fail), object())
 
     assert envelope.status is ExecutionStatus.FAILED
+    assert envelope.failure_stage == "pipeline"
     assert envelope.error_type == "ValueError"
     assert envelope.error_message == "invalid training state"
 
@@ -86,13 +89,17 @@ def test_envelope_cannot_execute_twice() -> None:
 
 
 def test_cli_does_not_print_completion_when_pipeline_returns_none(
+    tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
     capsys: pytest.CaptureFixture[str],
 ) -> None:
     resolved = ResolvedConfig(
         requested="broken",
-        path=Path("/tmp/broken.yaml"),
-        data={"pipeline": "Pipeline_01_Fault_Diagnosis"},
+        path=tmp_path / "broken.yaml",
+        data={
+            "pipeline": "Pipeline_01_Fault_Diagnosis",
+            "environment": {"output_dir": str(tmp_path / "outputs")},
+        },
         pipeline="Pipeline_01_Fault_Diagnosis",
         overrides={},
     )
@@ -114,3 +121,4 @@ def test_cli_does_not_print_completion_when_pipeline_returns_none(
 
     assert "完成所有实验" not in capsys.readouterr().out
     assert args.execution_envelope.status is ExecutionStatus.FAILED
+    assert Path(args.run_manifest_path).is_file()


### PR DESCRIPTION
## Objective

Create one mandatory invocation-level `run_manifest.json` for every public Pipeline execution after configuration compilation.

## Contract

```text
compile config
-> atomically write pending manifest
-> import and execute Pipeline
-> atomically replace with succeeded or failed manifest
```

Location:

```text
<environment.output_dir>/.phmfactory/runs/<run_id>/run_manifest.json
```

The schema records the run ID, run-spec hash, canonical Pipeline/module, requested and resolved config, explicit overrides, code revision when available, Python/platform summary, timestamps, structured failure, and extension slots for data/protocol/seed/environment/artifacts.

## Fail-closed behavior

- missing output directory or pending write failure prevents Pipeline import;
- import/contract/runtime failures write `failed` then re-raise the original error;
- final manifest failure invalidates success and suppresses the completion message;
- same-directory temp + flush + fsync + atomic replace;
- failed replacement preserves the previous valid manifest.

## Boundaries

```text
one invocation manifest, not six parallel systems
no Pipeline/reader/model/task/trainer algorithm change
no CWRU revision/hash change
no repository rename/version/tag/release change
```

## Validation

```text
public API and attestation negative tests: success
wheel contains attestation module: success
clean wheel install and checkout-outside manifest generation: success
Core quality gates and real Dummy smoke: success
UXFD and Pipeline 06 focused contracts: success
CWRU bundle contract: success
Repository layout: success
Submodule policy: success
```