### PR TITLE
refactor(pipeline02): make execution modes explicit

### DIFF
--- a/.github/workflows/core-quality-gates.yml
+++ b/.github/workflows/core-quality-gates.yml
@@ -202,7 +202,7 @@ jobs:
       - name: Record smoke environment
         run: python -m pip freeze > offline-smoke-environment.txt
 
-      - name: Run shared classification contract tests
+      - name: Run shared runtime and Pipeline 02 contract tests
         shell: bash
         run: |
           set -o pipefail
@@ -210,10 +210,14 @@ jobs:
             src/runtime/classification.py \
             src/runtime/explainability.py \
             src/Pipeline_01_Fault_Diagnosis.py \
+            src/Pipeline_02_Pretraining_Few_Shot.py \
             src/Pipeline_05_Explainable_Fault_Diagnosis.py \
-            test/test_classification_runtime.py
-          python -m pytest test/test_classification_runtime.py -vv --tb=long \
-            2>&1 | tee classification-runtime-pytest.log
+            test/test_classification_runtime.py \
+            test/test_pipeline02_runtime.py
+          python -m pytest \
+            test/test_classification_runtime.py \
+            test/test_pipeline02_runtime.py \
+            -vv --tb=long 2>&1 | tee runtime-contracts-pytest.log
 
       - name: Run repository-shipped dummy smoke
         shell: bash
@@ -231,7 +235,7 @@ jobs:
         with:
           name: offline-smoke-diagnostics
           path: |
-            classification-runtime-pytest.log
+            runtime-contracts-pytest.log
             offline-smoke.log
             offline-smoke-environment.txt
           if-no-files-found: warn

--- a/docs/developer_runtime_control_plane.md
+++ b/docs/developer_runtime_control_plane.md
@@ -84,6 +84,26 @@ Direct imports of the old Pipeline functions retain an explicit compatibility fa
 to the legacy config loader. The maintained public CLI path always uses the compiled
 contract and therefore applies base configs and CLI overrides exactly once.
 
+## Pipeline 02 mode selection
+
+Pipeline 02 has exactly three recognizable inputs and never changes mode after an error:
+
+```text
+compiled config without stages -> shared single-stage classification runtime
+compiled config with stages    -> one unified multi-stage orchestrator
+explicit legacy_dual_yaml       -> isolated dual-YAML adapter + one orchestrator
+```
+
+The maintained public demo currently has no `stages` list and therefore uses the same
+classification lifecycle as Pipeline 01/05. A non-empty `stages` list selects the
+orchestrator before execution. Orchestrator errors are propagated; they do not activate a
+manual pretrain/few-shot implementation or another algorithm.
+
+The historical `fs_config_path` input is rejected unless direct legacy callers also set
+`pipeline_mode=legacy_dual_yaml`. The public CLI does not expose this mode. Manual
+`run_stage`, `run_pretraining_stage`, `run_fewshot_stage`, and duplicate single-stage
+functions are no longer maintained entrypoints.
+
 The following invariants govern later refactors:
 
 1. the public config is compiled exactly once;
@@ -94,4 +114,5 @@ The following invariants govern later refactors:
    results, and execution failures raise rather than printing success;
 6. data and logging resources are closed through a shared `finally` boundary;
 7. every compiled invocation creates one mandatory minimal attestation;
-8. Pipeline-specific evidence extends the invocation manifest instead of redefining it.
+8. Pipeline-specific evidence extends the invocation manifest instead of redefining it;
+9. an exception never changes the selected execution mode or activates a fallback.

--- a/src/Pipeline_02_Pretraining_Few_Shot.py
+++ b/src/Pipeline_02_Pretraining_Few_Shot.py
@@ -1,222 +1,98 @@
-import argparse
-import os
-import pandas as pd
-from pytorch_lightning import seed_everything
-from pytorch_lightning.callbacks import ModelCheckpoint
+"""Pretraining/few-shot Pipeline with explicit, non-fallback execution modes."""
 
