### PR TITLE
refactor(config): establish one configuration truth across PHMFactory

### DIFF
--- a/.github/workflows/core-quality-gates.yml
+++ b/.github/workflows/core-quality-gates.yml
@@ -40,6 +40,15 @@ jobs:
       - name: Validate maintained configurations
         run: python -m scripts.validate_configs
 
+      - name: Verify one config truth across public tools
+        run: |
+          python -m py_compile \
+            phmfactory/config.py \
+            scripts/config_inspect.py \
+            scripts/validate_configs.py \
+            test/test_config_analysis_parity.py
+          python -m pytest test/test_config_analysis_parity.py -q
+
       - name: Verify generated configuration atlas
         run: |
           python -m scripts.gen_config_atlas
@@ -72,15 +81,17 @@ jobs:
       - name: Install focused test dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install "pytest>=7"
+          python -m pip install "pytest>=7" "PyYAML>=6"
 
-      - name: Compile Pipeline 06 shell and tests
+      - name: Compile Pipeline 06 adapter, shell, and tests
         run: |
           python -m py_compile \
+            phmfactory/runtime/pipeline06_adapter.py \
             src/Pipeline_06_Generative_Modeling.py \
             test/generative/test_pipeline06_import.py \
             test/generative/test_pipeline06_preflight.py \
-            test/generative/test_pipeline06_dispatch.py
+            test/generative/test_pipeline06_dispatch.py \
+            test/generative/test_pipeline06_compiled_config.py
 
       - name: Record focused environment
         run: python -m pip freeze > pipeline06-shell-environment.txt
@@ -93,6 +104,7 @@ jobs:
             test/generative/test_pipeline06_import.py \
             test/generative/test_pipeline06_preflight.py \
             test/generative/test_pipeline06_dispatch.py \
+            test/generative/test_pipeline06_compiled_config.py \
             2>&1 | tee pipeline06-shell-pytest.log
 
       - name: Upload focused diagnostics
@@ -243,6 +255,7 @@ jobs:
         run: |
           set -o pipefail
           phmfactory preflight --config smoke 2>&1 | tee offline-preflight.log
+          grep -E '^effective_config_sha256=[0-9a-f]{64}$' offline-preflight.log
           test ! -e results/demo/dummy_dg_smoke
 
       - name: Run the documented offline demo command
@@ -255,6 +268,7 @@ jobs:
         run: |
           python - <<'PY'
           import json
+          import re
           from pathlib import Path
 
           root = Path("results/demo/dummy_dg_smoke/.phmfactory/runs")
@@ -262,6 +276,10 @@ jobs:
           assert len(manifests) == 1, manifests
           payload = json.loads(manifests[0].read_text(encoding="utf-8"))
           assert payload["status"] == "succeeded"
+          assert re.fullmatch(
+              r"[0-9a-f]{64}",
+              payload["run_spec"]["effective_config_sha256"],
+          )
           roles = {item["role"] for item in payload["artifacts"]}
           assert "classification_test_metrics" in roles, roles
           assert "classification_aggregate_metrics" in roles, roles

--- a/.github/workflows/phmfactory-public-package.yml
+++ b/.github/workflows/phmfactory-public-package.yml
@@ -4,6 +4,8 @@ on:
   pull_request:
     paths:
       - "phmfactory/**"
+      - "scripts/config_inspect.py"
+      - "scripts/validate_configs.py"
       - "src/configs/config_utils.py"
       - "main.py"
       - "pyproject.toml"
@@ -17,6 +19,7 @@ on:
       - "configs/**"
       - "data/metadata_dummy.csv"
       - "data/raw/Dummy_Data/**"
+      - "test/test_config_analysis_parity.py"
       - "test/test_phmfactory_commands.py"
       - "test/test_phmfactory_entrypoints.py"
       - "test/test_phmfactory_config_resolver.py"
@@ -31,6 +34,8 @@ on:
       - main
     paths:
       - "phmfactory/**"
+      - "scripts/config_inspect.py"
+      - "scripts/validate_configs.py"
       - "src/configs/config_utils.py"
       - "main.py"
       - "pyproject.toml"
@@ -44,6 +49,7 @@ on:
       - "configs/**"
       - "data/metadata_dummy.csv"
       - "data/raw/Dummy_Data/**"
+      - "test/test_config_analysis_parity.py"
       - "test/test_phmfactory_commands.py"
       - "test/test_phmfactory_entrypoints.py"
       - "test/test_phmfactory_config_resolver.py"
@@ -76,16 +82,19 @@ jobs:
       - name: Install focused tooling
         run: |
           python -m pip install --upgrade pip
-          python -m pip install "build>=1.2" "pytest>=7" PyYAML
+          python -m pip install "build>=1.2" "pytest>=7" "PyYAML>=6" "pydantic>=2"
 
