### PR TITLE
feat(pipelines): gate experimental Pipeline maturity

### DIFF
--- a/.github/workflows/phmfactory-public-package.yml
+++ b/.github/workflows/phmfactory-public-package.yml
@@ -16,6 +16,7 @@ on:
       - "test/test_phmfactory_entrypoints.py"
       - "test/test_phmfactory_config_resolver.py"
       - "test/test_pipeline_name_migration.py"
+      - "test/test_pipeline_maturity.py"
       - "test/test_runtime_control_plane.py"
       - "test/test_runtime_execution.py"
       - "test/test_runtime_attestation.py"
@@ -37,6 +38,7 @@ on:
       - "test/test_phmfactory_entrypoints.py"
       - "test/test_phmfactory_config_resolver.py"
       - "test/test_pipeline_name_migration.py"
+      - "test/test_pipeline_maturity.py"
       - "test/test_runtime_control_plane.py"
       - "test/test_runtime_execution.py"
       - "test/test_runtime_attestation.py"
@@ -76,6 +78,7 @@ jobs:
           test/test_phmfactory_entrypoints.py
           test/test_phmfactory_config_resolver.py
           test/test_pipeline_name_migration.py
+          test/test_pipeline_maturity.py
           test/test_runtime_control_plane.py
           test/test_runtime_execution.py
           test/test_runtime_attestation.py
@@ -87,6 +90,7 @@ jobs:
           test/test_phmfactory_entrypoints.py
           test/test_phmfactory_config_resolver.py
           test/test_pipeline_name_migration.py
+          test/test_pipeline_maturity.py
           test/test_runtime_control_plane.py
           test/test_runtime_execution.py
           test/test_runtime_attestation.py

--- a/SUPPORTED_COMPONENTS.md
+++ b/SUPPORTED_COMPONENTS.md
@@ -1,14 +1,49 @@
-# Supported Components for v0.2.0
+# Supported Components for the PHMFactory v0.3 Pre-release
 
-## Release-Supported Components
+PHMFactory distinguishes three different claims:
 
-These components are covered by the maintained demo matrix and current cycle-03
-evidence.
+```text
+discoverable  = a canonical Pipeline or registry entry exists
+runnable      = the public control plane permits execution
+supported     = a maintained combination has current smoke evidence
+```
+
+The required relationship is:
+
+```text
+supported ⊆ runnable ⊆ discoverable
+```
+
+A source file, importable module, registry row, or explicit experimental opt-in is not a
+release-support claim.
+
+## Pipeline maturity
+
+The machine-readable authority is `phmfactory.pipelines.PIPELINE_DESCRIPTORS`.
+
+| Pipeline | Maturity | Default public access | v0.3 release support |
+|---|---|---:|---:|
+| `Pipeline_01_Fault_Diagnosis` | `supported` | yes | yes, only for maintained combinations |
+| `Pipeline_02_Pretraining_Few_Shot` | `supported_limited` | yes | single-stage maintained demo only |
+| `Pipeline_03_Multitask_Pretraining_Finetuning` | `experimental` | no; requires `--allow-experimental` | no |
+| `Pipeline_04_Unified_Evaluation` | `experimental_blocked` | no; requires `--allow-experimental` | no |
+| `Pipeline_05_Explainable_Fault_Diagnosis` | `compatibility` | yes | no maintained release combination |
+| `Pipeline_06_Generative_Modeling` | `experimental_contract` | yes | contract/smoke evidence only; no benchmark claim |
+| `Pipeline_ID` | `compatibility` | yes | no maintained release combination |
+
+Pipeline 03 has no maintained smoke combination and retains legacy error/checkpoint
+paths. Pipeline 04 additionally retains environment-specific path mutation, broad
+fallback, and unverified partial checkpoint loading. Their source remains available for
+research, but the public CLI requires explicit acknowledgement before importing them.
+
+## Release-supported component surface
+
+The maintained demo matrix currently supports:
 
 | Surface | Supported values |
 |---|---|