-from src.configs.config_utils import load_config, path_name, transfer_namespace, ConfigWrapper
-from src.utils.config_utils import parse_overrides, apply_overrides_to_config
-from typing import Optional
-from src.utils.training.two_stage_orchestrator import TwoStageOrchestrator
+from __future__ import annotations
+
+from typing import Any
+
+from src.configs.config_utils import load_config
+from src.runtime import run_classification_pipeline
 from src.utils.config.pipeline_adapters import adapt_p02
-from src.utils.utils import load_best_model_checkpoint, init_lab, close_lab
-from src.data_factory import build_data
-from src.model_factory import build_model
-from src.task_factory import build_task
-from src.trainer_factory import build_trainer
+from src.utils.config_utils import apply_overrides_to_config, parse_overrides
+from src.utils.training.two_stage_orchestrator import TwoStageOrchestrator
 
 
-def _run_single_stage_from_cfg(cfg: ConfigWrapper):
-    """在无需多阶段编排时，直接按单阶段配置运行一次训练+测试。
+LEGACY_DUAL_YAML_MODE = "legacy_dual_yaml"
 
-    用于：
-    - 仅包含单阶段配置的 YAML（无 `stages` 字段），例如实验4–7；
-    - 希望沿用 P02 入口但本质是单阶段 GFS/CDDG 训练的情况。
-    """
-    args_environment = transfer_namespace(getattr(cfg, 'environment', {}))
-    args_data = transfer_namespace(getattr(cfg, 'data', {}))
-    args_model = transfer_namespace(getattr(cfg, 'model', {}))
-    args_task = transfer_namespace(getattr(cfg, 'task', {}))
-    args_trainer = transfer_namespace(getattr(cfg, 'trainer', {}))
 
-    # 处理多任务特殊情况
-    if getattr(args_task, 'name', None) == 'Multitask':
-        args_data.task_list = args_task.task_list
-        args_model.task_list = args_task.task_list
+def _config_and_stage_overrides(args: Any) -> tuple[Any, list[str]]:
+    """Return one config object and only the overrides not already compiled."""
 
-    # 设置环境变量（VBENCH_HOME等）
-    env_section = getattr(cfg, 'environment', None)
-    if env_section is not None:
-        env_dict = env_section.__dict__ if hasattr(env_section, '__dict__') else env_section
-        if isinstance(env_dict, dict):
-            for key, value in env_dict.items():
-                if str(key).isupper():
-                    os.environ[str(key)] = str(value)
+    compiled = getattr(args, "compiled_run_spec", None)
+    if compiled is not None:
+        return compiled.runtime_config(), []
 
-    # 随机种子与日志初始化
-    seed_everything(getattr(args_environment, 'seed', 42))
-    # 单阶段默认使用 iteration=0
-    path, name = path_name(cfg, 0)
-    init_lab(args_environment, cfg, name)
+    config_path = getattr(args, "config_path", None)
+    if not isinstance(config_path, str) or not config_path.strip():
+        raise ValueError("Pipeline 02 requires args.config_path")
+    return load_config(config_path), list(getattr(args, "override", None) or ())
 