-      - name: Compile public package and dispatcher
+      - name: Compile public package and config adapters
         run: >-
           python -m py_compile
           phmfactory/*.py
           phmfactory/commands/*.py
           phmfactory/runtime/*.py
+          scripts/config_inspect.py
+          scripts/validate_configs.py
           src/configs/config_utils.py
           main.py
+          test/test_config_analysis_parity.py
           test/test_phmfactory_commands.py
           test/test_phmfactory_entrypoints.py
           test/test_phmfactory_config_resolver.py
@@ -95,10 +104,11 @@ jobs:
           test/test_runtime_execution.py
           test/test_runtime_attestation.py
 
-      - name: Run focused public API tests
+      - name: Run focused public API and config parity tests
         run: >-
           python -m pytest -vv
           --junitxml=pytest-public-package.xml
+          test/test_config_analysis_parity.py
           test/test_phmfactory_commands.py
           test/test_phmfactory_entrypoints.py
           test/test_phmfactory_config_resolver.py
@@ -151,6 +161,7 @@ jobs:
               "phmfactory/runtime/spec.py",
               "phmfactory/runtime/execution.py",
               "phmfactory/runtime/attestation.py",
+              "phmfactory/runtime/pipeline06_adapter.py",
               "src/__init__.py",
               "src/configs/config_utils.py",
               "configs/__init__.py",
@@ -226,7 +237,7 @@ jobs:
           fi
           grep -F "was not found" /tmp/phmfactory-invalid-preflight.log
 
-      - name: Verify clean installed experiment dispatch
+      - name: Verify clean installed experiment dispatch uses compiled config
         shell: bash
         run: |
           set -euxo pipefail
@@ -239,23 +250,23 @@ jobs:
 
           import data
           from phmfactory import cli
-          from phmfactory.config import resolve_config
-          from src.configs.config_utils import load_config
+          from phmfactory.config import analyze_config
 
-          resolved = resolve_config("smoke")
-          assert resolved.path.is_file(), resolved.path
-          assert resolved.data["data"]["metadata_file"] == "metadata_dummy.csv"
+          analysis = analyze_config("smoke")
+          assert analysis.path.is_file(), analysis.path
+          assert analysis.effective_config["data"]["metadata_file"] == "metadata_dummy.csv"
           data_root = Path(data.__file__).resolve().parent
           assert (data_root / "metadata_dummy.csv").is_file()
           assert (data_root / "raw/Dummy_Data/dummy1.csv").is_file()
           assert (data_root / "raw/Dummy_Data/dummy2.csv").is_file()
 
           def pipeline(args):
-              config = load_config(args.config_path)
-              assert config.data.metadata_file == "metadata_dummy.csv"
-              assert config.model.name == "M_01_ISFM"
-              assert config.task.name == "classification"
-              assert config.trainer.device == "cpu"
+              config = args.compiled_run_spec.runtime_config()
+              assert config["data"]["metadata_file"] == "metadata_dummy.csv"
+              assert config["model"]["name"] == "M_01_ISFM"
+              assert config["task"]["name"] == "classification"
+              assert config["trainer"]["device"] == "cpu"
+              assert args.effective_config_sha256 == args.compiled_run_spec.effective_config_sha256
               return "wheel-dispatch-pass"
 
           real_import_module = cli.importlib.import_module
@@ -273,4 +284,5 @@ jobs:
           payload = json.loads(manifests[0].read_text(encoding="utf-8"))
           assert payload["status"] == "succeeded"
           assert payload["run_spec"]["pipeline"] == "Pipeline_01_Fault_Diagnosis"
+          assert payload["run_spec"]["effective_config_sha256"] == analysis.effective_config_sha256
           PY

--- a/apps/streamlit/README.md
+++ b/apps/streamlit/README.md
@@ -1,187 +1,176 @@
 # PHMFactory Streamlit Experiment Workspace
 
-This directory contains the optional, configuration-first web workspace for
-PHMFactory. It is a user-facing adapter around the maintained CLI, not a second
+This optional browser workspace helps users select a maintained template, edit a bounded
+parameter surface, validate the exact configuration, launch the public CLI, and inspect
+logs and artifacts.
+
+It is an adapter around PHMFactory—not a second configuration parser, scheduler, or
 training framework.
-
-```text
-validated registry template
-+ first-run readiness checks
-+ portable YAML snapshot
-+ typed CLI overrides
-+ managed main.py process
-+ bounded result discovery
-```
-
-The experiment contract remains:
-
-```bash
-python main.py --config <yaml> [--override key=value ...]
-```
-
-The application never imports a Pipeline function, does not modify `main.py`, and
-does not change the five-block configuration schema.
 
 ## Install and start
 
-Install the core environment first, then the optional UI layer:
+Install the core source checkout first, then the optional UI dependencies:
 
 ```bash
-pip install -r requirements.txt
-pip install -r apps/streamlit/requirements.txt
+python -m pip install -e .
+python -m pip install -r apps/streamlit/requirements.txt
 streamlit run apps/streamlit/app.py
 ```
 
-`apps/streamlit/app.py` is the only maintained UI entrypoint. The historical
-`app/` prototype and root compatibility launcher were archived outside the public
-framework before removal.
-
-Run the command from the repository root. Streamlit 1.37 or newer is required for
-independent live-log refresh through `st.fragment`.
+Run the command from the repository root. `apps/streamlit/app.py` is the only maintained
+web entrypoint.
 
 ## First experiment
 
-Use the sidebar action **Use safe CPU smoke defaults**. It resets only the
-configuration editor; existing run history is preserved.
-
-The safe defaults are:
+Use **Use safe CPU smoke defaults** in the sidebar. It selects:
 
 ```text
 Template: demo_00_smoke_dummy_dg
 Mode:     Quick Start
 Device:   cpu
 Epochs:   1
+Data:     repository-shipped Dummy files
 ```
 
-The template uses repository-shipped dummy data and is the recommended way to
-verify the environment before selecting an external dataset or GPU.
+The workspace then guides the user through four steps:
 
-The workspace now checks, before launch:
+1. select a maintained template;
+2. change only the parameters needed for this run;
+3. validate the exact effective configuration and launch it;
+4. inspect live logs, metrics, files, and the reproduction command.
 
-- repository entrypoint and config directory;
-- Streamlit, PyYAML, PyTorch, and Lightning availability;
-- repository-shipped smoke assets;
-- write access for `outputs/streamlit/`;
-- whether `configs/local/local.yaml` is changing machine-local defaults;
-- whether the selected template's data directory and metadata file exist.
+## One configuration truth
 
-A failed readiness check does not prevent users from inspecting or downloading a
-valid configuration, but the **Run experiment** action stays disabled until the
-environment and selected data are ready.
-
-The workspace guides the user through four steps:
-
-1. select a maintained registry template;
-2. adjust a small catalog-approved parameter surface;
-3. validate and launch the public CLI;
-4. inspect live logs, metrics, images, artifacts, and the immutable command.
-
-## Template guidance
-
-User-facing template guidance is declarative in `template_profiles.yaml`. Each
-maintained demo can describe:
-
-- difficulty;
-- bundled or external data requirements;
-- recommended device;
-- honest runtime guidance;
-- onboarding badges and the next action.
-
-Adding a new template profile must not add model-specific branches to
-`workspace.py`. Unknown registry templates receive a conservative generic profile.
-
-## Experience modes
-
-### Quick Start
-
-Quick Start exposes only onboarding-safe fields. The selected template is resolved
-into a portable standalone YAML before execution. Machine-local configuration is
-not baked into that snapshot.
-
-### Advanced
-
-Advanced adds:
-
-- catalog-defined safe fields and ordered legacy aliases;
-- a portable full-YAML editor;
-- one typed `key=value` override per line;
-- a configuration diff;
-- the exact planned and actual reproduction commands.
-
-The precedence model is explicit:
+Streamlit delegates composition and validation to the same public inspector used by:
 
 ```text
-portable YAML
-< configs/local/local.yaml (when present)
-< catalog-safe CLI overrides
-< raw CLI overrides
+phmfactory preflight
+phmfactory run
+scripts.validate_configs
+scripts.config_inspect
 ```
 
-Overrides are passed as argv elements. The application never builds a
-`shell=True` command.
+The UI does not implement `base_configs` merging, Pipeline canonicalization, or hidden
+machine overrides itself.
+
+The public precedence is:
+
+```text
+base_configs
+< selected experiment YAML
+< explicit local config, only when supplied by a CLI user
+< explicit overrides
+```
+
+The current UI intentionally does not auto-discover or silently apply
+`configs/local/local.yaml`. Quick Start and Advanced mode therefore have no invisible
+machine-local layer. Machine-specific values are edited in the standalone YAML or entered
+as explicit overrides. The planned command shown by the UI is the command that is
+launched.
+
+A successful validation report carries the same `effective_config_sha256` that CLI
+preflight and the final run manifest record. If the visible YAML or overrides change, the
+validation becomes stale and the Run button is disabled until validation runs again.
+
+## Quick Start mode
+
+Quick Start exposes only catalog-approved fields. The selected template is resolved once
+through the public inspector. UI values are converted into typed `key=value` argv tokens.
+
+Use this mode for:
+
+- the first offline smoke;
+- common epoch, device, worker, seed, or data-path changes;
+- users who do not need to edit the full YAML.
+
+## Advanced mode
+
+Advanced mode adds:
+
+- the same safe field catalog;
+- a standalone effective-YAML editor;
+- one typed override per line;
+- a configuration diff;
+- exact planned and actual reproduction commands.
+
+The YAML shown in this mode already contains the fully resolved base configuration. It
+has no hidden local layer. Raw overrides remain highest precedence and are passed as argv
+elements; the UI never builds a `shell=True` command.
+
+## Readiness and launch blockers
+
+Before launch, the workspace checks:
+
+- the repository entrypoint and configuration inventory;
+- required Python imports;
+- repository-shipped smoke assets;
+- output-directory writability;
+- selected template data and metadata availability;
+- public config inspection and sanity checks.
+
+A failed readiness check does not prevent users from inspecting the template or editing
+YAML, but execution remains disabled until the relevant environment, data, or config
+problem is fixed.
 
 ## Run lifecycle
 
-Each run creates a durable workspace:
+Each UI run creates a managed workspace:
 
 ```text
-outputs/streamlit/<run_id>/
+outputs/streamlit/<run-id>/
 ├── execution.yaml
 ├── run.json
 └── run.log
 ```
 
-`run.json` is written atomically and records the template, mode, command,
-overrides, PID, timestamps, exit status, validation signature, output root, and
-restart ancestry.
+The process then invokes the public command contract. PHMFactory's own runtime writes the
+invocation manifest below the configured experiment output directory:
+
+```text
+<environment.output_dir>/.phmfactory/runs/<run-id>/run_manifest.json
+```
 
 The UI supports:
 
-- **Run** — start one managed experiment process;
+- **Run** — start one experiment process;
 - **Cancel** — terminate the process group, then force-kill after a grace period;
-- **Restart same run** — launch from the immutable YAML and override snapshot.
+- **Restart same run** — reuse the immutable YAML and override snapshot.
 
-Pause/resume is intentionally not implemented. It is not portable across Windows,
-CUDA workers, and data-loader subprocesses.
-
-A single Streamlit worker manages one active experiment at a time. This keeps the
-optional UI simple and prevents it from becoming an implicit scheduler.
+Pause/resume is intentionally absent because it is not portable across Windows, CUDA,
+and data-loader subprocesses. One Streamlit worker manages one active experiment at a
+time; the workspace is not an implicit cluster scheduler.
 
 ## Results
 
-Result discovery is bounded by directory depth, entry count, file count, metric
-file size, and metric row count. Symbolic links are skipped.
+Result discovery is bounded by directory depth, entry count, file count, metric file
+size, and row count. Symbolic links are skipped.
 
-The result tabs provide:
+The result views provide:
 
 - **Overview** — actual command, output roots, run metadata;
-- **Metrics** — headline values plus CSV/JSON tables;
-- **Artifacts** — images, file inventory, small-file downloads;
+- **Metrics** — headline values plus small CSV/JSON tables;
+- **Artifacts** — images, file inventory, and small-file downloads;
 - **Logs** — live tail and full-log download.
 
-Missing or malformed optional artifacts never invalidate a completed run. The user
-still receives the process status, command, manifest, and raw log.
+Malformed optional artifacts do not erase the process status, command, run manifest, or
+raw log.
 
-## Compatibility and extension boundary
+## Extension boundaries
 
-- `configs/config_registry.csv` remains the source of template identity/status.
-- `field_catalog.yaml` remains the source of editable fields, aliases, widgets,
-  and template groups.
-- `template_profiles.yaml` remains the source of user-facing difficulty, data,
-  device, and first-action guidance.
-- Unknown future registry columns are retained as metadata.
-- Key migrations should add an alias in `field_catalog.yaml`, not a model-specific
-  conditional in `app.py`.
-- Process lifecycle is isolated in `run_service.py`.
-- Artifact parsing is isolated in `result_service.py`.
-- Runtime/local-config precedence is isolated in `runtime_policy.py`.
-- First-run checks and template data resolution are isolated in `onboarding.py`.
-- Visual components and live-run views are isolated in `ui_theme.py`,
-  `ui_onboarding.py`, and `ui_runtime.py`.
+Use declarative files rather than model-specific UI branches:
 
-New metric formats should be added to `result_service.py`; new safe user-facing
-fields should be added to `field_catalog.yaml`; new user guidance should be added
-to `template_profiles.yaml`.
+- `configs/config_registry.csv` — maintained template identity and status;
+- `field_catalog.yaml` — editable fields, aliases, widgets, and template groups;
+- `template_profiles.yaml` — difficulty, data, device, and first-action guidance;
+- `config_service.py` — UI-safe serialization and public-inspector adapter;
+- `runtime_policy.py` — temporary standalone YAML inspection;
+- `run_service.py` — process lifecycle;
+- `result_service.py` — bounded artifact parsing;
+- `onboarding.py` — environment and data readiness;
+- `ui_*.py` — visual components only.
+
+New config semantics belong in `phmfactory.config`, not in Streamlit. New metrics formats
+belong in `result_service.py`. New safe fields belong in `field_catalog.yaml`.
 
 ## Validation
 
@@ -196,44 +185,45 @@ python -m pytest \
   test/test_streamlit_ui_imports.py
 python -m scripts.validate_configs
 python -m scripts.validate_docs
-python -m scripts.config_inspect \
-  --config configs/demo/00_smoke/dummy_dg.yaml \
-  --override trainer.num_epochs=1
-python main.py \
-  --config configs/demo/00_smoke/dummy_dg.yaml \
-  --override trainer.num_epochs=1 \
-  --override data.num_workers=0
+phmfactory preflight --config smoke
+phmfactory demo
 ```
 
-The focused Streamlit service tests run on Linux and Windows through
+Focused UI tests run on both Linux and Windows through
 `.github/workflows/streamlit-quality-gates.yml`.
 
 ## Troubleshooting
 
-### The inspector reports a missing module
+### Validation and the CLI disagree
 
-Install the repository's core dependencies. The optional UI requirements do not
-replace the training environment. The readiness panel lists the missing module and
-the relevant installation action.
+Copy the planned command from the UI and run it in the same environment. Report:
 
-### A data path does not exist
+```text
+exact command
+UI effective_config_sha256
+CLI preflight effective_config_sha256
+complete stderr
+```
 
-The selected template card displays the resolved data root and metadata path. Use
-the offline CPU smoke template, edit `data.data_dir` in Advanced mode, or put the
-machine-specific path in `configs/local/local.yaml`.
+Different hashes for the same visible YAML and overrides are a configuration-parity bug.
 
-### A GPU run fails
+### A local path is missing
 
-Return to **Use safe CPU smoke defaults**, verify the offline run, then validate
-CUDA and PyTorch independently.
+Use the offline smoke template to separate installation from external data availability.
+In Advanced mode, edit `data.data_dir` in the standalone YAML or add an explicit raw
+override. The UI does not read a hidden local file.
 
-### The worker restarted during a run
+### A dependency import fails
 
-On POSIX, a still-live process is marked `detached` and automatic cancellation is
-disabled to avoid killing a reused PID. Use the operating-system process manager,
-then start a new run.
+Run `phmfactory doctor` in the same environment. The optional UI requirements do not
+replace the core training environment.
+
+### CUDA initialization fails
+
+Return to CPU smoke, then verify the installed PyTorch build, driver, and device outside
+PHMFactory before changing experiment code.
 
 ### No structured metrics appear
 
-The run can still be inspected through `run.log`, `run.json`, and the output file
-inventory. Optional artifact parsing is deliberately failure-tolerant.
+Inspect `run.log`, `run.json`, and the PHMFactory `run_manifest.json`. Optional parser
+failure does not invalidate those primary records.

--- a/apps/streamlit/config_service.py
+++ b/apps/streamlit/config_service.py
@@ -1,8 +1,10 @@
-"""Configuration adapter for the optional PHM-Vibench Streamlit UI.
+"""Configuration utilities for the optional PHMFactory Streamlit workspace.
 
-The module has no Streamlit dependency. It treats the repository registry and
-``scripts.config_inspect`` CLI as authoritative, while keeping UI aliases and
-grouping declarative in ``field_catalog.yaml``.
+This module owns UI-only concerns: registry parsing, safe widgets, override
+serialization, command rendering, and conversion of the public config inspector's JSON
+into a ``ValidationReport``.  It does not merge base configs, canonicalize Pipelines, or
+apply hidden machine-local state; those semantics belong exclusively to
+``phmfactory.config`` and ``scripts.config_inspect``.
 """
 
 from __future__ import annotations
@@ -33,23 +35,23 @@ _OVERRIDE_KEY = re.compile(r"^[A-Za-z_][A-Za-z0-9_.]*$")
 
 
 class ConfigServiceError(RuntimeError):
-    """Base class for user-correctable configuration failures."""
+    """Base class for user-correctable workspace configuration failures."""
 
 
 class RegistryError(ConfigServiceError):
-    pass
+    """Raised when the maintained template registry is malformed."""
 
 
 class ConfigPathError(ConfigServiceError):
-    pass
+    """Raised when a UI-selected repository path is unsafe or missing."""
 
 
 class ConfigFormatError(ConfigServiceError):
-    pass
+    """Raised when edited YAML or catalog data is malformed."""
 
 
 class OverrideError(ConfigServiceError):
-    pass
+    """Raised when a user override cannot be represented safely."""
 
 
 @dataclass(frozen=True)
@@ -92,12 +94,16 @@ class Catalog:
 
 @dataclass(frozen=True)
 class ValidationReport:
+    """Public inspector result presented by the UI without changing its semantics."""
+
     ok: bool
     command: Tuple[str, ...]
     resolved: Mapping[str, Any] = field(default_factory=dict)
     sources: Mapping[str, str] = field(default_factory=dict)
     targets: Mapping[str, Any] = field(default_factory=dict)
     sanity: Tuple[Mapping[str, Any], ...] = ()
+    effective_config_sha256: str = ""
+    local_config_path: str | None = None
     stdout: str = ""
     stderr: str = ""
     error: str = ""
@@ -108,6 +114,8 @@ class ValidationReport:
 
 
 def find_repo_root(start: Optional[Path] = None) -> Path:
+    """Locate a checkout containing the public launcher and config directory."""
+
     current = (start or Path(__file__)).resolve()
     if current.is_file():
         current = current.parent
@@ -115,8 +123,8 @@ def find_repo_root(start: Optional[Path] = None) -> Path:
         if (candidate / "main.py").is_file() and (candidate / "configs").is_dir():
             return candidate
     raise ConfigPathError(
-        "Could not locate the PHM-Vibench repository root. Start the app from "
-        "a checkout containing main.py and configs/."
+        "Could not locate the PHMFactory repository root. Start the app from a "
+        "checkout containing main.py and configs/."
     )
 
 
@@ -125,9 +133,17 @@ def _within(root: Path, candidate: Path) -> Path:
     candidate = candidate.resolve()
     try:
         candidate.relative_to(root)
-    except ValueError as exc:
-        raise ConfigPathError(f"Path escapes the repository root: {candidate}") from exc
+    except ValueError as error:
+        raise ConfigPathError(f"Path escapes the repository root: {candidate}") from error
     return candidate
+
+
+def _is_relative_to(path: Path, parent: Path) -> bool:
+    try:
+        path.relative_to(parent)
+        return True
+    except ValueError:
+        return False
 
 
 def resolve_repo_path(
@@ -138,6 +154,8 @@ def resolve_repo_path(
     must_exist: bool = True,
     yaml_only: bool = False,
 ) -> Path:
+    """Resolve a user-selected path while preventing repository traversal."""
+
     if not isinstance(value, str) or not value.strip():
         raise ConfigPathError("Configuration path is empty.")
     raw = Path(value.strip())
@@ -159,18 +177,12 @@ def resolve_repo_path(
     return resolved
 
 
-def _is_relative_to(path: Path, parent: Path) -> bool:
-    try:
-        path.relative_to(parent)
-        return True
-    except ValueError:
-        return False
-
-
 def load_registry(
     repo_root: Path,
     registry_path: str = "configs/config_registry.csv",
 ) -> Tuple[RegistryEntry, ...]:
+    """Load maintained templates while preserving future registry columns."""
+
     path = resolve_repo_path(repo_root, registry_path, yaml_only=False)
     try:
         with path.open("r", encoding="utf-8-sig", newline="") as handle:
@@ -186,10 +198,11 @@ def load_registry(
                     + ", ".join(sorted(missing))
                 )
             entries: List[RegistryEntry] = []
-            seen = set()
+            seen: set[str] = set()
             for line_no, row in enumerate(reader, start=2):
                 data = {str(key): (value or "").strip() for key, value in row.items()}
-                entry_id, entry_path = data.get("id", ""), data.get("path", "")
+                entry_id = data.get("id", "")
+                entry_path = data.get("path", "")
                 if not entry_id or not entry_path:
                     raise RegistryError(
                         f"Registry row {line_no} must include non-empty id and path."
@@ -212,40 +225,46 @@ def load_registry(
                         metadata=data,
                     )
                 )
-    except OSError as exc:
-        raise RegistryError(f"Could not read registry: {path}") from exc
+    except OSError as error:
+        raise RegistryError(f"Could not read registry: {path}") from error
     if not entries:
         raise RegistryError(f"Registry contains no entries: {path}")
     return tuple(entries)
 
 
+def _yaml_error(error: yaml.YAMLError, message: str) -> str:
+    mark = getattr(error, "problem_mark", None)
+    return (
+        f"{message} at line {mark.line + 1}, column {mark.column + 1}"
+        if mark is not None
+        else message
+    )
+
+
 def load_yaml_mapping(path: Path) -> Dict[str, Any]:
+    """Read one UTF-8 YAML mapping for UI catalogs or edited source."""
+
     try:
         with path.open("r", encoding="utf-8") as handle:
             value = yaml.safe_load(handle) or {}
-    except FileNotFoundError as exc:
-        raise ConfigPathError(f"Configuration file does not exist: {path}") from exc
-    except UnicodeDecodeError as exc:
-        raise ConfigFormatError(f"Configuration must be UTF-8 encoded: {path}") from exc
-    except yaml.YAMLError as exc:
-        raise ConfigFormatError(_yaml_error(exc, f"Invalid YAML: {path}")) from exc
+    except FileNotFoundError as error:
+        raise ConfigPathError(f"Configuration file does not exist: {path}") from error
+    except UnicodeDecodeError as error:
+        raise ConfigFormatError(f"Configuration must be UTF-8 encoded: {path}") from error
+    except yaml.YAMLError as error:
+        raise ConfigFormatError(_yaml_error(error, f"Invalid YAML: {path}")) from error
     if not isinstance(value, dict):
         raise ConfigFormatError(f"YAML root must be a mapping: {path}")
     return value
 
 
-def _yaml_error(error: yaml.YAMLError, message: str) -> str:
-    mark = getattr(error, "problem_mark", None)
-    if mark is None:
-        return message
-    return f"{message} at line {mark.line + 1}, column {mark.column + 1}"
-
-
 def parse_yaml_text(text: str, *, source: str = "edited configuration") -> Dict[str, Any]:
+    """Parse standalone effective YAML and require the maintained five blocks."""
+
     try:
         value = yaml.safe_load(text) or {}
-    except yaml.YAMLError as exc:
-        raise ConfigFormatError(_yaml_error(exc, f"Invalid YAML in {source}")) from exc
+    except yaml.YAMLError as error:
+        raise ConfigFormatError(_yaml_error(error, f"Invalid YAML in {source}")) from error
     if not isinstance(value, dict):
         raise ConfigFormatError(f"{source} must contain a YAML mapping at its root.")
     missing = [block for block in CONFIG_BLOCKS if not isinstance(value.get(block), dict)]
@@ -271,6 +290,8 @@ def _number(value: Any, name: str) -> Optional[float]:
 
 
 def load_catalog(path: Path) -> Catalog:
+    """Load declarative UI fields without embedding model-specific Python branches."""
+
     raw = load_yaml_mapping(path)
     version = raw.get("version", 1)
     if not isinstance(version, int) or version < 1:
@@ -367,8 +388,8 @@ def validate_override_key(key: str) -> str:
     key = key.strip() if isinstance(key, str) else ""
     if not key or not _OVERRIDE_KEY.fullmatch(key):
         raise OverrideError(
-            f"Invalid override key {key!r}. Use dot-delimited identifiers "
-            "such as trainer.num_epochs."
+            f"Invalid override key {key!r}. Use dot-delimited identifiers such as "
+            "trainer.num_epochs."
         )
     if key == "base_configs" or key.startswith("base_configs."):
         raise OverrideError("base_configs cannot be changed through the UI override editor.")
@@ -385,19 +406,19 @@ def serialize_override_value(value: Any) -> str:
     if isinstance(value, (str, bool, list, dict)) or value is None:
         try:
             return json.dumps(value, ensure_ascii=False, separators=(",", ":"))
-        except (TypeError, ValueError) as exc:
+        except (TypeError, ValueError) as error:
             raise OverrideError(
                 f"Override value is not JSON/YAML serializable: {value!r}"
-            ) from exc
+            ) from error
     raise OverrideError(
-        f"Unsupported override value type: {type(value).__name__}. Use a "
-        "string, number, boolean, list, mapping, or null."
+        f"Unsupported override value type: {type(value).__name__}. Use a string, "
+        "number, boolean, list, mapping, or null."
     )
 
 
 def parse_override_lines(text: str) -> Tuple[Tuple[str, Any], ...]:
     parsed: List[Tuple[str, Any]] = []
-    seen = set()
+    seen: set[str] = set()
     for line_no, raw_line in enumerate(text.splitlines(), start=1):
         line = raw_line.strip()
         if not line or line.startswith("#"):
@@ -413,8 +434,8 @@ def parse_override_lines(text: str) -> Tuple[Tuple[str, Any], ...]:
         seen.add(key)
         try:
             value = yaml.safe_load(raw_value.strip())
-        except yaml.YAMLError as exc:
-            raise OverrideError(f"Invalid YAML value on override line {line_no}.") from exc
+        except yaml.YAMLError as error:
+            raise OverrideError(f"Invalid YAML value on override line {line_no}.") from error
         serialize_override_value(value)
         parsed.append((key, value))
     return tuple(parsed)
@@ -486,6 +507,8 @@ def build_main_command(
     *,
     python_executable: Optional[str] = None,
 ) -> Tuple[str, ...]:
+    """Build the exact argv list; no shell interpolation is used."""
+
     return (
         python_executable or sys.executable,
         "main.py",
@@ -510,6 +533,8 @@ def inspect_config(
     python_executable: Optional[str] = None,
     local_config_path: Optional[Path] = None,
 ) -> ValidationReport:
+    """Invoke the public inspector and preserve its effective config identity."""
+
     command = [
         python_executable or sys.executable,
         "-m",
@@ -522,7 +547,7 @@ def inspect_config(
         "json",
     ]
     if local_config_path is not None:
-        command.extend(("--local_config", str(local_config_path.resolve())))
+        command.extend(("--local-config", str(local_config_path.resolve())))
     command.extend(override_args(overrides))
     try:
         completed = subprocess.run(
@@ -533,19 +558,19 @@ def inspect_config(
             timeout=timeout,
             check=False,
         )
-    except subprocess.TimeoutExpired as exc:
+    except subprocess.TimeoutExpired as error:
         return ValidationReport(
             False,
             tuple(command),
-            stdout=exc.stdout or "",
-            stderr=exc.stderr or "",
+            stdout=error.stdout or "",
+            stderr=error.stderr or "",
             error=f"Configuration inspection timed out after {timeout:g} seconds.",
         )
-    except OSError as exc:
+    except OSError as error:
         return ValidationReport(
             False,
             tuple(command),
-            error=f"Could not start the config inspector: {exc}",
+            error=f"Could not start the config inspector: {error}",
         )
     if completed.returncode != 0:
         return ValidationReport(
@@ -554,8 +579,8 @@ def inspect_config(
             stdout=completed.stdout,
             stderr=completed.stderr,
             error=(
-                "The repository config inspector rejected the configuration. "
-                "Review stderr and install core dependencies if an import failed."
+                "The repository config inspector rejected the configuration. Review "
+                "stderr and install core dependencies if an import failed."
             ),
         )
     try:
@@ -576,14 +601,20 @@ def inspect_config(
             stderr=completed.stderr,
             error="The config inspector returned an unexpected payload.",
         )
-    resolved, sanity_raw = payload.get("resolved") or {}, payload.get("sanity") or []
-    if not isinstance(resolved, dict) or not isinstance(sanity_raw, list):
+    resolved = payload.get("resolved") or {}
+    sanity_raw = payload.get("sanity") or []
+    digest = str(payload.get("effective_config_sha256") or "")
+    if (
+        not isinstance(resolved, dict)
+        or not isinstance(sanity_raw, list)
+        or len(digest) != 64
+    ):
         return ValidationReport(
             False,
             tuple(command),
             stdout=completed.stdout,
             stderr=completed.stderr,
-            error="The config inspector returned an unexpected payload.",
+            error="The config inspector returned an incomplete payload.",
         )
     sanity = tuple(item for item in sanity_raw if isinstance(item, dict))
     passed = bool(sanity) and all(bool(item.get("ok")) for item in sanity)
@@ -594,6 +625,8 @@ def inspect_config(
         sources=payload.get("sources") or {},
         targets=payload.get("targets") or {},
         sanity=sanity,
+        effective_config_sha256=digest,
+        local_config_path=payload.get("local_config_path"),
         stdout=completed.stdout,
         stderr=completed.stderr,
         error="" if passed else "One or more repository sanity checks failed.",
@@ -607,21 +640,13 @@ def inspect_yaml_text(
     *,
     timeout: float = 90.0,
 ) -> ValidationReport:
+    """Inspect edited standalone YAML without a hidden local layer."""
+
     parse_yaml_text(yaml_text)
-    with tempfile.TemporaryDirectory(prefix="phm_vibench_streamlit_") as temp_dir:
+    with tempfile.TemporaryDirectory(prefix="phmfactory_streamlit_") as temp_dir:
         config_path = Path(temp_dir) / "edited_config.yaml"
-        empty_local = Path(temp_dir) / "empty_local.yaml"
         config_path.write_text(yaml_text, encoding="utf-8")
-        empty_local.write_text("{}\n", encoding="utf-8")
-        return inspect_config(
-            repo_root,
-            config_path,
-            overrides,
-            timeout=timeout,
-            # The YAML is already resolved. Prevent default local config from
-            # being applied a second time by the core loader.
-            local_config_path=empty_local,
-        )
+        return inspect_config(repo_root, config_path, overrides, timeout=timeout)
 
 
 def group_entries(

--- a/apps/streamlit/onboarding.py
+++ b/apps/streamlit/onboarding.py
@@ -1,8 +1,8 @@
 """First-run readiness and template guidance for the Streamlit workspace.
 
-This module deliberately has no Streamlit dependency. It converts repository,
-Python-environment, and selected-template facts into immutable reports that the
-UI can render without duplicating runtime logic.
+The module has no Streamlit dependency. It converts repository, Python-environment, and
+selected-template facts into immutable reports. Configuration composition remains owned
+by the public PHMFactory inspector; no machine-local YAML is discovered here.
 """
 
 from __future__ import annotations
@@ -106,12 +106,12 @@ _DEPENDENCIES = (
 def _read_yaml_mapping(path: Path) -> Mapping[str, Any]:
     try:
         value = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
-    except FileNotFoundError as exc:
-        raise OnboardingError(f"Template profile file does not exist: {path}") from exc
-    except (OSError, UnicodeDecodeError) as exc:
-        raise OnboardingError(f"Could not read template profile file: {path}") from exc
-    except yaml.YAMLError as exc:
-        raise OnboardingError(f"Invalid YAML in template profile file: {path}") from exc
+    except FileNotFoundError as error:
+        raise OnboardingError(f"Template profile file does not exist: {path}") from error
+    except (OSError, UnicodeDecodeError) as error:
+        raise OnboardingError(f"Could not read template profile file: {path}") from error
+    except yaml.YAMLError as error:
+        raise OnboardingError(f"Invalid YAML in template profile file: {path}") from error
     if not isinstance(value, dict):
         raise OnboardingError("Template profile YAML root must be a mapping.")
     return value
@@ -179,7 +179,8 @@ def load_template_profiles(path: Path) -> Mapping[str, TemplateProfile]:
 
 
 def profile_for(
-    profiles: Mapping[str, TemplateProfile], template_id: str
+    profiles: Mapping[str, TemplateProfile],
+    template_id: str,
 ) -> TemplateProfile:
     """Return explicit metadata or a conservative generic profile."""
 
@@ -201,7 +202,8 @@ def profile_for(
 
 
 def apply_safe_defaults(
-    state: MutableMapping[str, Any], default_template_id: str
+    state: MutableMapping[str, Any],
+    default_template_id: str,
 ) -> None:
     """Reset only configuration UI state; never discard run history."""
 
@@ -265,7 +267,7 @@ def collect_environment_readiness(
             "ready" if repository_ready else "blocked",
             "main.py and configs/ are available."
             if repository_ready
-            else "The app is not running from a PHM-Vibench checkout.",
+            else "The app is not running from a PHMFactory checkout.",
             "Start Streamlit from the repository root."
             if not repository_ready
             else "",
@@ -321,18 +323,13 @@ def collect_environment_readiness(
         )
     )
 
-    local_config = root / "configs" / "local" / "local.yaml"
     checks.append(
         ReadinessCheck(
-            "local-config",
-            "Machine-local override",
-            "warning" if local_config.is_file() else "ready",
-            "configs/local/local.yaml is active and can change smoke defaults."
-            if local_config.is_file()
-            else "No machine-local override is active.",
-            "Review configs/local/local.yaml before the first run."
-            if local_config.is_file()
-            else "",
+            "config-inputs",
+            "Configuration inputs",
+            "ready",
+            "Only the selected template, visible edits, and explicit overrides are active.",
+            "",
         )
     )
     return ReadinessReport(tuple(checks))
@@ -345,7 +342,8 @@ def _expanded_path(repo_root: Path, raw: str) -> Path:
 
 
 def _resolved_data_paths(
-    repo_root: Path, resolved: Mapping[str, Any]
+    repo_root: Path,
+    resolved: Mapping[str, Any],
 ) -> Tuple[Path, Path] | None:
     data = resolved.get("data") if isinstance(resolved.get("data"), Mapping) else {}
     data_dir = data.get("data_dir") if isinstance(data, Mapping) else None
@@ -370,7 +368,7 @@ def assess_template_data(
     resolved: Mapping[str, Any],
     profile: TemplateProfile,
 ) -> TemplateDataStatus:
-    """Resolve the final selected-template data and return an actionable status."""
+    """Resolve selected-template data and return an actionable status."""
 
     root = Path(repo_root).resolve()
     missing_required = [
@@ -388,7 +386,7 @@ def assess_template_data(
         return TemplateDataStatus(
             False,
             "The selected configuration needs data.data_dir and data.metadata_file.",
-            "Set the missing data fields in Advanced mode or configs/local/local.yaml.",
+            "Set the fields in Advanced mode or add explicit raw overrides.",
         )
     data_root, metadata_path = resolved_paths
 
@@ -402,7 +400,7 @@ def assess_template_data(
         return TemplateDataStatus(
             False,
             f"{kind} is not ready. Missing: " + ", ".join(missing),
-            "Set data.data_dir in Advanced mode or configs/local/local.yaml, then validate again.",
+            "Set data.data_dir in Advanced mode or add an explicit override, then validate again.",
             data_root=str(data_root),
             metadata_path=str(metadata_path),
         )

--- a/apps/streamlit/runtime_policy.py
+++ b/apps/streamlit/runtime_policy.py
@@ -1,8 +1,8 @@
-"""Runtime configuration policy shared by the Streamlit UI layers.
+"""Streamlit adapters for PHMFactory's explicit configuration policy.
 
-PHM-Vibench applies ``configs/local/local.yaml`` inside the core loader. The UI
-therefore keeps editable YAML portable (resolved without that local layer) and
-lets validation/execution apply the local layer exactly once.
+The public resolver never discovers ``configs/local/local.yaml``.  Template inspection,
+edited YAML inspection, CLI preflight, and real execution therefore share the same
+precedence unless the user explicitly supplies a local config through the CLI.
 """
 
 from __future__ import annotations
@@ -28,18 +28,9 @@ def inspect_portable_config(
     *,
     timeout: float = 90.0,
 ) -> ValidationReport:
-    """Resolve a template while suppressing the default machine-local layer."""
+    """Inspect a template through the same explicit public precedence chain."""
 
-    with tempfile.TemporaryDirectory(prefix="phm_vibench_streamlit_") as temp_dir:
-        empty_local = Path(temp_dir) / "empty_local.yaml"
-        empty_local.write_text("{}\n", encoding="utf-8")
-        return inspect_config(
-            repo_root,
-            config_path,
-            overrides,
-            timeout=timeout,
-            local_config_path=empty_local,
-        )
+    return inspect_config(repo_root, config_path, overrides, timeout=timeout)
 
 
 def inspect_execution_yaml(
@@ -49,10 +40,10 @@ def inspect_execution_yaml(
     *,
     timeout: float = 90.0,
 ) -> ValidationReport:
-    """Validate portable YAML through the normal core precedence chain."""
+    """Validate edited standalone YAML without hidden machine-local inputs."""
 
     parse_yaml_text(yaml_text)
-    with tempfile.TemporaryDirectory(prefix="phm_vibench_streamlit_") as temp_dir:
+    with tempfile.TemporaryDirectory(prefix="phmfactory_streamlit_") as temp_dir:
         config_path = Path(temp_dir) / "execution.yaml"
         config_path.write_text(yaml_text, encoding="utf-8")
         return inspect_config(repo_root, config_path, overrides, timeout=timeout)

--- a/apps/streamlit/ui_onboarding.py
+++ b/apps/streamlit/ui_onboarding.py
@@ -16,7 +16,7 @@ _STATUS_ICON = {"ready": "✓", "warning": "!", "blocked": "×"}
 
 
 def template_option_label(template_id: str, profile: TemplateProfile) -> str:
-    """Keep the select box readable while exposing the experiment intent."""
+    """Keep the select box readable while exposing experiment intent."""
 
     return f"{profile.title} — {template_id}"
 
@@ -26,7 +26,7 @@ def render_readiness_sidebar(report: ReadinessReport) -> None:
     if report.can_execute and not report.warnings:
         st.sidebar.success("CPU smoke prerequisites look ready.")
     elif report.can_execute:
-        st.sidebar.warning("Ready with a machine-local configuration warning.")
+        st.sidebar.warning("Ready with non-blocking environment warnings.")
     else:
         st.sidebar.error(f"{len(report.blocked)} prerequisite(s) need attention.")
 
@@ -49,8 +49,8 @@ def render_readiness_banner(report: ReadinessReport) -> None:
         )
     elif report.warnings:
         st.warning(
-            "The environment is runnable, but configs/local/local.yaml is active. "
-            "Review it before treating the smoke run as a clean baseline."
+            "The environment is runnable, but one or more non-blocking checks should "
+            "be reviewed before launch."
         )
     else:
         st.success("Environment ready for the repository-shipped CPU smoke experiment.")

--- a/apps/streamlit/workspace.py
+++ b/apps/streamlit/workspace.py
@@ -1,4 +1,9 @@
-"""Application orchestration for the PHM-Vibench Streamlit workspace."""
+"""Application orchestration for the optional PHMFactory Streamlit workspace.
+
+The UI edits user intent and delegates configuration semantics to the same public
+inspector used by CLI preflight.  It does not auto-discover machine-local YAML, import a
+Pipeline, or define a second training framework.
+"""
 
 from __future__ import annotations
 
@@ -39,7 +44,7 @@ try:
         profile_for,
     )
     from .run_service import RunConflictError, RunRequest, RunServiceError, start_run
-    from .runtime_policy import inspect_execution_yaml, inspect_portable_config
+    from .runtime_policy import inspect_execution_yaml
     from .ui_onboarding import (
         render_launch_blockers,
         render_readiness_banner,
@@ -60,7 +65,7 @@ try:
         _render_template_summary,
         _render_validation,
     )
-except ImportError:  # pragma: no cover
+except ImportError:  # pragma: no cover - Streamlit may execute app.py as a script.
     from config_service import (  # type: ignore
         Catalog,
         ConfigServiceError,
@@ -96,7 +101,7 @@ except ImportError:  # pragma: no cover
         RunServiceError,
         start_run,
     )
-    from runtime_policy import inspect_execution_yaml, inspect_portable_config  # type: ignore
+    from runtime_policy import inspect_execution_yaml  # type: ignore
     from ui_onboarding import (  # type: ignore
         render_launch_blockers,
         render_readiness_banner,
@@ -141,28 +146,17 @@ def _cached_inspection(
     repo_root: str,
     config_path: str,
     overrides: Tuple[Tuple[str, Any], ...],
-    apply_local: bool,
 ) -> ValidationReport:
-    if apply_local:
-        return inspect_config(Path(repo_root), Path(config_path), overrides)
-    return inspect_portable_config(Path(repo_root), Path(config_path), overrides)
+    """Inspect a template through the single public config authority."""
+
+    return inspect_config(Path(repo_root), Path(config_path), overrides)
 
 
 def _signature(mode: str, source: str, overrides: Sequence[Tuple[str, Any]]) -> str:
+    """Identify the visible UI inputs that were validated."""
+
     payload = repr((mode, source, tuple(overrides))).encode("utf-8")
     return hashlib.sha256(payload).hexdigest()
-
-
-def _local_config_fingerprint(repo_root: Path) -> str:
-    """Invalidate preflight when the machine-local configuration changes."""
-
-    path = repo_root / "configs" / "local" / "local.yaml"
-    if not path.is_file():
-        return "missing"
-    try:
-        return hashlib.sha256(path.read_bytes()).hexdigest()
-    except OSError as exc:
-        return f"unreadable:{type(exc).__name__}"
 
 
 def _initialize_state() -> None:
@@ -190,7 +184,7 @@ def _safe_smoke_reset(default_template_id: str) -> None:
 
 def main() -> None:
     st.set_page_config(
-        page_title="PHM-Vibench Experiment Workspace",
+        page_title="PHMFactory Experiment Workspace",
         page_icon="⚙️",
         layout="wide",
         initial_sidebar_state="expanded",
@@ -204,8 +198,8 @@ def main() -> None:
         catalog = _cached_catalog(str(APP_DIR / "field_catalog.yaml"))
         profiles = _cached_profiles(str(APP_DIR / "template_profiles.yaml"))
         registry = _cached_registry(str(repo_root))
-    except (ConfigServiceError, OnboardingError) as exc:
-        _render_error("The application contract could not be loaded.", exc)
+    except (ConfigServiceError, OnboardingError) as error:
+        _render_error("The application contract could not be loaded.", error)
         st.stop()
 
     default_profile = profile_for(profiles, catalog.default_template_id)
@@ -217,7 +211,7 @@ def main() -> None:
         "Use safe CPU smoke defaults",
         type="primary",
         use_container_width=True,
-        help="Return to Quick Start, the bundled dummy template, CPU, and one epoch.",
+        help="Return to Quick Start, bundled Dummy data, CPU, and one epoch.",
     ):
         _safe_smoke_reset(catalog.default_template_id)
     render_readiness_sidebar(readiness)
@@ -229,8 +223,8 @@ def main() -> None:
         ("Quick Start", "Advanced"),
         key="ui_mode",
         help=(
-            "Quick Start exposes the smallest safe surface. Advanced adds "
-            "full YAML and raw overrides."
+            "Quick Start exposes the smallest safe surface. Advanced adds a "
+            "standalone YAML editor and explicit raw overrides."
         ),
     )
     selected_run = _render_run_selector(repo_root)
@@ -273,38 +267,26 @@ def main() -> None:
 
     try:
         config_path = resolve_repo_path(repo_root, entry.path, yaml_only=True)
-    except (ConfigServiceError, OSError) as exc:
-        _render_error("The selected registry entry is not usable.", exc)
+    except (ConfigServiceError, OSError) as error:
+        _render_error("The selected registry entry is not usable.", error)
         st.stop()
 
-    with st.spinner("Resolving template through the repository inspector..."):
-        runtime_report = _cached_inspection(str(repo_root), str(config_path), (), True)
-    if not runtime_report.resolved:
+    with st.spinner("Resolving the template through PHMFactory's public inspector..."):
+        template_report = _cached_inspection(str(repo_root), str(config_path), ())
+    if not template_report.resolved:
         _render_error(
             "The template could not be fully resolved.",
-            RuntimeError(runtime_report.error or "Unknown inspector failure."),
-            details=runtime_report.stderr,
+            RuntimeError(template_report.error or "Unknown inspector failure."),
+            details=template_report.stderr,
         )
         st.stop()
 
-    with st.spinner("Preparing a portable standalone YAML before local overrides..."):
-        portable_report = _cached_inspection(str(repo_root), str(config_path), (), False)
-    if not portable_report.resolved:
-        _render_error(
-            "The portable source configuration could not be resolved.",
-            RuntimeError(portable_report.error or "Unknown inspector failure."),
-            details=portable_report.stderr,
-        )
-        st.stop()
-
-    baseline_resolved: Mapping[str, Any] = (
-        portable_report.resolved if mode == "Advanced" else runtime_report.resolved
-    )
-    portable_yaml_text = dump_yaml(portable_report.resolved)
+    baseline_resolved: Mapping[str, Any] = template_report.resolved
+    standalone_yaml = dump_yaml(template_report.resolved)
 
     st.header("2. 修改参数 | Configure safely")
     advanced_yaml_text = ""
-    execution_yaml_text = portable_yaml_text
+    execution_yaml_text = standalone_yaml
     configuration_has_error = False
     if mode == "Quick Start":
         st.info("Quick Start exposes only catalog-approved onboarding fields.")
@@ -314,7 +296,7 @@ def main() -> None:
             selected_id,
             quick_only=True,
         )
-        source_for_signature = portable_yaml_text
+        source_for_signature = standalone_yaml
     else:
         _ensure_advanced_yaml(selected_id, baseline_resolved)
         tabs = st.tabs(("Safe fields", "Full YAML", "Raw overrides"))
@@ -326,17 +308,16 @@ def main() -> None:
                 quick_only=False,
             )
             st.caption(
-                "Field aliases are declarative; no model-specific UI branches "
-                "are required."
+                "Field aliases are declarative; no model-specific UI branches are used."
             )
         with tabs[1]:
             advanced_yaml_text = st.text_area(
-                "Portable standalone YAML",
+                "Standalone effective YAML",
                 height=520,
                 key="advanced_yaml_text",
                 help=(
-                    "Machine-local configuration is applied exactly once during "
-                    "validation and execution."
+                    "This YAML has no hidden local layer. Machine-specific values must "
+                    "be edited here or supplied as explicit overrides."
                 ),
             )
             _render_diff(dump_yaml(baseline_resolved), advanced_yaml_text)
@@ -347,14 +328,14 @@ def main() -> None:
                 placeholder="data.data_dir=/path/to/data\ntrainer.num_epochs=1",
             )
             st.caption(
-                "Raw overrides have highest precedence and remain argv tokens, "
-                "never shell text."
+                "Raw overrides have highest precedence and remain argv tokens, never "
+                "shell text."
             )
         try:
             raw_overrides = parse_override_lines(override_text)
             overrides = normalize_overrides((*safe_overrides, *raw_overrides))
-        except ConfigServiceError as exc:
-            _render_error("Raw overrides are invalid.", exc)
+        except ConfigServiceError as error:
+            _render_error("Raw overrides are invalid.", error)
             overrides = safe_overrides
             configuration_has_error = True
         source_for_signature = advanced_yaml_text
@@ -372,8 +353,8 @@ def main() -> None:
         )
         try:
             preview_config = apply_overrides(parse_yaml_text(advanced_yaml_text), overrides)
-        except ConfigServiceError as exc:
-            st.error(str(exc))
+        except ConfigServiceError as error:
+            st.error(str(error))
             preview_config = {}
             configuration_has_error = True
 
@@ -397,18 +378,13 @@ def main() -> None:
     summary_cols[3].metric("Template status", entry.status or "unspecified")
     st.markdown("**Planned reproduction command**")
     st.code(format_command(command), language="bash")
-    with st.expander("Execution source preview"):
+    with st.expander("Effective configuration preview"):
         if preview_config:
             st.code(dump_yaml(preview_config), language="yaml")
         else:
             st.warning("Fix the configuration before validation.")
 
-    signature_source = (
-        source_for_signature
-        + "\n# local-config-sha256="
-        + _local_config_fingerprint(repo_root)
-    )
-    current_signature = _signature(mode, signature_source, overrides)
+    current_signature = _signature(mode, source_for_signature, overrides)
     validate_col, download_col, run_col = st.columns(3)
     if validate_col.button(
         "Validate configuration",
@@ -417,7 +393,7 @@ def main() -> None:
         use_container_width=True,
     ):
         try:
-            with st.spinner("Running repository config inspection..."):
+            with st.spinner("Running the public config analysis..."):
                 report = (
                     inspect_config(repo_root, config_path, overrides)
                     if mode == "Quick Start"
@@ -425,10 +401,10 @@ def main() -> None:
                 )
             st.session_state.validation_report = report
             st.session_state.validation_signature = current_signature
-        except ConfigServiceError as exc:
+        except ConfigServiceError as error:
             st.session_state.validation_report = None
             st.session_state.validation_signature = ""
-            _render_error("Validation could not start.", exc)
+            _render_error("Validation could not start.", error)
 
     report = st.session_state.validation_report
     report_is_current = (
@@ -442,9 +418,7 @@ def main() -> None:
             "The configuration changed after validation. Validate it again before running."
         )
 
-    can_download = bool(
-        report_is_current and report.ok and not configuration_has_error
-    )
+    can_download = bool(report_is_current and report.ok and not configuration_has_error)
     can_run = bool(can_download and readiness.can_execute and data_status.ready)
     render_launch_blockers(readiness, data_status)
 
@@ -452,7 +426,7 @@ def main() -> None:
         download_col.download_button(
             "Download execution YAML",
             data=execution_yaml_text,
-            file_name="phm_vibench_config.yaml",
+            file_name="phmfactory_config.yaml",
             mime="application/x-yaml",
             use_container_width=True,
         )
@@ -469,8 +443,8 @@ def main() -> None:
         disabled=not can_run,
         use_container_width=True,
         help=(
-            "Runs the public main.py --config contract after environment, data, "
-            "and configuration checks pass."
+            "Runs the public main.py --config contract after environment, data, and "
+            "configuration checks pass."
         ),
     ):
         assert isinstance(report, ValidationReport)
@@ -499,8 +473,8 @@ def main() -> None:
             st.session_state.selected_run_id = launched.run_id
             st.toast("Experiment started. Live logs are available below.")
             st.rerun()
-        except (RunServiceError, RunConflictError) as exc:
-            _render_error("The experiment could not start.", exc)
+        except (RunServiceError, RunConflictError) as error:
+            _render_error("The experiment could not start.", error)
 
     st.header("4. 运行与结果 | Live run and evidence")
     run_id = (
@@ -512,7 +486,7 @@ def main() -> None:
         _render_live_run(str(repo_root), run_id)
     else:
         st.info(
-            "Validate the CPU smoke template and start an experiment. This area "
-            "will show live logs, headline metrics, images, artifacts, and the "
-            "immutable reproduction command."
+            "Validate the CPU smoke template and start an experiment. This area will "
+            "show live logs, headline metrics, images, artifacts, and the immutable "
+            "reproduction command."
         )

--- a/configs/README.md
+++ b/configs/README.md
@@ -1,61 +1,128 @@
 # Configuration System
 
-This page is the maintained authority for PHM-Vibench configuration composition,
+This page is the maintained authority for PHMFactory configuration composition,
 precedence, inspection, and registry maintenance.
 
-The public runtime entrypoint is:
+## Public contract
+
+Use a maintained preset or YAML file through the same public interface:
 
 ```bash
-python main.py --config <yaml> [--override key=value ...]
+phmfactory preflight --config <preset-or-yaml> [--override key=value ...]
+phmfactory --config <preset-or-yaml> [--override key=value ...]
 ```
 
-For environment setup and the first successful run, use the
-[installation guide](../docs/installation.md) and
-[quickstart](../docs/quickstart.md) instead of duplicating those procedures here.
+The compatibility forms `python -m phmfactory` and `python main.py` use the same
+configuration analysis. For installation and the first offline run, start with the
+[installation guide](../docs/installation.md) and [quickstart](../docs/quickstart.md).
 
 ## Five-block model
 
-Maintained configurations use:
+Maintained configurations contain five logical mappings:
 
 ```yaml
-environment: {}
-data: {}
-model: {}
-task: {}
-trainer: {}
+environment: {}  # seed, iterations, output location, process settings
+data: {}         # metadata, raw data, windowing, workers, sampling inputs
+model: {}        # model family, components, and model hyperparameters
+task: {}         # diagnosis/pretraining objective and task-specific protocol fields
+trainer: {}      # device, epochs, precision, logging, checkpoint behavior
 ```
 
-A top-level `pipeline` selects the pipeline module. New datasets, models, tasks,
-and trainers should normally extend their factory rather than require a new
-pipeline.
+A top-level `pipeline` selects orchestration. New datasets, models, tasks, and trainers
+should normally extend their factory rather than add a special branch to `main.py`.
 
-## Composition and precedence
+## One configuration truth
 
-Configuration values are applied from lower to higher precedence:
+Every maintained public consumer uses `phmfactory.config.analyze_config`:
 
-1. YAML files referenced by `base_configs`;
-2. blocks in the selected experiment YAML;
-3. optional machine-local values from `configs/local/local.yaml`;
+```text
+run
+preflight
+scripts.validate_configs
+scripts.config_inspect
+support generation
+Pipeline 06 public adapter
+Streamlit validation and launch
+```
+
+For the same source and explicit inputs, these consumers must obtain the same effective
+configuration and `effective_config_sha256`.
+
+The precedence order, from lowest to highest, is:
+
+1. YAML files listed by `base_configs`, in declared order;
+2. values in the selected experiment YAML;
+3. an **explicitly supplied** machine-local YAML, when `--local-config` is present;
 4. repeatable CLI `--override key=value` arguments.
 
-Machine paths, credentials, and workstation-specific settings belong in local
-configuration or CLI overrides, not maintained demo files.
+There is no automatic search for `configs/local/local.yaml`. Hidden machine state would
+make two apparently identical commands execute different experiments, so a local file is
+an input only when it is visible in the command:
+
+```bash
+phmfactory preflight \
+  --config configs/experiments/my_experiment.yaml \
+  --local-config configs/local/my_machine.yaml \
+  --override trainer.num_epochs=1
+```
+
+Equivalent `--local_config` spelling remains accepted for compatibility, but new
+documentation uses `--local-config`.
+
+## Effective identity and invocation identity
+
+PHMFactory records two related hashes:
+
+```text
+effective_config_sha256
+  = hash of the canonical fully resolved configuration
+
+run_spec_sha256
+  = identity of this invocation, including requested source and explicit overrides
+```
+
+Two commands that produce the same effective configuration share
+`effective_config_sha256`, even when one uses a preset and another uses an explicit path.
+The invocation hash may differ because it preserves how the user requested the run.
+
+Use the effective hash for semantic comparisons. Use the run-spec hash and full command
+for provenance and debugging.
 
 ## Maintained directories
 
 - `configs/base/` — reusable environment, data, model, task, and trainer blocks;
 - `configs/demo/` — maintained user-facing examples;
-- `configs/experiments/` — local or research variants that are not automatically
-  release-supported;
-- `configs/local/` — untracked machine-local values, with tracked examples and
-  documentation;
-- `configs/reference/` and versioned historical directories — reference material,
-  not the maintained quickstart surface.
+- `configs/experiments/` — local or research variants not automatically supported;
+- `configs/local/` — optional untracked machine files that must be supplied explicitly;
+- `configs/reference/` and versioned historical directories — reference material, not
+  the maintained quickstart surface.
 
 Start a local experiment by copying the nearest maintained demo into
-`configs/experiments/` and changing only required behavior-affecting values.
+`configs/experiments/` and changing only behavior-affecting values required by the
+experiment.
 
-## Inspect a resolved configuration
+## Preflight before execution
+
+```bash
+phmfactory preflight \
+  --config configs/demo/00_smoke/dummy_dg.yaml \
+  --override trainer.num_epochs=1
+```
+
+The report includes:
+
+```text
+status=passed
+effective_config_sha256=<64-hex>
+run_spec_sha256=<64-hex>
+pipeline=<canonical-name>
+output_dir=<resolved-path>
+```
+
+Preflight does not import or execute the training Pipeline, construct factories, allocate
+a GPU, create the configured output directory, or start a run.
+
+## Inspect values, sources, and targets
 
 ```bash
 python -m scripts.config_inspect \
@@ -71,12 +138,24 @@ python -m scripts.config_inspect --config <yaml> --dump sources --format md
 python -m scripts.config_inspect --config <yaml> --dump targets --format json
 ```
 
-The inspector returns non-zero when any sanity check fails. A missing import or
-invalid target is not a successful inspection.
+`resolved` is the exact effective mapping used by the runtime. `sources` identifies the
+last source of each leaf field. `targets` reports the Pipeline and factory modules that
+would be selected without constructing them. The inspector exits non-zero when a sanity
+check fails.
 
-## Registry and generated atlas
+## Validate maintained configurations
 
-The authoritative maintained-config inventory is:
+```bash
+python -m scripts.validate_configs
+```
+
+The validator first uses the same public analysis, then applies the Pydantic experiment
+schema. A config cannot pass validation through a different legacy merge path than the
+one used for execution.
+
+## Registry and generated documentation
+
+The maintained config inventory is:
 
 ```text
 configs/config_registry.csv
@@ -84,41 +163,46 @@ configs/config_registry.csv
 
 Related files:
 
-- registry field reference: `docs/config_registry_schema.md`;
-- generated human-readable view: `docs/CONFIG_ATLAS.md`.
+- field reference: `docs/config_registry_schema.md`;
+- generated human-readable inventory: `docs/CONFIG_ATLAS.md`;
+- evidence-derived support boundaries: `SUPPORTED_COMPONENTS.md` and
+  `SUPPORTED_COMBINATIONS.md`.
 
 After an intentional registry change:
 
 ```bash
 python -m scripts.gen_config_atlas
 python -m scripts.validate_configs
-git diff --exit-code docs/CONFIG_ATLAS.md
+python -m scripts.gen_support_matrix
+git diff --exit-code \
+  docs/CONFIG_ATLAS.md \
+  SUPPORTED_COMPONENTS.md \
+  SUPPORTED_COMBINATIONS.md
 ```
 
-Do not hand-edit `docs/CONFIG_ATLAS.md`. A registry row records inventory and
-status; it does not by itself prove release support. The public support boundary is
-maintained in `SUPPORTED_COMPONENTS.md` and `SUPPORTED_COMBINATIONS.md`.
+Do not hand-edit generated output to hide source drift. A registry row proves inventory,
+not runtime or release support.
 
-## Common overrides
+## Common explicit overrides
 
 Run one epoch:
 
 ```bash
-python main.py --config <yaml> --override trainer.num_epochs=1
+phmfactory --config <yaml> --override trainer.num_epochs=1
 ```
 
-Use local data without editing a demo:
+Use local data without editing a maintained demo:
 
 ```bash
-python main.py --config <yaml> \
+phmfactory --config <yaml> \
   --override data.data_dir=/absolute/path/to/data \
   --override data.metadata_file=metadata.xlsx
 ```
 
-Select CPU and avoid worker-process complexity during a smoke test:
+Select a bounded CPU smoke setup:
 
 ```bash
-python main.py --config <yaml> \
+phmfactory --config <yaml> \
   --override trainer.device=cpu \
   --override trainer.num_epochs=1 \
   --override data.num_workers=0
@@ -128,22 +212,22 @@ python main.py --config <yaml> \
 
 A config should enter the maintained registry only when its PR includes:
 
-- a clear purpose and supported audience;
+- a clear purpose and intended audience;
 - valid five-block composition;
-- no personal absolute paths;
-- successful schema validation and inspection;
+- no committed personal absolute paths;
+- public analysis, schema validation, and inspection success;
 - the smallest applicable runtime evidence;
-- synchronized registry and generated atlas;
+- synchronized registry and generated documents;
 - updated support or limitation documentation when the public surface changes.
 
-Use `needs_smoke` or another explicit non-supported status until runtime evidence
-exists. Do not label a configuration `sanity_ok` based only on YAML parsing.
+Use `needs_smoke` or another explicit non-supported status until runtime evidence exists.
+Do not label a config `sanity_ok` based only on YAML parsing.
 
 ## Read next
 
 - Base blocks: `configs/base/README.md`
 - Maintained demos: `configs/demo/README.md`
 - Experiment variants: `configs/experiments/README.md`
-- Local overrides: `configs/local/README.md`
+- Explicit local overrides: `configs/local/README.md`
 - Documentation index: `docs/index.md`
 - Testing and evidence: `docs/testing.md`

--- a/configs/local/README.md
+++ b/configs/local/README.md
@@ -1,13 +1,48 @@
-# configs/local/
+# Explicit machine-local configuration
 
-Machine-local overrides (not meant to be committed).
+`configs/local/` is an optional workspace for untracked machine-specific values such as
+local data roots, scratch output directories, or device preferences.
 
-## Usage
+## Core rule
 
-- Create `configs/local/local.yaml` on your machine (git-ignored).
-- Put machine-specific paths here (most commonly `data.data_dir`).
-- Pipelines automatically merge this file if present; you can also pass `--local_config /path/to/override.yaml`.
+PHMFactory does **not** automatically read `configs/local/local.yaml` or any other file in
+this directory. A local YAML affects an experiment only when the user supplies it:
 
-## Template
+```bash
+phmfactory preflight \
+  --config configs/experiments/my_experiment.yaml \
+  --local-config configs/local/my_machine.yaml
 
-Start from `configs/local/local.sample.yaml`.
+phmfactory \
+  --config configs/experiments/my_experiment.yaml \
+  --local-config configs/local/my_machine.yaml
+```
+
+The same explicit file must be present in both preflight and run commands. CLI overrides
+still have highest precedence:
+
+```text
+base_configs
+< experiment YAML
+< explicit --local-config YAML
+< --override key=value
+```
+
+Start from `configs/local/local.sample.yaml`, rename the copy to a machine-specific file,
+and keep it untracked. Do not store credentials in experiment manifests or attach them to
+bug reports.
+
+## 中文说明
+
+`configs/local/` 用于保存本机路径、临时输出目录和设备偏好等不应提交到 Git 的
+配置。PHMFactory **不会自动读取** `configs/local/local.yaml`。只有命令中明确写出
+`--local-config` 时，该文件才会参与配置合并：
+
+```bash
+phmfactory preflight \
+  --config configs/experiments/my_experiment.yaml \
+  --local-config configs/local/my_machine.yaml
+```
+
+这样可以避免同一条命令在两台机器上因为隐藏的本地文件而执行不同实验。正式运行时
+必须再次显式提供同一个本地配置文件；`--override` 的优先级仍然最高。

--- a/docs/developer_runtime_control_plane.md
+++ b/docs/developer_runtime_control_plane.md
@@ -1,66 +1,205 @@
 # Runtime control plane
 
-PHMFactory's maintained entrypoints compile user intent before protected runtime code is
-imported:
+PHMFactory separates user intent, execution, and run records so one command cannot be
+silently reinterpreted by a downstream Pipeline.
+
+## Maintained public path
 
 ```text
-config or preset + CLI overrides
-  -> phmfactory.config.resolve_config
-  -> phmfactory.runtime.CompiledRunSpec
-  -> phmfactory.runtime.ExecutionEnvelope
-  -> phmfactory.runtime.RunAttestation (pending)
+preset or YAML
++ optional explicit --local-config
++ CLI --override values
+  -> phmfactory.config.analyze_config
+  -> ConfigAnalysis
+  -> CompiledRunSpec
+  -> RunAttestation (pending)
   -> Pipeline maturity gate
-  -> canonical Pipeline adapter
+  -> canonical Pipeline module or narrow adapter
   -> protected src runtime
-  -> evidence registration
+  -> Pipeline-specific evidence registration
   -> RunAttestation (succeeded or failed)
 ```
 
-`CompiledRunSpec` contains the fully composed configuration, canonical Pipeline
-identifier, explicit overrides, and a deterministic semantic SHA-256. Its hash excludes
-the absolute installation path, so an identical packaged preset has the same identity
-outside a repository checkout.
+The public path has one configuration authority. Validators, inspectors, preflight, the
+CLI, support generation, Pipeline 06, and the optional Streamlit workspace all consume the
+same effective mapping.
 
-`ExecutionEnvelope` is the public invocation boundary. It records pending, running,
-succeeded, or failed state and rejects ambiguous outcomes. A Pipeline module must expose
-a callable `pipeline(args)` and a successful invocation must return an explicit result.
-Returning `None`, omitting the entrypoint, or attempting to execute the same envelope
-twice is a contract error. Exceptions retain their original traceback while the envelope
-records the failure stage, type, and message.
+## `ConfigAnalysis`: one configuration truth
 
-The public CLI prints the completion message only after the envelope reaches
-`succeeded`. A failed Pipeline therefore produces a non-zero process outcome rather than
-`print + return` followed by apparent success.
-
-## Mandatory invocation manifest
-
-After configuration compilation and before Pipeline import, the CLI creates:
+`ConfigAnalysis` records:
 
 ```text
-<environment.output_dir>/.phmfactory/runs/<run_id>/run_manifest.json
+requested source or preset
+resolved YAML path
+fully effective configuration
+canonical Pipeline
+explicit overrides
+optional explicit local-config path
+ordered source files
+last source of each leaf field
+diagnostics
+effective_config_sha256
 ```
 
-The first atomic version has `status: pending`. The same path is atomically replaced with
-`succeeded` or `failed` after execution. Each manifest contains the run ID, run-spec hash,
-canonical Pipeline and module, config source, explicit overrides, code revision when
-available, Python/platform summary, execution timestamps, and structured failure data.
+The maintained precedence is:
 
-Manifest writes use a same-directory temporary file, flush and `fsync`, followed by
-`os.replace`. If the pending manifest cannot be created, the Pipeline is not imported. If
-the final succeeded manifest cannot be written, the public invocation fails and no
-completion message is printed. This makes the minimum attestation mandatory rather than
-best effort.
+```text
+base_configs
+< selected experiment YAML
+< explicit --local-config YAML
+< CLI --override values
+```
 
-Protected Pipeline code must consume `compiled_run_spec.runtime_config()` instead of
-reparsing the source YAML or automatically discovering machine-local files. Until a
-Pipeline is migrated, the legacy loader remains a compatibility implementation, not a
-second public configuration authority.
+No public component automatically searches for `configs/local/local.yaml`. Hidden files
+would make the same visible command execute different experiments on different machines.
+
+The effective hash includes only the canonical effective mapping. It deliberately excludes
+preset spelling, source path, installation path, and provenance metadata. Consequently:
+
+```text
+--config smoke
+```
+
+and:
+
+```text
+--config configs/demo/00_smoke/dummy_dg.yaml
+```
+
+share `effective_config_sha256` when their final mappings are equal.
+
+## `CompiledRunSpec`: runtime and invocation identity
+
+`CompiledRunSpec` contains a deep-copied runtime mapping and two hashes:
+
+```text
+effective_config_sha256
+  identifies the scientific configuration semantics
+
+sha256 / run_spec_sha256
+  identifies this invocation, including requested source and explicit overrides
+```
+
+Runtime adapters call `compiled_run_spec.runtime_config()` to obtain a mutable copy. They
+must not re-read the source YAML or reapply CLI overrides.
+
+The absolute resolved config path remains available for diagnostics but is excluded from
+both identities. An installed preset therefore behaves consistently across checkout and
+wheel locations.
+
+## Execution boundary
+
+`ExecutionEnvelope` records the finite states:
+
+```text
+pending -> running -> succeeded
+                   -> failed
+```
+
+A Pipeline module must expose `pipeline(args)` and return an explicit result. Returning
+`None`, omitting the callable, or executing one envelope twice is a contract error.
+Exceptions keep their traceback while the envelope records failure stage, type, and
+message.
+
+The public process prints the completion message only after execution, evidence
+registration, and final manifest writing succeed. A printed warning followed by `return
+None` cannot become a successful command.
+
+## Mandatory run manifest
+
+Before Pipeline import, PHMFactory creates:
+
+```text
+<environment.output_dir>/.phmfactory/runs/<run-id>/run_manifest.json
+```
+
+The pending file is atomically replaced with the terminal state. The manifest includes:
+
+```text
+run ID and status
+run_spec_sha256
+effective_config_sha256
+canonical Pipeline and imported module
+requested source, resolved path, and overrides
+code revision when available
+Python/platform summary
+execution timestamps
+structured failure information
+indexed artifacts and evidence sections
+```
+
+Writes use a same-directory temporary file, flush, `fsync`, and `os.replace`. Failure to
+create the pending manifest prevents Pipeline import. Failure to write the final success
+state prevents a success claim.
+
+## Shared classification runtime
+
+Pipeline 01 and Pipeline 05 use one lifecycle under `src.runtime.classification`:
+
+```text
+consume compiled config
+-> validate required blocks
+-> build data/model/task/trainer
+-> fit
+-> restore best checkpoint
+-> test and write metrics
+-> close data and logging resources in finally
+```
+
+Pipeline 01 is a thin default adapter. Pipeline 05 adds only explainability hooks. Hooks
+must not duplicate config loading, factory construction, training, testing, or cleanup.
+
+Pipeline 02 chooses exactly one mode before execution:
+
+```text
+compiled config without stages -> shared classification runtime
+compiled config with stages    -> unified multi-stage orchestrator
+explicit legacy_dual_yaml       -> compatibility adapter + orchestrator
+```
+
+An exception never changes the selected algorithm.
+
+## Pipeline 06 compiled-config adapter
+
+The train/sample/eval science remains in:
+
+```text
+src.Pipeline_06_Generative_Modeling
+```
+
+The public descriptor imports the narrow adapter:
+
+```text
+phmfactory.runtime.pipeline06_adapter
+```
+
+Its only responsibilities are:
+
+1. require the compiled Pipeline to be `Pipeline_06_Generative_Modeling`;
+2. convert `compiled_run_spec.runtime_config()` to the namespace shape expected by the
+   protected implementation;
+3. dispatch the already selected `train`, `sample`, or `eval` stage;
+4. preserve stage-ledger failure handling.
+
+It does not re-read YAML, apply overrides a second time, discover local files, or alter
+the generative algorithm. Direct imports of the historical `src` function keep an
+explicit compatibility loader, but that path is not the maintained CLI authority.
+
+## Streamlit boundary
+
+The optional UI edits values and calls the public inspector. It does not merge base
+configs in Python UI code, discover a local YAML, import a Pipeline, or construct a
+Trainer.
+
+The UI receives the same `effective_config_sha256` as CLI preflight. The displayed
+reproduction command is the command passed to the public runtime. Edited Advanced YAML is
+a standalone effective config and contains no invisible local layer.
 
 ## Evidence convergence
 
-`RunAttestation` is the only top-level run identity. Existing metrics, configuration
-snapshots, explainability files, stage ledgers, synthetic manifests, checkpoints, and
-evaluation manifests remain separate files, but they are indexed through two APIs:
+`RunAttestation` is the only invocation-level run identity. Metrics, checkpoints,
+explainability files, stage ledgers, synthetic manifests, and evaluation reports remain
+separate artifacts indexed through:
 
 ```python
 run_attestation.register_artifact(role=..., path=..., sha256=..., metadata=...)
@@ -68,105 +207,33 @@ run_attestation.set_evidence(section, value)
 run_attestation.append_evidence(section, value)
 ```
 
-Artifact registration accepts existing files only. Repeating an identical registration
-is idempotent; a conflicting role/path record fails. Evidence values must be JSON
-serializable, and a scalar/mapping section cannot be silently overwritten with a
-different value.
+A Pipeline-specific file extends the run; it does not create another top-level run
+identity. Missing required evidence changes the invocation to failed even when model code
+completed.
 
-The shared classification runtime registers each `test_result_<iteration>.csv`, the
-iteration seed/run directory, and the final `all_results.csv`. Pipeline 05 registers its
-config snapshot, metadata snapshot, eligibility record, and compatibility explain/report
-manifest as role-labelled artifacts. Those files no longer define an independent run
-identity.
+## Pipeline maturity
 
-Pipeline 06 is indexed after its explicit train, sample, or eval invocation returns. The
-control-plane adapter records the stage result, indexes any returned path/SHA records,
-and requires the existing `stage_ledger.json`. Missing or conflicting evidence changes
-the execution to `failed` with `failure.stage: evidence_finalize`; successful model
-execution alone is insufficient for a successful public invocation.
-
-## Shared classification runtime
-
-Pipeline 01 and Pipeline 05 use one lifecycle implementation under
-`src.runtime.classification`:
-
-```text
-load compiled config
-  -> validate required sections
-  -> construct data/model/task/trainer
-  -> fit
-  -> restore best checkpoint
-  -> test and write result CSV
-  -> close data and logging resources in finally
-```
-
-The Pipeline modules remain intentionally thin. Pipeline 01 selects the default shared
-runtime. Pipeline 05 selects the same runtime plus `ExplainabilityHooks`, which own only
-the UXFD-specific configuration snapshot, metadata snapshot, eligibility, and manifest
-refresh. Hooks must represent genuine extensions; they must not duplicate configuration
-loading, factory construction, training, testing, or cleanup.
-
-Direct imports of the old Pipeline functions retain an explicit compatibility fallback
-to the legacy config loader. The maintained public CLI path always uses the compiled
-contract and therefore applies base configs and CLI overrides exactly once.
-
-## Pipeline 02 mode selection
-
-Pipeline 02 has exactly three recognizable inputs and never changes mode after an error:
-
-```text
-compiled config without stages -> shared single-stage classification runtime
-compiled config with stages    -> one unified multi-stage orchestrator
-explicit legacy_dual_yaml       -> isolated dual-YAML adapter + one orchestrator
-```
-
-The maintained public demo currently has no `stages` list and therefore uses the same
-classification lifecycle as Pipeline 01/05. A non-empty `stages` list selects the
-orchestrator before execution. Orchestrator errors are propagated; they do not activate a
-manual pretrain/few-shot implementation or another algorithm.
-
-The historical `fs_config_path` input is rejected unless direct legacy callers also set
-`pipeline_mode=legacy_dual_yaml`. The public CLI does not expose this mode. Manual
-`run_stage`, `run_pretraining_stage`, `run_fewshot_stage`, and duplicate single-stage
-functions are no longer maintained entrypoints.
-
-## Pipeline maturity gate
-
-`phmfactory.pipelines.PIPELINE_DESCRIPTORS` separates discoverability from default
-execution and release support. The maturity gate runs after the pending manifest is
-created and before the Pipeline module is imported.
-
-Pipeline 03 and Pipeline 04 require explicit public opt-in:
+`phmfactory.pipelines.PIPELINE_DESCRIPTORS` separates discoverability, opt-in execution,
+and release support. Pipeline 03 and Pipeline 04 require:
 
 ```bash
 phmfactory --config <yaml> --allow-experimental
 ```
 
-Without that flag, the CLI writes a failed manifest with `failure.stage: maturity` and
-does not import the module. The flag is an acknowledgement of maturity, not a support
-promotion. Pipeline 03 remains experimental because no maintained smoke combination
-exists and its legacy implementation contains error/checkpoint paths that have not been
-normalized. Pipeline 04 remains `experimental_blocked` because it additionally contains
-environment-specific paths, `sys.path` mutation, broad fallback, and unverified partial
-checkpoint loading.
+The flag acknowledges maturity; it does not promote support. Pipeline 01 and the
+maintained single-stage Pipeline 02 path remain the release-supported surface. Pipeline
+05, Pipeline 06, and Pipeline_ID remain outside the maintained combination table unless
+current evidence promotes an exact configuration.
 
-Pipeline 01 and the maintained single-stage Pipeline 02 path remain the release-supported
-surface. Pipeline 05, Pipeline 06, and Pipeline_ID remain discoverable under their
-compatibility or experimental-contract descriptors; their presence is not a
-release-support claim. The user-facing distinction is recorded in
-`SUPPORTED_COMPONENTS.md`.
+## Invariants for future changes
 
-The following invariants govern later refactors:
-
-1. the public config is compiled exactly once;
-2. local configuration is an explicit input;
-3. the selected Pipeline and executed configuration share one contract;
-4. runtime code receives a mutable copy and cannot mutate the compiled contract;
-5. missing sections, invalid iterations, invalid factory results, `None` Pipeline
-   results, and execution failures raise rather than printing success;
-6. data and logging resources are closed through a shared `finally` boundary;
-7. every compiled invocation creates one mandatory minimal attestation;
-8. Pipeline-specific evidence extends the invocation manifest instead of redefining it;
-9. an exception never changes the selected execution mode or activates a fallback;
-10. discoverability, explicit experimental execution, and release support remain separate
-    machine-readable claims.
+1. Public configuration composition has one implementation.
+2. Machine-local YAML is an explicit input.
+3. Run, preflight, inspect, validate, UI, and Pipeline 06 share the effective hash.
+4. Overrides are applied exactly once.
+5. Runtime code receives a copy and cannot mutate the compiled contract.
+6. Errors propagate from their source; no exception activates another algorithm.
+7. `None` is not a successful Pipeline result.
+8. Resources close through `finally` boundaries.
+9. Every public run creates one mandatory terminal manifest.
+10. Discoverable, runnable, supported, and benchmark-valid remain distinct claims.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -11,10 +11,10 @@ It is a software smoke test, not a benchmark-performance run.
 By the end of this page you will have:
 
 1. checked the Python environment;
-2. checked one exact experiment configuration without training;
+2. checked one exact effective configuration without training;
 3. completed one offline train/test run;
-4. located the metrics and run record;
-5. understood the next step for local data or a custom experiment.
+4. located metrics and the run record;
+5. understood how to supply local paths explicitly.
 
 ## 1. Install the source checkout
 
@@ -39,7 +39,7 @@ named PHMFactory, but the repository has not yet been renamed.
 phmfactory doctor
 ```
 
-Expected shape of the output:
+Expected output shape:
 
 ```text
 PASS python: 3.10.x
@@ -53,24 +53,24 @@ PASS output:writable: .../results/demo/dummy_dg_smoke
 doctor=passed checks=8
 ```
 
-The exact versions and paths may differ. Every required line should start with `PASS`,
-and the command should exit with status code `0`.
+Exact versions and paths may differ. Every required line should start with `PASS`, and
+the command should exit with status code `0`.
 
-`doctor` does **not** start training. It checks real imports, the packaged smoke config,
-Pipeline discoverability, and output writability.
+`doctor` does not start training. It performs real imports, resolves the smoke config,
+checks Pipeline discoverability, and proves output writability.
 
 ### When `doctor` fails
 
 | Failure | Meaning | First action |
 | --- | --- | --- |
-| `import:torch` | PyTorch is missing or cannot load | Reinstall a platform-compatible PyTorch build |
-| `import:pytorch_lightning` | Lightning or one of its dependencies cannot load | Re-run `python -m pip install -e .` in the active environment |
-| `config:smoke` | Packaged config is missing or installation is stale | Reinstall the editable package from the repository root |
-| `pipeline:smoke` | The maintained Pipeline module is not discoverable | Confirm you are using the intended checkout and environment |
-| `output:writable` | The output parent cannot be written | Choose a writable working directory or fix permissions |
+| `import:torch` | PyTorch is missing or cannot load | Install a platform-compatible PyTorch build |
+| `import:pytorch_lightning` | Lightning or a dependency cannot load | Re-run `python -m pip install -e .` in the active environment |
+| `config:smoke` | Packaged config is missing or installation is stale | Reinstall from the repository root |
+| `pipeline:smoke` | Maintained Pipeline is not discoverable | Confirm the intended checkout and environment |
+| `output:writable` | Output parent cannot be written | Change directory or fix permissions |
 
-Use the complete exception type and message printed by the failed check. Do not modify
-framework source to hide a broken Python environment.
+Use the reported exception type and message. Do not modify framework source to hide a
+broken Python environment.
 
 ## 3. Check the experiment without training
 
@@ -83,22 +83,31 @@ Expected key lines:
 ```text
 status=passed
 requested_config=smoke
+local_config_path=none
+effective_config_sha256=<64-hex>
+run_spec_sha256=<64-hex>
 pipeline=Pipeline_01_Fault_Diagnosis
 maturity=supported
 output_dir=.../results/demo/dummy_dg_smoke
 ```
 
-Preflight checks the final configuration and output location, but it does not:
+The two hashes have different purposes:
 
-- import and execute the training Pipeline;
+- `effective_config_sha256` identifies the final resolved experiment semantics;
+- `run_spec_sha256` preserves this invocation, including requested source and explicit
+  overrides.
+
+Preflight does not:
+
+- import or execute the training Pipeline;
 - construct data loaders, models, tasks, or trainers;
 - allocate a GPU;
 - create the configured output directory;
 - start a run.
 
-A passing preflight should exit with status code `0`.
+A passing preflight exits with status code `0`.
 
-To test an override without editing YAML:
+Test an override without editing YAML:
 
 ```bash
 phmfactory preflight \
@@ -106,8 +115,8 @@ phmfactory preflight \
   --override trainer.num_epochs=2
 ```
 
-Later overrides replace earlier values. Invalid config paths, malformed overrides, unknown
-Pipelines, and unwritable output locations fail with a non-zero exit status.
+Later overrides replace earlier values. Invalid paths, malformed overrides, unknown
+Pipelines, and unwritable outputs fail with a non-zero status.
 
 ## 4. Run the offline demo
 
@@ -133,7 +142,7 @@ phmfactory demo --override trainer.num_epochs=2
 
 A successful run should:
 
-- initialize Dummy data from files shipped with the repository;
+- initialize Dummy data from repository files;
 - construct the maintained model, task, and trainer;
 - train and test without downloading an external dataset;
 - print `run_manifest=<path>`;
@@ -142,13 +151,13 @@ A successful run should:
 
 ## 5. Find the results
 
-List the files without assuming a fixed timestamped subdirectory:
+Linux/macOS:
 
 ```bash
 find results/demo/dummy_dg_smoke -maxdepth 7 -type f | sort
 ```
 
-On Windows PowerShell:
+Windows PowerShell:
 
 ```powershell
 Get-ChildItem results/demo/dummy_dg_smoke -Recurse -File |
@@ -159,17 +168,16 @@ The output normally contains:
 
 - per-iteration test metrics such as `test_result_0.csv`;
 - aggregate metrics such as `all_results.csv`;
-- checkpoints and logger outputs created by the configured trainer;
+- checkpoints and logger outputs;
 - one `run_manifest.json` under `.phmfactory/runs/<run-id>/`.
 
-The run manifest is the starting point for reproducing or debugging the invocation. It
-records the selected config, Pipeline, overrides, status, timestamps, code revision when
-available, and indexed output artifacts. You do not need to understand its internal
-schema to complete this quickstart.
+The manifest records both config hashes, selected Pipeline, overrides, status,
+timestamps, code revision when available, and indexed artifacts. You do not need to
+understand its internal schema to complete this quickstart.
 
-## 6. Verify the three compatible entrypoints
+## 6. Verify compatible entrypoints
 
-These commands should have the same process exit behavior:
+These commands should report the same effective config hash and process status:
 
 ```bash
 phmfactory preflight --config smoke
@@ -177,22 +185,22 @@ python -m phmfactory preflight --config smoke
 python main.py preflight --config smoke
 ```
 
-The first form is recommended after installation. `python main.py` remains only as a
-repository compatibility launcher.
+Use the first form after installation. `python main.py` is a repository compatibility
+launcher.
 
-Python code that needs a structured result rather than a process exit status may call:
+Python code that needs a structured result may call:
 
 ```python
 from phmfactory.cli import main
 
 report = main(["preflight", "--config", "smoke"])
-print(report["pipeline"])
+print(report["effective_config_sha256"])
 ```
 
 ## 7. Run a maintained config with local data
 
-Only the Dummy smoke is fully offline. For an external-data configuration, keep machine
-paths out of the tracked YAML and pass them explicitly:
+Only the Dummy smoke is fully offline. Keep machine paths out of maintained YAML and pass
+them explicitly:
 
 ```bash
 phmfactory preflight \
@@ -203,7 +211,7 @@ phmfactory preflight \
   --override trainer.num_epochs=1
 ```
 
-After preflight passes:
+After preflight passes, run the same visible inputs:
 
 ```bash
 phmfactory \
@@ -214,35 +222,54 @@ phmfactory \
   --override trainer.num_epochs=1
 ```
 
-Read [data/README.md](../data/README.md) for the expected directory layout and
-[Supported combinations](../SUPPORTED_COMBINATIONS.md) for the current maintained
-surface.
+For several machine-specific values, create an untracked YAML and supply it explicitly:
+
+```bash
+phmfactory preflight \
+  --config configs/experiments/my_experiment.yaml \
+  --local-config configs/local/my_machine.yaml
+
+phmfactory \
+  --config configs/experiments/my_experiment.yaml \
+  --local-config configs/local/my_machine.yaml
+```
+
+PHMFactory does not automatically read `configs/local/local.yaml`. The local file must be
+visible in both commands. CLI overrides have higher precedence than the explicit local
+file.
+
+Read [data/README.md](../data/README.md) for layout and
+[Supported combinations](../SUPPORTED_COMBINATIONS.md) for the maintained surface.
 
 ## 8. Create a local experiment variant
 
 1. Copy the nearest file from `configs/demo/` to `configs/experiments/`.
 2. Change only values required by the experiment.
-3. Keep local paths in CLI overrides rather than the tracked file.
-4. Run `phmfactory preflight --config <your-yaml>`.
+3. Keep machine paths in explicit overrides or an explicit `--local-config` file.
+4. Run `phmfactory preflight --config <your-yaml>` with the same extra inputs as the run.
 5. Run the smallest applicable test or one-epoch smoke.
-6. Record the commit, config, overrides, data source, seed, and environment.
+6. Record the commit, effective config hash, command, data source, seed, and environment.
 
 Do not add a local variant to `configs/config_registry.csv` unless it is being reviewed
 for promotion to the maintained surface.
 
 ## Troubleshooting
 
-### A command prints useful output but the shell reports exit code `1`
+### Preflight and run report different effective hashes
 
-Check the exact entrypoint and status:
+Use the same config, `--local-config`, and overrides in both commands. If visible inputs
+are identical but hashes differ, report both commands, both hashes, installed package
+location, stdout, and stderr. That is a config-parity bug.
+
+### A command prints useful output but the shell reports exit code `1`
 
 ```bash
 phmfactory preflight --config smoke
 echo $?
 ```
 
-A successful public process must exit with `0`. Report the command, installed package
-location, stdout, stderr, and exit code if the output and status disagree.
+A successful public process must exit with `0`. Report the exact entrypoint and complete
+output when display and status disagree.
 
 ### `preflight` cannot find the config
 
@@ -254,28 +281,27 @@ phmfactory preflight --config configs/demo/00_smoke/dummy_dg.yaml
 
 ### A local data path does not exist
 
-Return to `phmfactory demo` to separate software installation from data availability.
-Then verify `data.data_dir`, `data.metadata_file`, and the raw directory layout.
+Return to `phmfactory demo` to separate installation from data availability. Then verify
+`data.data_dir`, `data.metadata_file`, and raw layout.
 
 ### The demo fails during import
 
-Run `phmfactory doctor` again. A package may be installed but fail during import because
-of an incompatible binary, driver, or transitive dependency.
+Run `phmfactory doctor` again. An installed package can still fail during import because
+of a binary, driver, or transitive-dependency incompatibility.
 
 ### CUDA initialization fails
 
-Use the CPU Dummy demo first. Verify the PyTorch build and driver independently before
-changing PHMFactory source or experiment logic.
+Use the CPU Dummy demo first. Verify PyTorch and the driver independently before changing
+PHMFactory code or config.
 
 ### Metrics differ between runs
 
-The quickstart verifies execution, not fixed scientific metrics. A fair reproduction
-requires the same effective configuration, code revision, environment, data, split,
-seed, and protocol. See [Known limitations](../KNOWN_LIMITATIONS.md).
+The quickstart verifies execution, not fixed scientific metrics. Fair reproduction also
+requires the same code, data, split, seed, protocol, and environment. See
+[Known limitations](../KNOWN_LIMITATIONS.md).
 
 ## Developer details
 
-The public runtime internally compiles the config once, executes the selected Pipeline,
-and writes a structured run record. Developers working on those contracts should read
+Developers working on config compilation, execution, or evidence should read
 [Runtime control plane](developer_runtime_control_plane.md). First-time users do not need
-those implementation details to run experiments.
+those internals to run an experiment.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,60 +1,94 @@
 # Testing and Validation
 
-This page is the maintained source for PHM-Vibench test commands and evidence
-terminology. Run the narrowest test that exercises a change, then apply the
-relevant merge gate.
+Run the narrowest test that exercises a change, then apply the relevant integration gate.
+A passing import is not an end-to-end run, and a synthetic smoke is not scientific
+performance evidence.
 
 ## Evidence terms
 
 Use precise language in issues and pull requests:
 
-- **Local pass** — the command ran successfully in a named local environment.
-- **CI pass** — a GitHub Actions job attached to the commit completed successfully.
-- **Not executed** — the command was not run; do not infer a result.
-- **Expected failure** — an intentionally invalid case failed with the documented
-  error boundary.
-- **Smoke evidence** — a bounded path executed; this is not benchmark-performance
-  evidence.
-- **Contract evidence** — inputs, outputs, shapes, devices, errors, or artifacts
-  satisfied explicit assertions.
+- **Local pass** — the exact command succeeded in a named local environment.
+- **CI pass** — a GitHub Actions job attached to the commit succeeded.
+- **Not executed** — the command was not run; no result may be inferred.
+- **Expected failure** — an intentionally invalid input failed at the documented boundary.
+- **Smoke evidence** — a bounded execution path completed.
+- **Contract evidence** — explicit input, output, shape, error, state, or artifact
+  assertions passed.
+- **Benchmark-valid evidence** — the exact data/protocol/metric/seed policy required for
+  comparison was satisfied; ordinary smoke evidence is not enough.
 
-Never describe local output as CI output, an import as an end-to-end run, or
-synthetic data as evidence of scientific performance.
-
-## Maintained test directory
-
-The maintained pytest gate is:
+## Maintained pytest suite
 
 ```bash
 python -m pytest test/ -q
 ```
 
-Files under `dev/test_history/`, `test/todo_test/`, historical release folders, or
-research workspaces are diagnostic unless a maintained page explicitly promotes a
-specific command.
+Historical release folders, `dev/test_history/`, `test/todo_test/`, and isolated research
+workspaces are diagnostic unless a maintained document explicitly promotes a command.
 
-## Lightweight documentation and configuration gate
-
-Use this gate for documentation, registry, and YAML changes:
+## Documentation and configuration gate
 
 ```bash
 python -m scripts.validate_docs
 python -m scripts.validate_configs
+python -m pytest test/test_config_analysis_parity.py -q
 python -m scripts.gen_config_atlas
-git diff --exit-code docs/CONFIG_ATLAS.md
+python -m scripts.gen_support_matrix
+git diff --exit-code \
+  docs/CONFIG_ATLAS.md \
+  SUPPORTED_COMPONENTS.md \
+  SUPPORTED_COMBINATIONS.md
 git diff --check
 ```
 
-`docs/CONFIG_ATLAS.md` is generated from `configs/config_registry.csv`. Do not
-hand-edit the atlas to make the diff disappear.
+Generated files must be changed through their source registry or descriptor. Do not edit
+generated output to hide drift.
 
-A documentation-only pull request may stop at this gate when it does not change a
-command, configuration, runtime claim, or executable example. The pull-request
-description must explain why runtime tests are not applicable.
+## One configuration truth gate
 
-## Configuration inspection
+The core invariant is:
 
-Inspect the resolved values, sources, runtime targets, and sanity checks:
+```text
+run effective config
+= preflight effective config
+= inspector effective config
+= validator effective config
+= Streamlit effective config
+= Pipeline 06 effective config
+```
+
+For identical visible inputs, all paths must report the same
+`effective_config_sha256`. The focused gate is:
+
+```bash
+python -m pytest test/test_config_analysis_parity.py -q
+```
+
+It covers:
+
+- maintained preset versus explicit YAML path;
+- equivalent YAML value versus CLI override;
+- base/config/explicit-local/CLI precedence;
+- absence of implicit `configs/local/local.yaml` discovery;
+- compatibility `resolve_config` view;
+- inspector, validator, and preflight parity;
+- mapping-order-independent semantic hashing.
+
+When changing config behavior, also run:
+
+```bash
+python -m pytest \
+  test/test_phmfactory_config_resolver.py \
+  test/test_phmfactory_commands.py \
+  test/test_phmfactory_entrypoints.py \
+  test/test_pipeline_name_migration.py \
+  test/test_pipeline_maturity.py \
+  test/test_runtime_control_plane.py \
+  test/test_runtime_attestation.py -q
+```
+
+## Inspect one configuration
 
 ```bash
 python -m scripts.config_inspect \
@@ -62,93 +96,135 @@ python -m scripts.config_inspect \
   --override trainer.num_epochs=1
 ```
 
-The command must return non-zero when a sanity check fails. Missing dependencies,
-unknown imports, or invalid targets are failures, not warnings to ignore.
+The output includes the effective config hash, resolved values, leaf-field sources,
+factory targets, and sanity checks. A failed sanity check returns non-zero.
 
-## Offline end-to-end smoke
-
-The repository-shipped dummy configuration is the default runtime gate:
+To test an explicit machine-local layer:
 
 ```bash
-python main.py --config configs/demo/00_smoke/dummy_dg.yaml \
-  --override trainer.num_epochs=1 \
-  --override data.num_workers=0
+python -m scripts.config_inspect \
+  --config configs/experiments/my_experiment.yaml \
+  --local-config configs/local/my_machine.yaml
 ```
 
-A pass requires a clean exit through config loading, data construction, model and
-task assembly, trainer execution, and output creation. See the
-[quickstart](quickstart.md) for expected behavior.
+Omitting `--local-config` means no local YAML participates.
 
-This smoke uses synthetic repository data and does not validate accuracy on an
-industrial dataset.
+## User-first offline gate
 
-## Focused tests
-
-Examples of focused gates already present in the repository:
+The maintained first-run path is:
 
 ```bash
-# Configuration tooling
-python -m pytest test/test_config_tools.py -q
+python -m pip install --no-deps -e .
+phmfactory doctor
+phmfactory preflight --config smoke
+phmfactory demo
+```
 
-# Streamlit configuration and process boundaries
+A pass requires:
+
+- all required doctor checks pass;
+- preflight reports `effective_config_sha256` and does not create the configured output;
+- the Dummy data/model/task/trainer path completes;
+- the command exits zero;
+- the terminal run manifest records `succeeded` and the effective config hash;
+- per-iteration and aggregate metrics are indexed.
+
+This path uses synthetic repository data and does not validate industrial accuracy.
+
+## Pipeline 06 config contract
+
+Pipeline 06 keeps its scientific implementation in `src`, but the public CLI imports a
+narrow compiled-config adapter. Run:
+
+```bash
+python -m pytest \
+  test/generative/test_pipeline06_import.py \
+  test/generative/test_pipeline06_preflight.py \
+  test/generative/test_pipeline06_dispatch.py \
+  test/generative/test_pipeline06_compiled_config.py -q
+```
+
+The adapter test proves that the public path does not re-read YAML, reapply overrides, or
+accept a mismatched compiled Pipeline.
+
+## Streamlit parity gate
+
+```bash
 python -m pytest \
   test/test_streamlit_config_service.py \
   test/test_streamlit_runtime_policy.py \
+  test/test_streamlit_onboarding.py \
   test/test_streamlit_run_service.py \
-  test/test_streamlit_result_service.py -q
+  test/test_streamlit_result_service.py \
+  test/test_streamlit_ui_imports.py -q
+```
 
-# TSPN_UXFD assembly contract
+These tests run on Linux and Windows. The UI remains an adapter around the public
+inspector and CLI; it does not define hidden local config or a second training runtime.
+
+## Other focused gates
+
+```bash
+# UXFD assembly contract
 python -m pytest test/test_tspn_uxfd_assembly.py -q
 
-# Generative/pretraining contract tests
+# Shared classification lifecycle and evidence
+python -m pytest \
+  test/test_classification_runtime.py \
+  test/test_pipeline02_runtime.py \
+  test/test_runtime_evidence.py -q
+
+# Complete generative research tests when applicable
 python -m pytest test/generative/ -q
 ```
 
-Verify that a referenced test file exists on the branch before copying a command
-into documentation or a pull request.
+Verify every referenced file exists on the branch before copying a command into a PR.
 
-## Active GitHub Actions gate
+## Active GitHub Actions
 
-`.github/workflows/core-quality-gates.yml` currently runs on pull requests and
-pushes to `main`.
+Current pull requests can trigger:
 
-The active workflow checks:
+- **Core quality gates** — docs/config parity, Pipeline 06 adapter contract, UXFD focused
+  contract, and actual offline user-first smoke;
+- **PHMFactory public package** — source tests, wheel contents, clean-wheel preflight,
+  process exit semantics, and compiled-config dispatch;
+- **Streamlit quality gates** — focused UI services on Linux and Windows;
+- repository layout, dependency ownership, data-bundle, submodule, and release-readiness
+  gates as their paths require.
 
-1. documentation and maintained configuration consistency;
-2. generated atlas cleanliness and whitespace;
-3. focused CPU compilation and tests for the UXFD U1 assembly contract.
-
-The workflow is intentionally narrower than the entire optional research stack.
-A green focused workflow does not mean every model family, dataset, or external-
-data demo has been executed.
+A green focused workflow proves only its declared scope.
 
 ## Test selection by change type
 
-| Change | Minimum focused gate | Additional merge gate |
+| Change | Minimum focused gate | Additional integration gate |
 | --- | --- | --- |
-| Documentation wording or links | `validate_docs` | `validate_configs`, atlas clean diff, `git diff --check` |
-| Maintained YAML or registry | `validate_configs`, `config_inspect` | atlas clean diff and applicable smoke |
-| Data reader or sampler | focused contract test | dummy smoke plus affected real-data test when assets exist |
-| Model implementation | import/assembly/shape test | affected task integration and dummy smoke |
+| Documentation wording or links | `validate_docs` | config validation and clean generated diff when commands/claims change |
+| Config resolver, CLI, inspector, validator | config parity tests | public-package wheel and offline smoke |
+| Maintained YAML or registry | `validate_configs`, `config_inspect` | generated docs and applicable smoke |
+| Data reader or sampler | focused reader/adapter test | Dummy smoke plus affected real-data test when legal assets exist |
+| Model implementation | import/shape/assembly test | affected task integration and Dummy smoke |
 | Task, loss, or metric | focused behavior and negative tests | affected maintained demo smoke |
-| Trainer or checkpoint behavior | focused lifecycle test | dummy train/test loop and checkpoint round trip |
-| Streamlit | focused service tests | core config checks; CLI smoke remains authoritative |
-| Release support claim | linked runtime evidence | independent review of supported components/combinations |
+| Trainer or checkpoint | lifecycle and failure tests | Dummy train/test and checkpoint round trip |
+| Pipeline 06 shell/config | compiled-config adapter tests | affected train/sample/eval contract |
+| Streamlit | focused Linux/Windows service tests | public config parity and CLI smoke |
+| Release support claim | exact linked runtime evidence | independent review of support matrices and limitations |
 
 ## Environment reporting
 
-Include at least:
+Include:
 
 ```text
 operating system
 Python version
-PyTorch and PyTorch Lightning versions
-CPU/GPU and CUDA version when relevant
+PyTorch and Lightning versions
+CPU/GPU and CUDA when relevant
 repository commit
-configuration path and overrides
+config or preset
+effective_config_sha256
+explicit local config, if any
+CLI overrides
 data source
-full command
-exit code
+full command and exit code
 ```
 
 For dependency diagnostics:
@@ -158,12 +234,11 @@ python --version
 python -m pip freeze
 ```
 
-Do not commit a complete environment dump unless it is a deliberate, reviewed
-release artifact; attach it to an issue or CI artifact instead.
+Attach full environment dumps to an issue or CI artifact rather than committing them by
+default.
 
 ## Reproducibility
 
-For a reproducibility claim, record the commit, configuration, overrides, data
-version, split, seed, environment, and output artifact. A repeated run can be
-considered reproducible only against an explicit tolerance appropriate to the
-metric and hardware path; GPU bitwise identity is not assumed.
+A reproducibility claim requires the same effective configuration, code revision, data
+version, split, seed, protocol, environment, and relevant artifacts. Hardware-dependent
+numerical tolerance must be declared; GPU bitwise identity is not assumed.

--- a/phmfactory/cli.py
+++ b/phmfactory/cli.py
@@ -1,19 +1,8 @@
 """Public command routing and process entrypoints for PHMFactory.
 
-This module deliberately exposes two layers:
-
-``main(argv)``
-    Programmatic router. It returns structured command or Pipeline results so tests,
-    notebooks, and Python callers can inspect them directly.
-
-``entrypoint(argv)``
-    Operating-system process boundary used by the installed ``phmfactory`` command,
-    ``python -m phmfactory``, and the repository ``main.py`` compatibility launcher.
-    It converts every successful structured result into exit status ``0`` while
-    allowing ``SystemExit`` and runtime exceptions to retain their failure status.
-
-Keeping these contracts separate prevents a successful dictionary or list result from
-being passed to ``sys.exit`` and incorrectly reported as process exit code ``1``.
+This module exposes a programmatic API and an operating-system process boundary.  Both
+consume the same :class:`phmfactory.config.ConfigAnalysis`; neither reparses YAML or
+searches for machine-local configuration after compilation.
 """
 
 from __future__ import annotations
@@ -24,8 +13,12 @@ import sys
 from collections.abc import Sequence
 from typing import Any
 
-from phmfactory.commands.common import add_config_arguments, requested_config
-from phmfactory.config import resolve_config
+from phmfactory.commands.common import (
+    add_config_arguments,
+    requested_config,
+    requested_local_config,
+)
+from phmfactory.config import analyze_config
 from phmfactory.pipelines import pipeline_module_name, require_pipeline_access
 from phmfactory.runtime import (
     AttestationWriteError,
@@ -61,11 +54,12 @@ def _resolve_config_path(args: argparse.Namespace) -> str:
 
 
 def _resolve_pipeline(args: argparse.Namespace, config_path: str) -> str:
-    """Resolve the canonical Pipeline through the public config API."""
+    """Resolve the canonical Pipeline through the public config authority."""
 
-    return resolve_config(
+    return analyze_config(
         config_path,
         override_values=args.override,
+        local_config=requested_local_config(args),
     ).pipeline
 
 
@@ -83,26 +77,34 @@ def _write_failed_attestation(
 
 
 def run(args: argparse.Namespace) -> Any:
-    """Compile, record, authorize, execute, and index one Pipeline invocation.
+    """Analyze, record, authorize, execute, and index one Pipeline invocation.
 
-    The function is the single maintained experiment execution boundary. It returns the
-    Pipeline's explicit Python result for programmatic callers. Process exit handling is
-    owned by :func:`entrypoint`, not by this function.
+    Configuration composition occurs exactly once in :func:`analyze_config`.  Protected
+    runtime code receives a mutable copy through ``CompiledRunSpec.runtime_config()``.
+    The function returns the Pipeline's explicit Python result for programmatic callers;
+    process exit handling is owned by :func:`entrypoint`.
     """
 
     requested = requested_config(args)
-    resolved = resolve_config(requested, override_values=args.override)
+    analysis = analyze_config(
+        requested,
+        override_values=args.override,
+        local_config=requested_local_config(args),
+    )
+    resolved = analysis.to_resolved_config()
     compiled = CompiledRunSpec.compile(resolved)
 
     args.requested_config = requested
-    args.config_path = str(resolved.path)
-    args.resolved_config_path = str(resolved.path)
-    args.resolved_pipeline = resolved.pipeline
+    args.config_path = str(analysis.path)
+    args.resolved_config_path = str(analysis.path)
+    args.resolved_pipeline = analysis.pipeline
+    args.config_analysis = analysis
     args.compiled_run_spec = compiled
     args.resolved_config_data = compiled.runtime_config()
+    args.effective_config_sha256 = analysis.effective_config_sha256
     args.run_spec_sha256 = compiled.sha256
 
-    module_name = pipeline_module_name(resolved.pipeline, warn=False)
+    module_name = pipeline_module_name(analysis.pipeline, warn=False)
     envelope = ExecutionEnvelope(spec=compiled, pipeline_module=module_name)
     args.execution_envelope = envelope
 
@@ -118,7 +120,7 @@ def run(args: argparse.Namespace) -> Any:
 
     try:
         descriptor = require_pipeline_access(
-            resolved.pipeline,
+            analysis.pipeline,
             allow_experimental=bool(getattr(args, "allow_experimental", False)),
             warn=False,
         )
@@ -182,12 +184,7 @@ def _run_command(name: str, argv: Sequence[str]) -> Any:
 
 
 def main(argv: Sequence[str] | None = None) -> Any:
-    """Return the structured result of a named command or experiment.
-
-    This function is retained as the programmatic compatibility API. Code that starts an
-    operating-system process must call :func:`entrypoint` instead so a successful mapping,
-    list, or model result is not interpreted as an error exit message by ``sys.exit``.
-    """
+    """Return the structured result of a named command or experiment."""
 
     arguments = list(sys.argv[1:] if argv is None else argv)
     if arguments[:1] and arguments[0] in COMMANDS:
@@ -196,12 +193,11 @@ def main(argv: Sequence[str] | None = None) -> Any:
 
 
 def entrypoint(argv: Sequence[str] | None = None) -> int:
-    """Execute the public process contract and return an integer status code.
+    """Execute the public process contract and return integer status code ``0``.
 
-    Successful command and Pipeline results are intentionally discarded at this boundary;
-    their human-readable output and generated files remain available. ``argparse`` exits,
-    explicit command failures, and runtime exceptions are not caught, so their original
-    non-zero status and traceback are preserved.
+    Successful structured results are discarded at the process boundary. ``argparse``
+    exits and runtime exceptions are deliberately not caught, preserving non-zero status
+    and the original diagnostic.
     """
 
     main(argv)

--- a/phmfactory/commands/common.py
+++ b/phmfactory/commands/common.py
@@ -1,4 +1,9 @@
-"""Shared argument and filesystem helpers for PHMFactory commands."""
+"""Shared argument and filesystem helpers for PHMFactory commands.
+
+The helpers keep the user-facing command surface consistent.  In particular, a
+machine-local YAML file is an explicit input; the public path never searches for
+``configs/local/local.yaml`` on its own.
+"""
 
 from __future__ import annotations
 
@@ -15,7 +20,7 @@ def add_config_arguments(
     include_notes: bool = False,
     include_experimental: bool = True,
 ) -> None:
-    """Add the maintained config/preset and override surface to a parser."""
+    """Add the maintained config, explicit local layer, and override surface."""
 
     parser.add_argument(
         "--config",
@@ -28,6 +33,16 @@ def add_config_arguments(
         type=str,
         default=None,
         help="Deprecated alias for --config.",
+    )
+    parser.add_argument(
+        "--local-config",
+        "--local_config",
+        dest="local_config",
+        default=None,
+        help=(
+            "Optional machine-local YAML applied explicitly after the experiment "
+            "config and before CLI overrides. No local file is auto-discovered."
+        ),
     )
     if include_notes:
         parser.add_argument("--notes", default="", help="Experiment notes.")
@@ -52,6 +67,13 @@ def requested_config(args: argparse.Namespace) -> str:
     if getattr(args, "config_path", None) is not None:
         return str(args.config_path)
     return DEFAULT_CONFIG
+
+
+def requested_local_config(args: argparse.Namespace) -> str | None:
+    """Return the explicit machine-local YAML path, or ``None`` when omitted."""
+
+    value = getattr(args, "local_config", None)
+    return str(value) if value is not None else None
 
 
 def _probe_existing_directory(directory: Path) -> None:

--- a/phmfactory/commands/preflight.py
+++ b/phmfactory/commands/preflight.py
@@ -1,4 +1,4 @@
-"""Compile and validate a public run without importing or executing training code."""
+"""Validate one analyzed PHMFactory run without importing training code."""
 
 from __future__ import annotations
 
@@ -11,36 +11,55 @@ from phmfactory.commands.common import (
     add_config_arguments,
     check_writable_directory,
     requested_config,
+    requested_local_config,
 )
-from phmfactory.config import resolve_config
+from phmfactory.config import analyze_config
 from phmfactory.pipelines import pipeline_module_name, require_pipeline_access
 from phmfactory.runtime import CompiledRunSpec
 
 
 def build_parser() -> argparse.ArgumentParser:
+    """Build the preflight parser shared by console and module entrypoints."""
+
     parser = argparse.ArgumentParser(
         prog="phmfactory preflight",
-        description="Compile and validate one PHMFactory run without training.",
+        description="Analyze and validate one PHMFactory run without training.",
     )
     add_config_arguments(parser, include_experimental=True)
     return parser
 
 
 def run(argv: Sequence[str]) -> dict[str, Any]:
+    """Return and print the exact non-training preflight report.
+
+    The function uses the same :func:`phmfactory.config.analyze_config` call as the real
+    runtime. It does not import the Pipeline implementation, construct factories, create
+    the configured output directory, or start a run.
+    """
+
     args = build_parser().parse_args(list(argv))
     source = requested_config(args)
-    resolved = resolve_config(source, override_values=args.override)
-    compiled = CompiledRunSpec.compile(resolved)
+    analysis = analyze_config(
+        source,
+        override_values=args.override,
+        local_config=requested_local_config(args),
+    )
+    errors = [item for item in analysis.diagnostics if item.severity == "error"]
+    if errors:
+        detail = "; ".join(f"{item.field}: {item.message}" for item in errors)
+        raise ValueError(f"configuration analysis failed: {detail}")
+
+    compiled = CompiledRunSpec.compile(analysis.to_resolved_config())
     descriptor = require_pipeline_access(
-        resolved.pipeline,
+        analysis.pipeline,
         allow_experimental=bool(args.allow_experimental),
         warn=False,
     )
-    module_name = pipeline_module_name(resolved.pipeline, warn=False)
+    module_name = pipeline_module_name(analysis.pipeline, warn=False)
     if importlib.util.find_spec(module_name) is None:
         raise ModuleNotFoundError(module_name)
 
-    environment = compiled.config.get("environment")
+    environment = analysis.effective_config.get("environment")
     output_dir = environment.get("output_dir") if isinstance(environment, dict) else None
     if not isinstance(output_dir, str) or not output_dir.strip():
         raise ValueError("environment.output_dir is required for preflight")
@@ -48,9 +67,15 @@ def run(argv: Sequence[str]) -> dict[str, Any]:
     result = {
         "status": "passed",
         "requested_config": source,
-        "resolved_config_path": str(resolved.path),
+        "resolved_config_path": str(analysis.path),
+        "local_config_path": (
+            str(analysis.local_config_path)
+            if analysis.local_config_path is not None
+            else "none"
+        ),
+        "effective_config_sha256": analysis.effective_config_sha256,
         "run_spec_sha256": compiled.sha256,
-        "pipeline": compiled.pipeline,
+        "pipeline": analysis.pipeline,
         "pipeline_module": module_name,
         "maturity": descriptor.maturity,
         "output_dir": str(writable),

--- a/phmfactory/config.py
+++ b/phmfactory/config.py
@@ -1,17 +1,28 @@
-"""Public configuration resolution for PHMFactory.
+"""Single public configuration authority for PHMFactory.
 
-This module resolves a maintained preset or YAML path, applies CLI-style dotted
-key overrides, and returns a plain dictionary without importing the protected
-training runtime.
+This module owns the complete maintained precedence chain:
+
+``base_configs -> experiment YAML -> explicit local config -> CLI overrides``
+
+Every public caller—run, preflight, inspection, validation, support generation, and the
+optional Streamlit UI—must use :func:`analyze_config` or the compatibility wrapper
+:func:`resolve_config`.  The module deliberately does not import a Pipeline, model,
+task, trainer, or dataset.  It resolves user intent into one immutable analysis object
+without starting training or creating output directories.
+
+Machine-local configuration is never discovered implicitly.  A local YAML file affects
+an invocation only when the caller supplies it explicitly.
 """
 
 from __future__ import annotations
 
 from copy import deepcopy
-from dataclasses import dataclass
+from dataclasses import dataclass, field
+from hashlib import sha256
 from importlib import resources
+import json
 from pathlib import Path
-from typing import Any, Mapping, Sequence
+from typing import Any, Iterable, Mapping, Sequence
 
 import yaml
 
@@ -33,7 +44,11 @@ MAINTAINED_PRESETS: dict[str, str] = {
 
 @dataclass(frozen=True)
 class ResolvedConfig:
-    """Resolved public configuration metadata and payload."""
+    """Backward-compatible resolved configuration payload.
+
+    New public code should prefer :class:`ConfigAnalysis`, which also records field
+    provenance, diagnostics, source files, and the effective semantic hash.
+    """
 
     requested: str
     path: Path
@@ -42,8 +57,92 @@ class ResolvedConfig:
     overrides: dict[str, Any]
 
 
+@dataclass(frozen=True)
+class ConfigDiagnostic:
+    """One stable, user-correctable configuration observation."""
+
+    code: str
+    severity: str
+    message: str
+    field: str = ""
+    suggestion: str = ""
+
+    def as_dict(self) -> dict[str, str]:
+        """Return a JSON-serializable diagnostic record."""
+
+        return {
+            "code": self.code,
+            "severity": self.severity,
+            "message": self.message,
+            "field": self.field,
+            "suggestion": self.suggestion,
+        }
+
+
+@dataclass(frozen=True)
+class ConfigAnalysis:
+    """Immutable description of the exact effective configuration.
+
+    ``effective_config_sha256`` hashes only the canonical effective configuration.  It
+    excludes the requested alias, source paths, installation path, and override spelling,
+    so semantically identical invocations compare equal across checkouts and entrypoints.
+    """
+
+    requested: str
+    path: Path
+    effective_config: dict[str, Any]
+    pipeline: str
+    overrides: dict[str, Any]
+    local_config_path: Path | None
+    source_files: tuple[Path, ...]
+    sources: dict[str, str]
+    diagnostics: tuple[ConfigDiagnostic, ...]
+    effective_config_sha256: str
+
+    def runtime_config(self) -> dict[str, Any]:
+        """Return a mutable copy for one runtime or inspection consumer."""
+
+        return deepcopy(self.effective_config)
+
+    def to_resolved_config(self) -> ResolvedConfig:
+        """Return the legacy payload expected by ``CompiledRunSpec`` and callers."""
+
+        return ResolvedConfig(
+            requested=self.requested,
+            path=self.path,
+            data=self.runtime_config(),
+            pipeline=self.pipeline,
+            overrides=deepcopy(self.overrides),
+        )
+
+    def as_dict(self) -> dict[str, Any]:
+        """Return a portable representation for CLI and UI adapters."""
+
+        return {
+            "requested": self.requested,
+            "resolved_path": str(self.path),
+            "effective_config": self.runtime_config(),
+            "pipeline": self.pipeline,
+            "overrides": deepcopy(self.overrides),
+            "local_config_path": (
+                str(self.local_config_path) if self.local_config_path is not None else None
+            ),
+            "source_files": [str(path) for path in self.source_files],
+            "sources": dict(self.sources),
+            "diagnostics": [item.as_dict() for item in self.diagnostics],
+            "effective_config_sha256": self.effective_config_sha256,
+        }
+
+
 def parse_overrides(values: Sequence[str] | None) -> dict[str, Any]:
-    """Parse repeated ``key=value`` overrides into a nested dictionary."""
+    """Parse repeated ``key=value`` overrides into a nested dictionary.
+
+    Raises
+    ------
+    ValueError
+        If a token is missing ``=`` or attempts to traverse a non-mapping field.
+    """
+
     parsed: dict[str, Any] = {}
     for item in values or ():
         if "=" not in item:
@@ -60,6 +159,108 @@ def parse_overrides(values: Sequence[str] | None) -> dict[str, Any]:
     return parsed
 
 
+def semantic_config_sha256(config: Mapping[str, Any]) -> str:
+    """Return the stable SHA-256 of one effective configuration mapping."""
+
+    payload = json.dumps(
+        _json_compatible(config),
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+    return sha256(payload).hexdigest()
+
+
+def analyze_config(
+    source: str | Path | None = None,
+    *,
+    override_values: Sequence[str] | None = None,
+    local_config: str | Path | None = None,
+) -> ConfigAnalysis:
+    """Resolve one public configuration through the single maintained authority.
+
+    Parameters
+    ----------
+    source:
+        Maintained preset name or YAML path.  ``None`` selects ``DEFAULT_CONFIG``.
+    override_values:
+        Repeatable dotted ``key=value`` tokens applied last.
+    local_config:
+        Optional YAML path applied explicitly between the experiment YAML and CLI
+        overrides.  No default local file is searched when this argument is omitted.
+
+    Returns
+    -------
+    ConfigAnalysis
+        Immutable effective configuration, provenance, diagnostics, and semantic hash.
+
+    Raises
+    ------
+    FileNotFoundError, TypeError, ValueError, yaml.YAMLError
+        The original configuration error is propagated; there is no fallback to another
+        config or Pipeline.
+    """
+
+    requested = str(source or DEFAULT_CONFIG)
+    path = resolve_config_path(source)
+    data, sources, files = _load_recursive_with_sources(
+        path,
+        stack=(),
+        source_kind="config",
+    )
+
+    local_path: Path | None = None
+    if local_config is not None:
+        local_path = _resolve_explicit_local_path(local_config)
+        local_data, _, local_files = _load_recursive_with_sources(
+            local_path,
+            stack=(),
+            source_kind="local",
+        )
+        _deep_merge(data, local_data)
+        _mark_leaf_sources(sources, local_data, f"local:{local_path}")
+        files.extend(local_files)
+
+    overrides = parse_overrides(override_values)
+    _deep_merge(data, overrides)
+    _mark_leaf_sources(sources, overrides, "cli:--override")
+
+    raw_pipeline = data.get("pipeline", DEFAULT_PIPELINE)
+    if not isinstance(raw_pipeline, str) or not raw_pipeline.strip():
+        raise ValueError("pipeline must be a non-empty string")
+    pipeline = canonical_pipeline_name(raw_pipeline.strip())
+    data["pipeline"] = pipeline
+    sources.setdefault("pipeline", "default:Pipeline_01_Fault_Diagnosis")
+
+    effective = _json_compatible(deepcopy(data))
+    return ConfigAnalysis(
+        requested=requested,
+        path=path,
+        effective_config=effective,
+        pipeline=pipeline,
+        overrides=_json_compatible(deepcopy(overrides)),
+        local_config_path=local_path,
+        source_files=_unique_paths(files),
+        sources=dict(sorted(sources.items())),
+        diagnostics=_basic_diagnostics(effective),
+        effective_config_sha256=semantic_config_sha256(effective),
+    )
+
+
+def resolve_config(
+    source: str | Path | None = None,
+    *,
+    override_values: Sequence[str] | None = None,
+    local_config: str | Path | None = None,
+) -> ResolvedConfig:
+    """Compatibility wrapper around :func:`analyze_config`."""
+
+    return analyze_config(
+        source,
+        override_values=override_values,
+        local_config=local_config,
+    ).to_resolved_config()
+
 
 def _packaged_config_path(relative_path: str) -> Path | None:
     normalized = relative_path.replace("\\", "/")
@@ -68,7 +269,7 @@ def _packaged_config_path(relative_path: str) -> Path | None:
         return None
     try:
         resource = resources.files("configs").joinpath(
-            *Path(normalized[len(prefix):]).parts
+            *Path(normalized[len(prefix) :]).parts
         )
     except (ModuleNotFoundError, TypeError):
         return None
@@ -76,10 +277,18 @@ def _packaged_config_path(relative_path: str) -> Path | None:
     return candidate.resolve() if candidate.is_file() else None
 
 
-def _resolve_existing_config_path(source: str | Path, *, relative_to: Path | None = None) -> Path:
+def _resolve_existing_config_path(
+    source: str | Path,
+    *,
+    relative_to: Path | None = None,
+) -> Path:
     requested = str(source)
     candidate = Path(requested).expanduser()
-    if not candidate.is_absolute() and relative_to is not None and not requested.replace("\\", "/").startswith("configs/"):
+    if (
+        not candidate.is_absolute()
+        and relative_to is not None
+        and not requested.replace("\\", "/").startswith("configs/")
+    ):
         candidate = relative_to / candidate
     if candidate.is_file():
         return candidate.resolve()
@@ -88,8 +297,20 @@ def _resolve_existing_config_path(source: str | Path, *, relative_to: Path | Non
         return packaged
     raise FileNotFoundError(requested)
 
+
+def _resolve_explicit_local_path(source: str | Path) -> Path:
+    candidate = Path(source).expanduser()
+    if candidate.is_file():
+        return candidate.resolve()
+    raise FileNotFoundError(
+        f"Explicit local configuration was not found: {candidate}. "
+        "Remove --local-config or provide an existing YAML file."
+    )
+
+
 def resolve_config_path(source: str | Path | None) -> Path:
     """Resolve a public preset or YAML path from a checkout or installed wheel."""
+
     requested = str(source or DEFAULT_CONFIG)
     mapped = MAINTAINED_PRESETS.get(requested, requested)
     try:
@@ -103,46 +324,31 @@ def resolve_config_path(source: str | Path | None) -> Path:
 
 def load_config_dict(path: str | Path) -> dict[str, Any]:
     """Load YAML and recursively merge its ordered ``base_configs`` entries."""
-    return _load_recursive(Path(path).resolve(), stack=())
 
-
-def resolve_config(
-    source: str | Path | None = None,
-    *,
-    override_values: Sequence[str] | None = None,
-) -> ResolvedConfig:
-    """Resolve path, base configs, overrides, and canonical Pipeline name."""
-    requested = str(source or DEFAULT_CONFIG)
-    path = resolve_config_path(source)
-    data = load_config_dict(path)
-    overrides = parse_overrides(override_values)
-    _deep_merge(data, overrides)
-    raw_pipeline = data.get("pipeline", DEFAULT_PIPELINE)
-    if not isinstance(raw_pipeline, str) or not raw_pipeline.strip():
-        raise ValueError("pipeline must be a non-empty string")
-    pipeline = canonical_pipeline_name(raw_pipeline.strip())
-    data["pipeline"] = pipeline
-    return ResolvedConfig(
-        requested=requested,
-        path=path,
-        data=data,
-        pipeline=pipeline,
-        overrides=overrides,
+    data, _, _ = _load_recursive_with_sources(
+        Path(path).resolve(),
+        stack=(),
+        source_kind="config",
     )
+    return data
 
 
-def _load_recursive(path: Path, *, stack: tuple[Path, ...]) -> dict[str, Any]:
+def _load_recursive_with_sources(
+    path: Path,
+    *,
+    stack: tuple[Path, ...],
+    source_kind: str,
+) -> tuple[dict[str, Any], dict[str, str], list[Path]]:
+    path = path.resolve()
     if path in stack:
         chain = " -> ".join(str(item) for item in (*stack, path))
         raise ValueError(f"Cyclic base_configs reference: {chain}")
-    try:
-        payload = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
-    except UnicodeDecodeError:
-        payload = yaml.safe_load(path.read_text(encoding="gb18030", errors="ignore")) or {}
-    if not isinstance(payload, dict):
-        raise TypeError(f"Top-level YAML object must be a mapping: {path}")
 
+    payload = _read_yaml_mapping(path)
     merged: dict[str, Any] = {}
+    sources: dict[str, str] = {}
+    files: list[Path] = []
+
     base_configs = payload.get("base_configs") or {}
     if not isinstance(base_configs, Mapping):
         raise TypeError(f"base_configs must be a mapping: {path}")
@@ -151,11 +357,32 @@ def _load_recursive(path: Path, *, stack: tuple[Path, ...]) -> dict[str, Any]:
             str(base_source),
             relative_to=path.parent,
         )
-        _deep_merge(merged, _load_recursive(base_path, stack=(*stack, path)))
+        base_data, base_sources, base_files = _load_recursive_with_sources(
+            base_path,
+            stack=(*stack, path),
+            source_kind="base",
+        )
+        _deep_merge(merged, base_data)
+        sources.update(base_sources)
+        files.extend(base_files)
 
     current = {key: value for key, value in payload.items() if key != "base_configs"}
     _deep_merge(merged, current)
-    return merged
+    _mark_leaf_sources(sources, current, f"{source_kind}:{path}")
+    files.append(path)
+    return merged, sources, files
+
+
+def _read_yaml_mapping(path: Path) -> dict[str, Any]:
+    try:
+        payload = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+    except UnicodeDecodeError:
+        payload = yaml.safe_load(
+            path.read_text(encoding="gb18030", errors="ignore")
+        ) or {}
+    if not isinstance(payload, dict):
+        raise TypeError(f"Top-level YAML object must be a mapping: {path}")
+    return payload
 
 
 def _set_dotted(target: dict[str, Any], key: str, value: Any) -> None:
@@ -178,3 +405,67 @@ def _deep_merge(target: dict[str, Any], source: Mapping[str, Any]) -> None:
             _deep_merge(target[key], value)
         else:
             target[key] = deepcopy(value)
+
+
+def _leaf_items(
+    value: Mapping[str, Any],
+    *,
+    prefix: str = "",
+) -> Iterable[tuple[str, Any]]:
+    for key, item in value.items():
+        path = f"{prefix}.{key}" if prefix else str(key)
+        if isinstance(item, Mapping) and item:
+            yield from _leaf_items(item, prefix=path)
+        else:
+            yield path, item
+
+
+def _mark_leaf_sources(
+    target: dict[str, str],
+    value: Mapping[str, Any],
+    label: str,
+) -> None:
+    for path, _ in _leaf_items(value):
+        target[path] = label
+
+
+def _unique_paths(paths: Iterable[Path]) -> tuple[Path, ...]:
+    result: list[Path] = []
+    seen: set[Path] = set()
+    for path in paths:
+        resolved = path.resolve()
+        if resolved not in seen:
+            seen.add(resolved)
+            result.append(resolved)
+    return tuple(result)
+
+
+def _json_compatible(value: Any) -> Any:
+    if isinstance(value, Mapping):
+        return {str(key): _json_compatible(item) for key, item in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_json_compatible(item) for item in value]
+    if isinstance(value, Path):
+        return str(value)
+    if value is None or isinstance(value, (bool, int, float, str)):
+        return value
+    raise TypeError(
+        "Configuration values must be mappings, sequences, paths, or JSON scalars; "
+        f"got {type(value).__name__}"
+    )
+
+
+def _basic_diagnostics(config: Mapping[str, Any]) -> tuple[ConfigDiagnostic, ...]:
+    diagnostics: list[ConfigDiagnostic] = []
+    for block in ("environment", "data", "model", "task", "trainer"):
+        if not isinstance(config.get(block), Mapping):
+            diagnostics.append(
+                ConfigDiagnostic(
+                    code="missing_required_block",
+                    severity="error",
+                    field=block,
+                    message=f"The effective configuration has no mapping block {block!r}.",
+                    suggestion=f"Add `{block}:` directly or through base_configs.",
+                )
+            )
+    return tuple(diagnostics)

--- a/phmfactory/pipelines.py
+++ b/phmfactory/pipelines.py
@@ -1,4 +1,4 @@
-"""Canonical Pipeline identifiers, maturity, and compatibility aliases."""
+"""Canonical Pipeline identifiers, maturity, and public runtime adapters."""
 
 from __future__ import annotations
 
@@ -16,16 +16,22 @@ class PipelineMaturityError(RuntimeError):
 
 @dataclass(frozen=True)
 class PipelineDescriptor:
-    """Machine-readable public maturity contract for one protected Pipeline."""
+    """Machine-readable public maturity contract for one Pipeline.
+
+    ``module`` may point to a narrow public adapter when the scientific implementation
+    remains in ``src`` but requires a control-plane compatibility bridge.  The adapter
+    must not change the selected algorithm or silently fall back to another Pipeline.
+    """
 
     name: str
     maturity: str
     opt_in_required: bool = False
     reason: str = ""
+    module: str | None = None
 
     @property
     def module_name(self) -> str:
-        return f"src.{self.name}"
+        return self.module or f"src.{self.name}"
 
 
 PIPELINE_DESCRIPTORS: dict[str, PipelineDescriptor] = {
@@ -65,6 +71,7 @@ PIPELINE_DESCRIPTORS: dict[str, PipelineDescriptor] = {
         name="Pipeline_06_Generative_Modeling",
         maturity="experimental_contract",
         reason="guarded CFM contract evidence; no release-supported benchmark claim",
+        module="phmfactory.runtime.pipeline06_adapter",
     ),
     "Pipeline_ID": PipelineDescriptor(
         name="Pipeline_ID",
@@ -89,6 +96,7 @@ PIPELINE_ALIASES: dict[str, str] = {
 
 def canonical_pipeline_name(name: str, *, warn: bool = True) -> str:
     """Return the canonical Pipeline identifier or raise a bounded error."""
+
     if not isinstance(name, str) or not name.strip():
         raise ValueError("pipeline must be a non-empty string")
 
@@ -111,6 +119,7 @@ def canonical_pipeline_name(name: str, *, warn: bool = True) -> str:
 
 def pipeline_descriptor(name: str, *, warn: bool = True) -> PipelineDescriptor:
     """Return the descriptor for a canonical or legacy Pipeline identifier."""
+
     return PIPELINE_DESCRIPTORS[canonical_pipeline_name(name, warn=warn)]
 
 
@@ -121,6 +130,7 @@ def require_pipeline_access(
     warn: bool = True,
 ) -> PipelineDescriptor:
     """Require explicit opt-in for Pipelines outside the safe default surface."""
+
     descriptor = pipeline_descriptor(name, warn=warn)
     if descriptor.opt_in_required and not allow_experimental:
         detail = f" {descriptor.reason}" if descriptor.reason else ""
@@ -132,5 +142,6 @@ def require_pipeline_access(
 
 
 def pipeline_module_name(name: str, *, warn: bool = True) -> str:
-    """Resolve a public or legacy identifier to its protected runtime module."""
+    """Resolve a public or legacy identifier to its maintained runtime module."""
+
     return pipeline_descriptor(name, warn=warn).module_name

--- a/phmfactory/runtime/attestation.py
+++ b/phmfactory/runtime/attestation.py
@@ -183,7 +183,7 @@ class RunAttestation:
             raise AttestationError("evidence section must be non-empty")
         normalized = _json_copy(value, label=f"evidence section {key!r}")
         existing = self.evidence.get(key)
-        if existing not in (None, {}, [] ) and existing != normalized:
+        if existing not in (None, {}, []) and existing != normalized:
             raise AttestationError(f"conflicting evidence section: {key!r}")
         self.evidence[key] = normalized
 
@@ -209,6 +209,7 @@ class RunAttestation:
             "created_at": self.created_at,
             "run_spec": {
                 "sha256": self.spec.sha256,
+                "effective_config_sha256": self.spec.effective_config_sha256,
                 "pipeline": self.spec.pipeline,
                 "pipeline_module": self.pipeline_module,
                 "requested_config": self.spec.requested_config,

--- a/phmfactory/runtime/pipeline06_adapter.py
+++ b/phmfactory/runtime/pipeline06_adapter.py
@@ -1,0 +1,77 @@
+"""Public compiled-config adapter for Pipeline 06.
+
+The scientific train/sample/eval implementation remains in
+``src.Pipeline_06_Generative_Modeling``.  This adapter owns only the public control-plane
+boundary: it consumes ``CompiledRunSpec.runtime_config()`` exactly once and delegates the
+selected stage without re-reading YAML, reapplying CLI overrides, or discovering a local
+machine file.
+
+Direct legacy imports of the original ``src`` module retain its explicit compatibility
+loader.  The maintained CLI resolves Pipeline 06 to this adapter.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from src.configs.config_utils import dict_to_namespace
+
+
+PIPELINE_NAME = "Pipeline_06_Generative_Modeling"
+
+
+def _runtime_config(args: Any, implementation: Any) -> Any:
+    """Return compiled public config or the original direct-call compatibility config."""
+
+    compiled = getattr(args, "compiled_run_spec", None)
+    if compiled is None:
+        # Compatibility-only path for code that imports the historical src module contract
+        # without going through the PHMFactory public CLI.
+        return implementation._load_configs(args)
+
+    expected = getattr(args, "resolved_pipeline", compiled.pipeline)
+    if compiled.pipeline != PIPELINE_NAME or expected != PIPELINE_NAME:
+        raise ValueError(
+            "Pipeline 06 compiled Pipeline mismatch: "
+            f"spec={compiled.pipeline!r}, dispatch={expected!r}"
+        )
+    configs = dict_to_namespace(compiled.runtime_config())
+    implementation._validate_required_sections(configs)
+    return configs
+
+
+def pipeline(args: Any) -> list[Any]:
+    """Dispatch one explicit Pipeline 06 stage from the compiled config contract."""
+
+    import src.Pipeline_06_Generative_Modeling as implementation
+
+    configs = _runtime_config(args, implementation)
+    mode = implementation._resolve_mode(configs)
+    generative_cfg = implementation._generative_cfg(configs)
+    implementation._validate_stage_inputs(mode, generative_cfg)
+
+    handlers = {
+        "train": implementation._run_train_stage,
+        "sample": implementation._run_sample_stage,
+        "eval": implementation._run_eval_stage,
+    }
+    handler = handlers[mode]
+
+    results: list[Any] = []
+    for iteration in range(implementation._resolve_iterations(configs)):
+        try:
+            results.append(handler(args, configs, iteration))
+        except Exception as error:
+            try:
+                implementation._record_stage(
+                    configs,
+                    mode,
+                    status="failed",
+                    iteration=iteration,
+                    error_type=type(error).__name__,
+                    error=str(error),
+                )
+            except Exception as ledger_error:
+                raise error from ledger_error
+            raise
+    return results

--- a/phmfactory/runtime/spec.py
+++ b/phmfactory/runtime/spec.py
@@ -1,4 +1,4 @@
-"""Compile a resolved configuration into one deterministic runtime contract."""
+"""Compile one analyzed configuration into the immutable runtime contract."""
 
 from __future__ import annotations
 
@@ -9,11 +9,12 @@ import json
 from pathlib import Path
 from typing import Any, Mapping
 
-from phmfactory.config import ResolvedConfig
+from phmfactory.config import ResolvedConfig, semantic_config_sha256
 
 
 def _plain(value: Any) -> Any:
     """Return a deterministic JSON-compatible representation."""
+
     if isinstance(value, Mapping):
         return {str(key): _plain(item) for key, item in value.items()}
     if isinstance(value, (list, tuple)):
@@ -40,13 +41,13 @@ def _digest(payload: Mapping[str, Any]) -> str:
 
 @dataclass(frozen=True)
 class CompiledRunSpec:
-    """Immutable metadata for the exact configuration selected by the public CLI.
+    """Immutable runtime contract for one public invocation.
 
-    The nested configuration is copied at construction. Runtime adapters should use
-    :meth:`runtime_config` to obtain their own mutable copy rather than reparsing YAML.
-    The resolved absolute path is recorded for diagnostics but deliberately excluded
-    from ``sha256`` so the same packaged configuration hashes identically in different
-    installation directories.
+    ``effective_config_sha256`` identifies only the canonical effective configuration
+    and therefore compares equal across preset names, equivalent override spellings, and
+    installation paths. ``sha256`` retains the invocation contract identity, including
+    the requested source and explicit overrides. Runtime adapters use
+    :meth:`runtime_config` rather than reparsing YAML.
     """
 
     schema_version: int
@@ -55,17 +56,21 @@ class CompiledRunSpec:
     pipeline: str
     config: dict[str, Any]
     overrides: dict[str, Any]
+    effective_config_sha256: str
     sha256: str
 
     @classmethod
     def compile(cls, resolved: ResolvedConfig) -> "CompiledRunSpec":
+        """Compile a compatibility ``ResolvedConfig`` without changing its semantics."""
+
         config = _plain(deepcopy(resolved.data))
         overrides = _plain(deepcopy(resolved.overrides))
-        semantic_payload = {
+        effective_digest = semantic_config_sha256(config)
+        invocation_payload = {
             "schema_version": 1,
             "requested_config": resolved.requested,
             "pipeline": resolved.pipeline,
-            "config": config,
+            "effective_config_sha256": effective_digest,
             "overrides": overrides,
         }
         return cls(
@@ -75,15 +80,18 @@ class CompiledRunSpec:
             pipeline=resolved.pipeline,
             config=config,
             overrides=overrides,
-            sha256=_digest(semantic_payload),
+            effective_config_sha256=effective_digest,
+            sha256=_digest(invocation_payload),
         )
 
     def runtime_config(self) -> dict[str, Any]:
         """Return a mutable copy for one protected-runtime invocation."""
+
         return deepcopy(self.config)
 
     def as_dict(self) -> dict[str, Any]:
-        """Return a serializable representation including the semantic digest."""
+        """Return a serializable representation of both configuration identities."""
+
         return {
             "schema_version": self.schema_version,
             "requested_config": self.requested_config,
@@ -91,5 +99,6 @@ class CompiledRunSpec:
             "pipeline": self.pipeline,
             "config": self.runtime_config(),
             "overrides": deepcopy(self.overrides),
+            "effective_config_sha256": self.effective_config_sha256,
             "sha256": self.sha256,
         }

--- a/scripts/config_inspect.py
+++ b/scripts/config_inspect.py
@@ -1,135 +1,49 @@
+"""Inspect a PHMFactory configuration without defining a second resolver.
+
+The script is a presentation adapter over :func:`phmfactory.config.analyze_config`.
+Composition, explicit local configuration, CLI overrides, canonical Pipeline naming, and
+the semantic hash therefore match the real runtime and ``phmfactory preflight``.
+"""
+
 from __future__ import annotations
 
 import argparse
 import csv
-import importlib
+import importlib.util
 import json
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Dict, Iterable, List, Literal, Optional, Tuple
+from typing import Any, Dict, List, Literal, Optional, Tuple
 
 import yaml
 
-from phmfactory.pipelines import canonical_pipeline_name, pipeline_module_name
-
-from src.configs.config_utils import merge_with_local_override
-from src.utils.config_utils import apply_overrides_to_config, parse_overrides
+from phmfactory.config import ConfigAnalysis, analyze_config
+from phmfactory.pipelines import pipeline_module_name
 
 
 DumpMode = Literal["resolved", "sources", "targets", "all"]
 OutFormat = Literal["yaml", "json", "md"]
 
 
-def _namespace_to_dict(value: Any) -> Any:
-    if hasattr(value, "__dict__") and not isinstance(value, dict):
-        return {k: _namespace_to_dict(v) for k, v in value.__dict__.items()}
-    if isinstance(value, dict):
-        return {k: _namespace_to_dict(v) for k, v in value.items()}
-    if isinstance(value, list):
-        return [_namespace_to_dict(v) for v in value]
-    return value
-
-
-def _deep_merge(dst: Dict[str, Any], src: Dict[str, Any]) -> Dict[str, Any]:
-    for k, v in src.items():
-        if isinstance(v, dict) and isinstance(dst.get(k), dict):
-            _deep_merge(dst[k], v)
-        else:
-            dst[k] = v
-    return dst
-
-
-def _flatten(d: Dict[str, Any], prefix: str) -> Iterable[Tuple[str, Any]]:
-    for k, v in d.items():
-        key = f"{prefix}.{k}" if prefix else k
-        if isinstance(v, dict):
-            yield from _flatten(v, key)
-        else:
-            yield key, v
-
-
-def _load_yaml_dict(path: Path) -> Dict[str, Any]:
-    with path.open("r", encoding="utf-8") as f:
-        raw = yaml.safe_load(f) or {}
-    if not isinstance(raw, dict):
-        raise ValueError(f"YAML must be a mapping: {path}")
-    return raw
-
-
 @dataclass(frozen=True)
 class InspectResult:
+    """Resolved config plus human-facing discovery and sanity information."""
+
     resolved: Dict[str, Any]
     sources: Dict[str, str]
     targets: Dict[str, Any]
     sanity: List[Dict[str, Any]]
-
-
-def _find_local_override_path(explicit: Optional[str]) -> Optional[Path]:
-    if explicit:
-        p = Path(explicit)
-        return p if p.exists() else None
-    default_local = Path("configs/local/local.yaml")
-    return default_local if default_local.exists() else None
-
-
-def _collect_sources(
-    config_path: Path,
-    local_override: Optional[Path],
-    cli_overrides: Dict[str, Any],
-) -> Dict[str, str]:
-    cfg = _load_yaml_dict(config_path)
-    base_cfgs = cfg.get("base_configs") if isinstance(cfg.get("base_configs"), dict) else {}
-
-    sources: Dict[str, str] = {}
-    resolved_blocks: Dict[str, Dict[str, Any]] = {k: {} for k in ["environment", "data", "model", "task", "trainer"]}
-
-    for block in resolved_blocks.keys():
-        base_path = base_cfgs.get(block)
-        if isinstance(base_path, str) and base_path:
-            base_yaml = _load_yaml_dict(Path(base_path))
-            base_block = base_yaml.get(block, {})
-            if isinstance(base_block, dict):
-                resolved_blocks[block] = _deep_merge(resolved_blocks[block], base_block)
-                for key, _ in _flatten(base_block, prefix=block):
-                    sources[key] = f"base:{base_path}"
-
-    for block in resolved_blocks.keys():
-        override_block = cfg.get(block, {})
-        if isinstance(override_block, dict) and override_block:
-            _deep_merge(resolved_blocks[block], override_block)
-            for key, _ in _flatten(override_block, prefix=block):
-                sources[key] = f"config:{config_path.as_posix()}"
-
-    if local_override is not None:
-        local_yaml = _load_yaml_dict(local_override)
-        for block in resolved_blocks.keys():
-            local_block = local_yaml.get(block, {})
-            if isinstance(local_block, dict) and local_block:
-                _deep_merge(resolved_blocks[block], local_block)
-                for key, _ in _flatten(local_block, prefix=block):
-                    sources[key] = f"local:{local_override.as_posix()}"
-
-    for key, value in _flatten(cli_overrides, prefix=""):
-        sources[key] = "cli:--override"
-
-    if isinstance(cfg.get("pipeline"), str):
-        sources["pipeline"] = f"config:{config_path.as_posix()}"
-    if base_cfgs:
-        for block, base_path in base_cfgs.items():
-            if isinstance(base_path, str) and base_path:
-                sources[f"base_configs.{block}"] = f"config:{config_path.as_posix()}"
-
-    return sources
+    effective_config_sha256: str
+    local_config_path: str | None
 
 
 def _load_model_registry() -> Dict[Tuple[str, str], str]:
-    registry_path = Path("src/model_factory/model_registry.csv")
+    path = Path("src/model_factory/model_registry.csv")
     mapping: Dict[Tuple[str, str], str] = {}
-    if not registry_path.exists():
+    if not path.exists():
         return mapping
-    with registry_path.open("r", encoding="utf-8") as f:
-        reader = csv.DictReader(f)
-        for row in reader:
+    with path.open("r", encoding="utf-8") as handle:
+        for row in csv.DictReader(handle):
             model_type = (row.get("model.type") or "").strip()
             model_name = (row.get("model.name") or "").strip()
             module_path = (row.get("module_path") or "").strip()
@@ -139,187 +53,196 @@ def _load_model_registry() -> Dict[Tuple[str, str], str]:
 
 
 def _load_isfm_components() -> Dict[Tuple[str, str], str]:
-    registry_path = Path("src/model_factory/ISFM/isfm_components.csv")
+    path = Path("src/model_factory/ISFM/isfm_components.csv")
     mapping: Dict[Tuple[str, str], str] = {}
-    if not registry_path.exists():
+    if not path.exists():
         return mapping
-    with registry_path.open("r", encoding="utf-8") as f:
-        reader = csv.DictReader(f)
-        for row in reader:
-            comp_type = (row.get("component_type") or "").strip()
-            comp_id = (row.get("component_id") or "").strip()
+    with path.open("r", encoding="utf-8") as handle:
+        for row in csv.DictReader(handle):
+            component_type = (row.get("component_type") or "").strip()
+            component_id = (row.get("component_id") or "").strip()
             module_path = (row.get("module_path") or "").strip()
-            if comp_type and comp_id and module_path:
-                mapping[(comp_type, comp_id)] = module_path
+            if component_type and component_id and module_path:
+                mapping[(component_type, component_id)] = module_path
     return mapping
 
 
 def _load_task_registry() -> Dict[Tuple[str, str], Dict[str, str]]:
-    registry_path = Path("src/task_factory/task_registry.csv")
+    path = Path("src/task_factory/task_registry.csv")
     mapping: Dict[Tuple[str, str], Dict[str, str]] = {}
-    if not registry_path.exists():
+    if not path.exists():
         return mapping
-    with registry_path.open("r", encoding="utf-8") as f:
-        reader = csv.DictReader(f)
-        for row in reader:
+    with path.open("r", encoding="utf-8") as handle:
+        for row in csv.DictReader(handle):
             task_type = (row.get("task.type") or "").strip()
             task_name = (row.get("task.name") or "").strip()
-            if not task_type or not task_name:
-                continue
-            mapping[(task_type, task_name)] = {
-                "task_path": (row.get("path") or "").strip(),
-                "dataset_path": (row.get("dataset_path") or "").strip(),
-                "notes": (row.get("notes") or "").strip(),
-            }
+            if task_type and task_name:
+                mapping[(task_type, task_name)] = {
+                    "task_path": (row.get("path") or "").strip(),
+                    "dataset_path": (row.get("dataset_path") or "").strip(),
+                    "notes": (row.get("notes") or "").strip(),
+                }
     return mapping
 
 
-def _maybe_import(module_name: str) -> Tuple[bool, str]:
+def _module_discoverable(module_name: str) -> Tuple[bool, str]:
     try:
-        importlib.import_module(module_name)
-        return True, ""
-    except Exception as e:
-        return False, repr(e)
+        found = importlib.util.find_spec(module_name) is not None
+    except (ImportError, AttributeError, ValueError) as error:
+        return False, f"{type(error).__name__}: {error}"
+    return found, "" if found else f"module not found: {module_name}"
 
 
-def _instantiation_targets(resolved: Dict[str, Any]) -> Dict[str, Any]:
-    pipeline = canonical_pipeline_name(
-        str(resolved.get("pipeline") or "Pipeline_01_Fault_Diagnosis"),
-        warn=False,
-    )
-
+def _instantiation_targets(analysis: ConfigAnalysis) -> Dict[str, Any]:
+    resolved = analysis.effective_config
+    pipeline_module = pipeline_module_name(analysis.pipeline, warn=False)
+    pipeline_found, pipeline_error = _module_discoverable(pipeline_module)
     targets: Dict[str, Any] = {
-        "pipeline": {"name": pipeline, "module": pipeline_module_name(pipeline, warn=False), "symbol": "pipeline"},
+        "pipeline": {
+            "name": analysis.pipeline,
+            "module": pipeline_module,
+            "symbol": "pipeline",
+            "discoverable": pipeline_found,
+            "error": pipeline_error,
+        },
         "factories": {
-            "data_factory": "src/data_factory/__init__.py:build_data",
-            "model_factory": "src/model_factory/__init__.py:build_model",
-            "task_factory": "src/task_factory/__init__.py:build_task",
-            "trainer_factory": "src/trainer_factory/__init__.py:build_trainer",
+            "data_factory": "src.data_factory:build_data",
+            "model_factory": "src.model_factory:build_model",
+            "task_factory": "src.task_factory:build_task",
+            "trainer_factory": "src.trainer_factory:build_trainer",
         },
     }
 
-    model_cfg = resolved.get("model") if isinstance(resolved.get("model"), dict) else {}
-    model_type = str(model_cfg.get("type") or "")
-    model_name = str(model_cfg.get("name") or "")
-    model_registry = _load_model_registry()
-    model_module_path = model_registry.get((model_type, model_name))
+    model = resolved.get("model") if isinstance(resolved.get("model"), dict) else {}
+    model_type = str(model.get("type") or "")
+    model_name = str(model.get("name") or "")
+    model_path = _load_model_registry().get((model_type, model_name), "")
     targets["model"] = {
         "type": model_type,
         "name": model_name,
-        "module_path": model_module_path or "",
+        "module_path": model_path,
+        "registered": bool(model_path),
     }
-
     if model_type == "ISFM":
-        comps = _load_isfm_components()
-        emb = str(model_cfg.get("embedding") or "")
-        backbone = str(model_cfg.get("backbone") or "")
-        head = str(model_cfg.get("task_head") or "")
+        components = _load_isfm_components()
+        embedding = str(model.get("embedding") or "")
+        backbone = str(model.get("backbone") or "")
+        task_head = str(model.get("task_head") or "")
         targets["model"]["components"] = {
-            "embedding": {"id": emb, "module_path": comps.get(("embedding", emb), "")},
-            "backbone": {"id": backbone, "module_path": comps.get(("backbone", backbone), "")},
-            "task_head": {"id": head, "module_path": comps.get(("task_head", head), "")},
+            "embedding": {
+                "id": embedding,
+                "module_path": components.get(("embedding", embedding), ""),
+            },
+            "backbone": {
+                "id": backbone,
+                "module_path": components.get(("backbone", backbone), ""),
+            },
+            "task_head": {
+                "id": task_head,
+                "module_path": components.get(("task_head", task_head), ""),
+            },
         }
 
-    task_cfg = resolved.get("task") if isinstance(resolved.get("task"), dict) else {}
-    task_type = str(task_cfg.get("type") or "")
-    task_name = str(task_cfg.get("name") or "")
-    task_registry = _load_task_registry()
-    task_info = task_registry.get((task_type, task_name), {})
+    task = resolved.get("task") if isinstance(resolved.get("task"), dict) else {}
+    task_type = str(task.get("type") or "")
+    task_name = str(task.get("name") or "")
+    task_info = _load_task_registry().get((task_type, task_name), {})
     targets["task"] = {
         "type": task_type,
         "name": task_name,
         "task_path": task_info.get("task_path", ""),
         "dataset_path": task_info.get("dataset_path", ""),
         "notes": task_info.get("notes", ""),
+        "registered": bool(task_info),
     }
 
-    trainer_cfg = resolved.get("trainer") if isinstance(resolved.get("trainer"), dict) else {}
-    trainer_name = str(trainer_cfg.get("name") or "")
+    trainer = (
+        resolved.get("trainer") if isinstance(resolved.get("trainer"), dict) else {}
+    )
+    trainer_name = str(
+        trainer.get("trainer_name") or trainer.get("name") or "Default_trainer"
+    )
     trainer_module = f"src.trainer_factory.{trainer_name}"
-    ok, err = _maybe_import(trainer_module)
-    if not ok:
-        trainer_module = "src.trainer_factory.Default_trainer"
-    targets["trainer"] = {"name": trainer_name, "module": trainer_module, "import_ok": ok, "import_error": err}
-
+    trainer_found, trainer_error = _module_discoverable(trainer_module)
+    targets["trainer"] = {
+        "name": trainer_name,
+        "module": trainer_module,
+        "discoverable": trainer_found,
+        "error": trainer_error,
+    }
     return targets
 
 
-def _sanity_checks(resolved: Dict[str, Any]) -> List[Dict[str, Any]]:
+def _sanity_checks(
+    analysis: ConfigAnalysis,
+    targets: Dict[str, Any],
+) -> List[Dict[str, Any]]:
     checks: List[Dict[str, Any]] = []
 
     def add(name: str, ok: bool, message: str, fix: str = "") -> None:
         checks.append({"check": name, "ok": ok, "message": message, "fix": fix})
 
-    for block in ["environment", "data", "model", "task", "trainer"]:
+    for diagnostic in analysis.diagnostics:
         add(
-            f"has_{block}",
-            isinstance(resolved.get(block), dict),
-            f"{block} present: {block in resolved}",
-            fix=f"Ensure `{block}: ...` exists after base_configs merge.",
+            f"config:{diagnostic.code}:{diagnostic.field or 'root'}",
+            diagnostic.severity != "error",
+            diagnostic.message,
+            diagnostic.suggestion,
         )
 
-    pipeline = canonical_pipeline_name(
-        str(resolved.get("pipeline") or "Pipeline_01_Fault_Diagnosis"),
-        warn=False,
-    )
-    ok, err = _maybe_import(pipeline_module_name(pipeline, warn=False))
+    resolved = analysis.effective_config
+    pipeline = targets["pipeline"]
     add(
-        "pipeline_import",
-        ok,
-        f"pipeline={pipeline}",
-        fix="Set YAML top-level `pipeline:` to an existing src/Pipeline_*.py module.",
+        "pipeline_discoverable",
+        bool(pipeline["discoverable"]),
+        f"pipeline={analysis.pipeline}, module={pipeline['module']}",
+        "Correct the top-level pipeline value or install its required package.",
     )
-    if not ok:
-        add("pipeline_import_error", False, err, fix="Fix missing dependency or typo in pipeline name.")
 
-    env = resolved.get("environment") or {}
-    seed = env.get("seed")
+    environment = (
+        resolved.get("environment")
+        if isinstance(resolved.get("environment"), dict)
+        else {}
+    )
+    seed = environment.get("seed")
     add(
         "seed_type",
-        isinstance(seed, int),
+        isinstance(seed, int) and not isinstance(seed, bool),
         f"environment.seed={seed!r}",
-        fix="Set `environment.seed` to an integer.",
+        "Set environment.seed to an integer.",
     )
-    output_dir = env.get("output_dir")
+    output_dir = environment.get("output_dir")
     add(
         "output_dir_set",
         isinstance(output_dir, str) and bool(output_dir.strip()),
         f"environment.output_dir={output_dir!r}",
-        fix="Set `environment.output_dir` to a relative path like `results/demo/<exp>`.",
+        "Set environment.output_dir to a writable path.",
     )
-    if isinstance(output_dir, str) and output_dir.startswith("/"):
-        add(
-            "output_dir_not_absolute",
-            False,
-            f"environment.output_dir is absolute: {output_dir}",
-            fix="Prefer a repo-relative output_dir or use configs/local/local.yaml for machine paths.",
-        )
 
-    model = resolved.get("model") or {}
+    model = resolved.get("model") if isinstance(resolved.get("model"), dict) else {}
     add(
         "model_type_name",
         bool(model.get("type")) and bool(model.get("name")),
         f"model.type={model.get('type')!r}, model.name={model.get('name')!r}",
-        fix="Set `model.type` and `model.name`.",
+        "Set model.type and model.name.",
     )
-
-    task = resolved.get("task") or {}
+    task = resolved.get("task") if isinstance(resolved.get("task"), dict) else {}
     add(
         "task_type_name",
         bool(task.get("type")) and bool(task.get("name")),
         f"task.type={task.get('type')!r}, task.name={task.get('name')!r}",
-        fix="Set `task.type` and `task.name`.",
+        "Set task.type and task.name.",
     )
-
-    trainer = resolved.get("trainer") or {}
-    num_epochs = trainer.get("num_epochs")
+    trainer = (
+        resolved.get("trainer") if isinstance(resolved.get("trainer"), dict) else {}
+    )
+    epochs = trainer.get("num_epochs")
     add(
         "num_epochs_int",
-        isinstance(num_epochs, int) or num_epochs is None,
-        f"trainer.num_epochs={num_epochs!r}",
-        fix="Set `trainer.num_epochs` to an integer (or override via CLI).",
+        epochs is None or (isinstance(epochs, int) and not isinstance(epochs, bool)),
+        f"trainer.num_epochs={epochs!r}",
+        "Set trainer.num_epochs to an integer.",
     )
-
     return checks
 
 
@@ -328,103 +251,131 @@ def inspect_config(
     overrides: Optional[List[str]] = None,
     local_config: Optional[str] = None,
 ) -> InspectResult:
-    config_path_p = Path(config_path)
-    if not config_path_p.exists():
-        raise FileNotFoundError(f"--config not found: {config_path}")
+    """Inspect the exact config used by run and preflight."""
 
-    local_override_path = _find_local_override_path(local_config)
-
-    cfg = merge_with_local_override(config_path_p, local_override_path)
-    if overrides:
-        overrides_dict = parse_overrides(overrides)
-        cfg = apply_overrides_to_config(cfg, overrides_dict)
-    else:
-        overrides_dict = {}
-
-    resolved = _namespace_to_dict(cfg)
-    sources = _collect_sources(config_path_p, local_override=local_override_path, cli_overrides=overrides_dict)
-    targets = _instantiation_targets(resolved)
-    sanity = _sanity_checks(resolved)
-    return InspectResult(resolved=resolved, sources=sources, targets=targets, sanity=sanity)
+    analysis = analyze_config(
+        config_path,
+        override_values=overrides,
+        local_config=local_config,
+    )
+    targets = _instantiation_targets(analysis)
+    return InspectResult(
+        resolved=analysis.runtime_config(),
+        sources=dict(analysis.sources),
+        targets=targets,
+        sanity=_sanity_checks(analysis, targets),
+        effective_config_sha256=analysis.effective_config_sha256,
+        local_config_path=(
+            str(analysis.local_config_path)
+            if analysis.local_config_path is not None
+            else None
+        ),
+    )
 
 
 def _has_failed_sanity(result: InspectResult) -> bool:
     return any(not bool(item.get("ok")) for item in result.sanity)
 
 
-def _render_md(result: InspectResult, dump: DumpMode) -> str:
-    parts: List[str] = []
+def _payload(result: InspectResult, dump: DumpMode) -> Dict[str, Any]:
+    payload: Dict[str, Any] = {
+        "effective_config_sha256": result.effective_config_sha256,
+        "local_config_path": result.local_config_path,
+    }
     if dump in ("resolved", "all"):
-        parts.append("## RESOLVED CONFIG")
-        parts.append("```yaml")
-        parts.append(yaml.safe_dump(result.resolved, allow_unicode=True, sort_keys=False))
-        parts.append("```")
-        parts.append("")
+        payload["resolved"] = result.resolved
     if dump in ("sources", "all"):
-        parts.append("## FIELD SOURCES")
-        parts.append("")
-        parts.append("| Field | Source |")
-        parts.append("|---|---|")
-        for k in sorted(result.sources.keys()):
-            parts.append(f"| `{k}` | {result.sources[k]} |")
+        payload["sources"] = result.sources
+    if dump in ("targets", "all"):
+        payload["targets"] = result.targets
+    if dump == "all":
+        payload["sanity"] = result.sanity
+    return payload
+
+
+def _render_md(result: InspectResult, dump: DumpMode) -> str:
+    parts = [
+        f"effective_config_sha256: `{result.effective_config_sha256}`",
+        f"explicit_local_config: `{result.local_config_path or 'none'}`",
+        "",
+    ]
+    if dump in ("resolved", "all"):
+        parts.extend(
+            [
+                "## RESOLVED CONFIG",
+                "```yaml",
+                yaml.safe_dump(result.resolved, allow_unicode=True, sort_keys=False),
+                "```",
+                "",
+            ]
+        )
+    if dump in ("sources", "all"):
+        parts.extend(["## FIELD SOURCES", "", "| Field | Source |", "|---|---|"])
+        for key in sorted(result.sources):
+            parts.append(f"| `{key}` | {result.sources[key]} |")
         parts.append("")
     if dump in ("targets", "all"):
-        parts.append("## INSTANTIATION TARGETS")
-        parts.append("```yaml")
-        parts.append(yaml.safe_dump(result.targets, allow_unicode=True, sort_keys=False))
-        parts.append("```")
-        parts.append("")
-    if dump in ("all",):
-        parts.append("## SANITY CHECK")
-        parts.append("")
-        parts.append("| Check | OK | Message | Fix |")
-        parts.append("|---|---:|---|---|")
+        parts.extend(
+            [
+                "## INSTANTIATION TARGETS",
+                "```yaml",
+                yaml.safe_dump(result.targets, allow_unicode=True, sort_keys=False),
+                "```",
+                "",
+            ]
+        )
+    if dump == "all":
+        parts.extend(
+            [
+                "## SANITY CHECK",
+                "",
+                "| Check | OK | Message | Fix |",
+                "|---|---:|---|---|",
+            ]
+        )
         for item in result.sanity:
-            ok = "PASS" if item["ok"] else "FAIL"
-            fix = item.get("fix", "")
-            parts.append(f"| `{item['check']}` | {ok} | {item['message']} | {fix} |")
+            status = "PASS" if item["ok"] else "FAIL"
+            parts.append(
+                f"| `{item['check']}` | {status} | {item['message']} | "
+                f"{item.get('fix', '')} |"
+            )
         parts.append("")
     return "\n".join(parts).rstrip() + "\n"
 
 
 def main(argv: Optional[List[str]] = None) -> int:
-    parser = argparse.ArgumentParser(description="Inspect a config: resolved config + sources + targets + sanity")
-    parser.add_argument("--config", required=True, help="YAML config path")
-    parser.add_argument("--override", action="append", default=None, help="Override key=value (repeatable)")
-    parser.add_argument("--local_config", default=None, help="Optional machine-local override YAML")
-    parser.add_argument("--dump", choices=["resolved", "sources", "targets", "all"], default="all")
+    parser = argparse.ArgumentParser(
+        description="Inspect the effective config, sources, targets, and sanity checks"
+    )
+    parser.add_argument("--config", required=True, help="Preset name or YAML config path")
+    parser.add_argument(
+        "--override", action="append", default=None, help="Override key=value (repeatable)"
+    )
+    parser.add_argument(
+        "--local-config",
+        "--local_config",
+        dest="local_config",
+        default=None,
+        help="Optional explicit machine-local YAML; no file is auto-discovered.",
+    )
+    parser.add_argument(
+        "--dump", choices=["resolved", "sources", "targets", "all"], default="all"
+    )
     parser.add_argument("--format", choices=["yaml", "json", "md"], default="md")
     args = parser.parse_args(argv)
 
-    result = inspect_config(args.config, overrides=args.override, local_config=args.local_config)
-
+    result = inspect_config(
+        args.config,
+        overrides=args.override,
+        local_config=args.local_config,
+    )
+    payload = _payload(result, args.dump)
     if args.format == "json":
-        payload: Dict[str, Any] = {}
-        if args.dump in ("resolved", "all"):
-            payload["resolved"] = result.resolved
-        if args.dump in ("sources", "all"):
-            payload["sources"] = result.sources
-        if args.dump in ("targets", "all"):
-            payload["targets"] = result.targets
-        if args.dump in ("all",):
-            payload["sanity"] = result.sanity
         print(json.dumps(payload, indent=2, ensure_ascii=False))
-        return 1 if _has_failed_sanity(result) else 0
-
-    if args.format == "yaml":
-        payload_y: Dict[str, Any] = {}
-        if args.dump in ("resolved", "all"):
-            payload_y["resolved"] = result.resolved
-        if args.dump in ("sources", "all"):
-            payload_y["sources"] = result.sources
-        if args.dump in ("targets", "all"):
-            payload_y["targets"] = result.targets
-        if args.dump in ("all",):
-            payload_y["sanity"] = result.sanity
-        print(yaml.safe_dump(payload_y, allow_unicode=True, sort_keys=False))
-        return 1 if _has_failed_sanity(result) else 0
-
-    print(_render_md(result, dump=args.dump))
+    elif args.format == "yaml":
+        print(yaml.safe_dump(payload, allow_unicode=True, sort_keys=False))
+    else:
+        print(_render_md(result, dump=args.dump))
     return 1 if _has_failed_sanity(result) else 0
 
 

--- a/scripts/validate_configs.py
+++ b/scripts/validate_configs.py
@@ -1,99 +1,118 @@
+"""Validate maintained configs through PHMFactory's single public resolver.
+
+The validator intentionally shares composition and override semantics with ``run`` and
+``preflight``.  It never calls the legacy namespace loader and never auto-discovers a
+machine-local YAML file.
+"""
+
 from __future__ import annotations
 
 import argparse
 import csv
 from pathlib import Path
-from typing import Any, Dict, Iterable, List, Optional, Set
+from typing import Dict, Iterable, List, Optional, Set
 
 from pydantic import ValidationError
 
+from phmfactory.config import analyze_config
 from src.config_schema import ExperimentConfig
-from src.configs.config_utils import load_config
-
-
-def _namespace_to_dict(value: Any) -> Any:
-    if hasattr(value, "__dict__") and not isinstance(value, dict):
-        return {k: _namespace_to_dict(v) for k, v in value.__dict__.items()}
-    if isinstance(value, dict):
-        return {k: _namespace_to_dict(v) for k, v in value.items()}
-    if isinstance(value, list):
-        return [_namespace_to_dict(v) for v in value]
-    return value
 
 
 def iter_demo_configs() -> Iterable[Path]:
+    """Yield maintained demo YAML files in stable order."""
+
     yield from sorted(Path("configs/demo").rglob("*.yaml"))
 
 
 def iter_registry_active_configs(registry_path: Path) -> Iterable[Path]:
+    """Yield non-disabled paths from the maintained config registry."""
+
     if not registry_path.exists():
         return
-    with registry_path.open("r", encoding="utf-8") as f:
-        reader = csv.DictReader(f)
+    with registry_path.open("r", encoding="utf-8") as handle:
+        reader = csv.DictReader(handle)
         for row in reader:
             status = (row.get("status") or "").strip()
             path = (row.get("path") or "").strip()
-            if not path:
-                continue
-            if status and status != "/":
+            if path and status and status != "/":
                 yield Path(path)
 
 
 def validate_one(path: Path) -> List[str]:
-    cfg = load_config(path)
-    resolved = _namespace_to_dict(cfg)
+    """Return user-readable resolution and schema failures for one config."""
+
     try:
-        ExperimentConfig.model_validate(resolved)
+        analysis = analyze_config(path)
+    except Exception as error:
+        return [f"- resolution: {type(error).__name__}: {error}"]
+
+    lines = [
+        (
+            f"- {item.field or 'config'}: {item.message} "
+            f"[{item.code}]"
+        )
+        for item in analysis.diagnostics
+        if item.severity == "error"
+    ]
+    if lines:
+        return lines
+
+    try:
+        ExperimentConfig.model_validate(analysis.effective_config)
         return []
-    except ValidationError as e:
-        lines: List[str] = []
-        for err in e.errors():
-            loc = ".".join(str(x) for x in err.get("loc", []))
-            msg = err.get("msg", "")
-            typ = err.get("type", "")
-            lines.append(f"- {loc}: {msg} ({typ})")
+    except ValidationError as error:
+        for item in error.errors():
+            location = ".".join(str(value) for value in item.get("loc", []))
+            message = item.get("msg", "")
+            error_type = item.get("type", "")
+            lines.append(f"- {location}: {message} ({error_type})")
         return lines
 
 
 def main(argv: Optional[List[str]] = None) -> int:
-    parser = argparse.ArgumentParser(description="Validate demo configs with pydantic schema")
+    parser = argparse.ArgumentParser(
+        description="Validate maintained configs with the public resolver and schema"
+    )
     parser.add_argument(
         "--registry",
         type=str,
         default="configs/config_registry.csv",
-        help="Config registry CSV (used to include status!=/ paths).",
+        help="Config registry CSV used to include active paths.",
     )
     args = parser.parse_args(argv)
 
     seen: Set[Path] = set()
     paths: List[Path] = []
-    for p in iter_demo_configs():
-        if p not in seen:
-            seen.add(p)
-            paths.append(p)
-    for p in iter_registry_active_configs(Path(args.registry)):
-        if p.exists() and p not in seen:
-            seen.add(p)
-            paths.append(p)
+    for candidate in iter_demo_configs():
+        resolved = candidate.resolve()
+        if resolved not in seen:
+            seen.add(resolved)
+            paths.append(candidate)
+    for candidate in iter_registry_active_configs(Path(args.registry)):
+        resolved = candidate.resolve()
+        if candidate.exists() and resolved not in seen:
+            seen.add(resolved)
+            paths.append(candidate)
 
     failures: Dict[Path, List[str]] = {}
-    for p in paths:
-        errs = validate_one(p)
-        if errs:
-            failures[p] = errs
+    for path in paths:
+        errors = validate_one(path)
+        if errors:
+            failures[path] = errors
 
     if failures:
-        print(f"[FAIL] {len(failures)}/{len(paths)} configs failed schema validation:")
-        for p, errs in sorted(failures.items(), key=lambda x: str(x[0])):
-            print(f"\n{p}:")
-            for line in errs:
+        print(f"[FAIL] {len(failures)}/{len(paths)} configs failed validation:")
+        for path, errors in sorted(failures.items(), key=lambda item: str(item[0])):
+            print(f"\n{path}:")
+            for line in errors:
                 print(line)
         return 1
 
-    print(f"[OK] {len(paths)}/{len(paths)} configs passed schema validation.")
+    print(
+        f"[OK] {len(paths)}/{len(paths)} configs passed public resolution and schema validation."
+    )
     return 0
 
 
 if __name__ == "__main__":
     raise SystemExit(main())
-

--- a/src/configs/README.md
+++ b/src/configs/README.md
@@ -1,39 +1,43 @@
 # Legacy configuration compatibility layer
 
-`src/configs/` is the protected v0.3 compatibility implementation used by existing
-Pipelines and historical scripts. It is not the primary public configuration API.
+`src/configs/` is the protected compatibility implementation used by direct historical
+Pipeline calls and older scripts. It is **not** a second public configuration authority.
 
-Use the maintained public surfaces for new integrations:
+New code must use:
 
 ```python
-from phmfactory.config import resolve_config
+from phmfactory.config import analyze_config
 ```
+
+or a public command:
 
 ```bash
-python main.py --config <yaml> [--override key=value ...]
+phmfactory preflight --config <preset-or-yaml>
+phmfactory --config <preset-or-yaml>
 ```
 
-The authoritative configuration documentation is
-[`configs/README.md`](../../configs/README.md). Maintained examples live under
-`configs/demo/`, compose reusable blocks through `base_configs`, and are inventoried
-in `configs/config_registry.csv`.
+The maintained semantics are documented in [`configs/README.md`](../../configs/README.md).
 
 ## Compatibility API
 
-The existing internal API remains available to the protected runtime:
+The historical API remains available:
 
 ```python
 from src.configs import load_config
 ```
 
-`load_config(...)` accepts the legacy input forms implemented by
-`src/configs/config_utils.py` and returns a `ConfigWrapper` compatible with current
-Pipeline code. Do not remove or redesign this layer as part of repository cleanup.
+`load_config(...)` accepts legacy input forms and returns `ConfigWrapper`, which supports
+attribute and mapping-style access. Keep it only where a protected direct-call path still
+requires that interface.
+
+Do not use this loader in new validators, inspectors, UI code, support generation, or
+public Pipeline adapters. Those paths must consume `ConfigAnalysis` or
+`CompiledRunSpec.runtime_config()` so base configs and overrides are not applied twice.
 
 ## Historical presets
 
-`PRESET_TEMPLATES` still maps the following names to files under
-`configs/v0.0.9/` for historical-script compatibility:
+`PRESET_TEMPLATES` still maps these names to `configs/v0.0.9/` for historical-script
+compatibility:
 
 ```text
 quickstart
@@ -44,27 +48,32 @@ pretrain
 id
 ```
 
-Those presets are not the maintained PHMFactory v0.3 quickstart surface. New code
-should select a maintained YAML file or public preset through `phmfactory.config`.
+They are not the PHMFactory v0.3 maintained presets. New callers should use public
+presets such as `smoke` or a maintained YAML path through `phmfactory.config`.
 
-`configs/v0.0.9/` must remain while these compatibility mappings exist. Removing it
-requires a separate migration with zero runtime references and explicit downstream
-evidence.
+`configs/v0.0.9/` remains while compatibility references exist. Removing it requires a
+separate migration with zero runtime references and downstream validation.
 
-## Scope boundary
+## Machine-local values
 
-Do not add new public presets, machine-specific paths, or credentials here. New
-configuration behavior belongs in the public resolver and maintained root
-configuration tree; machine-specific values belong in `configs/local/local.yaml` or
-CLI overrides.
+Do not add personal paths or credentials to this compatibility package. Public machine
+inputs are explicit:
 
-Validation and inspection commands:
+```bash
+phmfactory \
+  --config configs/experiments/my_experiment.yaml \
+  --local-config configs/local/my_machine.yaml
+```
+
+No public command automatically reads `configs/local/local.yaml`. CLI overrides remain
+the highest-precedence input.
+
+## Validation
 
 ```bash
 python -m scripts.validate_configs
 python -m scripts.config_inspect --config <yaml>
-python -m scripts.gen_config_atlas
+python -m pytest test/test_config_analysis_parity.py -q
 ```
 
-The previous long-form v5 compatibility guide is preserved in immutable Git history
-and in the approved personal-fork archive used for the v0.3 repository migration.
+These commands use the public resolver, not this compatibility loader.

--- a/test/generative/test_pipeline06_compiled_config.py
+++ b/test/generative/test_pipeline06_compiled_config.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from phmfactory.runtime import pipeline06_adapter
+import src.Pipeline_06_Generative_Modeling as implementation
+
+
+class _Compiled:
+    pipeline = "Pipeline_06_Generative_Modeling"
+
+    def __init__(self, payload):
+        self.payload = payload
+
+    def runtime_config(self):
+        return self.payload
+
+
+def _payload(mode: str = "train") -> dict:
+    return {
+        "pipeline": "Pipeline_06_Generative_Modeling",
+        "environment": {"iterations": 1},
+        "data": {},
+        "model": {},
+        "task": {"generative": {"mode": mode}},
+        "trainer": {},
+    }
+
+
+def test_compiled_config_bypasses_legacy_yaml_reload(monkeypatch) -> None:
+    monkeypatch.setattr(
+        implementation,
+        "_load_configs",
+        lambda args: pytest.fail("legacy config loader must not run"),
+    )
+    args = SimpleNamespace(
+        compiled_run_spec=_Compiled(_payload()),
+        resolved_pipeline="Pipeline_06_Generative_Modeling",
+    )
+
+    configs = pipeline06_adapter._runtime_config(args, implementation)
+
+    assert configs.task.generative.mode == "train"
+    assert configs.environment.iterations == 1
+
+
+def test_compiled_pipeline_mismatch_fails_closed() -> None:
+    compiled = _Compiled(_payload())
+    compiled.pipeline = "Pipeline_01_Fault_Diagnosis"
+    args = SimpleNamespace(
+        compiled_run_spec=compiled,
+        resolved_pipeline="Pipeline_06_Generative_Modeling",
+    )
+
+    with pytest.raises(ValueError, match="compiled Pipeline mismatch"):
+        pipeline06_adapter._runtime_config(args, implementation)
+
+
+def test_adapter_dispatches_compiled_stage_without_reparse(monkeypatch) -> None:
+    calls = []
+    monkeypatch.setattr(
+        implementation,
+        "_load_configs",
+        lambda args: pytest.fail("legacy config loader must not run"),
+    )
+    monkeypatch.setattr(
+        implementation,
+        "_run_train_stage",
+        lambda args, configs, iteration: calls.append((configs, iteration))
+        or {"stage": "train", "iteration": iteration},
+    )
+    args = SimpleNamespace(
+        compiled_run_spec=_Compiled(_payload()),
+        resolved_pipeline="Pipeline_06_Generative_Modeling",
+    )
+
+    result = pipeline06_adapter.pipeline(args)
+
+    assert result == [{"stage": "train", "iteration": 0}]
+    assert len(calls) == 1
+    assert calls[0][0].task.generative.mode == "train"

--- a/test/test_config_analysis_parity.py
+++ b/test/test_config_analysis_parity.py
@@ -1,0 +1,163 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from phmfactory.commands import preflight
+from phmfactory.config import (
+    analyze_config,
+    resolve_config,
+    semantic_config_sha256,
+)
+from scripts.config_inspect import inspect_config
+from scripts.validate_configs import validate_one
+
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
+SMOKE_CONFIG = REPOSITORY_ROOT / "configs" / "demo" / "00_smoke" / "dummy_dg.yaml"
+
+
+def _minimal_config(path: Path, *, epochs: int) -> None:
+    path.write_text(
+        "pipeline: Pipeline_01_Fault_Diagnosis\n"
+        "environment:\n"
+        "  seed: 0\n"
+        "  iterations: 1\n"
+        "  output_dir: results/test\n"
+        "data: {}\n"
+        "model: {}\n"
+        "task: {}\n"
+        "trainer:\n"
+        f"  num_epochs: {epochs}\n",
+        encoding="utf-8",
+    )
+
+
+def test_preset_and_explicit_path_have_same_effective_identity() -> None:
+    preset = analyze_config("smoke")
+    explicit = analyze_config(SMOKE_CONFIG)
+
+    assert preset.effective_config == explicit.effective_config
+    assert preset.effective_config_sha256 == explicit.effective_config_sha256
+
+
+def test_equivalent_yaml_and_cli_override_have_same_effective_identity(
+    tmp_path: Path,
+) -> None:
+    direct = tmp_path / "direct.yaml"
+    overridden = tmp_path / "overridden.yaml"
+    _minimal_config(direct, epochs=2)
+    _minimal_config(overridden, epochs=1)
+
+    direct_analysis = analyze_config(direct)
+    override_analysis = analyze_config(
+        overridden,
+        override_values=["trainer.num_epochs=2"],
+    )
+
+    assert direct_analysis.effective_config == override_analysis.effective_config
+    assert (
+        direct_analysis.effective_config_sha256
+        == override_analysis.effective_config_sha256
+    )
+
+
+def test_precedence_is_base_then_config_then_explicit_local_then_cli(
+    tmp_path: Path,
+) -> None:
+    base = tmp_path / "base.yaml"
+    config = tmp_path / "config.yaml"
+    local = tmp_path / "machine.yaml"
+    base.write_text(
+        "environment: {seed: 0, iterations: 1, output_dir: results/test}\n"
+        "data: {}\nmodel: {}\ntask: {}\n"
+        "trainer: {num_epochs: 1, device: cpu}\n",
+        encoding="utf-8",
+    )
+    config.write_text(
+        "base_configs:\n  common: base.yaml\n"
+        "pipeline: Pipeline_01_Fault_Diagnosis\n"
+        "trainer: {num_epochs: 2}\n",
+        encoding="utf-8",
+    )
+    local.write_text("trainer: {num_epochs: 3, device: cuda}\n", encoding="utf-8")
+
+    local_only = analyze_config(config, local_config=local)
+    final = analyze_config(
+        config,
+        local_config=local,
+        override_values=["trainer.num_epochs=4"],
+    )
+
+    assert local_only.effective_config["trainer"] == {
+        "num_epochs": 3,
+        "device": "cuda",
+    }
+    assert final.effective_config["trainer"] == {
+        "num_epochs": 4,
+        "device": "cuda",
+    }
+    assert final.sources["trainer.num_epochs"] == "cli:--override"
+    assert final.sources["trainer.device"] == f"local:{local.resolve()}"
+    assert final.local_config_path == local.resolve()
+
+
+def test_unmentioned_local_yaml_is_not_an_input(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    config = tmp_path / "experiment.yaml"
+    _minimal_config(config, epochs=2)
+    hidden = tmp_path / "configs" / "local" / "local.yaml"
+    hidden.parent.mkdir(parents=True)
+    hidden.write_text("trainer: {num_epochs: 999}\n", encoding="utf-8")
+    monkeypatch.chdir(tmp_path)
+
+    analysis = analyze_config(config)
+
+    assert analysis.local_config_path is None
+    assert analysis.effective_config["trainer"]["num_epochs"] == 2
+    assert hidden not in analysis.source_files
+
+
+def test_resolve_config_is_a_compatibility_view_of_analysis() -> None:
+    analysis = analyze_config("smoke", override_values=["trainer.num_epochs=2"])
+    resolved = resolve_config("smoke", override_values=["trainer.num_epochs=2"])
+
+    assert resolved.data == analysis.effective_config
+    assert resolved.pipeline == analysis.pipeline
+    assert resolved.overrides == analysis.overrides
+    assert resolved.path == analysis.path
+
+
+def test_inspector_and_public_analysis_return_same_config_and_hash(
+    tmp_path: Path,
+) -> None:
+    override = f"environment.output_dir={tmp_path / 'output'}"
+    analysis = analyze_config("smoke", override_values=[override])
+    inspected = inspect_config("smoke", overrides=[override])
+
+    assert inspected.resolved == analysis.effective_config
+    assert inspected.effective_config_sha256 == analysis.effective_config_sha256
+
+
+def test_validator_accepts_the_same_maintained_smoke_config() -> None:
+    assert validate_one(SMOKE_CONFIG) == []
+
+
+def test_preflight_reports_the_same_effective_hash(
+    tmp_path: Path,
+) -> None:
+    override = f"environment.output_dir={tmp_path / 'preflight'}"
+    expected = analyze_config("smoke", override_values=[override])
+
+    report = preflight.run(["--config", "smoke", "--override", override])
+
+    assert report["effective_config_sha256"] == expected.effective_config_sha256
+    assert report["pipeline"] == expected.pipeline
+    assert not (tmp_path / "preflight").exists()
+
+
+def test_semantic_hash_is_stable_for_mapping_order() -> None:
+    left = {"pipeline": "P", "trainer": {"device": "cpu", "epochs": 1}}
+    right = {"trainer": {"epochs": 1, "device": "cpu"}, "pipeline": "P"}
+    assert semantic_config_sha256(left) == semantic_config_sha256(right)

--- a/test/test_phmfactory_commands.py
+++ b/test/test_phmfactory_commands.py
@@ -9,20 +9,44 @@ import pytest
 from phmfactory import cli
 from phmfactory.commands import demo, doctor, preflight
 from phmfactory.commands.common import check_writable_directory
-from phmfactory.config import ResolvedConfig
+from phmfactory.config import ConfigAnalysis, ResolvedConfig, semantic_config_sha256
+
+
+def _config(tmp_path: Path, *, output: bool = True) -> dict:
+    environment = {
+        "seed": 0,
+        "iterations": 1,
+        **({"output_dir": str(tmp_path / "new" / "outputs")} if output else {}),
+    }
+    return {
+        "pipeline": "Pipeline_01_Fault_Diagnosis",
+        "environment": environment,
+        "data": {},
+        "model": {},
+        "task": {},
+        "trainer": {},
+    }
+
+
+def _analysis(tmp_path: Path, *, output: bool = True) -> ConfigAnalysis:
+    config = _config(tmp_path, output=output)
+    path = tmp_path / "smoke.yaml"
+    return ConfigAnalysis(
+        requested="smoke",
+        path=path,
+        effective_config=config,
+        pipeline="Pipeline_01_Fault_Diagnosis",
+        overrides={},
+        local_config_path=None,
+        source_files=(path,),
+        sources={},
+        diagnostics=(),
+        effective_config_sha256=semantic_config_sha256(config),
+    )
 
 
 def _resolved(tmp_path: Path) -> ResolvedConfig:
-    return ResolvedConfig(
-        requested="smoke",
-        path=tmp_path / "smoke.yaml",
-        data={
-            "pipeline": "Pipeline_01_Fault_Diagnosis",
-            "environment": {"output_dir": str(tmp_path / "new" / "outputs")},
-        },
-        pipeline="Pipeline_01_Fault_Diagnosis",
-        overrides={},
-    )
+    return _analysis(tmp_path).to_resolved_config()
 
 
 def test_command_router_preserves_legacy_experiment_form(
@@ -68,12 +92,12 @@ def test_demo_uses_offline_defaults_and_user_override_wins() -> None:
     assert args.override[-1] == "trainer.num_epochs=2"
 
 
-def test_preflight_compiles_without_importing_pipeline(
+def test_preflight_uses_single_analysis_without_importing_pipeline(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    resolved = _resolved(tmp_path)
-    monkeypatch.setattr(preflight, "resolve_config", lambda *args, **kwargs: resolved)
+    analysis = _analysis(tmp_path)
+    monkeypatch.setattr(preflight, "analyze_config", lambda *args, **kwargs: analysis)
     monkeypatch.setattr(
         preflight.importlib.util,
         "find_spec",
@@ -84,6 +108,7 @@ def test_preflight_compiles_without_importing_pipeline(
 
     assert result["status"] == "passed"
     assert result["pipeline"] == "Pipeline_01_Fault_Diagnosis"
+    assert result["effective_config_sha256"] == analysis.effective_config_sha256
     assert len(result["run_spec_sha256"]) == 64
     assert not (tmp_path / "new").exists()
 
@@ -92,9 +117,8 @@ def test_preflight_requires_output_dir(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    resolved = _resolved(tmp_path)
-    resolved.data["environment"] = {}
-    monkeypatch.setattr(preflight, "resolve_config", lambda *args, **kwargs: resolved)
+    analysis = _analysis(tmp_path, output=False)
+    monkeypatch.setattr(preflight, "analyze_config", lambda *args, **kwargs: analysis)
     monkeypatch.setattr(
         preflight.importlib.util,
         "find_spec",

--- a/test/test_phmfactory_entrypoints.py
+++ b/test/test_phmfactory_entrypoints.py
@@ -9,13 +9,43 @@ from types import SimpleNamespace
 
 import pytest
 
-from phmfactory import __version__
-from phmfactory import cli
 from examples import cwru_quickstart
-from phmfactory.config import MAINTAINED_PRESETS, ResolvedConfig, resolve_config_path
+from phmfactory import __version__, cli
+from phmfactory.config import (
+    MAINTAINED_PRESETS,
+    ConfigAnalysis,
+    resolve_config_path,
+    semantic_config_sha256,
+)
 
 
 REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _analysis(
+    tmp_path: Path,
+    *,
+    requested: str,
+    pipeline: str,
+    overrides: dict | None = None,
+) -> ConfigAnalysis:
+    config = {
+        "pipeline": pipeline,
+        "environment": {"output_dir": str(tmp_path / "runs")},
+    }
+    path = tmp_path / "config.yaml"
+    return ConfigAnalysis(
+        requested=requested,
+        path=path,
+        effective_config=config,
+        pipeline=pipeline,
+        overrides=overrides or {},
+        local_config_path=None,
+        source_files=(path,),
+        sources={},
+        diagnostics=(),
+        effective_config_sha256=semantic_config_sha256(config),
+    )
 
 
 def test_public_version_is_v030_development_release() -> None:
@@ -27,8 +57,16 @@ def test_parser_preserves_legacy_config_path_alias() -> None:
     args = parser.parse_args(["--config_path", "legacy.yaml", "--notes", "compat"])
     assert args.config is None
     assert args.config_path == "legacy.yaml"
+    assert args.local_config is None
     assert args.notes == "compat"
     assert args.allow_experimental is False
+
+
+def test_parser_accepts_explicit_local_config() -> None:
+    args = cli.build_parser().parse_args(
+        ["--config", "experiment.yaml", "--local-config", "machine.yaml"]
+    )
+    assert args.local_config == "machine.yaml"
 
 
 def test_config_takes_precedence_over_legacy_alias() -> None:
@@ -44,8 +82,6 @@ def test_config_takes_precedence_over_legacy_alias() -> None:
 def test_process_entrypoint_discards_structured_success(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """The OS boundary must never pass a successful mapping to ``sys.exit``."""
-
     monkeypatch.setattr(cli, "main", lambda argv=None: {"status": "passed"})
     assert cli.entrypoint(["preflight"]) == 0
 
@@ -61,19 +97,27 @@ def test_process_entrypoint_preserves_runtime_failures(
         cli.entrypoint([])
 
 
-def test_run_dispatches_resolved_canonical_module(
+def test_run_dispatches_analyzed_canonical_module(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     observed: dict[str, object] = {}
+    analysis = _analysis(
+        tmp_path,
+        requested="missing.yaml",
+        pipeline="Pipeline_04_Unified_Evaluation",
+        overrides={"pipeline": "Pipeline_04_unified_metric"},
+    )
 
     def pipeline(args: argparse.Namespace) -> str:
         observed["requested_config"] = args.requested_config
         observed["config_path"] = args.config_path
         observed["resolved_config_path"] = args.resolved_config_path
         observed["resolved_pipeline"] = args.resolved_pipeline
+        observed["config_analysis"] = args.config_analysis
         observed["compiled_run_spec"] = args.compiled_run_spec
         observed["resolved_config_data"] = args.resolved_config_data
+        observed["effective_config_sha256"] = args.effective_config_sha256
         observed["run_spec_sha256"] = args.run_spec_sha256
         observed["notes"] = args.notes
         return "sentinel"
@@ -82,25 +126,18 @@ def test_run_dispatches_resolved_canonical_module(
         observed["module"] = name
         return SimpleNamespace(pipeline=pipeline)
 
-    def fake_resolve(source: str, *, override_values: list[str] | None = None) -> ResolvedConfig:
+    def fake_analyze(source: str, **kwargs) -> ConfigAnalysis:
         assert source == "missing.yaml"
-        assert override_values == ["pipeline=Pipeline_04_unified_metric"]
-        return ResolvedConfig(
-            requested=source,
-            path=tmp_path / "missing.yaml",
-            data={
-                "pipeline": "Pipeline_04_Unified_Evaluation",
-                "environment": {"output_dir": str(tmp_path / "runs")},
-            },
-            pipeline="Pipeline_04_Unified_Evaluation",
-            overrides={"pipeline": "Pipeline_04_unified_metric"},
-        )
+        assert kwargs["override_values"] == ["pipeline=Pipeline_04_unified_metric"]
+        assert kwargs["local_config"] is None
+        return analysis
 
-    monkeypatch.setattr(cli, "resolve_config", fake_resolve)
+    monkeypatch.setattr(cli, "analyze_config", fake_analyze)
     monkeypatch.setattr(cli.importlib, "import_module", fake_import)
     args = argparse.Namespace(
         config="missing.yaml",
         config_path=None,
+        local_config=None,
         notes="entrypoint-parity",
         override=["pipeline=Pipeline_04_unified_metric"],
         allow_experimental=True,
@@ -110,18 +147,18 @@ def test_run_dispatches_resolved_canonical_module(
     compiled = observed.pop("compiled_run_spec")
     resolved_data = observed.pop("resolved_config_data")
     run_spec_sha256 = observed.pop("run_spec_sha256")
+    config_analysis = observed.pop("config_analysis")
     assert compiled.pipeline == "Pipeline_04_Unified_Evaluation"
-    assert resolved_data == {
-        "pipeline": "Pipeline_04_Unified_Evaluation",
-        "environment": {"output_dir": str(tmp_path / "runs")},
-    }
+    assert resolved_data == analysis.effective_config
     assert run_spec_sha256 == compiled.sha256
+    assert config_analysis is analysis
     assert observed == {
         "module": "src.Pipeline_04_Unified_Evaluation",
         "requested_config": "missing.yaml",
-        "config_path": str(tmp_path / "missing.yaml"),
-        "resolved_config_path": str(tmp_path / "missing.yaml"),
+        "config_path": str(analysis.path),
+        "resolved_config_path": str(analysis.path),
         "resolved_pipeline": "Pipeline_04_Unified_Evaluation",
+        "effective_config_sha256": analysis.effective_config_sha256,
         "notes": "entrypoint-parity",
     }
     assert Path(args.run_manifest_path).is_file()
@@ -138,6 +175,7 @@ def test_run_passes_maintained_preset_path_to_runtime(
     def pipeline(args: argparse.Namespace) -> bool:
         observed["requested_config"] = args.requested_config
         observed["config_path"] = args.config_path
+        observed["effective_config_sha256"] = args.effective_config_sha256
         return True
 
     monkeypatch.setattr(
@@ -148,14 +186,15 @@ def test_run_passes_maintained_preset_path_to_runtime(
     args = argparse.Namespace(
         config=preset,
         config_path=None,
+        local_config=None,
         notes="",
         override=[f"environment.output_dir={tmp_path / 'runs'}"],
     )
 
     assert cli.run(args) is True
-
     assert observed["requested_config"] == preset
     assert Path(str(observed["config_path"])) == resolve_config_path(preset)
+    assert len(str(observed["effective_config_sha256"])) == 64
     assert Path(args.run_manifest_path).is_file()
 
 
@@ -201,6 +240,7 @@ def test_python_entrypoints_share_help_surface(command: list[str]) -> None:
     assert completed.returncode == 0, completed.stderr
     assert "--config" in completed.stdout
     assert "--config_path" in completed.stdout
+    assert "--local-config" in completed.stdout
     assert "--override" in completed.stdout
     assert "--allow-experimental" in completed.stdout
 
@@ -233,6 +273,7 @@ def test_python_process_entrypoints_return_zero_for_preflight(
     )
     assert completed.returncode == 0, completed.stderr
     assert "status=passed" in completed.stdout
+    assert "effective_config_sha256=" in completed.stdout
     assert not target.exists()
 
 
@@ -276,16 +317,14 @@ def test_run_dispatches_packaged_base_configs_outside_checkout(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    from src.configs.config_utils import load_config
-
     observed: dict[str, object] = {}
 
     def pipeline(args: argparse.Namespace) -> str:
-        config = load_config(args.config_path)
-        observed["data"] = config.data.metadata_file
-        observed["model"] = config.model.name
-        observed["task"] = config.task.name
-        observed["trainer"] = config.trainer.device
+        config = args.compiled_run_spec.runtime_config()
+        observed["data"] = config["data"]["metadata_file"]
+        observed["model"] = config["model"]["name"]
+        observed["task"] = config["task"]["name"]
+        observed["trainer"] = config["trainer"]["device"]
         return "dispatched"
 
     real_import_module = cli.importlib.import_module
@@ -300,6 +339,7 @@ def test_run_dispatches_packaged_base_configs_outside_checkout(
     args = argparse.Namespace(
         config="smoke",
         config_path=None,
+        local_config=None,
         notes="",
         override=None,
     )

--- a/test/test_pipeline_maturity.py
+++ b/test/test_pipeline_maturity.py
@@ -8,7 +8,7 @@ from types import SimpleNamespace
 import pytest
 
 from phmfactory import cli
-from phmfactory.config import ResolvedConfig
+from phmfactory.config import ConfigAnalysis, semantic_config_sha256
 from phmfactory.pipelines import (
     PipelineMaturityError,
     pipeline_descriptor,
@@ -16,16 +16,23 @@ from phmfactory.pipelines import (
 )
 
 
-def _resolved(tmp_path: Path, pipeline: str) -> ResolvedConfig:
-    return ResolvedConfig(
+def _analysis(tmp_path: Path, pipeline: str) -> ConfigAnalysis:
+    data = {
+        "pipeline": pipeline,
+        "environment": {"output_dir": str(tmp_path / "runs")},
+    }
+    path = tmp_path / "maturity.yaml"
+    return ConfigAnalysis(
         requested="maturity-test",
-        path=tmp_path / "maturity.yaml",
-        data={
-            "pipeline": pipeline,
-            "environment": {"output_dir": str(tmp_path / "runs")},
-        },
+        path=path,
+        effective_config=data,
         pipeline=pipeline,
         overrides={},
+        local_config_path=None,
+        source_files=(path,),
+        sources={},
+        diagnostics=(),
+        effective_config_sha256=semantic_config_sha256(data),
     )
 
 
@@ -68,8 +75,8 @@ def test_cli_blocks_experimental_before_import_and_writes_failed_manifest(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    resolved = _resolved(tmp_path, "Pipeline_03_Multitask_Pretraining_Finetuning")
-    monkeypatch.setattr(cli, "resolve_config", lambda *args, **kwargs: resolved)
+    analysis = _analysis(tmp_path, "Pipeline_03_Multitask_Pretraining_Finetuning")
+    monkeypatch.setattr(cli, "analyze_config", lambda *args, **kwargs: analysis)
     monkeypatch.setattr(
         cli.importlib,
         "import_module",
@@ -78,6 +85,7 @@ def test_cli_blocks_experimental_before_import_and_writes_failed_manifest(
     args = argparse.Namespace(
         config="maturity-test",
         config_path=None,
+        local_config=None,
         notes="",
         override=None,
         allow_experimental=False,
@@ -96,8 +104,8 @@ def test_cli_explicit_opt_in_allows_experimental_import(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    resolved = _resolved(tmp_path, "Pipeline_03_Multitask_Pretraining_Finetuning")
-    monkeypatch.setattr(cli, "resolve_config", lambda *args, **kwargs: resolved)
+    analysis = _analysis(tmp_path, "Pipeline_03_Multitask_Pretraining_Finetuning")
+    monkeypatch.setattr(cli, "analyze_config", lambda *args, **kwargs: analysis)
     monkeypatch.setattr(
         cli.importlib,
         "import_module",
@@ -106,6 +114,7 @@ def test_cli_explicit_opt_in_allows_experimental_import(
     args = argparse.Namespace(
         config="maturity-test",
         config_path=None,
+        local_config=None,
         notes="",
         override=None,
         allow_experimental=True,

--- a/test/test_pipeline_name_migration.py
+++ b/test/test_pipeline_name_migration.py
@@ -9,6 +9,7 @@ from phmfactory.pipelines import (
     PIPELINE_ALIASES,
     PipelineNameDeprecationWarning,
     canonical_pipeline_name,
+    pipeline_descriptor,
     pipeline_module_name,
 )
 
@@ -37,13 +38,23 @@ def test_legacy_pipeline_identifiers_resolve_with_warning(
 ) -> None:
     with pytest.warns(PipelineNameDeprecationWarning):
         assert canonical_pipeline_name(legacy) == canonical
-    assert pipeline_module_name(legacy, warn=False) == f"src.{canonical}"
+    assert pipeline_module_name(legacy, warn=False) == pipeline_descriptor(
+        canonical, warn=False
+    ).module_name
 
 
 @pytest.mark.parametrize("canonical", tuple(sorted(EXPECTED_CANONICAL)))
-def test_canonical_pipeline_modules_exist(canonical: str) -> None:
+def test_canonical_scientific_pipeline_modules_remain_present(canonical: str) -> None:
     assert canonical_pipeline_name(canonical) == canonical
     assert (REPOSITORY_ROOT / "src" / f"{canonical}.py").is_file()
+
+
+def test_pipeline06_public_module_is_narrow_compiled_config_adapter() -> None:
+    descriptor = pipeline_descriptor("Pipeline_06_Generative_Modeling", warn=False)
+    assert descriptor.module_name == "phmfactory.runtime.pipeline06_adapter"
+    assert (
+        REPOSITORY_ROOT / "phmfactory" / "runtime" / "pipeline06_adapter.py"
+    ).is_file()
 
 
 def test_unknown_pipeline_is_rejected_before_dynamic_import() -> None:

--- a/test/test_runtime_attestation.py
+++ b/test/test_runtime_attestation.py
@@ -8,7 +8,7 @@ from types import SimpleNamespace
 import pytest
 
 from phmfactory import cli
-from phmfactory.config import ResolvedConfig
+from phmfactory.config import ConfigAnalysis, ResolvedConfig, semantic_config_sha256
 from phmfactory.runtime import (
     AttestationError,
     AttestationWriteError,
@@ -33,6 +33,22 @@ def _resolved(tmp_path: Path) -> ResolvedConfig:
     )
 
 
+def _analysis(tmp_path: Path) -> ConfigAnalysis:
+    resolved = _resolved(tmp_path)
+    return ConfigAnalysis(
+        requested=resolved.requested,
+        path=resolved.path,
+        effective_config=resolved.data,
+        pipeline=resolved.pipeline,
+        overrides=resolved.overrides,
+        local_config_path=None,
+        source_files=(resolved.path,),
+        sources={},
+        diagnostics=(),
+        effective_config_sha256=semantic_config_sha256(resolved.data),
+    )
+
+
 def _load(path: Path) -> dict:
     return json.loads(path.read_text(encoding="utf-8"))
 
@@ -45,6 +61,10 @@ def test_prepare_writes_pending_manifest_atomically(tmp_path: Path) -> None:
     payload = _load(attestation.manifest_path)
     assert payload["status"] == "pending"
     assert payload["run_spec"]["sha256"] == spec.sha256
+    assert (
+        payload["run_spec"]["effective_config_sha256"]
+        == spec.effective_config_sha256
+    )
     assert payload["failure"] is None
     assert not list(attestation.manifest_path.parent.glob("*.tmp"))
 
@@ -115,19 +135,29 @@ def test_failed_atomic_replace_leaves_previous_manifest_valid(
 
 
 def test_cli_writes_success_manifest(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    resolved = _resolved(tmp_path)
-    monkeypatch.setattr(cli, "resolve_config", lambda *args, **kwargs: resolved)
+    analysis = _analysis(tmp_path)
+    monkeypatch.setattr(cli, "analyze_config", lambda *args, **kwargs: analysis)
     monkeypatch.setattr(
         cli.importlib,
         "import_module",
         lambda name: SimpleNamespace(pipeline=lambda args: ["ok"]),
     )
-    args = argparse.Namespace(config="smoke", config_path=None, notes="", override=None)
+    args = argparse.Namespace(
+        config="smoke",
+        config_path=None,
+        local_config=None,
+        notes="",
+        override=None,
+    )
 
     assert cli.run(args) == ["ok"]
     payload = _load(Path(args.run_manifest_path))
     assert payload["run_id"] == args.run_id
     assert payload["status"] == "succeeded"
+    assert (
+        payload["run_spec"]["effective_config_sha256"]
+        == analysis.effective_config_sha256
+    )
     assert args.execution_envelope.status is ExecutionStatus.SUCCEEDED
 
 
@@ -135,8 +165,8 @@ def test_cli_writes_failed_manifest_and_reraises(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    resolved = _resolved(tmp_path)
-    monkeypatch.setattr(cli, "resolve_config", lambda *args, **kwargs: resolved)
+    analysis = _analysis(tmp_path)
+    monkeypatch.setattr(cli, "analyze_config", lambda *args, **kwargs: analysis)
 
     def fail(args):
         raise ValueError("bad pipeline")
@@ -146,7 +176,13 @@ def test_cli_writes_failed_manifest_and_reraises(
         "import_module",
         lambda name: SimpleNamespace(pipeline=fail),
     )
-    args = argparse.Namespace(config="smoke", config_path=None, notes="", override=None)
+    args = argparse.Namespace(
+        config="smoke",
+        config_path=None,
+        local_config=None,
+        notes="",
+        override=None,
+    )
 
     with pytest.raises(ValueError, match="bad pipeline"):
         cli.run(args)

--- a/test/test_runtime_evidence.py
+++ b/test/test_runtime_evidence.py
@@ -8,7 +8,7 @@ from types import SimpleNamespace
 import pytest
 
 from phmfactory import cli
-from phmfactory.config import ResolvedConfig
+from phmfactory.config import ConfigAnalysis, ResolvedConfig, semantic_config_sha256
 from phmfactory.runtime import (
     AttestationError,
     CompiledRunSpec,
@@ -19,7 +19,10 @@ from phmfactory.runtime.evidence import register_pipeline_result_evidence
 from src.runtime.classification import _register_iteration_evidence
 
 
-def _spec(tmp_path: Path, pipeline: str = "Pipeline_01_Fault_Diagnosis") -> CompiledRunSpec:
+def _spec(
+    tmp_path: Path,
+    pipeline: str = "Pipeline_01_Fault_Diagnosis",
+) -> CompiledRunSpec:
     return CompiledRunSpec.compile(
         ResolvedConfig(
             requested="evidence-test",
@@ -31,6 +34,29 @@ def _spec(tmp_path: Path, pipeline: str = "Pipeline_01_Fault_Diagnosis") -> Comp
             pipeline=pipeline,
             overrides={},
         )
+    )
+
+
+def _analysis(
+    tmp_path: Path,
+    pipeline: str = "Pipeline_01_Fault_Diagnosis",
+) -> ConfigAnalysis:
+    data = {
+        "pipeline": pipeline,
+        "environment": {"output_dir": str(tmp_path / "outputs")},
+    }
+    path = tmp_path / "config.yaml"
+    return ConfigAnalysis(
+        requested="evidence-test",
+        path=path,
+        effective_config=data,
+        pipeline=pipeline,
+        overrides={},
+        local_config_path=None,
+        source_files=(path,),
+        sources={},
+        diagnostics=(),
+        effective_config_sha256=semantic_config_sha256(data),
     )
 
 
@@ -159,17 +185,8 @@ def test_cli_records_evidence_finalize_failure(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     pipeline = "Pipeline_06_Generative_Modeling"
-    resolved = ResolvedConfig(
-        requested="generative",
-        path=tmp_path / "generative.yaml",
-        data={
-            "pipeline": pipeline,
-            "environment": {"output_dir": str(tmp_path / "outputs")},
-        },
-        pipeline=pipeline,
-        overrides={},
-    )
-    monkeypatch.setattr(cli, "resolve_config", lambda *args, **kwargs: resolved)
+    analysis = _analysis(tmp_path, pipeline)
+    monkeypatch.setattr(cli, "analyze_config", lambda *args, **kwargs: analysis)
     monkeypatch.setattr(
         cli.importlib,
         "import_module",
@@ -182,6 +199,7 @@ def test_cli_records_evidence_finalize_failure(
     args = argparse.Namespace(
         config="generative",
         config_path=None,
+        local_config=None,
         notes="",
         override=None,
         allow_experimental=False,

--- a/test/test_runtime_execution.py
+++ b/test/test_runtime_execution.py
@@ -7,7 +7,7 @@ from types import SimpleNamespace
 import pytest
 
 from phmfactory import cli
-from phmfactory.config import ResolvedConfig
+from phmfactory.config import ConfigAnalysis, ResolvedConfig, semantic_config_sha256
 from phmfactory.runtime import (
     CompiledRunSpec,
     ExecutionEnvelope,
@@ -93,17 +93,24 @@ def test_cli_does_not_print_completion_when_pipeline_returns_none(
     monkeypatch: pytest.MonkeyPatch,
     capsys: pytest.CaptureFixture[str],
 ) -> None:
-    resolved = ResolvedConfig(
+    data = {
+        "pipeline": "Pipeline_01_Fault_Diagnosis",
+        "environment": {"output_dir": str(tmp_path / "outputs")},
+    }
+    path = tmp_path / "broken.yaml"
+    analysis = ConfigAnalysis(
         requested="broken",
-        path=tmp_path / "broken.yaml",
-        data={
-            "pipeline": "Pipeline_01_Fault_Diagnosis",
-            "environment": {"output_dir": str(tmp_path / "outputs")},
-        },
+        path=path,
+        effective_config=data,
         pipeline="Pipeline_01_Fault_Diagnosis",
         overrides={},
+        local_config_path=None,
+        source_files=(path,),
+        sources={},
+        diagnostics=(),
+        effective_config_sha256=semantic_config_sha256(data),
     )
-    monkeypatch.setattr(cli, "resolve_config", lambda *args, **kwargs: resolved)
+    monkeypatch.setattr(cli, "analyze_config", lambda *args, **kwargs: analysis)
     monkeypatch.setattr(
         cli.importlib,
         "import_module",
@@ -113,6 +120,7 @@ def test_cli_does_not_print_completion_when_pipeline_returns_none(
     args = argparse.Namespace(
         config="broken",
         config_path=None,
+        local_config=None,
         notes="",
         override=None,
     )

--- a/test/test_streamlit_config_service.py
+++ b/test/test_streamlit_config_service.py
@@ -10,6 +10,9 @@ import yaml
 from apps.streamlit import config_service as cs
 
 
+DIGEST = "a" * 64
+
+
 def _repo(tmp_path: Path) -> Path:
     (tmp_path / "main.py").write_text("# test\n", encoding="utf-8")
     (tmp_path / "configs" / "demo").mkdir(parents=True)
@@ -18,6 +21,17 @@ def _repo(tmp_path: Path) -> Path:
 
 def _write_registry(root: Path, body: str) -> None:
     (root / "configs" / "config_registry.csv").write_text(body, encoding="utf-8")
+
+
+def _inspector_payload() -> dict:
+    return {
+        "effective_config_sha256": DIGEST,
+        "local_config_path": None,
+        "resolved": {block: {} for block in cs.CONFIG_BLOCKS},
+        "sources": {},
+        "targets": {},
+        "sanity": [{"check": "ok", "ok": True, "message": "pass"}],
+    }
 
 
 def test_load_registry_preserves_unknown_columns(tmp_path: Path) -> None:
@@ -194,17 +208,13 @@ def test_apply_overrides_does_not_mutate_input() -> None:
 
 
 def test_inspect_config_parses_success(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
 ) -> None:
     root = _repo(tmp_path)
     config = root / "configs" / "demo" / "demo.yaml"
     config.write_text("environment: {}\n", encoding="utf-8")
-    payload = {
-        "resolved": {block: {} for block in cs.CONFIG_BLOCKS},
-        "sources": {},
-        "targets": {},
-        "sanity": [{"check": "ok", "ok": True, "message": "pass"}],
-    }
+    payload = _inspector_payload()
 
     def fake_run(command, **kwargs):
         assert kwargs["cwd"] == str(root)
@@ -216,10 +226,13 @@ def test_inspect_config_parses_success(
 
     assert report.ok is True
     assert report.resolved == payload["resolved"]
+    assert report.effective_config_sha256 == DIGEST
+    assert report.local_config_path is None
 
 
 def test_inspect_config_reports_subprocess_failure(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
 ) -> None:
     root = _repo(tmp_path)
     config = root / "configs" / "demo" / "demo.yaml"
@@ -229,7 +242,9 @@ def test_inspect_config_reports_subprocess_failure(
         cs.subprocess,
         "run",
         lambda *args, **kwargs: SimpleNamespace(
-            returncode=1, stdout="", stderr="ModuleNotFoundError: torch"
+            returncode=1,
+            stdout="",
+            stderr="ModuleNotFoundError: torch",
         ),
     )
     report = cs.inspect_config(root, config)
@@ -294,8 +309,9 @@ def test_catalog_aliases_match_maintained_smoke_keyspace() -> None:
     assert paths["epochs"] == "trainer.num_epochs"
 
 
-def test_inspect_yaml_text_uses_external_temporary_directory(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+def test_inspect_yaml_text_uses_external_temp_without_local_layer(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
 ) -> None:
     root = _repo(tmp_path)
     seen = {}
@@ -311,8 +327,7 @@ def test_inspect_yaml_text_uses_external_temporary_directory(
         seen["local"] = local_config_path
         assert repo_root == root
         assert config_path.is_file()
-        assert local_config_path is not None
-        assert local_config_path.read_text(encoding="utf-8") == "{}\n"
+        assert local_config_path is None
         with pytest.raises(ValueError):
             config_path.resolve().relative_to(root.resolve())
         return cs.ValidationReport(ok=True, command=("python",))
@@ -323,32 +338,30 @@ def test_inspect_yaml_text_uses_external_temporary_directory(
     report = cs.inspect_yaml_text(root, yaml_text)
 
     assert report.ok is True
+    assert seen["local"] is None
     assert not seen["path"].exists()
-    assert not seen["local"].exists()
     assert not (root / ".streamlit").exists()
 
 
-def test_inspect_config_can_explicitly_disable_default_local_override(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+def test_inspect_config_passes_only_an_explicit_local_config(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
 ) -> None:
     root = _repo(tmp_path)
     config = root / "configs" / "demo" / "demo.yaml"
     config.write_text("environment: {}\n", encoding="utf-8")
-    empty_local = tmp_path / "empty.yaml"
-    empty_local.write_text("{}\n", encoding="utf-8")
-    payload = {
-        "resolved": {block: {} for block in cs.CONFIG_BLOCKS},
-        "sources": {},
-        "targets": {},
-        "sanity": [{"check": "ok", "ok": True, "message": "pass"}],
-    }
+    local = tmp_path / "machine.yaml"
+    local.write_text("trainer: {device: cpu}\n", encoding="utf-8")
+    payload = _inspector_payload()
+    payload["local_config_path"] = str(local.resolve())
 
     def fake_run(command, **kwargs):
-        index = command.index("--local_config")
-        assert command[index + 1] == str(empty_local.resolve())
+        index = command.index("--local-config")
+        assert command[index + 1] == str(local.resolve())
         return SimpleNamespace(returncode=0, stdout=json.dumps(payload), stderr="")
 
     monkeypatch.setattr(cs.subprocess, "run", fake_run)
-    report = cs.inspect_config(root, config, local_config_path=empty_local)
+    report = cs.inspect_config(root, config, local_config_path=local)
 
     assert report.ok is True
+    assert report.local_config_path == str(local.resolve())

--- a/test/test_streamlit_onboarding.py
+++ b/test/test_streamlit_onboarding.py
@@ -108,6 +108,10 @@ def test_readiness_is_ready_for_complete_offline_environment(tmp_path: Path) -> 
 
     assert report.can_execute is True
     assert report.blocked == ()
+    assert report.warnings == ()
+    config_check = next(item for item in report.checks if item.key == "config-inputs")
+    assert config_check.status == "ready"
+    assert "explicit overrides" in config_check.detail
 
 
 def test_readiness_blocks_missing_training_dependency(tmp_path: Path) -> None:
@@ -126,7 +130,7 @@ def test_readiness_blocks_missing_training_dependency(tmp_path: Path) -> None:
     assert [item.key for item in report.blocked] == ["dependency:pytorch_lightning"]
 
 
-def test_local_config_is_visible_warning_not_blocker(tmp_path: Path) -> None:
+def test_unmentioned_local_yaml_does_not_change_readiness(tmp_path: Path) -> None:
     root = _repo(tmp_path)
     local = root / "configs" / "local"
     local.mkdir()
@@ -141,7 +145,9 @@ def test_local_config_is_visible_warning_not_blocker(tmp_path: Path) -> None:
     )
 
     assert report.can_execute is True
-    assert [item.key for item in report.warnings] == ["local-config"]
+    assert report.warnings == ()
+    config_check = next(item for item in report.checks if item.key == "config-inputs")
+    assert config_check.status == "ready"
 
 
 def test_bundled_template_requires_declared_assets(tmp_path: Path) -> None:
@@ -200,7 +206,9 @@ def test_external_template_returns_actionable_missing_path(tmp_path: Path) -> No
     )
 
     assert status.ready is False
-    assert "configs/local/local.yaml" in status.action
+    assert "Advanced mode" in status.action
+    assert "explicit override" in status.action
+    assert "local.yaml" not in status.action
 
 
 def test_every_maintained_demo_has_explicit_user_profile() -> None:

--- a/test/test_streamlit_runtime_policy.py
+++ b/test/test_streamlit_runtime_policy.py
@@ -8,7 +8,10 @@ from apps.streamlit import runtime_policy as policy
 from apps.streamlit.config_service import CONFIG_BLOCKS, ValidationReport
 
 
-def test_portable_resolution_uses_explicit_empty_local(monkeypatch, tmp_path: Path) -> None:
+def test_template_resolution_passes_no_hidden_local_config(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
     config_path = tmp_path / "config.yaml"
     config_path.write_text("environment: {}\n", encoding="utf-8")
     seen = {}
@@ -16,18 +19,20 @@ def test_portable_resolution_uses_explicit_empty_local(monkeypatch, tmp_path: Pa
     def fake_inspect(repo_root, path, overrides=(), timeout=90.0, local_config_path=None):
         seen["local"] = local_config_path
         assert path == config_path
-        assert local_config_path is not None
-        assert local_config_path.read_text(encoding="utf-8") == "{}\n"
+        assert local_config_path is None
         return ValidationReport(True, ("python",))
 
     monkeypatch.setattr(policy, "inspect_config", fake_inspect)
     report = policy.inspect_portable_config(tmp_path, config_path)
 
     assert report.ok
-    assert not seen["local"].exists()
+    assert seen["local"] is None
 
 
-def test_execution_yaml_allows_core_local_layer_once(monkeypatch, tmp_path: Path) -> None:
+def test_execution_yaml_passes_no_hidden_local_config(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
     seen = {}
 
     def fake_inspect(repo_root, path, overrides=(), timeout=90.0, local_config_path=None):
@@ -42,4 +47,5 @@ def test_execution_yaml_allows_core_local_layer_once(monkeypatch, tmp_path: Path
     report = policy.inspect_execution_yaml(tmp_path, yaml_text)
 
     assert report.ok
+    assert seen["local"] is None
     assert not seen["path"].exists()

--- a/test/test_streamlit_ui_imports.py
+++ b/test/test_streamlit_ui_imports.py
@@ -45,17 +45,32 @@ def test_legacy_root_streamlit_launcher_is_removed() -> None:
     assert find_spec("streamlit_app") is None
 
 
-def test_local_config_fingerprint_changes_with_file(monkeypatch, tmp_path):
+def test_validation_signature_uses_only_visible_ui_inputs(monkeypatch, tmp_path):
+    """An unmentioned local YAML must not invalidate or alter UI validation."""
+
     _install_streamlit_stub(monkeypatch)
     sys.modules.pop("apps.streamlit.workspace", None)
     workspace = importlib.import_module("apps.streamlit.workspace")
 
-    assert workspace._local_config_fingerprint(tmp_path) == "missing"
+    visible = workspace._signature(
+        "Quick Start",
+        "effective yaml",
+        (("trainer.device", "cpu"),),
+    )
     local_dir = tmp_path / "configs" / "local"
     local_dir.mkdir(parents=True)
     local_path = local_dir / "local.yaml"
-    local_path.write_text("trainer:\n  device: cpu\n", encoding="utf-8")
-    first = workspace._local_config_fingerprint(tmp_path)
     local_path.write_text("trainer:\n  device: cuda\n", encoding="utf-8")
-    second = workspace._local_config_fingerprint(tmp_path)
-    assert first != second
+    after_hidden_file = workspace._signature(
+        "Quick Start",
+        "effective yaml",
+        (("trainer.device", "cpu"),),
+    )
+    changed_visible_input = workspace._signature(
+        "Quick Start",
+        "effective yaml",
+        (("trainer.device", "cuda"),),
+    )
+
+    assert visible == after_hidden_file
+    assert visible != changed_visible_input


### PR DESCRIPTION
## Objective

Make every maintained public consumer resolve the same effective configuration:

```text
run
= preflight
= config inspector
= config validator
= support generation
= Pipeline 06 public path
= Streamlit validation and launch
```

`effective_config_sha256` is retained only as a compact configuration identity used by cross-entrypoint parity tests. It is not a security, tamper-detection, or runtime-attestation mechanism.

## First-principles contract

The only maintained precedence is:

```text
base_configs
< selected experiment YAML
< explicit --local-config YAML
< CLI --override values
```

No public path auto-discovers `configs/local/local.yaml`. The same visible inputs produce the same effective mapping across checkout, wheel, CLI, scripts, Pipeline 06, and UI paths.

## Core implementation

- add `ConfigAnalysis` as the single public configuration-composition result, carrying the effective config, canonical Pipeline, explicit inputs, source information, diagnostics, and `effective_config_sha256`;
- retain `ResolvedConfig` as a compatibility view over the same analysis;
- make CLI and preflight consume `analyze_config` exactly once;
- add explicit `--local-config` and compatibility `--local_config`;
- migrate `scripts.validate_configs` and `scripts.config_inspect` off the legacy loader;
- carry effective configuration identity into `CompiledRunSpec` and `run_manifest.json`;
- route Pipeline 06 through a narrow compiled-config adapter while leaving its scientific train/sample/eval implementation in `src`;
- make Streamlit validation a thin adapter over the public inspector and remove hidden-local behavior from onboarding and workspace logic.

`CompiledRunSpec` is a configuration-to-runtime handoff object. Configuration parsing stops before runtime dispatch, and runtime handlers receive an isolated copy through `runtime_config()`. It is treated as read-only; this PR does not claim recursive Python immutability.

## User and developer clarity

Updated authorities explain explicit local YAML usage, effective-configuration identity versus invocation identity, Pipeline 06's adapter boundary, UI/CLI parity, and the tests that prove the contract. `configs/local/README.md` includes a Chinese explanation of the explicit-local rule.

## Tests and CI

Current reviewed head:

```text
119c17f2140947d7063abbd419356672678fd6c0
```

Machine-checked cases include:

```text
preset path = explicit YAML path
equivalent YAML value = equivalent CLI override
base < config < explicit local < CLI
unmentioned local.yaml has no effect
resolve_config is a compatibility view
inspector = validator = preflight = public analysis
mapping order does not affect configuration identity
Pipeline 06 bypasses legacy reload
Streamlit passes no hidden local layer
manifest records effective_config_sha256
```

All triggered workflows pass on the current head:

- Core quality gates: docs/config, parity, Pipeline 06 shell, UXFD, actual offline training smoke;
- PHMFactory public package: focused API/parity tests, wheel/sdist, clean-wheel preflight, compiled-config dispatch;
- Streamlit quality gates on Linux and Windows;
- Pipeline 06 CFM quality gates;
- PHMFactory CWRU bundle contract;
- Repository layout;
- Submodule policy.

The first CI attempt exposed two stale compatibility tests rather than implementation failures: one old runtime test monkeypatched the removed `cli.resolve_config` path, and one old UI test expected a hidden-local fingerprint. Both were migrated to the new public contract. No gate was weakened.

## Boundaries

```text
no data/model/task/trainer scientific algorithm change
no CWRU revision/hash change
no repository rename
no version/tag/release change
no merge of PR #147 or #148
no removal of the legacy loader while direct compatibility callers remain
no per-source hashes, hash chains, source-tree attestation, or repeated runtime hash verification
```

## Review status

- one P2 thread noted that the explicit `local_config_path` is not yet displayed in `CompiledRunSpec` / the run record;
- this does not affect the effective configuration, Pipeline dispatch, or execution result and is deferred as a small provenance-readability follow-up;
- mergeable into `dev`;
- all current CI green;
- ready for squash merge.