-| Pipelines | `Pipeline_01_Fault_Diagnosis`, `Pipeline_02_Pretraining_Few_Shot` single-stage demo |
-| Data entry | repo dummy data; PHM-Vibench metadata/raw data via `data.data_dir` |
+| Pipelines | `Pipeline_01_Fault_Diagnosis`; `Pipeline_02_Pretraining_Few_Shot` single-stage demo |
+| Data entry | repo dummy data; external PHM metadata/raw data supplied through explicit config or overrides |
 | Model | `ISFM/M_01_ISFM` |
 | ISFM embedding | `E_01_HSE` |
 | ISFM backbone | `B_04_Dlinear` |
@@ -16,7 +51,11 @@ evidence.
 | Tasks | `DG/classification`, `CDDG/classification`, `FS/classification`, `GFS/classification`, `pretrain/hse_contrastive` |
 | Trainer | `Default_trainer` |
 
-## Code-Derived Sampler Routes
+Exact supported executions are defined by the maintained `category=demo` and
+`status=sanity_ok` rows in `configs/config_registry.csv` and summarized in
+`SUPPORTED_COMBINATIONS.md`.
+
+## Code-derived sampler routes
 
 | Task type | Runtime sampler route |
 |---|---|
@@ -26,17 +65,18 @@ evidence.
 | `GFS` | `HierarchicalFewShotSampler` for train; `Same_system_Sampler` for val/test |
 | `pretrain` | `Same_system_Sampler` |
 
-## Registry-Discovered Only
+## Registry-discovered only
 
-`src/model_factory/model_registry.csv` and `src/task_factory/task_registry.csv`
-contain more models and tasks than the release-supported demo surface. Those
-entries are inventoried, but they are not v0.2.0 release-supported unless they
-also appear in `SUPPORTED_COMBINATIONS.md` with runtime evidence.
+`src/model_factory/model_registry.csv` and `src/task_factory/task_registry.csv` contain
+more models and tasks than the release-supported demo surface. Those entries are
+inventory and discovery evidence only. They become supported only after a maintained
+configuration, focused contract tests, runtime smoke, and current evidence record exist.
 
-## Excluded From v0.2.0 Support
+## Excluded support claims
 
-- `Pipeline_03` public support.
 - Full model/task Cartesian-product compatibility.
-- Paper-only or historical configs under `configs/reference/`, `configs/v0.0.9/`,
-  or research/history archives outside the maintained documentation surface.
-- Performance claims across datasets or algorithms.
+- Pipeline 03 or Pipeline 04 release support.
+- Benchmark-performance claims inferred from one-epoch smoke tests.
+- Paper-only or historical configurations under `configs/reference/`,
+  `configs/v0.0.9/`, or archived research workspaces.
+- External dataset redistribution or availability guarantees.

--- a/docs/developer_runtime_control_plane.md
+++ b/docs/developer_runtime_control_plane.md
@@ -9,6 +9,7 @@ config or preset + CLI overrides
   -> phmfactory.runtime.CompiledRunSpec
   -> phmfactory.runtime.ExecutionEnvelope
   -> phmfactory.runtime.RunAttestation (pending)
+  -> Pipeline maturity gate
   -> canonical Pipeline adapter
   -> protected src runtime
   -> RunAttestation (succeeded or failed)
@@ -104,6 +105,32 @@ The historical `fs_config_path` input is rejected unless direct legacy callers a
 `run_stage`, `run_pretraining_stage`, `run_fewshot_stage`, and duplicate single-stage
 functions are no longer maintained entrypoints.
 
