### PR TITLE
feat(ux): make the PHMFactory first run truthful and predictable

### DIFF
--- a/.github/workflows/core-quality-gates.yml
+++ b/.github/workflows/core-quality-gates.yml
@@ -167,7 +167,7 @@ jobs:
           retention-days: 7
 
   offline-smoke:
-    name: Offline config-first smoke
+    name: Offline user-first smoke
     runs-on: ubuntu-latest
     timeout-minutes: 30
     env:
@@ -206,6 +206,9 @@ jobs:
             "openpyxl" \
             "pytest>=7"
 
+      - name: Install editable PHMFactory command
+        run: python -m pip install --no-deps -e .
+
       - name: Record smoke environment
         run: python -m pip freeze > offline-smoke-environment.txt
 
@@ -229,15 +232,24 @@ jobs:
             test/test_runtime_evidence.py \
             -vv --tb=long 2>&1 | tee runtime-contracts-pytest.log
 
-      - name: Run repository-shipped dummy smoke
+      - name: Diagnose the installed environment
         shell: bash
         run: |
           set -o pipefail
-          python main.py \
-            --config configs/demo/00_smoke/dummy_dg.yaml \
-            --override trainer.num_epochs=1 \
-            --override data.num_workers=0 \
-            2>&1 | tee offline-smoke.log
+          phmfactory doctor 2>&1 | tee offline-doctor.log
+
+      - name: Preflight the exact offline demo without training
+        shell: bash
+        run: |
+          set -o pipefail
+          phmfactory preflight --config smoke 2>&1 | tee offline-preflight.log
+          test ! -e results/demo/dummy_dg_smoke
+
+      - name: Run the documented offline demo command
+        shell: bash
+        run: |
+          set -o pipefail
+          phmfactory demo 2>&1 | tee offline-smoke.log
 
       - name: Verify Dummy run evidence index
         run: |
@@ -263,9 +275,11 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: offline-smoke-diagnostics
+          name: offline-user-first-smoke-diagnostics
           path: |
             runtime-contracts-pytest.log
+            offline-doctor.log
+            offline-preflight.log
             offline-smoke.log
             offline-smoke-environment.txt
             results/demo/dummy_dg_smoke/.phmfactory/runs/**/run_manifest.json

--- a/.github/workflows/phmfactory-public-package.yml
+++ b/.github/workflows/phmfactory-public-package.yml
@@ -8,6 +8,10 @@ on:
       - "main.py"
       - "pyproject.toml"
       - "requirements.txt"
+      - "README.md"
+      - "README_CN.md"
+      - "docs/installation.md"
+      - "docs/quickstart.md"
       - "MIGRATION_v0.2_to_v0.3.md"
       - "examples/cwru_quickstart.py"
       - "configs/**"
@@ -31,6 +35,10 @@ on:
       - "main.py"
       - "pyproject.toml"
       - "requirements.txt"
+      - "README.md"
+      - "README_CN.md"
+      - "docs/installation.md"
+      - "docs/quickstart.md"
       - "MIGRATION_v0.2_to_v0.3.md"
       - "examples/cwru_quickstart.py"
       - "configs/**"
@@ -111,7 +119,7 @@ jobs:
       - name: Build wheel and source distribution
         run: python -m build
 
-      - name: Inspect wheel contents
+      - name: Inspect wheel contents and console entrypoint
         run: |
           python - <<'PY'
           from pathlib import Path
@@ -121,6 +129,12 @@ jobs:
           assert len(wheels) == 1, wheels
           with ZipFile(wheels[0]) as archive:
               names = set(archive.namelist())