-    # 构建 data/model/task/trainer
-    data_factory = build_data(args_data, args_task)
-    model = build_model(args_model, metadata=data_factory.get_metadata())
-    task = build_task(
-        args_task=args_task,
-        network=model,
-        args_data=args_data,
-        args_model=args_model,
-        args_trainer=args_trainer,
-        args_environment=args_environment,
-        metadata=data_factory.get_metadata(),
+
+def _has_stages(config: Any) -> bool:
+    if isinstance(config, dict):
+        stages = config.get("stages")
+    else:
+        stages = getattr(config, "stages", None)
+    return isinstance(stages, (list, tuple)) and bool(stages)
+
+
+def _run_unified_multistage(args: Any, config: Any, overrides: list[str]) -> Any:
+    """Run the one supported multi-stage implementation without fallback."""
+
+    print("[INFO] Pipeline 02 mode: unified_multistage")
+    orchestrator = TwoStageOrchestrator(config, cli_overrides=overrides)
+    result = orchestrator.run_complete()
+    if result is None:
+        raise RuntimeError("Pipeline 02 orchestrator returned None")
+    return result
+
+
+def _run_legacy_dual_yaml(args: Any) -> Any:
+    """Run the isolated dual-YAML adapter only after explicit opt-in."""
+
+    mode = str(getattr(args, "pipeline_mode", "") or "")
+    if mode != LEGACY_DUAL_YAML_MODE:
+        raise ValueError(
+            "fs_config_path is a legacy dual-YAML input; set "
+            f"pipeline_mode={LEGACY_DUAL_YAML_MODE!r} explicitly"
+        )
+
+    config_path = getattr(args, "config_path", None)
+    fs_config_path = getattr(args, "fs_config_path", None)
+    if not config_path or not fs_config_path:
+        raise ValueError("legacy_dual_yaml requires config_path and fs_config_path")
+
+    unified = adapt_p02(
+        config_path,
+        fs_config_path,
+        getattr(args, "local_config", None),
     )
-    trainer = build_trainer(args_environment, args_trainer, args_data, path)
+    overrides = getattr(args, "override", None)
+    if overrides:
+        unified = apply_overrides_to_config(unified, parse_overrides(overrides))
 
-    # 运行训练与测试
-    trainer.fit(task, data_factory.get_dataloader('train'), data_factory.get_dataloader('val'))
-    task = load_best_model_checkpoint(task, trainer)
-    trainer.test(task, data_factory.get_dataloader('test'))
-    close_lab()
-    return True
-
-
-def run_stage(config_path, ckpt_path=None, iteration=0, local_config: Optional[str] = None):
-    """Run a single training/testing stage given a config path."""
-    configs = load_config(config_path, local_config)
-    args_environment = transfer_namespace(configs.get('environment', {}))
-    args_data = transfer_namespace(configs.get('data', {}))
-    args_model = transfer_namespace(configs.get('model', {}))
-    args_task = transfer_namespace(configs.get('task', {}))
-    args_trainer = transfer_namespace(configs.get('trainer', {}))
-
-    if args_task.name == 'Multitask':
-        args_data.task_list = args_task.task_list
-        args_model.task_list = args_task.task_list
-
-    if ckpt_path:
-        args_model.weights_path = ckpt_path
-
-    for key, value in configs['environment'].items():
-        if key.isupper():
-            os.environ[key] = str(value)
-
-    path, name = path_name(configs, iteration)
-    seed_everything(args_environment.seed)
-    init_lab(args_environment, configs, name)
-    data_factory = build_data(args_data, args_task)
-    model = build_model(args_model, metadata=data_factory.get_metadata())
-    task = build_task(
-        args_task=args_task,
-        network=model,
-        args_data=args_data,
-        args_model=args_model,
-        args_trainer=args_trainer,
-        args_environment=args_environment,
-        metadata=data_factory.get_metadata()
-    )
-    trainer = build_trainer(args_environment, args_trainer, args_data, path)
-    trainer.fit(task, data_factory.get_dataloader('train'), data_factory.get_dataloader('val'))
-    task = load_best_model_checkpoint(task, trainer)
-    result = trainer.test(task, data_factory.get_dataloader('test'))
-    result_df = pd.DataFrame([result[0]])
-    result_df.to_csv(os.path.join(path, 'test_result.csv'), index=False)
-    close_lab()
-    return task, trainer
+    print("[INFO] Pipeline 02 mode: legacy_dual_yaml")
+    result = TwoStageOrchestrator(unified).run_complete()
+    if result is None:
+        raise RuntimeError("Pipeline 02 legacy orchestrator returned None")
+    return result
 
 
-def run_pretraining_stage(config_path, local_config: Optional[str] = None):
-    """Run the pretraining stage and return the checkpoint path."""
-    # 加载配置以获取iterations设置
-    configs = load_config(config_path, local_config)
-    iterations = configs.get('environment', {}).get('iterations', 1)
+def pipeline(args: Any) -> Any:
+    """Select exactly one execution mode from explicit inputs and config structure.
 
-    ckpt_dict = {}
-    for it in range(iterations):
-        task, trainer = run_stage(config_path, iteration=it, local_config=local_config)
-        print(f"Pretraining stage iteration {it} completed.")
-        ckpt_path = None
-        for cb in trainer.callbacks:
-            if isinstance(cb, ModelCheckpoint):
-                ckpt_path = cb.best_model_path
-                break
-        ckpt_dict[it] = ckpt_path
-    return ckpt_dict
+    - ``fs_config_path`` requires explicit ``legacy_dual_yaml`` opt-in;
+    - a compiled config containing non-empty ``stages`` uses the unified orchestrator;
+    - a config without ``stages`` uses the shared classification runtime.
 
-
-def run_fewshot_stage(fs_config_path, ckpt_dict=None, local_config: Optional[str] = None):
-    """Run the few-shot stage. Optionally load a pretrained checkpoint."""
-    # 加载配置以获取iterations设置
-    configs = load_config(fs_config_path, local_config)
-    iterations = configs.get('environment', {}).get('iterations', 1)
-
-    for it1, ckpt_path in ckpt_dict.items():
-        for it2 in range(iterations):
-            print(f"Running few-shot stage iteration {it1}-{it2} with checkpoint {ckpt_path}")
-            if ckpt_path:
-                run_stage(fs_config_path, ckpt_path, iteration=it1 * len(ckpt_dict) + it2, local_config=local_config)
-            else:
-                print(f"No checkpoint found for iteration {it1}, skipping few-shot stage.")
-                run_stage(fs_config_path, iteration=it1 * len(ckpt_dict) + it2, local_config=local_config)
-    return True
-
-def pipeline(args):
-    """Run multi-stage training for P02.
-
-    优先支持“单 YAML + stages 列表”的统一配置范式：
-      - 推荐入口：只提供 `--config_path experiment_X_unified.yaml`；
-      - `fs_config_path` 仅用于兼容 legacy 双 YAML 配置（已移动到 configs/legacy_dual_yaml）。
+    No exception changes the selected mode or activates a second implementation.
     """
-    try:
-        # 新范式：只有 config_path（优先支持 unified YAML + stages 列表）
-        if not getattr(args, 'fs_config_path', None):
-            import yaml
 
-            with open(args.config_path, "r", encoding="utf-8") as f:
-                cfg_dict = yaml.safe_load(f) or {}
+    if getattr(args, "fs_config_path", None):
+        return _run_legacy_dual_yaml(args)
 
-            # 情况A：包含 stages → 走多阶段 Orchestrator
-            if 'stages' in cfg_dict:
-                print(f"[INFO] 使用 unified 多阶段配置运行训练: {args.config_path}")
-                cli_overrides = getattr(args, 'override', None) or []
-                orchestrator = TwoStageOrchestrator(cfg_dict, cli_overrides=cli_overrides)
-                summary = orchestrator.run_complete()
-                print("[INFO] Unified multi-stage pipeline (single YAML) completed.")
-                return summary
+    config, stage_overrides = _config_and_stage_overrides(args)
+    if _has_stages(config):
+        return _run_unified_multistage(args, config, stage_overrides)
 
-            # 情况B：不含 stages → 视为单阶段配置，直接运行一次训练/测试
-            print(f"[INFO] 检测到单阶段配置（无 stages），按单阶段模式运行: {args.config_path}")
-            # 使用通用 load_config + overrides 构造最终 ConfigWrapper
-            overrides = None
-            if hasattr(args, 'override') and args.override:
-                overrides = parse_overrides(args.override)
-            cfg = load_config(args.config_path, overrides=overrides)
-            _run_single_stage_from_cfg(cfg)
-            print("[INFO] Single-stage pipeline via P02 completed.")
-            return True
-
-        # 情况C 兼容路径：config_path + fs_config_path 双 YAML（legacy）
-        unified = adapt_p02(args.config_path, args.fs_config_path, getattr(args, 'local_config', None))
-
-        # 应用CLI override参数（最高优先级）——旧路径仍使用全局 override 机制
-        if hasattr(args, 'override') and args.override:
-            print(f"[INFO] 应用CLI override参数到两阶段流程: {args.override}")
-            overrides = parse_overrides(args.override)
-            unified = apply_overrides_to_config(unified, overrides)
-            print(f"[INFO] 已应用 {len(overrides)} 个override参数到两阶段配置")
-
-        orchestrator = TwoStageOrchestrator(unified)
-        summary = orchestrator.run_complete()
-        print("[INFO] Unified two-stage pipeline (legacy dual YAML) completed.")
-        return summary
-    except Exception as e:
-        print(f"[WARN] Unified orchestrator fallback due to: {e}")
-        # fallback 仅支持 legacy 双 YAML，unified 情况请使用 debug 脚本或修复配置
-        if getattr(args, 'fs_config_path', None):
-            ckpt_dict = run_pretraining_stage(args.config_path, local_config=getattr(args, 'local_config', None))
-            run_fewshot_stage(args.fs_config_path, ckpt_dict, local_config=getattr(args, 'local_config', None))
-            return True
-        raise
-
-
-
-
-
-if __name__ == "__main__":
-    parser = argparse.ArgumentParser()
-    parser.add_argument('--config_path', type=str, required=True, help='unified or pretrain config path')
-    parser.add_argument('--fs_config_path', type=str, default=None, help='[legacy] few-shot config path (dual YAML)')
-    parser.add_argument('--local_config', type=str, default=None, help='machine-specific override YAML')
-    parser.add_argument('--override', nargs='*', default=None, help='override key=value pairs')
-    args = parser.parse_args()
-    pipeline(args)
+    print("[INFO] Pipeline 02 mode: single_stage")
+    return run_classification_pipeline(args)

--- a/test/test_pipeline02_runtime.py
+++ b/test/test_pipeline02_runtime.py
@@ -1,0 +1,169 @@
+from __future__ import annotations
+
+from argparse import Namespace
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from phmfactory.config import ResolvedConfig
+from phmfactory.runtime import CompiledRunSpec
+import src.Pipeline_02_Pretraining_Few_Shot as pipeline02
+
+
+def _compiled(tmp_path: Path, *, stages=None) -> CompiledRunSpec:
+    data = {
+        "pipeline": "Pipeline_02_Pretraining_Few_Shot",
+        "environment": {"output_dir": str(tmp_path), "iterations": 1, "seed": 1},
+        "data": {"data_dir": str(tmp_path), "metadata_file": "metadata.csv"},
+        "model": {"name": "model", "type": "test"},
+        "task": {"name": "classification", "type": "pretrain"},
+        "trainer": {"device": "cpu", "gpus": 1},
+    }
+    if stages is not None:
+        data["stages"] = stages
+    return CompiledRunSpec.compile(
+        ResolvedConfig(
+            requested="pipeline02",
+            path=tmp_path / "pipeline02.yaml",
+            data=data,
+            pipeline="Pipeline_02_Pretraining_Few_Shot",
+            overrides={"trainer": {"num_epochs": 1}},
+        )
+    )
+
+
+def _args(tmp_path: Path, *, stages=None, **values) -> Namespace:
+    payload = {
+        "compiled_run_spec": _compiled(tmp_path, stages=stages),
+        "config_path": str(tmp_path / "pipeline02.yaml"),
+        "override": ["trainer.num_epochs=1"],
+        "fs_config_path": None,
+    }
+    payload.update(values)
+    return Namespace(**payload)
+
+
+def test_single_stage_reuses_shared_classification_runtime(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[object] = []
+    monkeypatch.setattr(
+        pipeline02,
+        "run_classification_pipeline",
+        lambda args: calls.append(args) or [{"loss": 1.0}],
+    )
+    monkeypatch.setattr(
+        pipeline02,
+        "TwoStageOrchestrator",
+        lambda *args, **kwargs: pytest.fail("orchestrator must not be constructed"),
+    )
+    args = _args(tmp_path)
+
+    assert pipeline02.pipeline(args) == [{"loss": 1.0}]
+    assert calls == [args]
+
+
+def test_compiled_stages_select_one_unified_orchestrator(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    observed: dict[str, object] = {}
+
+    class Orchestrator:
+        def __init__(self, config, cli_overrides):
+            observed["config"] = config
+            observed["overrides"] = cli_overrides
+
+        def run_complete(self):
+            return {"stages": 2}
+
+    monkeypatch.setattr(pipeline02, "TwoStageOrchestrator", Orchestrator)
+    monkeypatch.setattr(
+        pipeline02,
+        "run_classification_pipeline",
+        lambda args: pytest.fail("single-stage runtime must not run"),
+    )
+    args = _args(
+        tmp_path,
+        stages=[{"name": "pretrain", "overrides": {}}, {"name": "finetune", "overrides": {}}],
+    )
+
+    assert pipeline02.pipeline(args) == {"stages": 2}
+    assert observed["overrides"] == []
+    assert observed["config"]["stages"][0]["name"] == "pretrain"
+
+
+def test_orchestrator_error_is_not_converted_to_single_stage(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class Orchestrator:
+        def __init__(self, config, cli_overrides):
+            pass
+
+        def run_complete(self):
+            raise RuntimeError("stage failed")
+
+    monkeypatch.setattr(pipeline02, "TwoStageOrchestrator", Orchestrator)
+    monkeypatch.setattr(
+        pipeline02,
+        "run_classification_pipeline",
+        lambda args: pytest.fail("fallback is forbidden"),
+    )
+
+    with pytest.raises(RuntimeError, match="stage failed"):
+        pipeline02.pipeline(_args(tmp_path, stages=[{"overrides": {}}]))
+
+
+def test_legacy_dual_yaml_requires_explicit_mode(tmp_path: Path) -> None:
+    args = _args(tmp_path, fs_config_path="fewshot.yaml")
+    with pytest.raises(ValueError, match="legacy_dual_yaml"):
+        pipeline02.pipeline(args)
+
+
+def test_explicit_legacy_dual_yaml_uses_only_adapter_and_orchestrator(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    unified = SimpleNamespace(stages=[object(), object()])
+    observed: dict[str, object] = {}
+    monkeypatch.setattr(
+        pipeline02,
+        "adapt_p02",
+        lambda pretrain, fewshot, local: observed.update(
+            pretrain=pretrain, fewshot=fewshot, local=local
+        )
+        or unified,
+    )
+
+    class Orchestrator:
+        def __init__(self, config):
+            assert config is unified
+
+        def run_complete(self):
+            return {"legacy": True}
+
+    monkeypatch.setattr(pipeline02, "TwoStageOrchestrator", Orchestrator)
+    args = _args(
+        tmp_path,
+        fs_config_path="fewshot.yaml",
+        pipeline_mode="legacy_dual_yaml",
+        local_config=None,
+        override=None,
+    )
+
+    assert pipeline02.pipeline(args) == {"legacy": True}
+    assert observed == {
+        "pretrain": str(tmp_path / "pipeline02.yaml"),
+        "fewshot": "fewshot.yaml",
+        "local": None,
+    }
+
+
+def test_pipeline02_no_longer_exposes_manual_duplicate_stage_runners() -> None:
+    assert not hasattr(pipeline02, "run_stage")
+    assert not hasattr(pipeline02, "run_pretraining_stage")
+    assert not hasattr(pipeline02, "run_fewshot_stage")
+    assert not hasattr(pipeline02, "_run_single_stage_from_cfg")


### PR DESCRIPTION
## Objective

Remove Pipeline 02's duplicated manual stage runners and broad exception fallback so one input selects one implementation.

## Deterministic modes

```text
compiled config without stages -> shared single-stage classification runtime
compiled config with stages    -> unified multi-stage orchestrator
fs_config_path + explicit pipeline_mode=legacy_dual_yaml
                              -> isolated legacy adapter + orchestrator
```

## Removed duplication

- manual single-stage runner;
- manual generic stage runner;
- manual pretraining/few-shot loops;
- standalone Pipeline-specific CLI;
- broad exception fallback that changed algorithms.

Pipeline 02 is reduced by 124 net lines, and the maintained single-stage demo now uses the same lifecycle as Pipelines 01/05.

## Fail-closed behavior

- orchestrator exceptions propagate;
- `None` results fail;
- legacy dual YAML requires explicit opt-in;
- compiled overrides are not reapplied;
- no error changes execution mode.

## Boundaries

```text
no orchestrator internals or scientific algorithms changed
no maintained config changed
no CWRU/rename/version/tag/release change
```

## Validation

```text
Pipeline 02 explicit-mode and no-fallback tests: success
shared classification contract tests: success
real repository Dummy smoke: success
UXFD and Pipeline 06 focused contracts: success
documentation/config/atlas checks: success
Repository layout: success
Submodule policy: success
```