+## Pipeline maturity gate
+
+`phmfactory.pipelines.PIPELINE_DESCRIPTORS` separates discoverability from default
+execution and release support. The maturity gate runs after the pending manifest is
+created and before the Pipeline module is imported.
+
+Pipeline 03 and Pipeline 04 require explicit public opt-in:
+
+```bash
+phmfactory --config <yaml> --allow-experimental
+```
+
+Without that flag, the CLI writes a failed manifest with `failure.stage: maturity` and
+does not import the module. The flag is an acknowledgement of maturity, not a support
+promotion. Pipeline 03 remains experimental because no maintained smoke combination
+exists and its legacy implementation contains error/checkpoint paths that have not been
+normalized. Pipeline 04 remains `experimental_blocked` because it additionally contains
+environment-specific paths, `sys.path` mutation, broad fallback, and unverified partial
+checkpoint loading.
+
+Pipeline 01 and the maintained single-stage Pipeline 02 path remain the release-supported
+surface. Pipeline 05, Pipeline 06, and Pipeline_ID remain discoverable under their
+compatibility or experimental-contract descriptors; their presence is not a
+release-support claim. The user-facing distinction is recorded in
+`SUPPORTED_COMPONENTS.md`.
+
 The following invariants govern later refactors:
 
 1. the public config is compiled exactly once;
@@ -115,4 +142,6 @@ The following invariants govern later refactors:
 6. data and logging resources are closed through a shared `finally` boundary;
 7. every compiled invocation creates one mandatory minimal attestation;
 8. Pipeline-specific evidence extends the invocation manifest instead of redefining it;
-9. an exception never changes the selected execution mode or activates a fallback.
+9. an exception never changes the selected execution mode or activates a fallback;
+10. discoverability, explicit experimental execution, and release support remain separate
+    machine-readable claims.

--- a/phmfactory/cli.py
+++ b/phmfactory/cli.py
@@ -9,7 +9,7 @@ from collections.abc import Sequence
 from typing import Any
 
 from phmfactory.config import DEFAULT_CONFIG, resolve_config
-from phmfactory.pipelines import pipeline_module_name
+from phmfactory.pipelines import pipeline_module_name, require_pipeline_access
 from phmfactory.runtime import (
     AttestationWriteError,
     CompiledRunSpec,
@@ -46,6 +46,14 @@ def build_parser() -> argparse.ArgumentParser:
         "--override",
         action="append",
         help="Configuration override in key=value form; may be repeated.",
+    )
+    parser.add_argument(
+        "--allow-experimental",
+        action="store_true",
+        help=(
+            "Explicitly authorize a Pipeline whose maturity descriptor requires "
+            "experimental opt-in."
+        ),
     )
     return parser
 