+              entry_point_files = sorted(
+                  name for name in names if name.endswith(".dist-info/entry_points.txt")
+              )
+              assert len(entry_point_files) == 1, entry_point_files
+              entry_points = archive.read(entry_point_files[0]).decode("utf-8")
+          assert "phmfactory = phmfactory.cli:entrypoint" in entry_points
           required = {
               "phmfactory/__init__.py",
               "phmfactory/__main__.py",
@@ -160,7 +174,11 @@ jobs:
         shell: bash
         run: |
           set -euxo pipefail
-          rm -rf /tmp/phmfactory-wheel /tmp/phmfactory-preflight-output /tmp/results
+          rm -rf \
+            /tmp/phmfactory-wheel \
+            /tmp/phmfactory-console-preflight \
+            /tmp/phmfactory-module-preflight \
+            /tmp/results
           python -m venv /tmp/phmfactory-wheel
           /tmp/phmfactory-wheel/bin/python -m pip install --no-deps dist/*.whl
           /tmp/phmfactory-wheel/bin/python -m pip install PyYAML
@@ -178,14 +196,35 @@ jobs:
       - name: Verify clean installed demo help
         run: /tmp/phmfactory-wheel/bin/phmfactory demo --help
 
-      - name: Verify clean installed preflight
+      - name: Verify clean installed console preflight exits zero
         run: >-
           /tmp/phmfactory-wheel/bin/phmfactory preflight
           --config smoke
-          --override environment.output_dir=/tmp/phmfactory-preflight-output
+          --override environment.output_dir=/tmp/phmfactory-console-preflight
 
-      - name: Verify preflight leaves target absent
-        run: test ! -e /tmp/phmfactory-preflight-output
+      - name: Verify clean installed module preflight exits zero
+        run: >-
+          /tmp/phmfactory-wheel/bin/python -m phmfactory preflight
+          --config smoke
+          --override environment.output_dir=/tmp/phmfactory-module-preflight
+
+      - name: Verify preflight leaves configured targets absent
+        run: |
+          test ! -e /tmp/phmfactory-console-preflight
+          test ! -e /tmp/phmfactory-module-preflight
+
+      - name: Verify invalid clean installed preflight exits non-zero
+        shell: bash
+        run: |
+          set -euo pipefail
+          if /tmp/phmfactory-wheel/bin/phmfactory preflight \
+            --config /tmp/phmfactory-does-not-exist.yaml \
+            >/tmp/phmfactory-invalid-preflight.log 2>&1; then
+            cat /tmp/phmfactory-invalid-preflight.log
+            echo "invalid preflight unexpectedly returned exit code 0" >&2
+            exit 1
+          fi
+          grep -F "was not found" /tmp/phmfactory-invalid-preflight.log
 
       - name: Verify clean installed experiment dispatch
         shell: bash

--- a/.github/workflows/phmfactory-public-package.yml
+++ b/.github/workflows/phmfactory-public-package.yml
@@ -156,18 +156,33 @@ jobs:
           assert not any(name.startswith(("paper/", "dev/", "results/")) for name in names)
           PY
 
-      - name: Verify clean no-dependency installation and dispatch
+      - name: Install wheel in a clean environment
+        shell: bash
         run: |
+          set -euxo pipefail
+          rm -rf /tmp/phmfactory-wheel /tmp/phmfactory-preflight-output /tmp/results
           python -m venv /tmp/phmfactory-wheel
           /tmp/phmfactory-wheel/bin/python -m pip install --no-deps dist/*.whl
           /tmp/phmfactory-wheel/bin/python -m pip install PyYAML
           /tmp/phmfactory-wheel/bin/python -c "import phmfactory, phmfactory.commands, phmfactory.config, phmfactory.runtime, src; print(phmfactory.__version__)"
+
+      - name: Verify clean installed commands and preflight
+        shell: bash
+        run: |
+          set -euxo pipefail
           /tmp/phmfactory-wheel/bin/phmfactory --help
           /tmp/phmfactory-wheel/bin/python -m phmfactory --help
+          /tmp/phmfactory-wheel/bin/phmfactory doctor --help
+          /tmp/phmfactory-wheel/bin/phmfactory demo --help
           /tmp/phmfactory-wheel/bin/phmfactory preflight \
             --config smoke \
             --override environment.output_dir=/tmp/phmfactory-preflight-output
           test ! -e /tmp/phmfactory-preflight-output
+
+      - name: Verify clean installed experiment dispatch
+        shell: bash
+        run: |
+          set -euxo pipefail
           cd /tmp
           /tmp/phmfactory-wheel/bin/python - <<'PY'
           import json

--- a/.github/workflows/phmfactory-public-package.yml
+++ b/.github/workflows/phmfactory-public-package.yml
@@ -13,6 +13,7 @@ on:
       - "configs/**"
       - "data/metadata_dummy.csv"
       - "data/raw/Dummy_Data/**"
+      - "test/test_phmfactory_commands.py"
       - "test/test_phmfactory_entrypoints.py"
       - "test/test_phmfactory_config_resolver.py"
       - "test/test_pipeline_name_migration.py"
@@ -35,6 +36,7 @@ on:
       - "configs/**"
       - "data/metadata_dummy.csv"
       - "data/raw/Dummy_Data/**"
+      - "test/test_phmfactory_commands.py"
       - "test/test_phmfactory_entrypoints.py"
       - "test/test_phmfactory_config_resolver.py"
       - "test/test_pipeline_name_migration.py"
@@ -72,9 +74,11 @@ jobs:
         run: >-
           python -m py_compile
           phmfactory/*.py
+          phmfactory/commands/*.py
           phmfactory/runtime/*.py
           src/configs/config_utils.py
           main.py
+          test/test_phmfactory_commands.py
           test/test_phmfactory_entrypoints.py
           test/test_phmfactory_config_resolver.py
           test/test_pipeline_name_migration.py
@@ -87,6 +91,7 @@ jobs:
         run: >-
           python -m pytest -vv
           --junitxml=pytest-public-package.xml
+          test/test_phmfactory_commands.py
           test/test_phmfactory_entrypoints.py
           test/test_phmfactory_config_resolver.py
           test/test_pipeline_name_migration.py
@@ -122,6 +127,12 @@ jobs:
               "phmfactory/cli.py",
               "phmfactory/config.py",
               "phmfactory/pipelines.py",
+              "phmfactory/commands/__init__.py",
+              "phmfactory/commands/common.py",
+              "phmfactory/commands/data.py",
+              "phmfactory/commands/demo.py",
+              "phmfactory/commands/doctor.py",
+              "phmfactory/commands/preflight.py",
               "phmfactory/runtime/__init__.py",
               "phmfactory/runtime/spec.py",
               "phmfactory/runtime/execution.py",
@@ -150,9 +161,13 @@ jobs:
           python -m venv /tmp/phmfactory-wheel
           /tmp/phmfactory-wheel/bin/python -m pip install --no-deps dist/*.whl
           /tmp/phmfactory-wheel/bin/python -m pip install PyYAML
-          /tmp/phmfactory-wheel/bin/python -c "import phmfactory, phmfactory.config, phmfactory.runtime, src; print(phmfactory.__version__)"
+          /tmp/phmfactory-wheel/bin/python -c "import phmfactory, phmfactory.commands, phmfactory.config, phmfactory.runtime, src; print(phmfactory.__version__)"
           /tmp/phmfactory-wheel/bin/phmfactory --help
           /tmp/phmfactory-wheel/bin/python -m phmfactory --help
+          /tmp/phmfactory-wheel/bin/phmfactory preflight \
+            --config smoke \
+            --override environment.output_dir=/tmp/phmfactory-preflight-output
+          test ! -e /tmp/phmfactory-preflight-output
           cd /tmp
           /tmp/phmfactory-wheel/bin/python - <<'PY'
           import json

--- a/.github/workflows/phmfactory-public-package.yml
+++ b/.github/workflows/phmfactory-public-package.yml
@@ -166,18 +166,26 @@ jobs:
           /tmp/phmfactory-wheel/bin/python -m pip install PyYAML
           /tmp/phmfactory-wheel/bin/python -c "import phmfactory, phmfactory.commands, phmfactory.config, phmfactory.runtime, src; print(phmfactory.__version__)"
 
-      - name: Verify clean installed commands and preflight
-        shell: bash
-        run: |
-          set -euxo pipefail
-          /tmp/phmfactory-wheel/bin/phmfactory --help
-          /tmp/phmfactory-wheel/bin/python -m phmfactory --help
-          /tmp/phmfactory-wheel/bin/phmfactory doctor --help
-          /tmp/phmfactory-wheel/bin/phmfactory demo --help
-          /tmp/phmfactory-wheel/bin/phmfactory preflight \
-            --config smoke \
-            --override environment.output_dir=/tmp/phmfactory-preflight-output
-          test ! -e /tmp/phmfactory-preflight-output
+      - name: Verify clean installed root help
+        run: /tmp/phmfactory-wheel/bin/phmfactory --help
+
+      - name: Verify clean installed module help
+        run: /tmp/phmfactory-wheel/bin/python -m phmfactory --help
+
+      - name: Verify clean installed doctor help
+        run: /tmp/phmfactory-wheel/bin/phmfactory doctor --help
+
+      - name: Verify clean installed demo help
+        run: /tmp/phmfactory-wheel/bin/phmfactory demo --help
+
+      - name: Verify clean installed preflight
+        run: >-
+          /tmp/phmfactory-wheel/bin/phmfactory preflight
+          --config smoke
+          --override environment.output_dir=/tmp/phmfactory-preflight-output
+
+      - name: Verify preflight leaves target absent
+        run: test ! -e /tmp/phmfactory-preflight-output
 
       - name: Verify clean installed experiment dispatch
         shell: bash

--- a/KNOWN_LIMITATIONS.md
+++ b/KNOWN_LIMITATIONS.md
@@ -1,34 +1,108 @@
-# Known Limitations for v0.2.0
+# Known Limitations for the PHMFactory v0.3 Pre-release
 
-## Scope
+This page describes the current maintained source state. It does not imply that the final
+`v0.3.0` tag, repository rename, or package publication has occurred.
 
-- v0.2.0 supports the maintained demo combinations listed in
-  `SUPPORTED_COMBINATIONS.md`, not every discovered model/task pair.
-- `Pipeline_02_Pretraining_Few_Shot` is validated for the current single-stage
-  pretrain demo. Multi-stage `stages:` workflows need separate evidence.
-- `Pipeline_03` remains outside the public release-supported surface.
+## Repository and installation state
 
-## Data And Environment
+- The project and Python package are named PHMFactory, but the current GitHub repository
+  remains `PHMbench/PHM-Vibench`.
+- The source version is `0.3.0.dev0`.
+- The maintained pre-release installation path is an editable checkout installation:
+  `python -m pip install -e .`.
+- A final package-index release is not claimed. Do not document `pip install phmfactory`
+  as generally available until a real release is published and verified.
 
-- Only the dummy smoke demo is offline and repo-shipped.
-- Non-dummy demos require local PHM-Vibench metadata/raw data and may need a
-  machine-specific `data.data_dir` override.
-- Maintained validation uses the `LQ_signal` conda environment. Base Python may
-  lack required packages such as `pytorch_lightning`.
+## Supported surface
 
-## Evidence Boundaries
+- Release support is limited to the exact configurations listed in
+  `SUPPORTED_COMBINATIONS.md`, not every discovered model/task/data combination.
+- A registry row, importable module, source file, or experimental opt-in is discovery
+  information; it is not by itself a support claim.
+- `Pipeline_01_Fault_Diagnosis` is the primary maintained classification path.
+- `Pipeline_02_Pretraining_Few_Shot` is supported only for the current bounded maintained
+  path; multi-stage workflows require their own evidence.
+- Pipeline 03 and Pipeline 04 remain experimental and require explicit acknowledgement.
+- Pipeline 05, Pipeline 06, and Pipeline_ID have compatibility or experimental contracts
+  but are not automatically part of the release-supported combination table.
 
-- Smoke evidence is functional evidence, not performance evidence.
-- Registry rows are traceability evidence; runtime support requires a passing
-  maintained demo or an explicit additional smoke matrix.
-- Broad `python -m pytest -q` is diagnostic because it collects historical and
-  stray tests. The maintained gate is `python -m pytest test/ -q`.
+## Data availability
 
-## Compatibility Boundaries
+- Only the Dummy smoke demo is fully offline and shipped with the repository.
+- Most non-Dummy demos require local metadata and raw files supplied through explicit
+  configuration or CLI overrides.
+- Dataset source, license, citation, and redistribution rights remain the responsibility
+  of each dataset contribution and user environment.
+- The CWRU public bundle interface exists, but final provider revisions and required-file
+  SHA-256 values are not yet frozen. It is therefore not a finalized release artifact.
+- A successful software smoke does not prove external data availability, data quality, or
+  permission to redistribute the source data.
 
-- Sampler compatibility must be derived from current `Get_sampler.py`; stale
-  compatibility matrices are not release evidence.
-- Dataset adapter fallback to `Default_dataset` remains a behavior to inspect
-  carefully when adding new task names.
-- Unknown pipeline, model, and task values are expected to fail explicitly.
+## Platform and dependency coverage
 
+- The focused maintained baseline uses Python 3.10 and Ubuntu CI runners.
+- CPU smoke validation uses the PyTorch 2.6.0 family.
+- Windows and other platforms have selected tests, but not every model, reader, optional
+  dependency, or GPU path is covered across every operating system.
+- Optional model families may require research dependencies beyond the first-run path.
+  An unconditional optional import should be reported as a dependency-boundary bug.
+- `phmfactory doctor` verifies real imports in the active environment; it cannot guarantee
+  every optional research model or external system integration.
+
+## Configuration compatibility
+
+- Public process entrypoints resolve maintained configs and explicit CLI overrides through
+  the public resolver.
+- Historical direct Pipeline imports retain compatibility behavior and should not be
+  treated as a second public configuration contract.
+- Machine-specific paths should be passed explicitly or kept in an untracked local
+  experiment file. A public run must not silently change because a hidden local file is
+  discovered.
+- The current repository still contains historical configs under `configs/v0.0.9/`.
+  Their presence does not make them part of the v0.3 quickstart or supported surface.
+
+## Runtime and evidence boundaries
+
+- `sanity_ok` is bounded functional evidence, not benchmark-performance evidence.
+- The offline Dummy demo verifies configuration, factory construction, training, testing,
+  and result writing. Its metrics are not a scientific baseline.
+- Fair comparison requires the same effective config, code revision, environment, data,
+  split, seed, protocol, metric set, and aggregation rule.
+- The run manifest records the invocation and indexed artifacts, but not every historical
+  Pipeline has equally complete data, protocol, seed, and environment detail.
+- Failure to write the required run record makes a public invocation unsuccessful; richer
+  optional reports may still have Pipeline-specific limitations.
+
+## Factory compatibility risks
+
+- Model, task, and trainer factories still include historical compatibility paths. New
+  work should fail at the source error rather than printing and returning `None`.
+- Checkpoint compatibility must not be inferred from partial `strict=False` loading.
+  Missing, unexpected, and shape-mismatched parameters require explicit policy and user
+  acknowledgement.
+- Dataset-adapter fallback to `Default_dataset` is historical behavior and must be reviewed
+  carefully when adding a new task name.
+- Sampler compatibility must be derived from current runtime behavior and focused tests;
+  stale tables or comments are not release evidence.
+
+## Streamlit scope
+
+- The Streamlit workspace is optional and delegates execution to the public CLI.
+- One Streamlit worker manages one active experiment at a time; the UI is not a cluster
+  scheduler or experiment queue.
+- Process detachment, CUDA workers, and operating-system restart behavior have platform
+  limits documented in `apps/streamlit/README.md`.
+- The CLI remains the source of execution semantics when UI and documentation disagree.
+
+## Release blockers intentionally retained
+
+The following items are not resolved by ordinary usability refactors:
+
+- immutable CWRU provider revisions;
+- byte-identical required CWRU file hashes;
+- final GitHub repository rename;
+- version promotion from `0.3.0.dev0` to `0.3.0`;
+- final tag, GitHub Release, and package publication.
+
+The current authority is
+[`docs/PHMFACTORY_V0_3_RELEASE_READINESS.md`](docs/PHMFACTORY_V0_3_RELEASE_READINESS.md).

--- a/README.md
+++ b/README.md
@@ -8,143 +8,190 @@
     <a href="README_CN.md">中文</a>
   </p>
 
-  <p><strong>A configuration-first PHM research and evaluation framework for industrial vibration signals.</strong></p>
+  <p><strong>A configuration-first framework for reproducible PHM experiments on industrial signals.</strong></p>
 
   <p>
     <img src="https://img.shields.io/badge/status-alpha-orange" alt="Status: alpha"/>
     <img src="https://img.shields.io/badge/v0.3-pre--release-blue" alt="v0.3 pre-release"/>
-    <a href="https://github.com/PHMbench/phmfactory/actions/workflows/core-quality-gates.yml"><img src="https://github.com/PHMbench/phmfactory/actions/workflows/core-quality-gates.yml/badge.svg" alt="Core quality gates"/></a>
+    <a href="https://github.com/PHMbench/PHM-Vibench/actions/workflows/core-quality-gates.yml"><img src="https://github.com/PHMbench/PHM-Vibench/actions/workflows/core-quality-gates.yml/badge.svg" alt="Core quality gates"/></a>
     <img src="https://img.shields.io/badge/license-Apache%202.0-green" alt="Apache 2.0 license"/>
   </p>
 </div>
 
+> **Current repository identity.** The project and Python package are named
+> **PHMFactory**, while the GitHub repository remains
+> [`PHMbench/PHM-Vibench`](https://github.com/PHMbench/PHM-Vibench) during the v0.3
+> pre-release. Use the repository URL shown here until an eventual rename is completed.
+
 PHMFactory connects data loading, model construction, task logic, training, evaluation,
-and experiment configuration through one public dispatcher. The following entrypoints
-have the same semantics:
+and run records through one configuration-first interface. You select a maintained
+configuration, override only the values that differ on your machine, and run the same
+contract from the command line, Python module, or compatibility launcher.
+
+## Start with the offline demo
+
+The following path uses repository-shipped synthetic data and does not download an
+external dataset.
 
 ```bash
-python main.py --config <yaml> [--override key=value ...]
-python -m phmfactory --config <yaml> [--override key=value ...]
+git clone https://github.com/PHMbench/PHM-Vibench.git
+cd PHM-Vibench
+
+python -m venv .venv
+source .venv/bin/activate          # Windows: .venv\Scripts\activate
+python -m pip install --upgrade pip
+python -m pip install -e .
+
+phmfactory doctor
+phmfactory preflight --config smoke
+phmfactory demo
+```
+
+A successful first run should:
+
+- report every required `doctor` check as `PASS`;
+- print `status=passed` during `preflight` without starting training;
+- complete one CPU Dummy experiment through data → model → task → trainer;
+- print the path to `run_manifest.json`;
+- write results below `results/demo/dummy_dg_smoke/`;
+- exit with status code `0` for all three commands.
+
+If a command fails, keep the complete terminal output and follow the relevant section in
+[Quickstart](docs/quickstart.md). Installation variants, including CPU-only PyTorch, are
+covered in [Installation](docs/installation.md).
+
+## Choose your next task
+
+| Goal | Start here |
+| --- | --- |
+| Understand the first run and its outputs | [Quickstart](docs/quickstart.md) |
+| Install on CPU, GPU, Linux, macOS, or Windows | [Installation](docs/installation.md) |
+| Use an existing maintained experiment | [Configuration guide](configs/README.md) |
+| Connect local PHM data | [Data layout](data/README.md) and [custom dataset guide](docs/custom_dataset.md) |
+| Select or add a model | [Model Factory](src/model_factory/README.md) |
+| Select or add a task | [Task Factory](src/task_factory/README.md) |
+| Use the browser interface | [Streamlit workspace](apps/streamlit/README.md) |
+| Extend or maintain the framework | [Developer guide](docs/developer_guide.md) |
+| Check the exact maintained surface | [Supported combinations](SUPPORTED_COMBINATIONS.md) |
+
+The complete documentation map is in [docs/index.md](docs/index.md).
+
+## The configuration model
+
+Maintained configurations use five logical blocks:
+
+```yaml
+environment:  # output location, seed, repeat count, process-level settings
+  ...
+data:         # metadata, raw data root, windows, workers, sampling policy
+  ...
+model:        # model family and model-specific parameters
+  ...
+task:         # diagnosis, domain generalization, few-shot, or pretraining logic
+  ...
+trainer:      # device, epochs, precision, logging, and checkpoint behavior
+  ...
+```
+
+A top-level `pipeline` selects the orchestration path. New datasets, models, tasks, and
+trainers should normally extend their factory instead of adding special cases to
+`main.py`.
+
+Start from the nearest maintained file under `configs/demo/`. Put research variants under
+`configs/experiments/`, and pass machine-specific values explicitly:
+
+```bash
+phmfactory preflight \
+  --config configs/demo/01_cross_domain/cwru_dg.yaml \
+  --override data.data_dir=/absolute/path/to/phm-data \
+  --override data.metadata_file=metadata.xlsx \
+  --override trainer.num_epochs=1
+```
+
+After preflight passes, remove the word `preflight` to execute the same configuration:
+
+```bash
+phmfactory \
+  --config configs/demo/01_cross_domain/cwru_dg.yaml \
+  --override data.data_dir=/absolute/path/to/phm-data \
+  --override data.metadata_file=metadata.xlsx \
+  --override trainer.num_epochs=1
+```
+
+The exact composition and precedence rules are defined in
+[configs/README.md](configs/README.md).
+
+## Public entrypoints
+
+The following process entrypoints share the same configuration and exit-status semantics:
+
+```bash
 phmfactory --config <yaml> [--override key=value ...]
+python -m phmfactory --config <yaml> [--override key=value ...]
+python main.py --config <yaml> [--override key=value ...]
 ```
 
-PHMFactory is the v0.3 successor to PHM-Vibench. The v0.3 compatibility release adds
-the public `phmfactory` package while retaining the established `src.*` runtime as a
-protected internal engine. The project remains in alpha; release support is limited to
-the maintained configurations documented in
-[SUPPORTED_COMBINATIONS.md](SUPPORTED_COMBINATIONS.md).
+Use the installed `phmfactory` command in normal work. `python main.py` remains a
+repository compatibility launcher. Python callers that need the structured command or
+Pipeline result may import `phmfactory.cli.main` directly.
 
-## Branch policy
-
-`main` is the user-facing stable branch and remains the default branch for cloning,
-documentation, and releases. `dev` is the integration and development branch. All
-routine feature, fix, documentation, test, CI, cleanup, and migration pull requests
-must target `dev`, and topic branches must start from the latest `dev`.
-
-Only an explicitly authorized release-promotion pull request (`dev` or
-`release/<version>` to `main`) or an emergency hotfix may target `main`. A hotfix
-must be synchronized back to `dev`. Both long-lived branches are pull-request-only;
-direct pushes are outside the maintained workflow. See
-[CONTRIBUTING.md](CONTRIBUTING.md) for the full contract.
-
-## Run the offline example
-
-Install the core environment, then execute the repository-shipped Dummy configuration:
+Useful bounded commands:
 
 ```bash
-git clone https://github.com/PHMbench/phmfactory.git
-cd phmfactory
-conda create -n phmfactory python=3.10
-conda activate phmfactory
-python -m pip install -r requirements.txt
-
-python main.py --config configs/demo/00_smoke/dummy_dg.yaml \
-  --override trainer.num_epochs=1 \
-  --override data.num_workers=0
+phmfactory doctor
+phmfactory preflight --config <preset-or-yaml>
+phmfactory demo
+phmfactory data --help
 ```
 
-A successful run exits cleanly, prints the completion message, and writes output below
-`results/demo/dummy_dg_smoke/`. This validates the maintained software path; it is not
-a benchmark-performance claim.
+## Maintained support boundary
 
-Detailed setup and troubleshooting:
-
-- [Installation](docs/installation.md)
-- [Quickstart](docs/quickstart.md)
-- [Known limitations](KNOWN_LIMITATIONS.md)
-- [v0.2 to v0.3 migration](RELEASE_NOTES_v0.3.0.md)
-
-## Public data bundle interface
-
-The v0.3 source tree includes a provider-neutral CWRU bundle interface for:
+PHMFactory distinguishes three claims:
 
 ```text
-metadata.xlsx          required
-RM_001_CWRU.h5         required
-corpus.xlsx            optional
+discoverable  = an implementation or registry entry exists
+runnable      = a reviewed execution path exists
+supported     = a maintained configuration has current smoke evidence
 ```
 
-The public commands are:
+The required relation is:
 
-```bash
-python main.py data download --source huggingface
-python main.py data download --source modelscope
-python main.py data validate --path <bundle-dir>
-python main.py data compare --left <hf-dir> --right <modelscope-dir>
+```text
+supported ⊆ runnable ⊆ discoverable
 ```
 
-The final v0.3 release remains blocked until both public providers use immutable
-revisions and byte-identical required-file SHA-256 values. See
-[docs/CWRU_DEMO_V0_3.md](docs/CWRU_DEMO_V0_3.md).
-
-## Maintained surface
-
-The maintained demo surface covers:
-
-- the fully offline Dummy domain-generalization smoke;
-- cross-domain and cross-system classification examples;
-- few-shot and generalized few-shot examples;
-- bounded HSE pretraining examples;
-- an optional Streamlit workspace around the same public CLI.
-
-Files, registry entries, research notes, and historical configurations outside the
-maintained surface are not automatically supported. The exact model, task, data, and
-trainer combinations are listed in:
+A source file, model registry row, or successful import is not by itself a support claim.
+The current maintained surface is generated from the configuration registry and current
+runtime descriptors:
 
 - [Supported components](SUPPORTED_COMPONENTS.md)
 - [Supported combinations](SUPPORTED_COMBINATIONS.md)
 - [Configuration registry](configs/config_registry.csv)
-- [Generated configuration atlas](docs/CONFIG_ATLAS.md)
+- [Configuration Atlas](docs/CONFIG_ATLAS.md)
 
-`sanity_ok` means smoke evidence exists. It does not mean state-of-the-art performance,
-universal component compatibility, or permission to redistribute an external dataset.
+`sanity_ok` means bounded functional evidence exists. It does not mean state-of-the-art
+performance, universal component compatibility, or permission to redistribute an
+external dataset.
 
-## Configuration-first workflow
+## Optional Streamlit workspace
 
-Maintained configurations use five logical blocks:
-
-```text
-environment / data / model / task / trainer
-```
-
-Start from the nearest file under `configs/demo/`, place local experiment variants
-under `configs/experiments/`, and use CLI overrides for machine-specific values:
+The web workspace is an adapter around the same public CLI, not a second training system:
 
 ```bash
-python -m scripts.config_inspect \
-  --config configs/demo/00_smoke/dummy_dg.yaml \
-  --override trainer.num_epochs=1
+python -m pip install -r apps/streamlit/requirements.txt
+streamlit run apps/streamlit/app.py
 ```
 
-The authoritative composition and precedence rules are in
-[configs/README.md](configs/README.md). Data layout and external-source boundaries are
-in [data/README.md](data/README.md).
+Start with **Use safe CPU smoke defaults**. The UI can prepare a configuration, validate
+it, launch the public command, and display logs and artifacts. See
+[apps/streamlit/README.md](apps/streamlit/README.md) for its single-worker scope and
+troubleshooting.
 
-## Architecture
+## Architecture for developers
 
 ```text
-main.py / python -m phmfactory / phmfactory
-  └── phmfactory.cli
+phmfactory command / python -m phmfactory / main.py
+  └── public command router
       └── resolved configuration + canonical Pipeline
           └── protected src runtime
               ├── data factory
@@ -155,63 +202,66 @@ main.py / python -m phmfactory / phmfactory
 
 Primary paths:
 
-- `phmfactory/` — public package, CLI, configuration resolver, Pipeline registry, and data providers;
-- `configs/` — base blocks, maintained demos, experiments, and configuration registry;
-- `src/data_factory/` — metadata, readers, datasets, samplers, and data wiring;
-- `src/model_factory/` — model families, components, and model construction;
-- `src/task_factory/` — tasks, losses, metrics, and task registry;
+- `phmfactory/` — public package, commands, config resolver, Pipeline descriptors, and run control plane;
+- `configs/` — reusable blocks, maintained demos, research experiments, and registry;
+- `src/data_factory/` — metadata, readers, datasets, samplers, and data assembly;
+- `src/model_factory/` — model families and model construction;
+- `src/task_factory/` — tasks, losses, metrics, and task construction;
 - `src/trainer_factory/` — trainer construction and extensions;
-- `apps/streamlit/` — optional browser workspace around the same CLI;
+- `apps/streamlit/` — optional browser workspace;
 - `test/` — maintained pytest suite;
-- `docs/` — user, development, migration, release, and historical documentation.
+- `docs/` — user, extension, development, release, and historical documentation.
 
-The v0.3 release does not mechanically move or rewrite the mature dataset readers.
-Extend the existing factory boundaries rather than adding dataset- or model-specific
-branches to `main.py`.
-
-## Validate a change
+Run the maintained checks before requesting review:
 
 ```bash
 python -m scripts.validate_docs
 python -m scripts.validate_configs
 python -m scripts.gen_config_atlas
 git diff --exit-code docs/CONFIG_ATLAS.md
+python -m scripts.gen_support_matrix
+git diff --exit-code SUPPORTED_COMPONENTS.md SUPPORTED_COMBINATIONS.md
 python -m pytest test/ -q
-python tools/repo/check_case_collisions.py
-python tools/repo/check_release_readiness.py --mode audit
 ```
 
-Runtime or configuration changes should also run the offline smoke command above.
-The [testing guide](docs/testing.md) defines evidence terminology and focused commands.
+See [docs/testing.md](docs/testing.md) for focused gates and evidence terminology.
 
-## Optional Streamlit workspace
+## Branch policy
 
-```bash
-python -m pip install -r requirements.txt
-python -m pip install -r apps/streamlit/requirements.txt
-streamlit run apps/streamlit/app.py
-```
+`main` is the user-facing stable branch and the default branch. `dev` is the integration
+branch. Routine feature, fix, documentation, test, CI, cleanup, and migration pull
+requests target `dev` and start from the latest `dev`.
 
-`apps/streamlit/app.py` is the only maintained web entrypoint. It delegates experiment
-execution to the public CLI and does not define a second training framework.
+Only an explicitly authorized release-promotion pull request or emergency hotfix may
+target `main`. A hotfix must be synchronized back to `dev`. See
+[CONTRIBUTING.md](CONTRIBUTING.md) for the full workflow.
 
-## Contributing and support
+## Current pre-release limits
 
-Read [CONTRIBUTING.md](CONTRIBUTING.md) before opening an issue or pull request. Keep
-changes bounded, update the authoritative document instead of copying it, and report
-the exact commit, configuration, overrides, environment, and logs. Participation is
-governed by [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md).
+PHMFactory remains an alpha `0.3.0.dev0` source release. In particular:
 
-- Bugs and feature requests: [GitHub Issues](https://github.com/PHMbench/phmfactory/issues)
+- only the Dummy demo is fully offline and repository-shipped;
+- most real-data demos require local metadata and raw data;
+- CWRU provider revisions and required-file hashes are not yet finalized;
+- the GitHub repository has not been renamed;
+- no final `v0.3.0` tag or package publication is claimed;
+- experimental Pipelines and unlisted model/task combinations are not release-supported.
+
+Read [Known limitations](KNOWN_LIMITATIONS.md) and the
+[v0.3 release-readiness page](docs/PHMFACTORY_V0_3_RELEASE_READINESS.md) before making a
+release or benchmark claim.
+
+## Contributing, support, and citation
+
+Read [CONTRIBUTING.md](CONTRIBUTING.md) before opening an issue or pull request. Report the
+exact commit, configuration, overrides, environment, data source, and complete error
+output.
+
+- Bugs and feature requests: [GitHub Issues](https://github.com/PHMbench/PHM-Vibench/issues)
 - Security reports: [SECURITY.md](SECURITY.md)
 - Development workflow: [docs/developer_guide.md](docs/developer_guide.md)
 - Release readiness: [docs/PHMFACTORY_V0_3_RELEASE_READINESS.md](docs/PHMFACTORY_V0_3_RELEASE_READINESS.md)
 
-## Citation and license
-
-PHMFactory is licensed under the [Apache License 2.0](LICENSE). Dataset and model
-artifacts may have separate source licenses.
-
-Use [CITATION.cff](CITATION.cff) as the software citation metadata. Cite the exact Git
-commit or release tag used for an experiment and record the configuration, overrides,
-data source and revision, random seed, and environment.
+PHMFactory is licensed under the [Apache License 2.0](LICENSE). Dataset and model artifacts
+may have separate source licenses. Use [CITATION.cff](CITATION.cff) for software citation
+metadata, and cite the exact commit or release used for each experiment.

--- a/README_CN.md
+++ b/README_CN.md
@@ -8,136 +8,181 @@
     <a href="README_CN.md"><strong>中文</strong></a>
   </p>
 
-  <p><strong>面向工业振动信号的配置优先 PHM 研究与评估框架。</strong></p>
+  <p><strong>面向工业信号、强调可复现性的配置优先 PHM 实验框架。</strong></p>
 
   <p>
     <img src="https://img.shields.io/badge/状态-alpha-orange" alt="状态：alpha"/>
     <img src="https://img.shields.io/badge/v0.3-预发布-blue" alt="v0.3 预发布"/>
-    <a href="https://github.com/PHMbench/phmfactory/actions/workflows/core-quality-gates.yml"><img src="https://github.com/PHMbench/phmfactory/actions/workflows/core-quality-gates.yml/badge.svg" alt="核心质量门禁"/></a>
+    <a href="https://github.com/PHMbench/PHM-Vibench/actions/workflows/core-quality-gates.yml"><img src="https://github.com/PHMbench/PHM-Vibench/actions/workflows/core-quality-gates.yml/badge.svg" alt="核心质量门禁"/></a>
     <img src="https://img.shields.io/badge/许可-Apache%202.0-green" alt="Apache 2.0 许可"/>
   </p>
 </div>
 
-PHMFactory 通过一个公开 dispatcher 连接数据加载、模型构建、任务逻辑、训练、
-评估和实验配置。以下三个入口具有相同语义：
+> **当前仓库身份。** 项目名称和 Python 包名已经统一为 **PHMFactory**，但在
+> v0.3 预发布阶段，GitHub 仓库仍是
+> [`PHMbench/PHM-Vibench`](https://github.com/PHMbench/PHM-Vibench)。正式改名前请始终
+> 使用这里给出的真实仓库地址。
+
+PHMFactory 用一个配置优先入口连接数据加载、模型构建、任务逻辑、训练、评估和
+运行记录。用户选择一个维护中的配置，只覆盖本机路径或实验参数，即可通过命令行、
+Python 模块或兼容入口执行同一份实验语义。
+
+## 先运行完全离线的示例
+
+下面的路径只使用仓库自带的合成数据，不下载外部数据集：
 
 ```bash
-python main.py --config <yaml> [--override key=value ...]
-python -m phmfactory --config <yaml> [--override key=value ...]
+git clone https://github.com/PHMbench/PHM-Vibench.git
+cd PHM-Vibench
+
+python -m venv .venv
+source .venv/bin/activate          # Windows：.venv\Scripts\activate
+python -m pip install --upgrade pip
+python -m pip install -e .
+
+phmfactory doctor
+phmfactory preflight --config smoke
+phmfactory demo
+```
+
+首次运行成功时，应满足：
+
+- `doctor` 的必需检查全部显示 `PASS`；
+- `preflight` 打印 `status=passed`，且不会启动训练；
+- `demo` 在 CPU 上完成一次 Dummy 数据的 data → model → task → trainer 链路；
+- 终端打印 `run_manifest.json` 的路径；
+- 结果写入 `results/demo/dummy_dg_smoke/`；
+- 三条命令的进程退出码均为 `0`。
+
+命令失败时请保留完整终端输出，并根据[快速开始](docs/quickstart.md)中的对应故障
+处理。CPU-only PyTorch、GPU 和不同操作系统的安装方式见[安装指南](docs/installation.md)。
+
+## 根据任务选择文档
+
+| 你的目标 | 从这里开始 |
+| --- | --- |
+| 理解第一次运行及其输出 | [快速开始](docs/quickstart.md) |
+| 在 CPU、GPU、Linux、macOS 或 Windows 上安装 | [安装指南](docs/installation.md) |
+| 运行一个已有的维护实验 | [配置系统](configs/README.md) |
+| 接入本地 PHM 数据 | [数据目录](data/README.md)和[自定义数据集](docs/custom_dataset.md) |
+| 选择或新增模型 | [模型工厂](src/model_factory/README_CN.md) |
+| 选择或新增任务 | [任务工厂](src/task_factory/README.md) |
+| 使用浏览器界面 | [Streamlit 工作区](apps/streamlit/README.md) |
+| 扩展或维护框架 | [开发者指南](docs/developer_guide.md) |
+| 核对当前真正支持的组合 | [支持组合](SUPPORTED_COMBINATIONS.md) |
+
+完整文档地图见 [docs/index.md](docs/index.md)。
+
+## 配置的五个逻辑块
+
+维护中的配置统一使用：
+
+```yaml
+environment:  # 输出路径、随机种子、重复次数和进程级设置
+  ...
+data:         # metadata、原始数据根目录、窗口和 worker
+  ...
+model:        # 模型家族及模型专有参数
+  ...
+task:         # 诊断、域泛化、小样本或预训练逻辑
+  ...
+trainer:      # 设备、epoch、精度、日志和 checkpoint
+  ...
+```
+
+顶层 `pipeline` 只负责选择编排路径。新增数据集、模型、任务和训练器时，原则上应扩展
+对应 factory，不应在 `main.py` 中加入项目专用分支。
+
+本地实验从 `configs/demo/` 中最接近的维护配置开始，研究变体放到
+`configs/experiments/`，本机路径通过显式 override 传入：
+
+```bash
+phmfactory preflight \
+  --config configs/demo/01_cross_domain/cwru_dg.yaml \
+  --override data.data_dir=/absolute/path/to/phm-data \
+  --override data.metadata_file=metadata.xlsx \
+  --override trainer.num_epochs=1
+```
+
+预检通过后，去掉 `preflight` 即可执行同一份配置：
+
+```bash
+phmfactory \
+  --config configs/demo/01_cross_domain/cwru_dg.yaml \
+  --override data.data_dir=/absolute/path/to/phm-data \
+  --override data.metadata_file=metadata.xlsx \
+  --override trainer.num_epochs=1
+```
+
+配置组合和优先级的权威说明位于 [configs/README.md](configs/README.md)。
+
+## 公开入口
+
+以下三个进程入口具有相同的配置和退出码语义：
+
+```bash
 phmfactory --config <yaml> [--override key=value ...]
+python -m phmfactory --config <yaml> [--override key=value ...]
+python main.py --config <yaml> [--override key=value ...]
 ```
 
-PHMFactory 是 PHM-Vibench 的 v0.3 后继项目。v0.3 兼容性版本增加公开的
-`phmfactory` Python 包，同时将成熟的 `src.*` 运行时保留为受保护的内部内核。
-项目仍处于 alpha 阶段；发布支持范围仅限
-[SUPPORTED_COMBINATIONS.md](SUPPORTED_COMBINATIONS.md) 中记录的维护配置。
+正常使用时推荐安装后的 `phmfactory` 命令；`python main.py` 只作为仓库兼容入口保留。
+需要直接读取结构化 Python 返回值的调用者可以导入 `phmfactory.cli.main`。
 
-## 分支策略
-
-`main` 是面向用户的稳定分支，并继续作为 clone、用户文档和发布的默认分支；
-`dev` 是集成与开发分支。常规功能、修复、文档、测试、CI、清理和迁移 PR
-必须以 `dev` 为目标分支，topic branch 也必须从最新 `dev` 创建。
-
-只有明确授权的发布提升 PR（`dev` 或 `release/<version>` → `main`）或紧急
-hotfix 可以指向 `main`；hotfix 必须同步回 `dev`。两个长期分支都只能通过
-Pull Request 更新，不属于维护流程的直接 push 不应使用。完整规则见
-[CONTRIBUTING_CN.md](CONTRIBUTING_CN.md)。
-
-## 运行离线示例
-
-安装核心环境后，运行仓库自带的 Dummy 配置：
+常用的轻量命令：
 
 ```bash
-git clone https://github.com/PHMbench/phmfactory.git
-cd phmfactory
-conda create -n phmfactory python=3.10
-conda activate phmfactory
-python -m pip install -r requirements.txt
-
-python main.py --config configs/demo/00_smoke/dummy_dg.yaml \
-  --override trainer.num_epochs=1 \
-  --override data.num_workers=0
+phmfactory doctor
+phmfactory preflight --config <preset-or-yaml>
+phmfactory demo
+phmfactory data --help
 ```
 
-成功运行应正常退出、打印完成信息，并在 `results/demo/dummy_dg_smoke/`
-下写入输出。该命令验证维护中的软件链路，不代表基准性能。
+## 如何理解“支持”
 
-详细安装和故障排查：
-
-- [安装指南](docs/installation.md)
-- [快速开始](docs/quickstart.md)
-- [已知限制](KNOWN_LIMITATIONS.md)
-- [v0.2 到 v0.3 迁移说明](RELEASE_NOTES_v0.3.0.md)
-
-## 公共数据包接口
-
-v0.3 源码提供面向 CWRU 的 provider-neutral 数据包接口：
+PHMFactory 明确区分：
 
 ```text
-metadata.xlsx          必需
-RM_001_CWRU.h5         必需
-corpus.xlsx            可选
+discoverable  = 源码或注册表条目存在
+runnable      = 已建立可审查的执行路径
+supported     = 维护配置具有当前的功能冒烟结果
 ```
 
-公开命令：
+必须满足：
 
-```bash
-python main.py data download --source huggingface
-python main.py data download --source modelscope
-python main.py data validate --path <bundle-dir>
-python main.py data compare --left <hf-dir> --right <modelscope-dir>
+```text
+supported ⊆ runnable ⊆ discoverable
 ```
 
-最终 v0.3 发布仍被阻塞，直到 Hugging Face 与 ModelScope 均使用不可变 revision，
-且必需文件的 SHA-256 完全一致。详见
-[docs/CWRU_DEMO_V0_3.md](docs/CWRU_DEMO_V0_3.md)。
-
-## 当前维护范围
-
-维护中的 demo 覆盖：
-
-- 完全离线的 Dummy 域泛化冒烟；
-- 跨域和跨系统分类示例；
-- 小样本和广义小样本示例；
-- 边界明确的 HSE 预训练示例；
-- 围绕同一公共 CLI 的可选 Streamlit 工作区。
-
-维护范围之外的文件、注册表条目、研究笔记和历史配置不应自动视为受支持能力。
-准确的模型、任务、数据和训练器组合见：
+源码文件、模型注册表条目或 import 成功都不自动等于“已支持”。当前维护范围由配置注册表
+和运行时 descriptor 生成：
 
 - [支持组件](SUPPORTED_COMPONENTS.md)
 - [支持组合](SUPPORTED_COMBINATIONS.md)
 - [配置注册表](configs/config_registry.csv)
-- [生成的配置图谱](docs/CONFIG_ATLAS.md)
+- [配置图谱](docs/CONFIG_ATLAS.md)
 
-`sanity_ok` 表示已有功能冒烟证据，不表示达到 SOTA、任意组件均兼容，
-也不表示外部数据集可以自由再分发。
+`sanity_ok` 只表示已有边界明确的功能冒烟，不表示达到 SOTA、任意组件都可组合，也不
+表示外部数据可以重新分发。
 
-## 配置优先工作流
+## 可选 Streamlit 工作区
 
-维护配置使用五个逻辑块：
-
-```text
-environment / data / model / task / trainer
-```
-
-从 `configs/demo/` 中最接近的配置开始，将本地实验变体放在
-`configs/experiments/`，机器相关值使用 CLI override：
+Web 工作区只是同一公共 CLI 的适配层，不是第二套训练框架：
 
 ```bash
-python -m scripts.config_inspect \
-  --config configs/demo/00_smoke/dummy_dg.yaml \
-  --override trainer.num_epochs=1
+python -m pip install -r apps/streamlit/requirements.txt
+streamlit run apps/streamlit/app.py
 ```
 
-配置组合和优先级的权威说明位于 [configs/README.md](configs/README.md)，数据布局和
-外部数据边界位于 [data/README.md](data/README.md)。
+首次使用选择 **Use safe CPU smoke defaults**。界面可以准备配置、验证、启动公共命令，
+并查看日志和产物。其单 worker 边界和故障处理见
+[apps/streamlit/README.md](apps/streamlit/README.md)。
 
-## 架构
+## 开发者架构
 
 ```text
-main.py / python -m phmfactory / phmfactory
-  └── phmfactory.cli
+phmfactory 命令 / python -m phmfactory / main.py
+  └── 公共命令路由
       └── 已解析配置 + canonical Pipeline
           └── 受保护的 src 运行时
               ├── data factory
@@ -148,60 +193,61 @@ main.py / python -m phmfactory / phmfactory
 
 主要目录：
 
-- `phmfactory/`：公开 Python 包、CLI、配置解析器、Pipeline 注册表和数据 provider；
-- `configs/`：base block、维护 demo、实验配置和配置注册表；
-- `src/data_factory/`：metadata、reader、dataset、sampler 与数据装配；
-- `src/model_factory/`：模型家族、组件与模型构建；
-- `src/task_factory/`：任务、loss、metric 与任务注册表；
-- `src/trainer_factory/`：训练器构建和扩展；
-- `apps/streamlit/`：围绕同一 CLI 的可选浏览器工作区；
+- `phmfactory/`：公开包、命令、配置解析、Pipeline descriptor 和运行控制层；
+- `configs/`：复用块、维护 demo、研究实验和配置注册表；
+- `src/data_factory/`：metadata、reader、dataset、sampler 和数据装配；
+- `src/model_factory/`：模型家族和模型构造；
+- `src/task_factory/`：任务、损失、指标和任务构造；
+- `src/trainer_factory/`：训练器构造和扩展；
+- `apps/streamlit/`：可选浏览器工作区；
 - `test/`：维护中的 pytest 测试；
-- `docs/`：用户、开发、迁移、发布和历史文档。
+- `docs/`：用户、扩展、开发、发布和历史文档。
 
-v0.3 不会机械移动或重写成熟的数据 reader。添加数据集或模型时应扩展现有 factory，
-不要在 `main.py` 中加入专用分支。
-
-## 验证改动
+提交 PR 前运行：
 
 ```bash
 python -m scripts.validate_docs
 python -m scripts.validate_configs
 python -m scripts.gen_config_atlas
 git diff --exit-code docs/CONFIG_ATLAS.md
+python -m scripts.gen_support_matrix
+git diff --exit-code SUPPORTED_COMPONENTS.md SUPPORTED_COMBINATIONS.md
 python -m pytest test/ -q
-python tools/repo/check_case_collisions.py
-python tools/repo/check_release_readiness.py --mode audit
 ```
 
-运行时或配置改动还应执行前面的离线冒烟命令。证据术语和聚焦命令见
-[测试指南](docs/testing.md)。
+聚焦测试和验证术语见 [docs/testing.md](docs/testing.md)。
 
-## 可选 Streamlit 工作区
+## 分支策略
 
-```bash
-python -m pip install -r requirements.txt
-python -m pip install -r apps/streamlit/requirements.txt
-streamlit run apps/streamlit/app.py
-```
+`main` 是面向用户的稳定默认分支，`dev` 是集成分支。常规功能、修复、文档、测试、CI、
+清理和迁移 PR 都应以最新 `dev` 为起点并合入 `dev`。
 
-`apps/streamlit/app.py` 是唯一维护中的 Web 入口。它将实验执行委托给公共 CLI，
-不会定义第二套训练框架。
+只有明确授权的发布提升 PR 或紧急 hotfix 可以指向 `main`；hotfix 必须同步回 `dev`。
+完整流程见 [CONTRIBUTING_CN.md](CONTRIBUTING_CN.md)。
 
-## 贡献与支持
+## 当前预发布限制
 
-提交 Issue 或 Pull Request 前请阅读 [CONTRIBUTING_CN.md](CONTRIBUTING_CN.md)。
-保持改动边界清晰，修改权威文档而不是复制内容，并提供准确的 commit、配置、
-override、环境和日志。社区参与遵循 [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)。
+PHMFactory 仍是 alpha 阶段的 `0.3.0.dev0` 源码版本：
 
-- Bug 与功能建议：[GitHub Issues](https://github.com/PHMbench/phmfactory/issues)
+- 只有 Dummy demo 完全离线并随仓库提供；
+- 大部分真实数据 demo 需要本地 metadata 和原始数据；
+- CWRU provider revision 和必需文件 hash 尚未最终冻结；
+- GitHub 仓库尚未改名；
+- 当前不宣称已有最终 `v0.3.0` tag 或包发布；
+- experimental Pipeline 和未列出的模型/任务组合不属于发布支持范围。
+
+进行发布或 benchmark 声明前，请阅读[已知限制](KNOWN_LIMITATIONS.md)和
+[v0.3 发布就绪状态](docs/PHMFACTORY_V0_3_RELEASE_READINESS.md)。
+
+## 贡献、支持与引用
+
+提交 Issue 或 PR 前请阅读 [CONTRIBUTING_CN.md](CONTRIBUTING_CN.md)。问题报告应包含
+准确 commit、配置、override、环境、数据来源和完整错误输出。
+
+- Bug 与功能建议：[GitHub Issues](https://github.com/PHMbench/PHM-Vibench/issues)
 - 安全问题：[SECURITY.md](SECURITY.md)
 - 开发流程：[docs/developer_guide.md](docs/developer_guide.md)
-- 发布就绪状态：[docs/PHMFACTORY_V0_3_RELEASE_READINESS.md](docs/PHMFACTORY_V0_3_RELEASE_READINESS.md)
+- 发布状态：[docs/PHMFACTORY_V0_3_RELEASE_READINESS.md](docs/PHMFACTORY_V0_3_RELEASE_READINESS.md)
 
-## 引用与许可
-
-PHMFactory 使用 [Apache License 2.0](LICENSE)。数据集和模型产物可能适用
-原始来源的独立许可。
-
-软件引用元数据见 [CITATION.cff](CITATION.cff)。请引用实验所使用的准确 Git commit
-或 release tag，并记录配置、override、数据来源及 revision、随机种子和运行环境。
+PHMFactory 使用 [Apache License 2.0](LICENSE)。数据集和模型产物可能适用独立来源许可。
+软件引用信息见 [CITATION.cff](CITATION.cff)，每次实验应记录并引用准确的 commit 或 tag。

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,41 +1,35 @@
 # Installation
 
-This page is the maintained installation reference for PHM-Vibench. The project
-currently runs from a repository checkout; it is not documented as an installed
-Python package.
+This page is the maintained installation reference for the PHMFactory v0.3 pre-release.
+The project name and Python package are `PHMFactory` / `phmfactory`; the current GitHub
+repository is still `PHMbench/PHM-Vibench`.
 
-## Supported installation baseline
+## Supported baseline
 
-The active repository checks use:
+The maintained repository and package checks use:
 
 - Python 3.10;
 - Ubuntu runners;
-- PyTorch 2.6.0 for focused CPU tests.
+- PyTorch 2.6.0 for the focused CPU path;
+- an editable source installation for development and pre-release use.
 
-Other Python versions and operating systems may work, but they are not part of
-the documented validation baseline. See [known limitations](../KNOWN_LIMITATIONS.md)
-before reporting a platform-specific problem.
+Other Python versions and operating systems may work, but they are not yet part of the
+full maintained matrix. Read [Known limitations](../KNOWN_LIMITATIONS.md) before reporting
+a platform-specific issue.
 
-## Clone the repository
+## 1. Clone the current repository
 
 ```bash
 git clone https://github.com/PHMbench/PHM-Vibench.git
 cd PHM-Vibench
 ```
 
-Run commands from the repository root unless a page explicitly says otherwise.
+Do not use the future `PHMbench/phmfactory` repository URL until the GitHub rename is
+actually completed.
 
-## Create an isolated environment
+## 2. Create an isolated Python environment
 
-Conda example:
-
-```bash
-conda create -n phm-vibench python=3.10
-conda activate phm-vibench
-python -m pip install --upgrade pip
-```
-
-Standard-library `venv` is also acceptable:
+### Standard-library `venv`
 
 ```bash
 python3.10 -m venv .venv
@@ -43,69 +37,207 @@ source .venv/bin/activate
 python -m pip install --upgrade pip
 ```
 
-On Windows, activate a `venv` with `.venv\Scripts\activate`.
+On Windows:
 
-## Install dependencies
-
-The repository dependency file includes the core runtime plus optional research
-libraries used by model families that are not all release-supported:
-
-```bash
-python -m pip install -r requirements.txt
+```powershell
+py -3.10 -m venv .venv
+.venv\Scripts\activate
+python -m pip install --upgrade pip
 ```
 
-For a CPU-only PyTorch installation, install the pinned CPU wheels first:
+### Conda
+
+```bash
+conda create -n phmfactory python=3.10
+conda activate phmfactory
+python -m pip install --upgrade pip
+```
+
+Use one environment manager for a given checkout. Mixing packages from multiple active
+environments is a common cause of import and binary-compatibility failures.
+
+## 3. Choose the PyTorch build
+
+### CPU-only setup
+
+Install the pinned CPU family first:
 
 ```bash
 python -m pip install --index-url https://download.pytorch.org/whl/cpu \
   torch==2.6.0 torchvision==0.21.0 torchaudio==2.6.0
-python -m pip install -r requirements.txt
 ```
 
-For CUDA, choose the PyTorch wheel compatible with the local driver and hardware.
-Do not copy a CUDA command from an unrelated machine. Keep the repository's
-pinned PyTorch family versions aligned unless a dedicated compatibility PR changes
-them.
+### CUDA setup
+
+Choose the official PyTorch wheel that matches the local driver and CUDA runtime. Do not
+copy a CUDA command from an unrelated machine. Verify PyTorch and CUDA independently
+before diagnosing PHMFactory:
+
+```bash
+python - <<'PY'
+import torch
+
+print("torch:", torch.__version__)
+print("cuda_available:", torch.cuda.is_available())
+if torch.cuda.is_available():
+    print("device:", torch.cuda.get_device_name(0))
+PY
+```
+
+## 4. Install PHMFactory from the checkout
+
+```bash
+python -m pip install -e .
+```
+
+The editable installation:
+
+- installs dependencies declared by the project;
+- creates the `phmfactory` command;
+- keeps source edits immediately visible in the active environment;
+- installs the packaged configs and repository Dummy data used by the first-run path.
+
+The final public package has not been released yet. This guide therefore does **not**
+claim that `pip install phmfactory` from a package index is currently available.
+
+To inspect the installed command and package location:
+
+```bash
+which phmfactory                    # Windows: where phmfactory
+python -c "import phmfactory; print(phmfactory.__version__, phmfactory.__file__)"
+```
+
+## 5. Verify the environment without training
+
+```bash
+phmfactory doctor
+```
+
+`doctor` performs real imports of the core runtime packages, resolves the packaged
+`smoke` configuration, checks Pipeline discoverability, and verifies output-directory
+writability. It does not create a model, DataLoader, Trainer, or training process.
+
+All required checks should display `PASS`. A failed import includes the exception type
+and message so a missing package can be distinguished from an ABI or transitive-import
+problem.
+
+Then compile the exact offline run without training:
+
+```bash
+phmfactory preflight --config smoke
+```
+
+A successful preflight prints:
+
+```text
+status=passed
+pipeline=Pipeline_01_Fault_Diagnosis
+```
+
+The process should exit with status code `0` and should not create the configured output
+directory.
+
+## 6. Run the repository-shipped offline demo
+
+```bash
+phmfactory demo
+```
+
+This command uses bundled Dummy data, CPU, one epoch, and zero DataLoader workers. It is a
+software-path verification, not a performance benchmark. Continue with
+[Quickstart](quickstart.md) for expected files and troubleshooting.
 
 ## Optional Streamlit interface
 
-The command-line interface is the maintained runtime entrypoint. Install the web
-workspace only when needed:
+Install the browser layer only after the command-line demo succeeds:
 
 ```bash
 python -m pip install -r apps/streamlit/requirements.txt
 streamlit run apps/streamlit/app.py
 ```
 
-See the [Streamlit guide](../apps/streamlit/README.md) for its local single-worker
-scope and validation commands.
+The Streamlit workspace delegates execution to the public CLI. Its single-worker scope,
+first-run defaults, and validation commands are documented in
+[apps/streamlit/README.md](../apps/streamlit/README.md).
 
-## Verify the installation
-
-Check lightweight documentation and configuration contracts:
-
-```bash
-python -m scripts.validate_docs
-python -m scripts.validate_configs
-python -m scripts.config_inspect \
-  --config configs/demo/00_smoke/dummy_dg.yaml \
-  --override trainer.num_epochs=1
-```
-
-Then run the repository-shipped offline example:
+## Updating an existing checkout
 
 ```bash
-python main.py --config configs/demo/00_smoke/dummy_dg.yaml \
-  --override trainer.num_epochs=1 \
-  --override data.num_workers=0
+git switch dev
+
+git pull --ff-only
+python -m pip install -e .
+phmfactory doctor
+phmfactory preflight --config smoke
 ```
 
-Continue with the [quickstart](quickstart.md) for expected behavior, outputs, and
-troubleshooting.
+Use `main` for the stable user-facing line and `dev` only when testing development work.
+Do not pull an unrelated topic branch into an environment and assume it has release
+support.
 
-## External data
+## Troubleshooting
 
-Only the dummy example is fully contained in the repository. Other maintained
-demos require local PHM-Vibench metadata and raw data. Do not hard-code a personal
-path into a maintained YAML file; use CLI overrides or `configs/local/local.yaml`.
-See the [data directory guide](../data/README.md).
+### `phmfactory` is not found
+
+Confirm that the intended environment is active, then reinstall from the repository root:
+
+```bash
+python -m pip install -e .
+python -m phmfactory --help
+```
+
+If `python -m phmfactory` works but `phmfactory` does not, inspect the environment's
+scripts directory and shell `PATH`.
+
+### `doctor` reports a missing package
+
+Run:
+
+```bash
+python -m pip install -e .
+```
+
+Do not install packages into a different Python interpreter. Compare:
+
+```bash
+which python
+python -m pip --version
+which phmfactory
+```
+
+### `doctor` reports an ABI or shared-library error
+
+The package exists but cannot be imported. Recreate the environment, install a PyTorch
+build compatible with the platform, and then reinstall PHMFactory. Do not edit framework
+source to work around a broken Python binary environment.
+
+### CUDA is unavailable
+
+Return to the CPU path and run `phmfactory demo`. Treat driver, CUDA toolkit, and PyTorch
+wheel compatibility as a separate system problem before changing experiment configs.
+
+### An external-data demo cannot find metadata or raw files
+
+Only the `smoke` demo is fully self-contained. Pass real-data locations explicitly:
+
+```bash
+phmfactory preflight \
+  --config configs/demo/01_cross_domain/cwru_dg.yaml \
+  --override data.data_dir=/absolute/path/to/phm-data \
+  --override data.metadata_file=metadata.xlsx
+```
+
+Read [data/README.md](../data/README.md) before changing a maintained YAML file.
+
+### A command prints success information but the shell reports failure
+
+This is a process-entrypoint bug. Record the exact command, exit status, stdout, and
+stderr:
+
+```bash
+phmfactory preflight --config smoke
+echo $?
+```
+
+The maintained contract is: successful `doctor`, `preflight`, and `demo` commands exit
+with `0`; user, environment, or runtime failures exit non-zero.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,213 +1,281 @@
 # Quickstart
 
-This walkthrough verifies the maintained configuration-first path with repository-
-shipped Dummy data. It is a software smoke test, not a benchmark-performance run.
+This walkthrough proves that PHMFactory is installed correctly and can complete one
+fully offline experiment. It uses repository-shipped synthetic data, runs on CPU, and is
+intended to take only a few minutes after dependencies are installed.
 
-## 1. Install the environment
+It is a software smoke test, not a benchmark-performance run.
 
-Complete the [installation guide](installation.md), activate the environment, and run
-all commands from the repository root.
+## What you will complete
 
-## 2. Diagnose the installation
+By the end of this page you will have:
+
+1. checked the Python environment;
+2. checked one exact experiment configuration without training;
+3. completed one offline train/test run;
+4. located the metrics and run record;
+5. understood the next step for local data or a custom experiment.
+
+## 1. Install the source checkout
+
+Follow [Installation](installation.md), or use the maintained source path:
+
+```bash
+git clone https://github.com/PHMbench/PHM-Vibench.git
+cd PHM-Vibench
+
+python -m venv .venv
+source .venv/bin/activate          # Windows: .venv\Scripts\activate
+python -m pip install --upgrade pip
+python -m pip install -e .
+```
+
+The current GitHub repository is `PHMbench/PHM-Vibench`. The project and package are
+named PHMFactory, but the repository has not yet been renamed.
+
+## 2. Diagnose the environment
 
 ```bash
 phmfactory doctor
 ```
 
-`doctor` performs bounded checks without constructing a model, DataLoader, Pipeline, or
-Trainer. It verifies:
+Expected shape of the output:
 
-- Python 3.10 or newer;
-- real imports of the core YAML, PyTorch, pandas, and Lightning modules;
-- the packaged `smoke` preset;
-- discoverability of its canonical Pipeline module;
-- output-directory writability without leaving probe files or newly created directories.
+```text
+PASS python: 3.10.x
+PASS import:yaml: imported version=...
+PASS import:torch: imported version=...
+PASS import:pandas: imported version=...
+PASS import:pytorch_lightning: imported version=...
+PASS config:smoke: .../configs/demo/00_smoke/dummy_dg.yaml
+PASS pipeline:smoke: src.Pipeline_01_Fault_Diagnosis
+PASS output:writable: .../results/demo/dummy_dg_smoke
+doctor=passed checks=8
+```
 
-Every check is printed as `PASS` or `FAIL`. Any required failure produces a non-zero exit
-code and includes the underlying exception type and message.
+The exact versions and paths may differ. Every required line should start with `PASS`,
+and the command should exit with status code `0`.
 
-## 3. Compile the exact run without training
+`doctor` does **not** start training. It checks real imports, the packaged smoke config,
+Pipeline discoverability, and output writability.
+
+### When `doctor` fails
+
+| Failure | Meaning | First action |
+| --- | --- | --- |
+| `import:torch` | PyTorch is missing or cannot load | Reinstall a platform-compatible PyTorch build |
+| `import:pytorch_lightning` | Lightning or one of its dependencies cannot load | Re-run `python -m pip install -e .` in the active environment |
+| `config:smoke` | Packaged config is missing or installation is stale | Reinstall the editable package from the repository root |
+| `pipeline:smoke` | The maintained Pipeline module is not discoverable | Confirm you are using the intended checkout and environment |
+| `output:writable` | The output parent cannot be written | Choose a writable working directory or fix permissions |
+
+Use the complete exception type and message printed by the failed check. Do not modify
+framework source to hide a broken Python environment.
+
+## 3. Check the experiment without training
+
+```bash
+phmfactory preflight --config smoke
+```
+
+Expected key lines:
+
+```text
+status=passed
+requested_config=smoke
+pipeline=Pipeline_01_Fault_Diagnosis
+maturity=supported
+output_dir=.../results/demo/dummy_dg_smoke
+```
+
+Preflight checks the final configuration and output location, but it does not:
+
+- import and execute the training Pipeline;
+- construct data loaders, models, tasks, or trainers;
+- allocate a GPU;
+- create the configured output directory;
+- start a run.
+
+A passing preflight should exit with status code `0`.
+
+To test an override without editing YAML:
 
 ```bash
 phmfactory preflight \
   --config smoke \
-  --override trainer.num_epochs=1 \
-  --override data.num_workers=0
+  --override trainer.num_epochs=2
 ```
 
-`preflight` resolves base configurations and overrides exactly once, compiles the
-`CompiledRunSpec`, applies Pipeline maturity policy, verifies Pipeline discoverability,
-and proves that the configured output location is writable. It does not import the
-Pipeline implementation, create a run manifest, allocate a model, or start training.
+Later overrides replace earlier values. Invalid config paths, malformed overrides, unknown
+Pipelines, and unwritable output locations fail with a non-zero exit status.
 
-A pass prints, among other fields:
-
-```text
-status=passed
-run_spec_sha256=<64-hex>
-pipeline=Pipeline_01_Fault_Diagnosis
-```
-
-Resolve every preflight failure before training.
-
-## 4. Run the maintained offline demo
+## 4. Run the offline demo
 
 ```bash
 phmfactory demo
 ```
 
-The command is a thin wrapper around the same public experiment runner. It selects the
-packaged `smoke` preset with bounded defaults:
+The command applies bounded defaults:
 
 ```text
-trainer.num_epochs=1
-trainer.device=cpu
-trainer.gpus=1
-data.num_workers=0
+preset: smoke
+trainer.num_epochs: 1
+trainer.device: cpu
+trainer.gpus: 1
+ data.num_workers: 0
 ```
 
-Additional overrides are applied after these defaults, so an explicit user value wins:
+An explicit user override still wins:
 
 ```bash
 phmfactory demo --override trainer.num_epochs=2
 ```
 
-A successful demo should:
+A successful run should:
 
-- exit with status code `0`;
-- complete the config → data → model → task → trainer path;
-- print `run_manifest=<path>` followed by the completion message;
-- create output beneath `results/demo/dummy_dg_smoke/`;
-- create one invocation manifest below
-  `results/demo/dummy_dg_smoke/.phmfactory/runs/<run_id>/run_manifest.json`;
-- require no external dataset download.
+- initialize Dummy data from files shipped with the repository;
+- construct the maintained model, task, and trainer;
+- train and test without downloading an external dataset;
+- print `run_manifest=<path>`;
+- print the completion message;
+- exit with status code `0`.
 
-The invocation manifest is created with `status: pending` before Pipeline import and is
-atomically replaced with `succeeded` or `failed`. A run is not successful when its final
-manifest or required evidence cannot be written.
+## 5. Find the results
 
-Inspect the output tree without assuming a fixed experiment subdirectory name:
+List the files without assuming a fixed timestamped subdirectory:
 
 ```bash
-find results/demo/dummy_dg_smoke -maxdepth 6 -type f | sort
+find results/demo/dummy_dg_smoke -maxdepth 7 -type f | sort
 ```
 
-## 5. Use the compatible explicit experiment form
+On Windows PowerShell:
 
-The following entrypoints retain equivalent experiment semantics:
+```powershell
+Get-ChildItem results/demo/dummy_dg_smoke -Recurse -File |
+  Select-Object -ExpandProperty FullName
+```
+
+The output normally contains:
+
+- per-iteration test metrics such as `test_result_0.csv`;
+- aggregate metrics such as `all_results.csv`;
+- checkpoints and logger outputs created by the configured trainer;
+- one `run_manifest.json` under `.phmfactory/runs/<run-id>/`.
+
+The run manifest is the starting point for reproducing or debugging the invocation. It
+records the selected config, Pipeline, overrides, status, timestamps, code revision when
+available, and indexed output artifacts. You do not need to understand its internal
+schema to complete this quickstart.
+
+## 6. Verify the three compatible entrypoints
+
+These commands should have the same process exit behavior:
 
 ```bash
-phmfactory --config configs/demo/00_smoke/dummy_dg.yaml \
-  --override trainer.num_epochs=1 \
-  --override data.num_workers=0
-
-python -m phmfactory --config configs/demo/00_smoke/dummy_dg.yaml \
-  --override trainer.num_epochs=1 \
-  --override data.num_workers=0
-
-python main.py --config configs/demo/00_smoke/dummy_dg.yaml \
-  --override trainer.num_epochs=1 \
-  --override data.num_workers=0
+phmfactory preflight --config smoke
+python -m phmfactory preflight --config smoke
+python main.py preflight --config smoke
 ```
 
-Runtime outputs are evidence for the exact commit, resolved configuration, overrides,
-data, and environment used. They are not a configuration source of truth and should not
-be committed unless a review requires a small fixture.
+The first form is recommended after installation. `python main.py` remains only as a
+repository compatibility launcher.
 
-## 6. Run repository checks
+Python code that needs a structured result rather than a process exit status may call:
 
-```bash
-python -m scripts.validate_docs
-python -m scripts.validate_configs
-python -m scripts.gen_config_atlas
-git diff --exit-code docs/CONFIG_ATLAS.md
-python -m scripts.gen_support_matrix
-git diff --exit-code SUPPORTED_COMPONENTS.md SUPPORTED_COMBINATIONS.md
-python -m pytest test/ -q
+```python
+from phmfactory.cli import main
+
+report = main(["preflight", "--config", "smoke"])
+print(report["pipeline"])
 ```
 
-Use the narrowest focused test during development; run the broader maintained gate before
-requesting review for runtime or configuration changes. See the [testing guide](testing.md).
+## 7. Run a maintained config with local data
 
-## 7. Run a maintained configuration with local data
-
-Only the Dummy demo is fully offline. For another maintained configuration, pass local
-data paths as explicit overrides rather than editing tracked YAML or relying on
-machine-local auto-discovery:
+Only the Dummy smoke is fully offline. For an external-data configuration, keep machine
+paths out of the tracked YAML and pass them explicitly:
 
 ```bash
 phmfactory preflight \
   --config configs/demo/01_cross_domain/cwru_dg.yaml \
-  --override data.data_dir=/absolute/path/to/PHM-Vibench-data \
+  --override data.data_dir=/absolute/path/to/phm-data \
   --override data.metadata_file=metadata.xlsx \
-  --override trainer.num_epochs=1 \
-  --override data.num_workers=0
-
-phmfactory \
-  --config configs/demo/01_cross_domain/cwru_dg.yaml \
-  --override data.data_dir=/absolute/path/to/PHM-Vibench-data \
-  --override data.metadata_file=metadata.xlsx \
-  --override trainer.num_epochs=1 \
-  --override data.num_workers=0
+  --override data.num_workers=0 \
+  --override trainer.num_epochs=1
 ```
 
-Read the [data directory guide](../data/README.md), then check the exact maintained
-surface in [supported combinations](../SUPPORTED_COMBINATIONS.md).
+After preflight passes:
 
-## Configuration variants
+```bash
+phmfactory \
+  --config configs/demo/01_cross_domain/cwru_dg.yaml \
+  --override data.data_dir=/absolute/path/to/phm-data \
+  --override data.metadata_file=metadata.xlsx \
+  --override data.num_workers=0 \
+  --override trainer.num_epochs=1
+```
 
-For a local experiment:
+Read [data/README.md](../data/README.md) for the expected directory layout and
+[Supported combinations](../SUPPORTED_COMBINATIONS.md) for the current maintained
+surface.
 
-1. copy the nearest YAML from `configs/demo/` to `configs/experiments/`;
-2. change only behavior-affecting fields required by the experiment;
-3. run `phmfactory preflight` against the resulting file;
-4. run the smallest applicable test;
-5. record the commit, config, overrides, seed, data source, and environment.
+## 8. Create a local experiment variant
+
+1. Copy the nearest file from `configs/demo/` to `configs/experiments/`.
+2. Change only values required by the experiment.
+3. Keep local paths in CLI overrides rather than the tracked file.
+4. Run `phmfactory preflight --config <your-yaml>`.
+5. Run the smallest applicable test or one-epoch smoke.
+6. Record the commit, config, overrides, data source, seed, and environment.
 
 Do not add a local variant to `configs/config_registry.csv` unless it is being reviewed
-for promotion to the maintained surface. The complete composition and precedence rules
-live in the [configuration guide](../configs/README.md).
+for promotion to the maintained surface.
 
 ## Troubleshooting
 
-### `doctor` reports an import failure
+### A command prints useful output but the shell reports exit code `1`
 
-The check performs a real import rather than only looking for a module name. Use the
-reported exception to distinguish a missing package from an ABI, binary, or transitive-
-dependency problem. Reinstall the environment before modifying PHMFactory source.
+Check the exact entrypoint and status:
 
-### `preflight` reports a missing module
+```bash
+phmfactory preflight --config smoke
+echo $?
+```
 
-Install the core dependencies from `requirements.txt`. A model family may import an
-optional research dependency even when it is outside the maintained release surface;
-report unconditional optional imports as dependency-boundary bugs.
+A successful public process must exit with `0`. Report the command, installed package
+location, stdout, stderr, and exit code if the output and status disagree.
 
-### A data or metadata path does not exist
+### `preflight` cannot find the config
 
-Return to `phmfactory demo` to verify the software environment. For local data, use
-explicit `data.data_dir` and `data.metadata_file` overrides or create a reviewable
-experiment YAML under `configs/experiments/`.
+Use a maintained preset such as `smoke`, or a path relative to the repository root:
 
-### The run fails before training starts
+```bash
+phmfactory preflight --config configs/demo/00_smoke/dummy_dg.yaml
+```
 
-Open the expected manifest path below
-`<environment.output_dir>/.phmfactory/runs/`. A failed manifest records the stage,
-exception type, and message. Configuration compilation failures that cannot determine a
-valid `environment.output_dir` occur before a manifest can be created.
+### A local data path does not exist
+
+Return to `phmfactory demo` to separate software installation from data availability.
+Then verify `data.data_dir`, `data.metadata_file`, and the raw directory layout.
+
+### The demo fails during import
+
+Run `phmfactory doctor` again. A package may be installed but fail during import because
+of an incompatible binary, driver, or transitive dependency.
 
 ### CUDA initialization fails
 
-Run the CPU Dummy demo first. Verify the local PyTorch build, driver, and device
-independently before changing PHMFactory configuration.
+Use the CPU Dummy demo first. Verify the PyTorch build and driver independently before
+changing PHMFactory source or experiment logic.
 
-### A generated authority changes
+### Metrics differ between runs
 
-`docs/CONFIG_ATLAS.md`, `SUPPORTED_COMPONENTS.md`, and `SUPPORTED_COMBINATIONS.md` are
-generated. Change their source registry or descriptor, regenerate them, and commit the
-result; do not hand-edit generated output to hide drift.
+The quickstart verifies execution, not fixed scientific metrics. A fair reproduction
+requires the same effective configuration, code revision, environment, data, split,
+seed, and protocol. See [Known limitations](../KNOWN_LIMITATIONS.md).
 
-### The run succeeds but metrics differ
+## Developer details
 
-The quickstart verifies execution, not fixed scientific metrics. Reproducibility claims
-require the same effective configuration, commit, environment, data, split, seed, and
-protocol. See [known limitations](../KNOWN_LIMITATIONS.md).
+The public runtime internally compiles the config once, executes the selected Pipeline,
+and writes a structured run record. Developers working on those contracts should read
+[Runtime control plane](developer_runtime_control_plane.md). First-time users do not need
+those implementation details to run experiments.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -122,7 +122,7 @@ preset: smoke
 trainer.num_epochs: 1
 trainer.device: cpu
 trainer.gpus: 1
- data.num_workers: 0
+data.num_workers: 0
 ```
 
 An explicit user override still wins:

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,55 +1,90 @@
 # Quickstart
 
 This walkthrough verifies the maintained configuration-first path with repository-
-shipped dummy data. It is a software smoke test, not a benchmark-performance run.
+shipped Dummy data. It is a software smoke test, not a benchmark-performance run.
 
 ## 1. Install the environment
 
-Complete the [installation guide](installation.md), activate the environment, and
-run all commands from the repository root.
+Complete the [installation guide](installation.md), activate the environment, and run
+all commands from the repository root.
 
-## 2. Inspect the configuration
-
-```bash
-python -m scripts.config_inspect \
-  --config configs/demo/00_smoke/dummy_dg.yaml \
-  --override trainer.num_epochs=1
-```
-
-The inspector resolves the composed configuration, reports field sources and
-runtime targets, and returns a non-zero exit code when a sanity check fails.
-Resolve inspector errors before starting training.
-
-The maintained configuration contains the five public blocks:
-
-```text
-environment / data / model / task / trainer
-```
-
-It selects `Pipeline_01_Fault_Diagnosis`, uses `data/metadata_dummy.csv`, runs on CPU, and
-writes below `results/demo/dummy_dg_smoke/`.
-
-## 3. Run one offline epoch
+## 2. Diagnose the installation
 
 ```bash
-python main.py --config configs/demo/00_smoke/dummy_dg.yaml \
+phmfactory doctor
+```
+
+`doctor` performs bounded checks without constructing a model, DataLoader, Pipeline, or
+Trainer. It verifies:
+
+- Python 3.10 or newer;
+- real imports of the core YAML, PyTorch, pandas, and Lightning modules;
+- the packaged `smoke` preset;
+- discoverability of its canonical Pipeline module;
+- output-directory writability without leaving probe files or newly created directories.
+
+Every check is printed as `PASS` or `FAIL`. Any required failure produces a non-zero exit
+code and includes the underlying exception type and message.
+
+## 3. Compile the exact run without training
+
+```bash
+phmfactory preflight \
+  --config smoke \
   --override trainer.num_epochs=1 \
   --override data.num_workers=0
 ```
 
-A successful smoke run should:
+`preflight` resolves base configurations and overrides exactly once, compiles the
+`CompiledRunSpec`, applies Pipeline maturity policy, verifies Pipeline discoverability,
+and proves that the configured output location is writable. It does not import the
+Pipeline implementation, create a run manifest, allocate a model, or start training.
+
+A pass prints, among other fields:
+
+```text
+status=passed
+run_spec_sha256=<64-hex>
+pipeline=Pipeline_01_Fault_Diagnosis
+```
+
+Resolve every preflight failure before training.
+
+## 4. Run the maintained offline demo
+
+```bash
+phmfactory demo
+```
+
+The command is a thin wrapper around the same public experiment runner. It selects the
+packaged `smoke` preset with bounded defaults:
+
+```text
+trainer.num_epochs=1
+trainer.device=cpu
+trainer.gpus=1
+data.num_workers=0
+```
+
+Additional overrides are applied after these defaults, so an explicit user value wins:
+
+```bash
+phmfactory demo --override trainer.num_epochs=2
+```
+
+A successful demo should:
 
 - exit with status code `0`;
 - complete the config → data → model → task → trainer path;
 - print `run_manifest=<path>` followed by the completion message;
-- create run output beneath `results/demo/dummy_dg_smoke/`;
+- create output beneath `results/demo/dummy_dg_smoke/`;
 - create one invocation manifest below
   `results/demo/dummy_dg_smoke/.phmfactory/runs/<run_id>/run_manifest.json`;
 - require no external dataset download.
 
 The invocation manifest is created with `status: pending` before Pipeline import and is
-atomically updated to `succeeded` or `failed`. A run is not considered successful when
-the final manifest cannot be written.
+atomically replaced with `succeeded` or `failed`. A run is not successful when its final
+manifest or required evidence cannot be written.
 
 Inspect the output tree without assuming a fixed experiment subdirectory name:
 
@@ -57,32 +92,59 @@ Inspect the output tree without assuming a fixed experiment subdirectory name:
 find results/demo/dummy_dg_smoke -maxdepth 6 -type f | sort
 ```
 
-Runtime outputs are evidence for the exact commit, configuration, overrides, data,
-and environment used. They are not a configuration source of truth and should not
-be committed unless a specific review requires a small fixture.
+## 5. Use the compatible explicit experiment form
 
-## 4. Run repository checks
+The following entrypoints retain equivalent experiment semantics:
+
+```bash
+phmfactory --config configs/demo/00_smoke/dummy_dg.yaml \
+  --override trainer.num_epochs=1 \
+  --override data.num_workers=0
+
+python -m phmfactory --config configs/demo/00_smoke/dummy_dg.yaml \
+  --override trainer.num_epochs=1 \
+  --override data.num_workers=0
+
+python main.py --config configs/demo/00_smoke/dummy_dg.yaml \
+  --override trainer.num_epochs=1 \
+  --override data.num_workers=0
+```
+
+Runtime outputs are evidence for the exact commit, resolved configuration, overrides,
+data, and environment used. They are not a configuration source of truth and should not
+be committed unless a review requires a small fixture.
+
+## 6. Run repository checks
 
 ```bash
 python -m scripts.validate_docs
 python -m scripts.validate_configs
 python -m scripts.gen_config_atlas
 git diff --exit-code docs/CONFIG_ATLAS.md
+python -m scripts.gen_support_matrix
+git diff --exit-code SUPPORTED_COMPONENTS.md SUPPORTED_COMBINATIONS.md
 python -m pytest test/ -q
 ```
 
-Use the focused test closest to a change during development; use the broader gate
-before requesting review for runtime or configuration changes. See the
-[testing guide](testing.md).
+Use the narrowest focused test during development; run the broader maintained gate before
+requesting review for runtime or configuration changes. See the [testing guide](testing.md).
 
-## 5. Run a maintained demo with local data
+## 7. Run a maintained configuration with local data
 
-Only the dummy demo is fully offline. For another maintained configuration, pass
-local data paths as explicit overrides instead of editing tracked YAML or relying on
+Only the Dummy demo is fully offline. For another maintained configuration, pass local
+data paths as explicit overrides rather than editing tracked YAML or relying on
 machine-local auto-discovery:
 
 ```bash
-python main.py --config configs/demo/01_cross_domain/cwru_dg.yaml \
+phmfactory preflight \
+  --config configs/demo/01_cross_domain/cwru_dg.yaml \
+  --override data.data_dir=/absolute/path/to/PHM-Vibench-data \
+  --override data.metadata_file=metadata.xlsx \
+  --override trainer.num_epochs=1 \
+  --override data.num_workers=0
+
+phmfactory \
+  --config configs/demo/01_cross_domain/cwru_dg.yaml \
   --override data.data_dir=/absolute/path/to/PHM-Vibench-data \
   --override data.metadata_file=metadata.xlsx \
   --override trainer.num_epochs=1 \
@@ -98,48 +160,54 @@ For a local experiment:
 
 1. copy the nearest YAML from `configs/demo/` to `configs/experiments/`;
 2. change only behavior-affecting fields required by the experiment;
-3. inspect the resolved configuration;
+3. run `phmfactory preflight` against the resulting file;
 4. run the smallest applicable test;
 5. record the commit, config, overrides, seed, data source, and environment.
 
-Do not add a local variant to `configs/config_registry.csv` unless it is being
-reviewed for promotion to the maintained surface. The complete composition and
-precedence rules live in the [configuration guide](../configs/README.md).
+Do not add a local variant to `configs/config_registry.csv` unless it is being reviewed
+for promotion to the maintained surface. The complete composition and precedence rules
+live in the [configuration guide](../configs/README.md).
 
 ## Troubleshooting
 
-### The inspector reports a missing module
+### `doctor` reports an import failure
 
-Install the core dependencies from `requirements.txt`. A model family may import
-an optional research dependency even when it is outside the maintained release
-surface; report unconditional optional imports as dependency-boundary bugs.
+The check performs a real import rather than only looking for a module name. Use the
+reported exception to distinguish a missing package from an ABI, binary, or transitive-
+dependency problem. Reinstall the environment before modifying PHMFactory source.
+
+### `preflight` reports a missing module
+
+Install the core dependencies from `requirements.txt`. A model family may import an
+optional research dependency even when it is outside the maintained release surface;
+report unconditional optional imports as dependency-boundary bugs.
 
 ### A data or metadata path does not exist
 
-Return to the offline dummy config to verify the software environment. For local
-data, use explicit `data.data_dir` and `data.metadata_file` overrides or create a
-reviewable experiment YAML under `configs/experiments/`.
+Return to `phmfactory demo` to verify the software environment. For local data, use
+explicit `data.data_dir` and `data.metadata_file` overrides or create a reviewable
+experiment YAML under `configs/experiments/`.
 
 ### The run fails before training starts
 
-Open the printed or expected manifest path below
+Open the expected manifest path below
 `<environment.output_dir>/.phmfactory/runs/`. A failed manifest records the stage,
 exception type, and message. Configuration compilation failures that cannot determine a
-valid `environment.output_dir` fail before a manifest can be created.
+valid `environment.output_dir` occur before a manifest can be created.
 
 ### CUDA initialization fails
 
-Run the CPU dummy config first. Verify the local PyTorch build, driver, and device
-independently before changing PHM-Vibench configuration.
+Run the CPU Dummy demo first. Verify the local PyTorch build, driver, and device
+independently before changing PHMFactory configuration.
 
-### The generated atlas changes
+### A generated authority changes
 
-`docs/CONFIG_ATLAS.md` is generated from `configs/config_registry.csv`. If the
-registry change is intentional, regenerate and commit the atlas. Otherwise revert
-the unintended registry change.
+`docs/CONFIG_ATLAS.md`, `SUPPORTED_COMPONENTS.md`, and `SUPPORTED_COMBINATIONS.md` are
+generated. Change their source registry or descriptor, regenerate them, and commit the
+result; do not hand-edit generated output to hide drift.
 
 ### The run succeeds but metrics differ
 
-The quickstart verifies execution, not fixed scientific metrics. Reproducibility
-claims require the same commit, environment, data, split, seed, and configuration.
-See [known limitations](../KNOWN_LIMITATIONS.md).
+The quickstart verifies execution, not fixed scientific metrics. Reproducibility claims
+require the same effective configuration, commit, environment, data, split, seed, and
+protocol. See [known limitations](../KNOWN_LIMITATIONS.md).

--- a/main.py
+++ b/main.py
@@ -1,9 +1,14 @@
-"""Compatibility entrypoint for ``python main.py``."""
+"""Compatibility process entrypoint for ``python main.py``.
+
+The repository launcher intentionally shares the same integer process boundary as the
+installed ``phmfactory`` command and ``python -m phmfactory``. Programmatic callers that
+need the structured command or Pipeline result should import ``phmfactory.cli.main``.
+"""
 
 from __future__ import annotations
 
-from phmfactory.cli import main
+from phmfactory.cli import entrypoint
 
 
 if __name__ == "__main__":
-    main()
+    raise SystemExit(entrypoint())

--- a/phmfactory/__main__.py
+++ b/phmfactory/__main__.py
@@ -1,9 +1,14 @@
-"""Module entrypoint for ``python -m phmfactory``."""
+"""Process entrypoint for ``python -m phmfactory``.
+
+The programmatic router may return dictionaries, lists, or Pipeline results. This module
+uses the dedicated integer process entrypoint so successful structured results always
+produce operating-system exit code ``0``.
+"""
 
 from __future__ import annotations
 
-from phmfactory.cli import main
+from phmfactory.cli import entrypoint
 
 
 if __name__ == "__main__":
-    main()
+    raise SystemExit(entrypoint())

--- a/phmfactory/cli.py
+++ b/phmfactory/cli.py
@@ -1,4 +1,4 @@
-"""Public command-line interface for PHMFactory."""
+"""Public command router and experiment execution boundary for PHMFactory."""
 
 from __future__ import annotations
 
@@ -8,7 +8,8 @@ import sys
 from collections.abc import Sequence
 from typing import Any
 
-from phmfactory.config import DEFAULT_CONFIG, resolve_config
+from phmfactory.commands.common import add_config_arguments, requested_config
+from phmfactory.config import resolve_config
 from phmfactory.pipelines import pipeline_module_name, require_pipeline_access
 from phmfactory.runtime import (
     AttestationWriteError,
@@ -19,89 +20,33 @@ from phmfactory.runtime import (
 from phmfactory.runtime.evidence import register_pipeline_result_evidence
 
 
+COMMANDS = ("data", "doctor", "demo", "preflight")
+
+
 def build_parser() -> argparse.ArgumentParser:
-    """Build the parser shared by the three experiment entrypoints."""
+    """Build the backward-compatible experiment parser."""
+
     parser = argparse.ArgumentParser(
         prog="phmfactory",
         description="PHMFactory task pipeline",
-    )
-    parser.add_argument(
-        "--config",
-        type=str,
-        default=None,
-        help="Configuration path or maintained preset name.",
-    )
-    parser.add_argument(
-        "--config_path",
-        type=str,
-        default=None,
-        help="Deprecated alias for --config.",
-    )
-    parser.add_argument(
-        "--notes",
-        type=str,
-        default="",
-        help="Experiment notes.",
-    )
-    parser.add_argument(
-        "--override",
-        action="append",
-        help="Configuration override in key=value form; may be repeated.",
-    )
-    parser.add_argument(
-        "--allow-experimental",
-        action="store_true",
-        help=(
-            "Explicitly authorize a Pipeline whose maturity descriptor requires "
-            "experimental opt-in."
+        epilog=(
+            "Commands: doctor, demo, preflight, data. "
+            "Legacy experiment form remains: phmfactory --config <yaml>."
         ),
     )
-    return parser
-
-
-def build_data_parser() -> argparse.ArgumentParser:
-    """Build the bounded dataset-bundle management command surface."""
-    parser = argparse.ArgumentParser(
-        prog="phmfactory data",
-        description="Download and validate PHMFactory dataset bundles.",
-    )
-    commands = parser.add_subparsers(dest="data_command", required=True)
-
-    download = commands.add_parser("download", help="Download one versioned bundle.")
-    download.add_argument("--bundle", default="cwru-demo-v1")
-    download.add_argument(
-        "--source",
-        choices=("huggingface", "modelscope"),
-        default="huggingface",
-    )
-    download.add_argument("--destination", default=None)
-    download.add_argument("--revision", default=None)
-    download.add_argument("--force", action="store_true")
-
-    validate = commands.add_parser("validate", help="Validate a local bundle.")
-    validate.add_argument("--bundle", default="cwru-demo-v1")
-    validate.add_argument("--path", required=True)
-
-    compare = commands.add_parser(
-        "compare",
-        help="Require identical core-file hashes for two local bundles.",
-    )
-    compare.add_argument("--bundle", default="cwru-demo-v1")
-    compare.add_argument("--left", required=True)
-    compare.add_argument("--right", required=True)
+    add_config_arguments(parser, include_notes=True, include_experimental=True)
     return parser
 
 
 def _resolve_config_path(args: argparse.Namespace) -> str:
-    if args.config is not None:
-        return args.config
-    if args.config_path is not None:
-        return args.config_path
-    return DEFAULT_CONFIG
+    """Compatibility wrapper retained for callers and tests."""
+
+    return requested_config(args)
 
 
 def _resolve_pipeline(args: argparse.Namespace, config_path: str) -> str:
     """Resolve the canonical Pipeline through the public config API."""
+
     return resolve_config(
         config_path,
         override_values=args.override,
@@ -121,13 +66,12 @@ def _write_failed_attestation(
 
 def run(args: argparse.Namespace) -> Any:
     """Compile, attest, authorize, execute, and index one Pipeline."""
-    requested_config = _resolve_config_path(args)
-    resolved = resolve_config(requested_config, override_values=args.override)
+
+    requested = requested_config(args)
+    resolved = resolve_config(requested, override_values=args.override)
     compiled = CompiledRunSpec.compile(resolved)
 
-    # Keep the user's source for provenance, but pass the resolved file path to
-    # the protected runtime so public presets never fall into legacy aliases.
-    args.requested_config = requested_config
+    args.requested_config = requested
     args.config_path = str(resolved.path)
     args.resolved_config_path = str(resolved.path)
     args.resolved_pipeline = resolved.pipeline
@@ -152,9 +96,7 @@ def run(args: argparse.Namespace) -> Any:
     try:
         descriptor = require_pipeline_access(
             resolved.pipeline,
-            allow_experimental=bool(
-                getattr(args, "allow_experimental", False)
-            ),
+            allow_experimental=bool(getattr(args, "allow_experimental", False)),
             warn=False,
         )
     except BaseException as error:
@@ -194,56 +136,32 @@ def run(args: argparse.Namespace) -> Any:
     return result
 
 
-def _run_data_command(argv: Sequence[str]) -> Any:
-    from phmfactory.data_sources import (
-        compare_bundle_hashes,
-        download_bundle,
-        load_bundle_spec,
-        validate_bundle,
-    )
+def _run_command(name: str, argv: Sequence[str]) -> Any:
+    """Load one small command module only when selected."""
 
-    parser = build_data_parser()
-    args = parser.parse_args(list(argv))
-    spec = load_bundle_spec(args.bundle)
+    if name == "data":
+        from phmfactory.commands import data
 
-    if args.data_command == "download":
-        result = download_bundle(
-            args.bundle,
-            source=args.source,
-            destination=args.destination,
-            revision=args.revision,
-            force=args.force,
-        )
-        validation = result.validation
-        print(f"bundle={validation.spec.bundle_id}")
-        print(f"provider={result.provider}")
-        print(f"revision={result.requested_revision}")
-        print(f"path={result.directory}")
-        print(f"selected_rows={validation.selected_rows}")
-        print(f"corpus_present={str(validation.corpus_present).lower()}")
-        return result
+        return data.run(argv)
+    if name == "doctor":
+        from phmfactory.commands import doctor
 
-    if args.data_command == "validate":
-        validation = validate_bundle(args.path, spec=spec)
-        print(f"bundle={validation.spec.bundle_id}")
-        print(f"path={validation.directory}")
-        print(f"metadata_rows={validation.metadata_rows}")
-        print(f"selected_rows={validation.selected_rows}")
-        print(f"signal_keys={validation.signal_keys}")
-        print(f"corpus_present={str(validation.corpus_present).lower()}")
-        return validation
+        return doctor.run(argv)
+    if name == "preflight":
+        from phmfactory.commands import preflight
 
-    hashes = compare_bundle_hashes(args.left, args.right, spec=spec)
-    for name, digest in hashes.items():
-        print(f"{name}={digest}")
-    return hashes
+        return preflight.run(argv)
+    if name == "demo":
+        from phmfactory.commands import demo
+
+        return demo.run(argv, experiment_runner=run)
+    raise ValueError(f"unknown PHMFactory command: {name!r}")
 
 
 def main(argv: Sequence[str] | None = None) -> Any:
-    """Execute a data subcommand or the backward-compatible experiment CLI."""
+    """Route a named command or execute the compatible experiment form."""
+
     arguments = list(sys.argv[1:] if argv is None else argv)
-    if arguments[:1] == ["data"]:
-        return _run_data_command(arguments[1:])
-    parser = build_parser()
-    args = parser.parse_args(arguments)
-    return run(args)
+    if arguments[:1] and arguments[0] in COMMANDS:
+        return _run_command(arguments[0], arguments[1:])
+    return run(build_parser().parse_args(arguments))

--- a/phmfactory/cli.py
+++ b/phmfactory/cli.py
@@ -1,4 +1,20 @@
-"""Public command router and experiment execution boundary for PHMFactory."""
+"""Public command routing and process entrypoints for PHMFactory.
+
+This module deliberately exposes two layers:
+
+``main(argv)``
+    Programmatic router. It returns structured command or Pipeline results so tests,
+    notebooks, and Python callers can inspect them directly.
+
+``entrypoint(argv)``
+    Operating-system process boundary used by the installed ``phmfactory`` command,
+    ``python -m phmfactory``, and the repository ``main.py`` compatibility launcher.
+    It converts every successful structured result into exit status ``0`` while
+    allowing ``SystemExit`` and runtime exceptions to retain their failure status.
+
+Keeping these contracts separate prevents a successful dictionary or list result from
+being passed to ``sys.exit`` and incorrectly reported as process exit code ``1``.
+"""
 
 from __future__ import annotations
 
@@ -31,7 +47,7 @@ def build_parser() -> argparse.ArgumentParser:
         description="PHMFactory task pipeline",
         epilog=(
             "Commands: doctor, demo, preflight, data. "
-            "Legacy experiment form remains: phmfactory --config <yaml>."
+            "Compatible experiment form: phmfactory --config <yaml>."
         ),
     )
     add_config_arguments(parser, include_notes=True, include_experimental=True)
@@ -39,7 +55,7 @@ def build_parser() -> argparse.ArgumentParser:
 
 
 def _resolve_config_path(args: argparse.Namespace) -> str:
-    """Compatibility wrapper retained for callers and tests."""
+    """Return the selected config while preserving the deprecated alias."""
 
     return requested_config(args)
 
@@ -58,6 +74,8 @@ def _write_failed_attestation(
     envelope: ExecutionEnvelope,
     original_error: BaseException,
 ) -> None:
+    """Persist terminal failure state without replacing the original exception."""
+
     try:
         attestation.write(envelope)
     except AttestationWriteError as write_error:
@@ -65,7 +83,12 @@ def _write_failed_attestation(
 
 
 def run(args: argparse.Namespace) -> Any:
-    """Compile, attest, authorize, execute, and index one Pipeline."""
+    """Compile, record, authorize, execute, and index one Pipeline invocation.
+
+    The function is the single maintained experiment execution boundary. It returns the
+    Pipeline's explicit Python result for programmatic callers. Process exit handling is
+    owned by :func:`entrypoint`, not by this function.
+    """
 
     requested = requested_config(args)
     resolved = resolve_config(requested, override_values=args.override)
@@ -159,9 +182,27 @@ def _run_command(name: str, argv: Sequence[str]) -> Any:
 
 
 def main(argv: Sequence[str] | None = None) -> Any:
-    """Route a named command or execute the compatible experiment form."""
+    """Return the structured result of a named command or experiment.
+
+    This function is retained as the programmatic compatibility API. Code that starts an
+    operating-system process must call :func:`entrypoint` instead so a successful mapping,
+    list, or model result is not interpreted as an error exit message by ``sys.exit``.
+    """
 
     arguments = list(sys.argv[1:] if argv is None else argv)
     if arguments[:1] and arguments[0] in COMMANDS:
         return _run_command(arguments[0], arguments[1:])
     return run(build_parser().parse_args(arguments))
+
+
+def entrypoint(argv: Sequence[str] | None = None) -> int:
+    """Execute the public process contract and return an integer status code.
+
+    Successful command and Pipeline results are intentionally discarded at this boundary;
+    their human-readable output and generated files remain available. ``argparse`` exits,
+    explicit command failures, and runtime exceptions are not caught, so their original
+    non-zero status and traceback are preserved.
+    """
+
+    main(argv)
+    return 0

--- a/phmfactory/commands/__init__.py
+++ b/phmfactory/commands/__init__.py
@@ -1,0 +1,1 @@
+"""Small user-facing command modules used by :mod:`phmfactory.cli`."""

--- a/phmfactory/commands/common.py
+++ b/phmfactory/commands/common.py
@@ -1,0 +1,85 @@
+"""Shared argument and filesystem helpers for PHMFactory commands."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+import shutil
+from uuid import uuid4
+
+from phmfactory.config import DEFAULT_CONFIG
+
+
+def add_config_arguments(
+    parser: argparse.ArgumentParser,
+    *,
+    include_notes: bool = False,
+    include_experimental: bool = True,
+) -> None:
+    """Add the maintained config/preset and override surface to a parser."""
+
+    parser.add_argument(
+        "--config",
+        type=str,
+        default=None,
+        help="Configuration path or maintained preset name.",
+    )
+    parser.add_argument(
+        "--config_path",
+        type=str,
+        default=None,
+        help="Deprecated alias for --config.",
+    )
+    if include_notes:
+        parser.add_argument("--notes", default="", help="Experiment notes.")
+    parser.add_argument(
+        "--override",
+        action="append",
+        help="Configuration override in key=value form; may be repeated.",
+    )
+    if include_experimental:
+        parser.add_argument(
+            "--allow-experimental",
+            action="store_true",
+            help="Explicitly authorize an opt-in experimental Pipeline.",
+        )
+
+
+def requested_config(args: argparse.Namespace) -> str:
+    """Return the preferred config argument while preserving the legacy alias."""
+
+    if getattr(args, "config", None) is not None:
+        return str(args.config)
+    if getattr(args, "config_path", None) is not None:
+        return str(args.config_path)
+    return DEFAULT_CONFIG
+
+
+def check_writable_directory(path: str | Path) -> Path:
+    """Prove a directory is writable without leaving probe files or new trees."""
+
+    target = Path(path).expanduser()
+    if not target.is_absolute():
+        target = Path.cwd() / target
+    target = target.resolve()
+
+    ancestor = target
+    while not ancestor.exists() and ancestor != ancestor.parent:
+        ancestor = ancestor.parent
+    cleanup_root = ancestor
+    if ancestor != target:
+        relative = target.relative_to(ancestor)
+        cleanup_root = ancestor / relative.parts[0]
+
+    target.mkdir(parents=True, exist_ok=True)
+    probe = target / f".phmfactory-write-probe-{uuid4().hex}"
+    try:
+        probe.write_text("ok\n", encoding="utf-8")
+        probe.unlink()
+    except OSError:
+        probe.unlink(missing_ok=True)
+        raise
+    finally:
+        if cleanup_root != ancestor and cleanup_root.exists():
+            shutil.rmtree(cleanup_root)
+    return target

--- a/phmfactory/commands/common.py
+++ b/phmfactory/commands/common.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import argparse
 from pathlib import Path
-import shutil
 from uuid import uuid4
 
 from phmfactory.config import DEFAULT_CONFIG
@@ -56,30 +55,49 @@ def requested_config(args: argparse.Namespace) -> str:
 
 
 def check_writable_directory(path: str | Path) -> Path:
-    """Prove a directory is writable without leaving probe files or new trees."""
+    """Prove a directory is writable without deleting unowned filesystem content.
+
+    Only directories created successfully by this invocation are candidates for
+    cleanup. They are removed with ``rmdir`` from child to parent and cleanup stops as
+    soon as a directory is non-empty. Concurrent files or directories are therefore
+    preserved.
+    """
 
     target = Path(path).expanduser()
     if not target.is_absolute():
         target = Path.cwd() / target
     target = target.resolve()
 
-    ancestor = target
-    while not ancestor.exists() and ancestor != ancestor.parent:
-        ancestor = ancestor.parent
-    cleanup_root = ancestor
-    if ancestor != target:
-        relative = target.relative_to(ancestor)
-        cleanup_root = ancestor / relative.parts[0]
+    missing: list[Path] = []
+    cursor = target
+    while not cursor.exists():
+        missing.append(cursor)
+        if cursor == cursor.parent:
+            break
+        cursor = cursor.parent
 
-    target.mkdir(parents=True, exist_ok=True)
+    created: list[Path] = []
+    for directory in reversed(missing):
+        try:
+            directory.mkdir()
+        except FileExistsError:
+            # Another process created it after the initial observation. It is not ours.
+            continue
+        else:
+            created.append(directory)
+
+    if not target.is_dir():
+        raise NotADirectoryError(target)
+
     probe = target / f".phmfactory-write-probe-{uuid4().hex}"
     try:
         probe.write_text("ok\n", encoding="utf-8")
-        probe.unlink()
-    except OSError:
-        probe.unlink(missing_ok=True)
-        raise
     finally:
-        if cleanup_root != ancestor and cleanup_root.exists():
-            shutil.rmtree(cleanup_root)
+        probe.unlink(missing_ok=True)
+        for directory in reversed(created):
+            try:
+                directory.rmdir()
+            except OSError:
+                # Non-empty, concurrently claimed, or otherwise no longer safe to remove.
+                break
     return target

--- a/phmfactory/commands/common.py
+++ b/phmfactory/commands/common.py
@@ -54,13 +54,33 @@ def requested_config(args: argparse.Namespace) -> str:
     return DEFAULT_CONFIG
 
 
-def check_writable_directory(path: str | Path) -> Path:
-    """Prove a directory is writable without deleting unowned filesystem content.
+def _probe_existing_directory(directory: Path) -> None:
+    """Create and remove one owned file inside an existing directory."""
 
-    Only directories created successfully by this invocation are candidates for
-    cleanup. They are removed with ``rmdir`` from child to parent and cleanup stops as
-    soon as a directory is non-empty. Concurrent files or directories are therefore
-    preserved.
+    probe = directory / f".phmfactory-write-probe-{uuid4().hex}"
+    try:
+        probe.write_text("ok\n", encoding="utf-8")
+    finally:
+        probe.unlink(missing_ok=True)
+
+
+def _nearest_existing_ancestor(path: Path) -> Path:
+    ancestor = path
+    while not ancestor.exists() and ancestor != ancestor.parent:
+        ancestor = ancestor.parent
+    if not ancestor.is_dir():
+        raise NotADirectoryError(ancestor)
+    return ancestor
+
+
+def check_writable_directory(path: str | Path) -> Path:
+    """Prove output writability without creating the configured target path.
+
+    Existing targets are probed with one owned temporary file. For a missing target,
+    PHMFactory creates a unique sibling probe directory below the nearest existing
+    ancestor, writes one file there, and removes only those owned objects. This proves
+    that the missing path could be created while avoiding destructive cleanup and
+    leaving the configured target absent.
     """
 
     target = Path(path).expanduser()
@@ -68,36 +88,21 @@ def check_writable_directory(path: str | Path) -> Path:
         target = Path.cwd() / target
     target = target.resolve()
 
-    missing: list[Path] = []
-    cursor = target
-    while not cursor.exists():
-        missing.append(cursor)
-        if cursor == cursor.parent:
-            break
-        cursor = cursor.parent
+    if target.exists():
+        if not target.is_dir():
+            raise NotADirectoryError(target)
+        _probe_existing_directory(target)
+        return target
 
-    created: list[Path] = []
-    for directory in reversed(missing):
-        try:
-            directory.mkdir()
-        except FileExistsError:
-            # Another process created it after the initial observation. It is not ours.
-            continue
-        else:
-            created.append(directory)
-
-    if not target.is_dir():
-        raise NotADirectoryError(target)
-
-    probe = target / f".phmfactory-write-probe-{uuid4().hex}"
+    ancestor = _nearest_existing_ancestor(target.parent)
+    probe_directory = ancestor / f".phmfactory-dir-probe-{uuid4().hex}"
+    probe_directory.mkdir()
     try:
-        probe.write_text("ok\n", encoding="utf-8")
+        _probe_existing_directory(probe_directory)
     finally:
-        probe.unlink(missing_ok=True)
-        for directory in reversed(created):
-            try:
-                directory.rmdir()
-            except OSError:
-                # Non-empty, concurrently claimed, or otherwise no longer safe to remove.
-                break
+        try:
+            probe_directory.rmdir()
+        except OSError:
+            # Never recursively delete content that may have appeared concurrently.
+            pass
     return target

--- a/phmfactory/commands/data.py
+++ b/phmfactory/commands/data.py
@@ -1,0 +1,83 @@
+"""Dataset-bundle command surface."""
+
+from __future__ import annotations
+
+import argparse
+from collections.abc import Sequence
+from typing import Any
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="phmfactory data",
+        description="Download and validate PHMFactory dataset bundles.",
+    )
+    commands = parser.add_subparsers(dest="data_command", required=True)
+
+    download = commands.add_parser("download", help="Download one versioned bundle.")
+    download.add_argument("--bundle", default="cwru-demo-v1")
+    download.add_argument(
+        "--source",
+        choices=("huggingface", "modelscope"),
+        default="huggingface",
+    )
+    download.add_argument("--destination", default=None)
+    download.add_argument("--revision", default=None)
+    download.add_argument("--force", action="store_true")
+
+    validate = commands.add_parser("validate", help="Validate a local bundle.")
+    validate.add_argument("--bundle", default="cwru-demo-v1")
+    validate.add_argument("--path", required=True)
+
+    compare = commands.add_parser(
+        "compare",
+        help="Require identical core-file hashes for two local bundles.",
+    )
+    compare.add_argument("--bundle", default="cwru-demo-v1")
+    compare.add_argument("--left", required=True)
+    compare.add_argument("--right", required=True)
+    return parser
+
+
+def run(argv: Sequence[str]) -> Any:
+    from phmfactory.data_sources import (
+        compare_bundle_hashes,
+        download_bundle,
+        load_bundle_spec,
+        validate_bundle,
+    )
+
+    args = build_parser().parse_args(list(argv))
+    spec = load_bundle_spec(args.bundle)
+
+    if args.data_command == "download":
+        result = download_bundle(
+            args.bundle,
+            source=args.source,
+            destination=args.destination,
+            revision=args.revision,
+            force=args.force,
+        )
+        validation = result.validation
+        print(f"bundle={validation.spec.bundle_id}")
+        print(f"provider={result.provider}")
+        print(f"revision={result.requested_revision}")
+        print(f"path={result.directory}")
+        print(f"selected_rows={validation.selected_rows}")
+        print(f"corpus_present={str(validation.corpus_present).lower()}")
+        return result
+
+    if args.data_command == "validate":
+        validation = validate_bundle(args.path, spec=spec)
+        print(f"bundle={validation.spec.bundle_id}")
+        print(f"path={validation.directory}")
+        print(f"metadata_rows={validation.metadata_rows}")
+        print(f"selected_rows={validation.selected_rows}")
+        print(f"signal_keys={validation.signal_keys}")
+        print(f"corpus_present={str(validation.corpus_present).lower()}")
+        return validation
+
+    hashes = compare_bundle_hashes(args.left, args.right, spec=spec)
+    for name, digest in hashes.items():
+        print(f"{name}={digest}")
+    return hashes

--- a/phmfactory/commands/demo.py
+++ b/phmfactory/commands/demo.py
@@ -1,0 +1,45 @@
+"""One-command wrapper around the maintained offline Dummy smoke."""
+
+from __future__ import annotations
+
+import argparse
+from collections.abc import Callable, Sequence
+from typing import Any
+
+
+DEFAULT_OVERRIDES = (
+    "trainer.num_epochs=1",
+    "trainer.device=cpu",
+    "trainer.gpus=1",
+    "data.num_workers=0",
+)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="phmfactory demo",
+        description="Run the repository-shipped offline Dummy smoke.",
+    )
+    parser.add_argument("--notes", default="", help="Experiment notes.")
+    parser.add_argument(
+        "--override",
+        action="append",
+        help="Additional key=value override; later values replace demo defaults.",
+    )
+    return parser
+
+
+def run(
+    argv: Sequence[str],
+    *,
+    experiment_runner: Callable[[argparse.Namespace], Any],
+) -> Any:
+    args = build_parser().parse_args(list(argv))
+    experiment_args = argparse.Namespace(
+        config="smoke",
+        config_path=None,
+        notes=args.notes,
+        override=[*DEFAULT_OVERRIDES, *(args.override or ())],
+        allow_experimental=False,
+    )
+    return experiment_runner(experiment_args)

--- a/phmfactory/commands/doctor.py
+++ b/phmfactory/commands/doctor.py
@@ -1,0 +1,80 @@
+"""Environment diagnostics that never start training."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import importlib.util
+from pathlib import Path
+import sys
+from collections.abc import Sequence
+
+from phmfactory.commands.common import check_writable_directory
+from phmfactory.config import resolve_config
+from phmfactory.pipelines import pipeline_module_name
+
+
+CORE_MODULES = ("yaml", "torch", "pandas", "pytorch_lightning")
+
+
+@dataclass(frozen=True)
+class DoctorCheck:
+    name: str
+    passed: bool
+    detail: str
+
+
+def collect_checks() -> list[DoctorCheck]:
+    checks: list[DoctorCheck] = []
+    python_ok = sys.version_info >= (3, 10)
+    checks.append(
+        DoctorCheck(
+            "python",
+            python_ok,
+            f"{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}",
+        )
+    )
+
+    for module in CORE_MODULES:
+        found = importlib.util.find_spec(module) is not None
+        checks.append(DoctorCheck(f"import:{module}", found, "available" if found else "missing"))
+
+    try:
+        resolved = resolve_config("smoke")
+    except Exception as error:
+        checks.append(DoctorCheck("config:smoke", False, str(error)))
+        return checks
+
+    checks.append(DoctorCheck("config:smoke", True, str(resolved.path)))
+    module_name = pipeline_module_name(resolved.pipeline, warn=False)
+    module_found = importlib.util.find_spec(module_name) is not None
+    checks.append(
+        DoctorCheck(
+            "pipeline:smoke",
+            module_found,
+            module_name if module_found else f"missing {module_name}",
+        )
+    )
+
+    environment = resolved.data.get("environment") or {}
+    output_dir = environment.get("output_dir")
+    try:
+        writable = check_writable_directory(str(output_dir))
+    except Exception as error:
+        checks.append(DoctorCheck("output:writable", False, str(error)))
+    else:
+        checks.append(DoctorCheck("output:writable", True, str(writable)))
+    return checks
+
+
+def run(argv: Sequence[str]) -> list[DoctorCheck]:
+    if argv:
+        raise SystemExit("phmfactory doctor takes no arguments")
+    checks = collect_checks()
+    for check in checks:
+        label = "PASS" if check.passed else "FAIL"
+        print(f"{label} {check.name}: {check.detail}")
+    failed = [check for check in checks if not check.passed]
+    if failed:
+        raise SystemExit(1)
+    print(f"doctor=passed checks={len(checks)}")
+    return checks

--- a/phmfactory/commands/doctor.py
+++ b/phmfactory/commands/doctor.py
@@ -2,11 +2,13 @@
 
 from __future__ import annotations
 
+import argparse
+from collections.abc import Sequence
 from dataclasses import dataclass
+import importlib
 import importlib.util
 from pathlib import Path
 import sys
-from collections.abc import Sequence
 
 from phmfactory.commands.common import check_writable_directory
 from phmfactory.config import resolve_config
@@ -23,7 +25,23 @@ class DoctorCheck:
     detail: str
 
 
+def build_parser() -> argparse.ArgumentParser:
+    """Build the zero-option doctor parser so standard ``--help`` works."""
+
+    return argparse.ArgumentParser(
+        prog="phmfactory doctor",
+        description="Validate the installed PHMFactory runtime without training.",
+    )
+
+
+def _module_detail(module: object) -> str:
+    version = getattr(module, "__version__", None)
+    return f"imported version={version}" if version else "imported"
+
+
 def collect_checks() -> list[DoctorCheck]:
+    """Collect bounded diagnostics without constructing a Pipeline or Trainer."""
+
     checks: list[DoctorCheck] = []
     python_ok = sys.version_info >= (3, 10)
     checks.append(
@@ -34,41 +52,72 @@ def collect_checks() -> list[DoctorCheck]:
         )
     )
 
-    for module in CORE_MODULES:
-        found = importlib.util.find_spec(module) is not None
-        checks.append(DoctorCheck(f"import:{module}", found, "available" if found else "missing"))
+    for module_name in CORE_MODULES:
+        try:
+            module = importlib.import_module(module_name)
+        except Exception as error:
+            checks.append(
+                DoctorCheck(
+                    f"import:{module_name}",
+                    False,
+                    f"{type(error).__name__}: {error}",
+                )
+            )
+        else:
+            checks.append(
+                DoctorCheck(f"import:{module_name}", True, _module_detail(module))
+            )
 
     try:
         resolved = resolve_config("smoke")
     except Exception as error:
-        checks.append(DoctorCheck("config:smoke", False, str(error)))
+        checks.append(
+            DoctorCheck("config:smoke", False, f"{type(error).__name__}: {error}")
+        )
         return checks
 
     checks.append(DoctorCheck("config:smoke", True, str(resolved.path)))
     module_name = pipeline_module_name(resolved.pipeline, warn=False)
-    module_found = importlib.util.find_spec(module_name) is not None
-    checks.append(
-        DoctorCheck(
-            "pipeline:smoke",
-            module_found,
-            module_name if module_found else f"missing {module_name}",
+    try:
+        module_found = importlib.util.find_spec(module_name) is not None
+    except (ImportError, AttributeError, ValueError) as error:
+        checks.append(
+            DoctorCheck(
+                "pipeline:smoke",
+                False,
+                f"{type(error).__name__}: {error}",
+            )
         )
-    )
+    else:
+        checks.append(
+            DoctorCheck(
+                "pipeline:smoke",
+                module_found,
+                module_name if module_found else f"missing {module_name}",
+            )
+        )
 
     environment = resolved.data.get("environment") or {}
     output_dir = environment.get("output_dir")
     try:
         writable = check_writable_directory(str(output_dir))
     except Exception as error:
-        checks.append(DoctorCheck("output:writable", False, str(error)))
+        checks.append(
+            DoctorCheck(
+                "output:writable",
+                False,
+                f"{type(error).__name__}: {error}",
+            )
+        )
     else:
         checks.append(DoctorCheck("output:writable", True, str(writable)))
     return checks
 
 
 def run(argv: Sequence[str]) -> list[DoctorCheck]:
-    if argv:
-        raise SystemExit("phmfactory doctor takes no arguments")
+    """Print diagnostic records and exit non-zero when any required check fails."""
+
+    build_parser().parse_args(list(argv))
     checks = collect_checks()
     for check in checks:
         label = "PASS" if check.passed else "FAIL"

--- a/phmfactory/commands/preflight.py
+++ b/phmfactory/commands/preflight.py
@@ -7,7 +7,11 @@ from collections.abc import Sequence
 import importlib.util
 from typing import Any
 
-from phmfactory.commands.common import add_config_arguments, check_writable_directory, requested_config
+from phmfactory.commands.common import (
+    add_config_arguments,
+    check_writable_directory,
+    requested_config,
+)
 from phmfactory.config import resolve_config
 from phmfactory.pipelines import pipeline_module_name, require_pipeline_access
 from phmfactory.runtime import CompiledRunSpec
@@ -36,9 +40,11 @@ def run(argv: Sequence[str]) -> dict[str, Any]:
     if importlib.util.find_spec(module_name) is None:
         raise ModuleNotFoundError(module_name)
 
-    environment = compiled.config.get("environment") or {}
-    output_dir = environment.get("output_dir")
-    writable = check_writable_directory(str(output_dir))
+    environment = compiled.config.get("environment")
+    output_dir = environment.get("output_dir") if isinstance(environment, dict) else None
+    if not isinstance(output_dir, str) or not output_dir.strip():
+        raise ValueError("environment.output_dir is required for preflight")
+    writable = check_writable_directory(output_dir)
     result = {
         "status": "passed",
         "requested_config": source,

--- a/phmfactory/commands/preflight.py
+++ b/phmfactory/commands/preflight.py
@@ -1,0 +1,54 @@
+"""Compile and validate a public run without importing or executing training code."""
+
+from __future__ import annotations
+
+import argparse
+from collections.abc import Sequence
+import importlib.util
+from typing import Any
+
+from phmfactory.commands.common import add_config_arguments, check_writable_directory, requested_config
+from phmfactory.config import resolve_config
+from phmfactory.pipelines import pipeline_module_name, require_pipeline_access
+from phmfactory.runtime import CompiledRunSpec
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="phmfactory preflight",
+        description="Compile and validate one PHMFactory run without training.",
+    )
+    add_config_arguments(parser, include_experimental=True)
+    return parser
+
+
+def run(argv: Sequence[str]) -> dict[str, Any]:
+    args = build_parser().parse_args(list(argv))
+    source = requested_config(args)
+    resolved = resolve_config(source, override_values=args.override)
+    compiled = CompiledRunSpec.compile(resolved)
+    descriptor = require_pipeline_access(
+        resolved.pipeline,
+        allow_experimental=bool(args.allow_experimental),
+        warn=False,
+    )
+    module_name = pipeline_module_name(resolved.pipeline, warn=False)
+    if importlib.util.find_spec(module_name) is None:
+        raise ModuleNotFoundError(module_name)
+
+    environment = compiled.config.get("environment") or {}
+    output_dir = environment.get("output_dir")
+    writable = check_writable_directory(str(output_dir))
+    result = {
+        "status": "passed",
+        "requested_config": source,
+        "resolved_config_path": str(resolved.path),
+        "run_spec_sha256": compiled.sha256,
+        "pipeline": compiled.pipeline,
+        "pipeline_module": module_name,
+        "maturity": descriptor.maturity,
+        "output_dir": str(writable),
+    }
+    for key, value in result.items():
+        print(f"{key}={value}")
+    return result

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,14 +8,14 @@ version = "0.3.0.dev0"
 description = "Configuration-first PHM research and evaluation framework"
 readme = "README.md"
 requires-python = ">=3.10"
-license = { text = "Apache-2.0" }
+license = "Apache-2.0"
 authors = [
   { name = "PHMFactory contributors" },
 ]
 dynamic = ["dependencies"]
 
 [project.scripts]
-phmfactory = "phmfactory.cli:main"
+phmfactory = "phmfactory.cli:entrypoint"
 
 [tool.setuptools]
 include-package-data = true

--- a/test/test_phmfactory_commands.py
+++ b/test/test_phmfactory_commands.py
@@ -46,9 +46,7 @@ def test_command_router_preserves_legacy_experiment_form(
 
 
 @pytest.mark.parametrize("command", ("doctor", "demo", "preflight", "data"))
-def test_named_command_help_is_standard_argparse(
-    command: str,
-) -> None:
+def test_named_command_help_is_standard_argparse(command: str) -> None:
     with pytest.raises(SystemExit) as error:
         cli.main([command, "--help"])
     assert error.value.code == 0
@@ -126,11 +124,7 @@ def test_doctor_exercises_real_imports(
         "find_spec",
         lambda name: SimpleNamespace(name=name),
     )
-    monkeypatch.setattr(
-        doctor,
-        "check_writable_directory",
-        lambda path: Path(path),
-    )
+    monkeypatch.setattr(doctor, "check_writable_directory", lambda path: Path(path))
 
     checks = doctor.collect_checks()
     torch_check = next(check for check in checks if check.name == "import:torch")
@@ -140,9 +134,7 @@ def test_doctor_exercises_real_imports(
     assert "OSError: binary ABI mismatch" in torch_check.detail
 
 
-def test_doctor_failure_has_nonzero_exit(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
+def test_doctor_failure_has_nonzero_exit(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(
         doctor,
         "collect_checks",
@@ -153,25 +145,36 @@ def test_doctor_failure_has_nonzero_exit(
     assert error.value.code == 1
 
 
-def test_doctor_success_returns_check_records(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
+def test_doctor_success_returns_check_records(monkeypatch: pytest.MonkeyPatch) -> None:
     expected = [doctor.DoctorCheck("python", True, "3.10")]
     monkeypatch.setattr(doctor, "collect_checks", lambda: expected)
     assert doctor.run([]) == expected
 
 
-def test_writable_probe_removes_only_its_new_empty_directory_tree(tmp_path: Path) -> None:
+def test_writable_probe_leaves_missing_target_absent(tmp_path: Path) -> None:
     target = tmp_path / "new" / "nested" / "output"
     assert check_writable_directory(target) == target.resolve()
+    assert not target.exists()
     assert not (tmp_path / "new").exists()
+    assert not list(tmp_path.glob(".phmfactory-dir-probe-*"))
 
 
-def test_writable_probe_preserves_concurrent_content(
+def test_writable_probe_preserves_existing_directory_content(tmp_path: Path) -> None:
+    target = tmp_path / "output"
+    target.mkdir()
+    marker = target / "owned-by-user.txt"
+    marker.write_text("preserve\n", encoding="utf-8")
+
+    assert check_writable_directory(target) == target.resolve()
+    assert marker.read_text(encoding="utf-8") == "preserve\n"
+    assert not list(target.glob(".phmfactory-write-probe-*"))
+
+
+def test_writable_probe_never_recursively_deletes_concurrent_content(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    target = tmp_path / "new" / "nested" / "output"
+    target = tmp_path / "new" / "output"
     original_write_text = Path.write_text
 
     def write_text(path: Path, *args, **kwargs):
@@ -187,6 +190,9 @@ def test_writable_probe_preserves_concurrent_content(
     monkeypatch.setattr(Path, "write_text", write_text)
 
     assert check_writable_directory(target) == target.resolve()
-    assert (target / "concurrent.txt").read_text(encoding="utf-8") == (
+    assert not target.exists()
+    probe_directories = list(tmp_path.glob(".phmfactory-dir-probe-*"))
+    assert len(probe_directories) == 1
+    assert (probe_directories[0] / "concurrent.txt").read_text(encoding="utf-8") == (
         "created by another owner\n"
     )

--- a/test/test_phmfactory_commands.py
+++ b/test/test_phmfactory_commands.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from phmfactory import cli
+from phmfactory.commands import demo, doctor, preflight
+from phmfactory.commands.common import check_writable_directory
+from phmfactory.config import ResolvedConfig
+
+
+def _resolved(tmp_path: Path) -> ResolvedConfig:
+    return ResolvedConfig(
+        requested="smoke",
+        path=tmp_path / "smoke.yaml",
+        data={
+            "pipeline": "Pipeline_01_Fault_Diagnosis",
+            "environment": {"output_dir": str(tmp_path / "new" / "outputs")},
+        },
+        pipeline="Pipeline_01_Fault_Diagnosis",
+        overrides={},
+    )
+
+
+def test_command_router_preserves_legacy_experiment_form(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    routed: list[object] = []
+    monkeypatch.setattr(
+        cli,
+        "_run_command",
+        lambda name, argv: routed.append((name, list(argv))) or "command",
+    )
+    monkeypatch.setattr(
+        cli,
+        "run",
+        lambda args: routed.append(("experiment", args.config)) or "experiment",
+    )
+
+    assert cli.main(["doctor"]) == "command"
+    assert cli.main(["--config", "smoke"]) == "experiment"
+    assert routed == [("doctor", []), ("experiment", "smoke")]
+
+
+def test_demo_uses_offline_defaults_and_user_override_wins() -> None:
+    observed: list[argparse.Namespace] = []
+    result = demo.run(
+        ["--override", "trainer.num_epochs=2", "--notes", "demo-test"],
+        experiment_runner=lambda args: observed.append(args) or "ok",
+    )
+
+    assert result == "ok"
+    args = observed[0]
+    assert args.config == "smoke"
+    assert args.notes == "demo-test"
+    assert args.allow_experimental is False
+    assert args.override[:4] == list(demo.DEFAULT_OVERRIDES)
+    assert args.override[-1] == "trainer.num_epochs=2"
+
+
+def test_preflight_compiles_without_importing_pipeline(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    resolved = _resolved(tmp_path)
+    monkeypatch.setattr(preflight, "resolve_config", lambda *args, **kwargs: resolved)
+    monkeypatch.setattr(
+        preflight.importlib.util,
+        "find_spec",
+        lambda name: SimpleNamespace(name=name),
+    )
+
+    result = preflight.run(["--config", "smoke"])
+
+    assert result["status"] == "passed"
+    assert result["pipeline"] == "Pipeline_01_Fault_Diagnosis"
+    assert len(result["run_spec_sha256"]) == 64
+    assert not (tmp_path / "new").exists()
+
+
+def test_preflight_requires_output_dir(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    resolved = _resolved(tmp_path)
+    resolved.data["environment"] = {}
+    monkeypatch.setattr(preflight, "resolve_config", lambda *args, **kwargs: resolved)
+    monkeypatch.setattr(
+        preflight.importlib.util,
+        "find_spec",
+        lambda name: SimpleNamespace(name=name),
+    )
+
+    with pytest.raises(ValueError, match="environment.output_dir"):
+        preflight.run(["--config", "smoke"])
+
+
+def test_doctor_failure_has_nonzero_exit(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        doctor,
+        "collect_checks",
+        lambda: [doctor.DoctorCheck("import:torch", False, "missing")],
+    )
+    with pytest.raises(SystemExit) as error:
+        doctor.run([])
+    assert error.value.code == 1
+
+
+def test_doctor_success_returns_check_records(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    expected = [doctor.DoctorCheck("python", True, "3.10")]
+    monkeypatch.setattr(doctor, "collect_checks", lambda: expected)
+    assert doctor.run([]) == expected
+
+
+def test_writable_probe_removes_new_directory_tree(tmp_path: Path) -> None:
+    target = tmp_path / "new" / "nested" / "output"
+    assert check_writable_directory(target) == target.resolve()
+    assert not (tmp_path / "new").exists()

--- a/test/test_phmfactory_commands.py
+++ b/test/test_phmfactory_commands.py
@@ -45,6 +45,15 @@ def test_command_router_preserves_legacy_experiment_form(
     assert routed == [("doctor", []), ("experiment", "smoke")]
 
 
+@pytest.mark.parametrize("command", ("doctor", "demo", "preflight", "data"))
+def test_named_command_help_is_standard_argparse(
+    command: str,
+) -> None:
+    with pytest.raises(SystemExit) as error:
+        cli.main([command, "--help"])
+    assert error.value.code == 0
+
+
 def test_demo_uses_offline_defaults_and_user_override_wins() -> None:
     observed: list[argparse.Namespace] = []
     result = demo.run(
@@ -98,6 +107,39 @@ def test_preflight_requires_output_dir(
         preflight.run(["--config", "smoke"])
 
 
+def test_doctor_exercises_real_imports(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    imported: list[str] = []
+
+    def fake_import(name: str) -> object:
+        imported.append(name)
+        if name == "torch":
+            raise OSError("binary ABI mismatch")
+        return SimpleNamespace(__version__="test")
+
+    monkeypatch.setattr(doctor.importlib, "import_module", fake_import)
+    monkeypatch.setattr(doctor, "resolve_config", lambda source: _resolved(tmp_path))
+    monkeypatch.setattr(
+        doctor.importlib.util,
+        "find_spec",
+        lambda name: SimpleNamespace(name=name),
+    )
+    monkeypatch.setattr(
+        doctor,
+        "check_writable_directory",
+        lambda path: Path(path),
+    )
+
+    checks = doctor.collect_checks()
+    torch_check = next(check for check in checks if check.name == "import:torch")
+
+    assert imported == list(doctor.CORE_MODULES)
+    assert torch_check.passed is False
+    assert "OSError: binary ABI mismatch" in torch_check.detail
+
+
 def test_doctor_failure_has_nonzero_exit(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -119,7 +161,32 @@ def test_doctor_success_returns_check_records(
     assert doctor.run([]) == expected
 
 
-def test_writable_probe_removes_new_directory_tree(tmp_path: Path) -> None:
+def test_writable_probe_removes_only_its_new_empty_directory_tree(tmp_path: Path) -> None:
     target = tmp_path / "new" / "nested" / "output"
     assert check_writable_directory(target) == target.resolve()
     assert not (tmp_path / "new").exists()
+
+
+def test_writable_probe_preserves_concurrent_content(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    target = tmp_path / "new" / "nested" / "output"
+    original_write_text = Path.write_text
+
+    def write_text(path: Path, *args, **kwargs):
+        result = original_write_text(path, *args, **kwargs)
+        if path.name.startswith(".phmfactory-write-probe-"):
+            original_write_text(
+                path.parent / "concurrent.txt",
+                "created by another owner\n",
+                encoding="utf-8",
+            )
+        return result
+
+    monkeypatch.setattr(Path, "write_text", write_text)
+
+    assert check_writable_directory(target) == target.resolve()
+    assert (target / "concurrent.txt").read_text(encoding="utf-8") == (
+        "created by another owner\n"
+    )

--- a/test/test_phmfactory_entrypoints.py
+++ b/test/test_phmfactory_entrypoints.py
@@ -13,7 +13,6 @@ from phmfactory import __version__
 from phmfactory import cli
 from examples import cwru_quickstart
 from phmfactory.config import MAINTAINED_PRESETS, ResolvedConfig, resolve_config_path
-from phmfactory.pipelines import PipelineNameDeprecationWarning
 
 
 REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
@@ -40,6 +39,26 @@ def test_config_takes_precedence_over_legacy_alias() -> None:
         override=None,
     )
     assert cli._resolve_config_path(args) == "public.yaml"
+
+
+def test_process_entrypoint_discards_structured_success(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The OS boundary must never pass a successful mapping to ``sys.exit``."""
+
+    monkeypatch.setattr(cli, "main", lambda argv=None: {"status": "passed"})
+    assert cli.entrypoint(["preflight"]) == 0
+
+
+def test_process_entrypoint_preserves_runtime_failures(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def fail(argv=None):
+        raise RuntimeError("runtime failed")
+
+    monkeypatch.setattr(cli, "main", fail)
+    with pytest.raises(RuntimeError, match="runtime failed"):
+        cli.entrypoint([])
 
 
 def test_run_dispatches_resolved_canonical_module(
@@ -186,10 +205,70 @@ def test_python_entrypoints_share_help_surface(command: list[str]) -> None:
     assert "--allow-experimental" in completed.stdout
 
 
-def test_root_main_is_only_a_dispatcher(monkeypatch: pytest.MonkeyPatch) -> None:
+@pytest.mark.parametrize(
+    "prefix",
+    (
+        [sys.executable, "main.py"],
+        [sys.executable, "-m", "phmfactory"],
+    ),
+)
+def test_python_process_entrypoints_return_zero_for_preflight(
+    prefix: list[str],
+    tmp_path: Path,
+) -> None:
+    target = tmp_path / "preflight-output"
+    completed = subprocess.run(
+        [
+            *prefix,
+            "preflight",
+            "--config",
+            "smoke",
+            "--override",
+            f"environment.output_dir={target}",
+        ],
+        cwd=REPOSITORY_ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert completed.returncode == 0, completed.stderr
+    assert "status=passed" in completed.stdout
+    assert not target.exists()
+
+
+@pytest.mark.parametrize(
+    "prefix",
+    (
+        [sys.executable, "main.py"],
+        [sys.executable, "-m", "phmfactory"],
+    ),
+)
+def test_python_process_entrypoints_return_nonzero_for_invalid_config(
+    prefix: list[str],
+    tmp_path: Path,
+) -> None:
+    missing = tmp_path / "missing.yaml"
+    completed = subprocess.run(
+        [*prefix, "preflight", "--config", str(missing)],
+        cwd=REPOSITORY_ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert completed.returncode != 0
+    assert "was not found" in completed.stderr
+
+
+def test_root_main_is_only_a_process_wrapper(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     calls: list[object] = []
-    monkeypatch.setattr(cli, "main", lambda argv=None: calls.append(argv))
-    runpy.run_path(str(REPOSITORY_ROOT / "main.py"), run_name="__main__")
+    monkeypatch.setattr(cli, "entrypoint", lambda argv=None: calls.append(argv) or 0)
+
+    with pytest.raises(SystemExit) as error:
+        runpy.run_path(str(REPOSITORY_ROOT / "main.py"), run_name="__main__")
+
+    assert error.value.code == 0
     assert calls == [None]
 
 


### PR DESCRIPTION
## Objective

Deliver a truthful, copy-pasteable first-run path for the PHMFactory v0.3 pre-release:

```text
install from the real repository
→ doctor
→ preflight
→ offline demo
→ find results and the run manifest
```

This PR supersedes its earlier narrow CLI-router framing. The implementation now closes the complete user-facing Slice A while preserving the existing config-first runtime and protected factory algorithms.

## Root cause fixed

The installed console script previously pointed to `phmfactory.cli:main`. Programmatic commands such as `preflight` return dictionaries and `doctor` returns check records. The generated console wrapper passed those successful objects to `sys.exit`, which printed the object and returned process exit code `1`.

The public contracts are now separated:

```text
phmfactory.cli.main(argv)
  → programmatic API
  → returns structured command or Pipeline results

phmfactory.cli.entrypoint(argv)
  → process API
  → discards a successful structured result
  → returns integer exit code 0
  → preserves argparse exits and runtime failures
```

The following process entrypoints use the same integer boundary:

```text
phmfactory
python -m phmfactory
python main.py
```

## User-facing commands

- `phmfactory doctor` performs real core imports, resolves the packaged smoke config, checks Pipeline discoverability, and proves output writability without training.
- `phmfactory preflight --config ...` resolves the exact config and checks the selected Pipeline and output location without importing or executing training code.
- `phmfactory demo` runs the maintained repository-shipped CPU Dummy experiment; explicit user overrides win over bounded demo defaults.
- `phmfactory data ...` remains isolated in its command module.

## Truthful documentation

- README and README_CN use the current real repository `PHMbench/PHM-Vibench` for clone, badges, and Issues.
- The brand/package remains `PHMFactory` / `phmfactory`, with the not-yet-completed repository rename stated explicitly.
- The maintained pre-release install path is `python -m pip install -e .`; no package-index publication is claimed.
- Quickstart is organized around user actions, expected output, result locations, and repair steps rather than internal control-plane terminology.
- Stale v0.2 and personal-environment claims were removed from `KNOWN_LIMITATIONS.md`.

## Developer clarity

- CLI command implementations are split into small modules.
- `cli.py` owns only routing and the single experiment execution boundary.
- Public functions and process wrappers document responsibilities, side effects, and exit invariants.
- Programmatic compatibility is retained through `phmfactory.cli.main`.
- No Pipeline, data, model, task, trainer, metric, or scientific algorithm was changed.

## CI and tests

Current head: `df1f3d74ab27a4cac29a2ca6868c1664426b1a9e`

All current workflows pass:

- Core quality gates
  - docs and config contracts
  - Pipeline 06 shell contract
  - UXFD focused contract
  - offline user-first smoke
- PHMFactory public package
- PHMFactory CWRU bundle contract
- PHMFactory dependency ownership
- Repository layout
- Submodule policy
- PHMFactory release readiness

The public-package workflow verifies from a clean wheel installation:

```text
console help
module help
doctor/demo help
console preflight exits 0
module preflight exits 0
preflight leaves configured targets absent
invalid preflight exits non-zero
programmatic structured result remains available
```

The core offline job executes the exact documented path:

```text
editable install
→ phmfactory doctor
→ phmfactory preflight --config smoke
→ phmfactory demo
→ verify succeeded run_manifest and metrics artifacts
```

## Boundaries retained

```text
no CWRU revision/hash change
no repository rename
no 0.3.0.dev0 → 0.3.0 promotion
no tag or release
no PR #147/#148 integration
no experimental Pipeline algorithm rewrite
```
