### PR TITLE
feat(evidence): converge Pipeline artifacts into run attestation

### DIFF
--- a/.github/workflows/core-quality-gates.yml
+++ b/.github/workflows/core-quality-gates.yml
@@ -202,21 +202,24 @@ jobs:
       - name: Record smoke environment
         run: python -m pip freeze > offline-smoke-environment.txt
 
-      - name: Run shared runtime and Pipeline 02 contract tests
+      - name: Run shared runtime, evidence, and Pipeline 02 contract tests
         shell: bash
         run: |
           set -o pipefail
           python -m py_compile \
+            phmfactory/runtime/evidence.py \
             src/runtime/classification.py \
             src/runtime/explainability.py \
             src/Pipeline_01_Fault_Diagnosis.py \
             src/Pipeline_02_Pretraining_Few_Shot.py \
             src/Pipeline_05_Explainable_Fault_Diagnosis.py \
             test/test_classification_runtime.py \
-            test/test_pipeline02_runtime.py
+            test/test_pipeline02_runtime.py \
+            test/test_runtime_evidence.py
           python -m pytest \
             test/test_classification_runtime.py \
             test/test_pipeline02_runtime.py \
+            test/test_runtime_evidence.py \
             -vv --tb=long 2>&1 | tee runtime-contracts-pytest.log
 
       - name: Run repository-shipped dummy smoke

--- a/.github/workflows/core-quality-gates.yml
+++ b/.github/workflows/core-quality-gates.yml
@@ -232,6 +232,26 @@ jobs:
             --override data.num_workers=0 \
             2>&1 | tee offline-smoke.log
 
+      - name: Verify Dummy run evidence index
+        run: |
+          python - <<'PY'
+          import json
+          from pathlib import Path
+
+          root = Path("results/demo/dummy_dg_smoke/.phmfactory/runs")
+          manifests = sorted(root.glob("*/run_manifest.json"))
+          assert len(manifests) == 1, manifests
+          payload = json.loads(manifests[0].read_text(encoding="utf-8"))
+          assert payload["status"] == "succeeded"
+          roles = {item["role"] for item in payload["artifacts"]}
+          assert "classification_test_metrics" in roles, roles
+          assert "classification_aggregate_metrics" in roles, roles
+          iterations = payload["evidence"].get("classification_iterations")
+          assert isinstance(iterations, list) and len(iterations) == 1, iterations
+          assert iterations[0]["iteration"] == 0
+          assert iterations[0]["metrics_artifact"]["role"] == "classification_test_metrics"
+          PY
+
       - name: Upload smoke diagnostics
         if: always()
         uses: actions/upload-artifact@v4
@@ -241,5 +261,7 @@ jobs:
             runtime-contracts-pytest.log
             offline-smoke.log
             offline-smoke-environment.txt
+            results/demo/dummy_dg_smoke/.phmfactory/runs/**/run_manifest.json
           if-no-files-found: warn
+          include-hidden-files: true
           retention-days: 7

--- a/docs/developer_runtime_control_plane.md
+++ b/docs/developer_runtime_control_plane.md
@@ -12,6 +12,7 @@ config or preset + CLI overrides
   -> Pipeline maturity gate
   -> canonical Pipeline adapter
   -> protected src runtime