@@ -111,7 +119,7 @@ def _write_failed_attestation(
 
 
 def run(args: argparse.Namespace) -> Any:
-    """Compile, attest, and execute one Pipeline through the public boundary."""
+    """Compile, attest, authorize, and execute one Pipeline."""
     requested_config = _resolve_config_path(args)
     resolved = resolve_config(requested_config, override_values=args.override)
     compiled = CompiledRunSpec.compile(resolved)
@@ -139,6 +147,20 @@ def run(args: argparse.Namespace) -> Any:
     args.run_attestation = attestation
     args.run_id = attestation.run_id
     args.run_manifest_path = str(attestation.manifest_path)
+
+    try:
+        descriptor = require_pipeline_access(
+            resolved.pipeline,
+            allow_experimental=bool(
+                getattr(args, "allow_experimental", False)
+            ),
+            warn=False,
+        )
+    except BaseException as error:
+        envelope.record_failure(error, stage="maturity")
+        _write_failed_attestation(attestation, envelope, error)
+        raise
+    args.pipeline_descriptor = descriptor
 
     try:
         pipeline_module = importlib.import_module(module_name)

--- a/phmfactory/pipelines.py
+++ b/phmfactory/pipelines.py
@@ -1,7 +1,8 @@
-"""Canonical Pipeline identifiers and compatibility aliases for PHMFactory."""
+"""Canonical Pipeline identifiers, maturity, and compatibility aliases."""
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 import warnings
 
 
@@ -9,15 +10,70 @@ class PipelineNameDeprecationWarning(FutureWarning):
     """Visible warning for legacy Pipeline identifiers."""
 
 
-CANONICAL_PIPELINES: tuple[str, ...] = (
-    "Pipeline_01_Fault_Diagnosis",
-    "Pipeline_02_Pretraining_Few_Shot",
-    "Pipeline_03_Multitask_Pretraining_Finetuning",
-    "Pipeline_04_Unified_Evaluation",
-    "Pipeline_05_Explainable_Fault_Diagnosis",
-    "Pipeline_06_Generative_Modeling",
-    "Pipeline_ID",
-)
+class PipelineMaturityError(RuntimeError):
+    """Raised when an opt-in Pipeline is selected without explicit authorization."""
+
+
+@dataclass(frozen=True)
+class PipelineDescriptor:
+    """Machine-readable public maturity contract for one protected Pipeline."""
+
+    name: str
+    maturity: str
+    opt_in_required: bool = False
+    reason: str = ""
+
+    @property
+    def module_name(self) -> str:
+        return f"src.{self.name}"
+
+
+PIPELINE_DESCRIPTORS: dict[str, PipelineDescriptor] = {
+    "Pipeline_01_Fault_Diagnosis": PipelineDescriptor(
+        name="Pipeline_01_Fault_Diagnosis",
+        maturity="supported",
+    ),
+    "Pipeline_02_Pretraining_Few_Shot": PipelineDescriptor(
+        name="Pipeline_02_Pretraining_Few_Shot",
+        maturity="supported_limited",
+        reason="release support is limited to the maintained single-stage demo",
+    ),
+    "Pipeline_03_Multitask_Pretraining_Finetuning": PipelineDescriptor(
+        name="Pipeline_03_Multitask_Pretraining_Finetuning",
+        maturity="experimental",
+        opt_in_required=True,
+        reason=(
+            "no maintained smoke combination; legacy implementation catches stage "
+            "errors and contains unverified checkpoint compatibility paths"
+        ),
+    ),
+    "Pipeline_04_Unified_Evaluation": PipelineDescriptor(
+        name="Pipeline_04_Unified_Evaluation",
+        maturity="experimental_blocked",
+        opt_in_required=True,
+        reason=(
+            "legacy implementation contains environment-specific paths, sys.path "
+            "mutation, broad fallback, and unverified partial checkpoint loading"
+        ),
+    ),
+    "Pipeline_05_Explainable_Fault_Diagnosis": PipelineDescriptor(
+        name="Pipeline_05_Explainable_Fault_Diagnosis",
+        maturity="compatibility",
+        reason="UXFD focused contract exists; no release-supported demo combination",
+    ),
+    "Pipeline_06_Generative_Modeling": PipelineDescriptor(
+        name="Pipeline_06_Generative_Modeling",
+        maturity="experimental_contract",
+        reason="guarded CFM contract evidence; no release-supported benchmark claim",
+    ),
+    "Pipeline_ID": PipelineDescriptor(
+        name="Pipeline_ID",
+        maturity="compatibility",
+        reason="legacy research entrypoint outside the maintained demo matrix",
+    ),
+}
+
+CANONICAL_PIPELINES: tuple[str, ...] = tuple(PIPELINE_DESCRIPTORS)
 
 PIPELINE_ALIASES: dict[str, str] = {
     "Pipeline_01_default": "Pipeline_01_Fault_Diagnosis",
@@ -45,7 +101,7 @@ def canonical_pipeline_name(name: str, *, warn: bool = True) -> str:
             stacklevel=2,
         )
 
-    if canonical not in CANONICAL_PIPELINES:
+    if canonical not in PIPELINE_DESCRIPTORS:
         accepted = ", ".join(CANONICAL_PIPELINES)
         raise ValueError(
             f"Unknown pipeline {requested!r}. Canonical identifiers: {accepted}"
@@ -53,6 +109,28 @@ def canonical_pipeline_name(name: str, *, warn: bool = True) -> str:
     return canonical
 
 
+def pipeline_descriptor(name: str, *, warn: bool = True) -> PipelineDescriptor:
+    """Return the descriptor for a canonical or legacy Pipeline identifier."""
+    return PIPELINE_DESCRIPTORS[canonical_pipeline_name(name, warn=warn)]
+
+
+def require_pipeline_access(
+    name: str,
+    *,
+    allow_experimental: bool = False,
+    warn: bool = True,
+) -> PipelineDescriptor:
+    """Require explicit opt-in for Pipelines outside the safe default surface."""
+    descriptor = pipeline_descriptor(name, warn=warn)
+    if descriptor.opt_in_required and not allow_experimental:
+        detail = f" {descriptor.reason}" if descriptor.reason else ""
+        raise PipelineMaturityError(
+            f"Pipeline {descriptor.name!r} has maturity {descriptor.maturity!r} and "
+            f"requires --allow-experimental.{detail}"
+        )
+    return descriptor
+
+
 def pipeline_module_name(name: str, *, warn: bool = True) -> str:
     """Resolve a public or legacy identifier to its protected runtime module."""
-    return f"src.{canonical_pipeline_name(name, warn=warn)}"
+    return pipeline_descriptor(name, warn=warn).module_name

--- a/test/test_phmfactory_entrypoints.py
+++ b/test/test_phmfactory_entrypoints.py
@@ -29,6 +29,7 @@ def test_parser_preserves_legacy_config_path_alias() -> None:
     assert args.config is None
     assert args.config_path == "legacy.yaml"
     assert args.notes == "compat"
+    assert args.allow_experimental is False
 
 
 def test_config_takes_precedence_over_legacy_alias() -> None:
@@ -83,6 +84,7 @@ def test_run_dispatches_resolved_canonical_module(
         config_path=None,
         notes="entrypoint-parity",
         override=["pipeline=Pipeline_04_unified_metric"],
+        allow_experimental=True,
     )
 
     assert cli.run(args) == "sentinel"
@@ -181,6 +183,7 @@ def test_python_entrypoints_share_help_surface(command: list[str]) -> None:
     assert "--config" in completed.stdout
     assert "--config_path" in completed.stdout
     assert "--override" in completed.stdout
+    assert "--allow-experimental" in completed.stdout
 
 
 def test_root_main_is_only_a_dispatcher(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/test/test_pipeline_maturity.py
+++ b/test/test_pipeline_maturity.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from phmfactory import cli
+from phmfactory.config import ResolvedConfig
+from phmfactory.pipelines import (
+    PipelineMaturityError,
+    pipeline_descriptor,
+    require_pipeline_access,
+)
+
+
+def _resolved(tmp_path: Path, pipeline: str) -> ResolvedConfig:
+    return ResolvedConfig(
+        requested="maturity-test",
+        path=tmp_path / "maturity.yaml",
+        data={
+            "pipeline": pipeline,
+            "environment": {"output_dir": str(tmp_path / "runs")},
+        },
+        pipeline=pipeline,
+        overrides={},
+    )
+
+
+def _manifest(args: argparse.Namespace) -> dict:
+    return json.loads(Path(args.run_manifest_path).read_text(encoding="utf-8"))
+
+
+def test_supported_pipeline_requires_no_opt_in() -> None:
+    descriptor = require_pipeline_access("Pipeline_01_Fault_Diagnosis")
+    assert descriptor.maturity == "supported"
+    assert descriptor.opt_in_required is False
+
+
+@pytest.mark.parametrize(
+    "pipeline,maturity",
+    (
+        ("Pipeline_03_Multitask_Pretraining_Finetuning", "experimental"),
+        ("Pipeline_04_Unified_Evaluation", "experimental_blocked"),
+    ),
+)
+def test_experimental_pipelines_are_blocked_by_default(
+    pipeline: str,
+    maturity: str,
+) -> None:
+    with pytest.raises(PipelineMaturityError, match="--allow-experimental"):
+        require_pipeline_access(pipeline)
+    descriptor = require_pipeline_access(pipeline, allow_experimental=True)
+    assert descriptor.maturity == maturity
+    assert descriptor.opt_in_required is True
+
+
+def test_legacy_alias_resolves_to_same_descriptor() -> None:
+    assert pipeline_descriptor("Pipeline_04_unified_metric") == pipeline_descriptor(
+        "Pipeline_04_Unified_Evaluation",
+        warn=False,
+    )
+
+
+def test_cli_blocks_experimental_before_import_and_writes_failed_manifest(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    resolved = _resolved(tmp_path, "Pipeline_03_Multitask_Pretraining_Finetuning")
+    monkeypatch.setattr(cli, "resolve_config", lambda *args, **kwargs: resolved)
+    monkeypatch.setattr(
+        cli.importlib,
+        "import_module",
+        lambda name: pytest.fail("blocked Pipeline must not be imported"),
+    )
+    args = argparse.Namespace(
+        config="maturity-test",
+        config_path=None,
+        notes="",
+        override=None,
+        allow_experimental=False,
+    )
+
+    with pytest.raises(PipelineMaturityError):
+        cli.run(args)
+
+    payload = _manifest(args)
+    assert payload["status"] == "failed"
+    assert payload["failure"]["stage"] == "maturity"
+    assert payload["failure"]["type"] == "PipelineMaturityError"
+
+
+def test_cli_explicit_opt_in_allows_experimental_import(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    resolved = _resolved(tmp_path, "Pipeline_03_Multitask_Pretraining_Finetuning")
+    monkeypatch.setattr(cli, "resolve_config", lambda *args, **kwargs: resolved)
+    monkeypatch.setattr(
+        cli.importlib,
+        "import_module",
+        lambda name: SimpleNamespace(pipeline=lambda args: {"experimental": True}),
+    )
+    args = argparse.Namespace(
+        config="maturity-test",
+        config_path=None,
+        notes="",
+        override=None,
+        allow_experimental=True,
+    )
+
+    assert cli.run(args) == {"experimental": True}
+    assert args.pipeline_descriptor.maturity == "experimental"
+    assert _manifest(args)["status"] == "succeeded"
+
+
+def test_non_opt_in_descriptors_remain_discoverable() -> None:
+    assert pipeline_descriptor("Pipeline_05_Explainable_Fault_Diagnosis").maturity == (
+        "compatibility"
+    )
+    assert pipeline_descriptor("Pipeline_06_Generative_Modeling").maturity == (
+        "experimental_contract"
+    )


### PR DESCRIPTION
## Objective

Separate Pipeline discoverability, explicit experimental execution, and release support so legacy research modules are not mistaken for maintained capability.

## Machine-readable authority

`phmfactory.pipelines.PIPELINE_DESCRIPTORS` records maturity, opt-in requirements, and reasons:

```text
Pipeline 01: supported
Pipeline 02: supported_limited
Pipeline 03: experimental, opt-in required
Pipeline 04: experimental_blocked, opt-in required
Pipeline 05: compatibility
Pipeline 06: experimental_contract
Pipeline_ID: compatibility
```

## Public behavior

Pipeline 03/04 require `--allow-experimental`. The maturity gate runs after pending attestation and before module import. Without opt-in, the CLI writes a failed manifest with `failure.stage: maturity`, does not import the module, and raises `PipelineMaturityError`.

Explicit opt-in preserves research access but does not promote support.

## Support semantics

`SUPPORTED_COMPONENTS.md` now enforces:

```text
supported ⊆ runnable ⊆ discoverable
```

## Boundaries

```text
no Pipeline 03/04 source or algorithm change
no maintained config or runtime algorithm change
no CWRU/rename/version/tag/release change
```

## Validation

```text
maturity descriptor and pre-import blocking tests: success
failed maturity manifest and explicit opt-in tests: success
public package, wheel, and clean-install dispatch: success
Core quality gates and real Dummy smoke: success
UXFD and Pipeline 06 focused contracts: success
CWRU contract, layout, and submodule policy: success
```