+  -> evidence registration
   -> RunAttestation (succeeded or failed)
 ```
 
@@ -50,15 +51,39 @@ the final succeeded manifest cannot be written, the public invocation fails and 
 completion message is printed. This makes the minimum attestation mandatory rather than
 best effort.
 
-The first schema intentionally keeps `data`, `protocol`, `seed`, and `environment`
-evidence as nested extension points. Pipeline-specific evidence such as the Pipeline 06
-stage ledger or UXFD explainability artifacts should be referenced from this manifest in
-later bounded PRs; they must not create another top-level run identity.
-
 Protected Pipeline code must consume `compiled_run_spec.runtime_config()` instead of
 reparsing the source YAML or automatically discovering machine-local files. Until a
 Pipeline is migrated, the legacy loader remains a compatibility implementation, not a
 second public configuration authority.
+
+## Evidence convergence
+
+`RunAttestation` is the only top-level run identity. Existing metrics, configuration
+snapshots, explainability files, stage ledgers, synthetic manifests, checkpoints, and
+evaluation manifests remain separate files, but they are indexed through two APIs:
+
+```python
+run_attestation.register_artifact(role=..., path=..., sha256=..., metadata=...)
+run_attestation.set_evidence(section, value)
+run_attestation.append_evidence(section, value)
+```
+
+Artifact registration accepts existing files only. Repeating an identical registration
+is idempotent; a conflicting role/path record fails. Evidence values must be JSON
+serializable, and a scalar/mapping section cannot be silently overwritten with a
+different value.
+
+The shared classification runtime registers each `test_result_<iteration>.csv`, the
+iteration seed/run directory, and the final `all_results.csv`. Pipeline 05 registers its
+config snapshot, metadata snapshot, eligibility record, and compatibility explain/report
+manifest as role-labelled artifacts. Those files no longer define an independent run
+identity.
+
+Pipeline 06 is indexed after its explicit train, sample, or eval invocation returns. The
+control-plane adapter records the stage result, indexes any returned path/SHA records,
+and requires the existing `stage_ledger.json`. Missing or conflicting evidence changes
+the execution to `failed` with `failure.stage: evidence_finalize`; successful model
+execution alone is insufficient for a successful public invocation.
 
 ## Shared classification runtime
 

--- a/phmfactory/cli.py
+++ b/phmfactory/cli.py
@@ -16,6 +16,7 @@ from phmfactory.runtime import (
     ExecutionEnvelope,
     RunAttestation,
 )
+from phmfactory.runtime.evidence import register_pipeline_result_evidence
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -119,7 +120,7 @@ def _write_failed_attestation(
 
 
 def run(args: argparse.Namespace) -> Any:
-    """Compile, attest, authorize, and execute one Pipeline."""
+    """Compile, attest, authorize, execute, and index one Pipeline."""
     requested_config = _resolve_config_path(args)
     resolved = resolve_config(requested_config, override_values=args.override)
     compiled = CompiledRunSpec.compile(resolved)
@@ -172,6 +173,13 @@ def run(args: argparse.Namespace) -> Any:
     try:
         result = envelope.execute(pipeline_module, args)
     except BaseException as error:
+        _write_failed_attestation(attestation, envelope, error)
+        raise
+
+    try:
+        register_pipeline_result_evidence(attestation, compiled, result)
+    except BaseException as error:
+        envelope.record_failure(error, stage="evidence_finalize")
         _write_failed_attestation(attestation, envelope, error)
         raise
 

--- a/phmfactory/runtime/attestation.py
+++ b/phmfactory/runtime/attestation.py
@@ -2,12 +2,14 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from copy import deepcopy
+from dataclasses import dataclass, field
 from datetime import datetime, timezone
 import json
 import os
 from pathlib import Path
 import platform
+import re
 import subprocess
 import sys
 from typing import Any, Mapping
@@ -15,6 +17,9 @@ from uuid import uuid4
 
 from phmfactory.runtime.execution import ExecutionEnvelope
 from phmfactory.runtime.spec import CompiledRunSpec
+
+
+SHA256 = re.compile(r"[0-9a-f]{64}")
 
 
 class AttestationError(RuntimeError):
@@ -66,6 +71,13 @@ def _code_revision() -> dict[str, str | None]:
     return {"value": revision or None, "source": "git"}
 
 
+def _json_copy(value: Any, *, label: str) -> Any:
+    try:
+        return json.loads(json.dumps(value, ensure_ascii=False, sort_keys=True))
+    except (TypeError, ValueError) as error:
+        raise AttestationError(f"{label} must be JSON serializable: {error}") from error
+
+
 def _atomic_json_write(path: Path, payload: Mapping[str, Any]) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     temporary = path.with_name(f".{path.name}.{uuid4().hex}.tmp")
@@ -84,15 +96,25 @@ def _atomic_json_write(path: Path, payload: Mapping[str, Any]) -> None:
         raise AttestationWriteError(f"could not write run manifest {path}: {error}") from error
 
 
-@dataclass(frozen=True)
+@dataclass
 class RunAttestation:
-    """Location and immutable identity of one invocation-level run manifest."""
+    """Identity and accumulated evidence for one public invocation."""
 
     spec: CompiledRunSpec
     pipeline_module: str
     run_id: str
     manifest_path: Path
     created_at: str
+    artifacts: list[dict[str, Any]] = field(default_factory=list, repr=False)
+    evidence: dict[str, Any] = field(
+        default_factory=lambda: {
+            "data": {},
+            "protocol": {},
+            "seed": {},
+            "environment": {},
+        },
+        repr=False,
+    )
 
     @classmethod
     def prepare(
@@ -116,6 +138,66 @@ class RunAttestation:
         )
         attestation.write(envelope)
         return attestation
+
+    def register_artifact(
+        self,
+        *,
+        role: str,
+        path: str | Path,
+        sha256: str | None = None,
+        metadata: Mapping[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        """Register one existing artifact without silently replacing conflicts."""
+
+        normalized_role = str(role).strip()
+        if not normalized_role:
+            raise AttestationError("artifact role must be non-empty")
+        artifact_path = Path(path).expanduser().resolve()
+        if not artifact_path.is_file():
+            raise AttestationError(f"artifact does not exist or is not a file: {artifact_path}")
+        digest = str(sha256 or "").strip().lower() or None
+        if digest is not None and SHA256.fullmatch(digest) is None:
+            raise AttestationError(f"artifact sha256 is not 64 lowercase hex: {digest!r}")
+        record = {
+            "role": normalized_role,
+            "path": str(artifact_path),
+            "sha256": digest,
+            "metadata": _json_copy(dict(metadata or {}), label="artifact metadata"),
+        }
+        for existing in self.artifacts:
+            if existing["role"] == normalized_role and existing["path"] == str(artifact_path):
+                if existing != record:
+                    raise AttestationError(
+                        "conflicting artifact registration for "
+                        f"role={normalized_role!r}, path={artifact_path}"
+                    )
+                return deepcopy(existing)
+        self.artifacts.append(record)
+        return deepcopy(record)
+
+    def set_evidence(self, section: str, value: Any) -> None:
+        """Set one evidence section exactly once unless the value is identical."""
+
+        key = str(section).strip()
+        if not key:
+            raise AttestationError("evidence section must be non-empty")
+        normalized = _json_copy(value, label=f"evidence section {key!r}")
+        existing = self.evidence.get(key)
+        if existing not in (None, {}, [] ) and existing != normalized:
+            raise AttestationError(f"conflicting evidence section: {key!r}")
+        self.evidence[key] = normalized
+
+    def append_evidence(self, section: str, value: Any) -> None:
+        """Append one JSON evidence record to an ordered section."""
+
+        key = str(section).strip()
+        if not key:
+            raise AttestationError("evidence section must be non-empty")
+        normalized = _json_copy(value, label=f"evidence section {key!r}")
+        current = self.evidence.setdefault(key, [])
+        if not isinstance(current, list):
+            raise AttestationError(f"evidence section {key!r} is not appendable")
+        current.append(normalized)
 
     def payload(self, envelope: ExecutionEnvelope) -> dict[str, Any]:
         """Build the single invocation-level evidence document."""
@@ -148,13 +230,8 @@ class RunAttestation:
                 if envelope.status.value == "failed"
                 else None
             ),
-            "artifacts": [],
-            "evidence": {
-                "data": {},
-                "protocol": {},
-                "seed": {},
-                "environment": {},
-            },
+            "artifacts": deepcopy(self.artifacts),
+            "evidence": deepcopy(self.evidence),
         }
 
     def write(self, envelope: ExecutionEnvelope) -> None:

--- a/phmfactory/runtime/evidence.py
+++ b/phmfactory/runtime/evidence.py
@@ -1,0 +1,108 @@
+"""Pipeline-result adapters for the single invocation-level run attestation."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Mapping
+
+from phmfactory.runtime.attestation import AttestationError, RunAttestation
+from phmfactory.runtime.spec import CompiledRunSpec
+
+
+PIPELINE_06 = "Pipeline_06_Generative_Modeling"
+
+
+def _path_from_spec(value: str, *, cwd: Path | None = None) -> Path:
+    path = Path(value).expanduser()
+    if not path.is_absolute():
+        path = (cwd or Path.cwd()) / path
+    return path.resolve()
+
+
+def _generative_stage_ledger(spec: CompiledRunSpec) -> Path:
+    task = spec.config.get("task")
+    task = task if isinstance(task, Mapping) else {}
+    generative = task.get("generative")
+    generative = generative if isinstance(generative, Mapping) else {}
+    configured = generative.get("stage_ledger_path")
+    if isinstance(configured, str) and configured.strip():
+        return _path_from_spec(configured)
+
+    environment = spec.config.get("environment")
+    environment = environment if isinstance(environment, Mapping) else {}
+    output_dir = environment.get("output_dir")
+    if not isinstance(output_dir, str) or not output_dir.strip():
+        raise AttestationError(
+            "Pipeline 06 evidence requires environment.output_dir or "
+            "task.generative.stage_ledger_path"
+        )
+    return _path_from_spec(str(Path(output_dir) / "stage_ledger.json"))
+
+
+def _register_path_records(
+    attestation: RunAttestation,
+    *,
+    stage: str,
+    result: Mapping[str, Any],
+) -> None:
+    for name, value in result.items():
+        if not isinstance(value, Mapping):
+            continue
+        path = value.get("path")
+        if not isinstance(path, str) or not path.strip():
+            continue
+        candidate = _path_from_spec(path)
+        if not candidate.is_file():
+            continue
+        sha256 = value.get("sha256")
+        attestation.register_artifact(
+            role=f"generative_{stage}_{name}",
+            path=candidate,
+            sha256=str(sha256) if sha256 else None,
+            metadata={"stage": stage, "source": "pipeline_result"},
+        )
+
+
+def _register_pipeline06(
+    attestation: RunAttestation,
+    spec: CompiledRunSpec,
+    result: Any,
+) -> None:
+    if not isinstance(result, list) or not result:
+        raise AttestationError("Pipeline 06 must return a non-empty stage result list")
+
+    for index, item in enumerate(result):
+        if not isinstance(item, Mapping):
+            raise AttestationError(
+                f"Pipeline 06 result[{index}] must be a mapping, got {type(item).__name__}"
+            )
+        stage = str(item.get("stage") or "").strip()
+        if stage not in {"train", "sample", "eval"}:
+            raise AttestationError(
+                f"Pipeline 06 result[{index}] has unsupported stage {stage!r}"
+            )
+        attestation.append_evidence(
+            "generative_stages",
+            {"iteration": index, **dict(item)},
+        )
+        _register_path_records(attestation, stage=stage, result=item)
+
+    ledger = _generative_stage_ledger(spec)
+    if not ledger.is_file():
+        raise AttestationError(f"Pipeline 06 stage ledger is missing: {ledger}")
+    attestation.register_artifact(
+        role="generative_stage_ledger",
+        path=ledger,
+        metadata={"pipeline": PIPELINE_06},
+    )
+
+
+def register_pipeline_result_evidence(
+    attestation: RunAttestation,
+    spec: CompiledRunSpec,
+    result: Any,
+) -> None:
+    """Attach Pipeline-specific evidence without creating another run identity."""
+
+    if spec.pipeline == PIPELINE_06:
+        _register_pipeline06(attestation, spec, result)

--- a/src/runtime/classification.py
+++ b/src/runtime/classification.py
@@ -130,6 +130,33 @@ def _result_row(result: Any) -> dict[str, Any]:
     return dict(result[0])
 
 
+def _register_iteration_evidence(
+    args: Any,
+    *,
+    iteration: int,
+    seed: int,
+    path: Path,
+    metrics_path: Path,
+) -> None:
+    attestation = getattr(args, "run_attestation", None)
+    if attestation is None:
+        return
+    artifact = attestation.register_artifact(
+        role="classification_test_metrics",
+        path=metrics_path,
+        metadata={"iteration": iteration, "run_dir": str(path)},
+    )
+    attestation.append_evidence(
+        "classification_iterations",
+        {
+            "iteration": iteration,
+            "seed": seed,
+            "run_dir": str(path),
+            "metrics_artifact": artifact,
+        },
+    )
+
+
 def run_classification_pipeline(
     args: Any,
     *,
@@ -248,9 +275,14 @@ def run_classification_pipeline(
             all_results.append(context.result)
 
             print("[INFO] 保存测试结果...")
-            pd.DataFrame([context.result]).to_csv(
-                path / f"test_result_{iteration}.csv",
-                index=False,
+            metrics_path = path / f"test_result_{iteration}.csv"
+            pd.DataFrame([context.result]).to_csv(metrics_path, index=False)
+            _register_iteration_evidence(
+                args,
+                iteration=iteration,
+                seed=current_seed,
+                path=path,
+                metrics_path=metrics_path,
             )
             hooks.after_test(context)
         finally:
@@ -261,6 +293,14 @@ def run_classification_pipeline(
 
     if final_path is None:
         raise RuntimeError("classification Pipeline produced no iteration path")
-    pd.DataFrame(all_results).to_csv(final_path / "all_results.csv", index=False)
+    aggregate_path = final_path / "all_results.csv"
+    pd.DataFrame(all_results).to_csv(aggregate_path, index=False)
+    attestation = getattr(args, "run_attestation", None)
+    if attestation is not None:
+        attestation.register_artifact(
+            role="classification_aggregate_metrics",
+            path=aggregate_path,
+            metadata={"iterations": iterations},
+        )
     print(f"\n{'=' * 50}\n[INFO] 所有实验已完成\n{'=' * 50}")
     return all_results

--- a/src/runtime/explainability.py
+++ b/src/runtime/explainability.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import os
+from pathlib import Path
+from typing import Any, Mapping
 
 from src.configs.config_utils import save_config
 from src.explain_factory.eligibility import explain_ready, write_eligibility
@@ -14,14 +16,40 @@ from src.explain_factory.metadata_reader import (
 from src.runtime.classification import ClassificationContext, ClassificationHooks
 
 
+def _register_if_present(
+    context: ClassificationContext,
+    *,
+    role: str,
+    path: Path,
+    metadata: Mapping[str, Any] | None = None,
+) -> None:
+    attestation = getattr(context.args, "run_attestation", None)
+    if attestation is None or not path.is_file():
+        return
+    try:
+        attestation.register_artifact(
+            role=role,
+            path=path,
+            metadata={"iteration": context.iteration, **dict(metadata or {})},
+        )
+    except Exception as exc:
+        print(f"[WARN] 登记 {role} 到 run manifest 失败: {exc}")
+
+
 class ExplainabilityHooks(ClassificationHooks):
-    """Add UXFD config, metadata, eligibility, and final manifest artifacts."""
+    """Add UXFD evidence while preserving one invocation-level run identity."""
 
     def on_iteration_start(self, context: ClassificationContext) -> None:
+        snapshot_path = context.path / "config_snapshot.yaml"
         try:
-            save_config(context.configs, context.path / "config_snapshot.yaml")
+            save_config(context.configs, snapshot_path)
         except Exception as exc:
             print(f"[WARN] 保存 config_snapshot.yaml 失败: {exc}")
+        _register_if_present(
+            context,
+            role="explainability_config_snapshot",
+            path=snapshot_path,
+        )
 
     def after_stack_built(self, context: ClassificationContext) -> None:
         artifacts_dir = context.path / "artifacts"
@@ -50,20 +78,27 @@ class ExplainabilityHooks(ClassificationHooks):
                 )
             except Exception:
                 pass
+        _register_if_present(
+            context,
+            role="explainability_data_metadata",
+            path=snapshot_path,
+            metadata={"meta_source": str(meta_source), "degraded": bool(degraded)},
+        )
 
         extensions = getattr(context.args_trainer, "extensions", None)
         explain_cfg = getattr(extensions, "explain", None) if extensions else None
         if not bool(getattr(explain_cfg, "enable", False)):
             return
+        eligibility_path = artifacts_dir / "explain" / "eligibility.json"
+        explainer_id = str(getattr(explain_cfg, "explainer", "") or "unknown")
         try:
-            explainer_id = str(getattr(explain_cfg, "explainer", "") or "unknown")
             required_meta_keys = (
                 ["sampling_rate"]
                 if explainer_id in {"timefreq", "time_freq"}
                 else []
             )
             write_eligibility(
-                artifacts_dir / "explain" / "eligibility.json",
+                eligibility_path,
                 explain_ready(
                     explainer_id=explainer_id,
                     meta=batch_meta,
@@ -74,8 +109,15 @@ class ExplainabilityHooks(ClassificationHooks):
             )
         except Exception as exc:
             print(f"[WARN] 写入 explain eligibility 失败: {exc}")
+        _register_if_present(
+            context,
+            role="explainability_eligibility",
+            path=eligibility_path,
+            metadata={"explainer": explainer_id},
+        )
 
     def after_test(self, context: ClassificationContext) -> None:
+        legacy_manifest = context.path / "artifacts" / "manifest.json"
         try:
             from src.trainer_factory.extensions import ManifestWriterCallback
 
@@ -97,3 +139,9 @@ class ExplainabilityHooks(ClassificationHooks):
             ).on_test_end(context.trainer, context.task)
         except Exception as exc:
             print(f"[WARN] 更新 artifacts/manifest.json 失败: {exc}")
+        _register_if_present(
+            context,
+            role="explainability_legacy_manifest",
+            path=legacy_manifest,
+            metadata={"compatibility_only": True},
+        )

--- a/test/test_runtime_evidence.py
+++ b/test/test_runtime_evidence.py
@@ -1,0 +1,195 @@
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from phmfactory import cli
+from phmfactory.config import ResolvedConfig
+from phmfactory.runtime import (
+    AttestationError,
+    CompiledRunSpec,
+    ExecutionEnvelope,
+    RunAttestation,
+)
+from phmfactory.runtime.evidence import register_pipeline_result_evidence
+from src.runtime.classification import _register_iteration_evidence
+
+
+def _spec(tmp_path: Path, pipeline: str = "Pipeline_01_Fault_Diagnosis") -> CompiledRunSpec:
+    return CompiledRunSpec.compile(
+        ResolvedConfig(
+            requested="evidence-test",
+            path=tmp_path / "config.yaml",
+            data={
+                "pipeline": pipeline,
+                "environment": {"output_dir": str(tmp_path / "outputs")},
+            },
+            pipeline=pipeline,
+            overrides={},
+        )
+    )
+
+
+def _attestation(tmp_path: Path, pipeline: str = "Pipeline_01_Fault_Diagnosis"):
+    spec = _spec(tmp_path, pipeline)
+    envelope = ExecutionEnvelope(spec=spec, pipeline_module=f"src.{pipeline}")
+    return spec, envelope, RunAttestation.prepare(spec, f"src.{pipeline}", envelope)
+
+
+def test_artifact_registry_is_idempotent_and_conflict_safe(tmp_path: Path) -> None:
+    _, _, attestation = _attestation(tmp_path)
+    artifact = tmp_path / "metrics.csv"
+    artifact.write_text("metric,value\nacc,1\n", encoding="utf-8")
+
+    first = attestation.register_artifact(
+        role="metrics",
+        path=artifact,
+        metadata={"iteration": 0},
+    )
+    second = attestation.register_artifact(
+        role="metrics",
+        path=artifact,
+        metadata={"iteration": 0},
+    )
+    assert first == second
+    assert len(attestation.artifacts) == 1
+
+    with pytest.raises(AttestationError, match="conflicting artifact"):
+        attestation.register_artifact(
+            role="metrics",
+            path=artifact,
+            metadata={"iteration": 1},
+        )
+
+
+def test_artifact_registry_rejects_missing_files_and_bad_hashes(tmp_path: Path) -> None:
+    _, _, attestation = _attestation(tmp_path)
+    with pytest.raises(AttestationError, match="does not exist"):
+        attestation.register_artifact(role="missing", path=tmp_path / "missing.csv")
+
+    artifact = tmp_path / "metrics.csv"
+    artifact.write_text("ok", encoding="utf-8")
+    with pytest.raises(AttestationError, match="64 lowercase hex"):
+        attestation.register_artifact(role="metrics", path=artifact, sha256="ABC")
+
+
+def test_evidence_sections_reject_conflicting_overwrite(tmp_path: Path) -> None:
+    _, _, attestation = _attestation(tmp_path)
+    attestation.set_evidence("protocol", {"name": "dg"})
+    attestation.set_evidence("protocol", {"name": "dg"})
+    with pytest.raises(AttestationError, match="conflicting evidence"):
+        attestation.set_evidence("protocol", {"name": "cddg"})
+
+    attestation.append_evidence("iterations", {"index": 0})
+    attestation.append_evidence("iterations", {"index": 1})
+    assert attestation.evidence["iterations"] == [{"index": 0}, {"index": 1}]
+
+
+def test_classification_metrics_are_registered_without_new_output_files(
+    tmp_path: Path,
+) -> None:
+    _, _, attestation = _attestation(tmp_path)
+    metrics = tmp_path / "run" / "test_result_0.csv"
+    metrics.parent.mkdir()
+    metrics.write_text("acc\n1\n", encoding="utf-8")
+    args = SimpleNamespace(run_attestation=attestation)
+
+    _register_iteration_evidence(
+        args,
+        iteration=0,
+        seed=7,
+        path=metrics.parent,
+        metrics_path=metrics,
+    )
+
+    assert attestation.artifacts[0]["role"] == "classification_test_metrics"
+    assert attestation.evidence["classification_iterations"][0]["seed"] == 7
+
+
+def test_pipeline06_result_indexes_existing_stage_artifacts(tmp_path: Path) -> None:
+    spec, _, attestation = _attestation(tmp_path, "Pipeline_06_Generative_Modeling")
+    output_root = Path(spec.config["environment"]["output_dir"])
+    output_root.mkdir(parents=True)
+    ledger = output_root / "stage_ledger.json"
+    ledger.write_text('{"stages": {}}\n', encoding="utf-8")
+    run_dir = tmp_path / "stage"
+    run_dir.mkdir()
+    metrics = run_dir / "generative_eval_metrics.csv"
+    metrics.write_text("metric,value\n", encoding="utf-8")
+    evaluation = run_dir / "evaluation_evidence_manifest.json"
+    evaluation.write_text("{}\n", encoding="utf-8")
+
+    result = [
+        {
+            "stage": "eval",
+            "status": "completed",
+            "run_dir": str(run_dir),
+            "metrics": {"path": str(metrics)},
+            "evaluation_manifest": {"path": str(evaluation)},
+            "metric_summary": {},
+        }
+    ]
+    register_pipeline_result_evidence(attestation, spec, result)
+
+    roles = {artifact["role"] for artifact in attestation.artifacts}
+    assert roles == {
+        "generative_eval_metrics",
+        "generative_eval_evaluation_manifest",
+        "generative_stage_ledger",
+    }
+    assert attestation.evidence["generative_stages"][0]["stage"] == "eval"
+
+
+def test_pipeline06_missing_ledger_invalidates_evidence(tmp_path: Path) -> None:
+    spec, _, attestation = _attestation(tmp_path, "Pipeline_06_Generative_Modeling")
+    with pytest.raises(AttestationError, match="stage ledger is missing"):
+        register_pipeline_result_evidence(
+            attestation,
+            spec,
+            [{"stage": "train", "status": "completed", "run_dir": str(tmp_path)}],
+        )
+
+
+def test_cli_records_evidence_finalize_failure(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    pipeline = "Pipeline_06_Generative_Modeling"
+    resolved = ResolvedConfig(
+        requested="generative",
+        path=tmp_path / "generative.yaml",
+        data={
+            "pipeline": pipeline,
+            "environment": {"output_dir": str(tmp_path / "outputs")},
+        },
+        pipeline=pipeline,
+        overrides={},
+    )
+    monkeypatch.setattr(cli, "resolve_config", lambda *args, **kwargs: resolved)
+    monkeypatch.setattr(
+        cli.importlib,
+        "import_module",
+        lambda name: SimpleNamespace(
+            pipeline=lambda args: [
+                {"stage": "train", "status": "completed", "run_dir": str(tmp_path)}
+            ]
+        ),
+    )
+    args = argparse.Namespace(
+        config="generative",
+        config_path=None,
+        notes="",
+        override=None,
+        allow_experimental=False,
+    )
+
+    with pytest.raises(AttestationError, match="stage ledger is missing"):
+        cli.run(args)
+
+    payload = json.loads(Path(args.run_manifest_path).read_text(encoding="utf-8"))
+    assert payload["status"] == "failed"
+    assert payload["failure"]["stage"] == "evidence_finalize"

--- a/test/test_runtime_evidence.py
+++ b/test/test_runtime_evidence.py
@@ -113,7 +113,7 @@ def test_classification_metrics_are_registered_without_new_output_files(
 def test_pipeline06_result_indexes_existing_stage_artifacts(tmp_path: Path) -> None:
     spec, _, attestation = _attestation(tmp_path, "Pipeline_06_Generative_Modeling")
     output_root = Path(spec.config["environment"]["output_dir"])
-    output_root.mkdir(parents=True)
+    output_root.mkdir(parents=True, exist_ok=True)
     ledger = output_root / "stage_ledger.json"
     ledger.write_text('{"stages": {}}\n', encoding="utf-8")
     run_dir = tmp_path / "stage"


### PR DESCRIPTION
## Objective

Use one invocation-level `run_manifest.json` as the top-level identity for classification, UXFD, and Pipeline 06 evidence without copying or replacing their existing artifact files.

## Shared registry

`RunAttestation` provides conflict-safe artifact and evidence registration. Existing files are indexed by role; identical registration is idempotent, conflicting records fail, and evidence must be JSON serializable.

## Convergence

- shared classification runtime indexes per-iteration test CSVs, seeds/run directories, and aggregate results;
- Pipeline 05 indexes config snapshot, metadata snapshot, eligibility, and its compatibility explain/report manifest;
- Pipeline 06 scientific source is unchanged; a control-plane adapter indexes stage results, returned path/SHA evidence, and the existing stage ledger;
- missing or conflicting evidence changes the invocation to `failed/evidence_finalize`.

Existing Pipeline-specific files remain available but no longer define a second run identity.

## Boundaries

```text
no Pipeline 06 scientific code change
no model/task/trainer/data algorithm change
no new output copies
no CWRU/rename/version/tag/release change
```

## Validation

```text
artifact/evidence conflict and failure tests: success
Pipeline 06 ledger/result adapter tests: success
real Dummy smoke: success
real Dummy manifest contains classification_test_metrics: success
real Dummy manifest contains classification_aggregate_metrics: success
real Dummy iteration seed/run_dir evidence: success
UXFD and Pipeline 06 existing focused contracts: success
public package, CWRU, layout, and submodule gates: success
```