### PR TITLE
fix(data): make dataset splits truthful and evaluation-safe

### DIFF
--- a/src/data_factory/dataset_task/Default_dataset.py
+++ b/src/data_factory/dataset_task/Default_dataset.py
@@ -1,172 +1,239 @@
+"""Default window dataset used by maintained PHMFactory data paths."""
+
+from __future__ import annotations
+
 import numpy as np
-import torch
 from torch.utils.data import Dataset
-from torch.utils.data import random_split
-from pytorch_lightning.utilities import CombinedLoader
-class Default_dataset(Dataset): # THU_006or018_basic
+
+
+_WITHIN_ID_TEST_TASK_TYPES = frozenset({"FS", "GFS", "pretrain", "Pretrain"})
+
+
+class Default_dataset(Dataset):  # THU_006or018_basic
+    """Convert one raw time-series file into deterministic train/val/test windows.
+
+    Public callers keep using the historical constructor. ``mode="test"`` means
+    the full file for tasks whose test IDs are distinct from training IDs. For
+    FS/GFS/pretrain tasks, where the current ID search intentionally reuses the
+    same files, ``mode="test"`` selects the held-out tail of the window sequence.
+    """
+
     def __init__(self, data, metadata, args_data, args_task, mode="train"):
-        """
-        简化的数据集类
-        Args:
-            data: 输入数据，可能是单一ID的数据 [L, C]，或字典格式 {ID: 数据}
-            metadata: 数据元信息，格式为 {ID: {字段: 值}} 字典
-            args_data: 数据处理参数
-            args_task: 任务参数
-            mode: 数据模式，可选 "train", "valid", "test"
-        """
+        if not data:
+            raise ValueError("dataset input must contain one file ID")
+
         self.key = list(data.keys())[0]
-        self.data = data[self.key]  # 取出第一个键的数据
-        # self.metadata = metadata
+        self.data = data[self.key]
         self.args_data = args_data
-        self.mode = mode
-        
-        # 数据处理参数
-        self.window_size = args_data.window_size
-        self.stride = args_data.stride
-        self.train_ratio = args_data.train_ratio
-        self.num_window = args_data.num_window
-        self.window_sampling_strategy = getattr(args_data, 'window_sampling_strategy', 'evenly_spaced') # 新增：获取窗口采样策略，默认为evenly_spaced
+        self.args_task = args_task
 
-        # 数据预处理
-        self.processed_data = []  # 存储处理后的样本
-                
-        # 处理数据
+        requested_mode = str(mode).lower()
+        if requested_mode == "valid":
+            requested_mode = "val"
+        if (
+            requested_mode == "test"
+            and getattr(args_task, "type", None) in _WITHIN_ID_TEST_TASK_TYPES
+        ):
+            requested_mode = "test_holdout"
+        if requested_mode not in {"train", "val", "test", "test_holdout"}:
+            raise ValueError(
+                "mode must be one of train, val/valid, test; "
+                f"got {mode!r}"
+            )
+        self.mode = requested_mode
+
+        self.window_size = int(args_data.window_size)
+        self.stride = int(args_data.stride)
+        self.num_window = int(args_data.num_window)
+        self.window_sampling_strategy = getattr(
+            args_data,
+            "window_sampling_strategy",
+            "evenly_spaced",
+        )
+        self.window_sampling_seed = int(
+            getattr(args_data, "window_sampling_seed", 0)
+        )
+
+        self.train_ratio = float(getattr(args_data, "train_ratio", 0.8))
+        self.val_ratio = float(
+            getattr(args_data, "val_ratio", max(0.0, 1.0 - self.train_ratio))
+        )
+        self.test_ratio = float(
+            getattr(
+                args_data,
+                "test_ratio",
+                max(0.0, 1.0 - self.train_ratio - self.val_ratio),
+            )
+        )
+        self._validate_split_ratios()
+
+        self.processed_data = []
         self.prepare_data(metadata)
-        
-    def prepare_data(self,metadata=None):
-        """
-        准备数据：将原始数据按窗口大小和步长分割成样本
-        如果mode是train或valid，则划分数据集
-        """
-        self._process_single_data(self.data)
 
-        # 如果是train或valid模式，进行数据集划分
-        if self.mode in ["train", "valid"]:
+    def _validate_split_ratios(self) -> None:
+        ratios = {
+            "train_ratio": self.train_ratio,
+            "val_ratio": self.val_ratio,
+            "test_ratio": self.test_ratio,
+        }
+        invalid = {
+            name: value
+            for name, value in ratios.items()
+            if not 0 <= value <= 1
+        }
+        if invalid:
+            raise ValueError(f"data split ratios must be within [0, 1]: {invalid}")
+        total = sum(ratios.values())
+        if total > 1.0 + 1e-8:
+            raise ValueError(
+                "data split ratios must sum to at most 1.0; "
+                f"got train+val+test={total:.6f}"
+            )
+
+    def prepare_data(self, metadata=None):
+        """Create windows, normalize them, and select the requested split."""
+        self._process_single_data(self.data)
+        if self.mode in {"train", "val", "test_holdout"}:
             self._split_data_for_mode()
-            
-        self.total_samples = len(self.processed_data) # L'
+
+        self.total_samples = len(self.processed_data)
         self.label = metadata[self.key]["Label"]
-    
+
     def _sequential_sampling(self, sample_data, data_length):
-        """顺序采样"""
-        num_samples = max(0, (data_length - self.window_size) // self.stride + 1)
-        num_samples = min(num_samples, self.num_window) 
-        
-        for i in range(num_samples):
-            start_idx = i * self.stride
+        """Create windows from left to right."""
+        num_samples = max(
+            0,
+            (data_length - self.window_size) // self.stride + 1,
+        )
+        num_samples = min(num_samples, self.num_window)
+
+        for index in range(num_samples):
+            start_idx = index * self.stride
             end_idx = start_idx + self.window_size
             self.processed_data.append(sample_data[start_idx:end_idx])
 
     def _random_sampling(self, sample_data, data_length):
-        """随机采样"""
-        if data_length == self.window_size: # 如果数据长度刚好等于窗口大小
-             self.processed_data.append(sample_data)
-        else:
-            possible_starts = np.arange(data_length - self.window_size + 1)
-            if len(possible_starts) < self.num_window:
-                # 如果可能的起始点少于请求的窗口数，则取所有可能的窗口
-                selected_starts = possible_starts
-            else:
-                selected_starts = np.random.choice(possible_starts, size=self.num_window, replace=False)
-            
-            for start_idx in selected_starts:
-                end_idx = start_idx + self.window_size
-                self.processed_data.append(sample_data[start_idx:end_idx])
-
-    def _evenly_spaced_sampling(self, sample_data, data_length):
-        """等间隔采样"""
-        if self.num_window == 0:
-            return
-        if data_length == self.window_size: # 如果数据长度刚好等于窗口大小
+        """Create a deterministic random window set shared by every split mode."""
+        if data_length == self.window_size:
             self.processed_data.append(sample_data)
-        elif self.num_window == 1: # 如果只需要一个窗口，则从中间取
-            start_idx = (data_length - self.window_size) // 2
+            return
+
+        possible_starts = np.arange(data_length - self.window_size + 1)
+        if len(possible_starts) <= self.num_window:
+            selected_starts = possible_starts
+        else:
+            rng = np.random.default_rng(self.window_sampling_seed)
+            selected_starts = rng.choice(
+                possible_starts,
+                size=self.num_window,
+                replace=False,
+            )
+            selected_starts.sort()
+
+        for start_idx in selected_starts:
             end_idx = start_idx + self.window_size
             self.processed_data.append(sample_data[start_idx:end_idx])
+
+    def _evenly_spaced_sampling(self, sample_data, data_length):
+        """Create windows distributed across the complete file."""
+        if self.num_window == 0:
+            return
+        if data_length == self.window_size:
+            self.processed_data.append(sample_data)
+        elif self.num_window == 1:
+            start_idx = (data_length - self.window_size) // 2
+            self.processed_data.append(
+                sample_data[start_idx : start_idx + self.window_size]
+            )
         else:
-            effective_length = data_length - self.window_size 
+            effective_length = data_length - self.window_size
             if effective_length < 0:
                 return
-
-            if self.num_window > effective_length + 1: 
-                step = max(0, effective_length / (self.num_window -1) if self.num_window > 1 else 0)
-            else:
-                step = effective_length / (self.num_window - 1) if self.num_window > 1 else 0
-            
-            for i in range(self.num_window):
-                start_idx = int(round(i * step))
-                start_idx = min(start_idx, data_length - self.window_size)
-                end_idx = start_idx + self.window_size
-                self.processed_data.append(sample_data[start_idx:end_idx])
+            step = effective_length / (self.num_window - 1)
+            for index in range(self.num_window):
+                start_idx = min(
+                    int(round(index * step)),
+                    data_length - self.window_size,
+                )
+                self.processed_data.append(
+                    sample_data[start_idx : start_idx + self.window_size]
+                )
 
     def _process_single_data(self, sample_data):
-        """
-        处理单个数据样本，应用滑动窗口
-        """
-        # 根据配置转换数据类型
-        if self.args_data.dtype:
-            if self.args_data.dtype == 'float32':
-                sample_data = sample_data.astype(np.float32)
-            elif self.args_data.dtype == 'float64':
-                sample_data = sample_data.astype(np.float64)
-        if sample_data.ndim == 3:
-            # 如果数据是三维的，转换为二维
-            sample_data = sample_data.reshape(sample_data.shape[0], -1)
-        
-        data_length = len(sample_data)
-        
-        if data_length < self.window_size:
-            # 如果数据长度小于窗口大小，则不处理或进行填充等操作（此处简单跳过）
-            # 可以根据需求添加更复杂的处理逻辑，例如报错、填充等
-            print(f"Warning: Data length ({data_length}) is less than window size ({self.window_size}). Skipping this data.")
-            return
+        """Validate one raw array and apply the configured windowing strategy."""
+        if not isinstance(sample_data, np.ndarray):
+            sample_data = np.asarray(sample_data)
 
-        # print(self.key,sample_data.shape)
-        # windows 
-        if self.window_sampling_strategy == 'sequential':
+        dtype = getattr(self.args_data, "dtype", None)
+        if dtype == "float32":
+            sample_data = sample_data.astype(np.float32)
+        elif dtype == "float64":
+            sample_data = sample_data.astype(np.float64)
+
+        if sample_data.ndim == 3:
+            sample_data = sample_data.reshape(sample_data.shape[0], -1)
+        if sample_data.ndim not in {1, 2}:
+            raise ValueError(
+                f"data ID {self.key!r} must be rank 1 or 2 after reader output; "
+                f"got shape {sample_data.shape}"
+            )
+
+        data_length = len(sample_data)
+        if data_length < self.window_size:
+            raise ValueError(
+                f"data ID {self.key!r} has length {data_length}, shorter than "
+                f"data.window_size={self.window_size}. Reduce window_size or "
+                "provide a longer signal."
+            )
+
+        if self.window_sampling_strategy == "sequential":
             self._sequential_sampling(sample_data, data_length)
-        elif self.window_sampling_strategy == 'random':
+        elif self.window_sampling_strategy == "random":
             self._random_sampling(sample_data, data_length)
-        elif self.window_sampling_strategy == 'evenly_spaced':
+        elif self.window_sampling_strategy == "evenly_spaced":
             self._evenly_spaced_sampling(sample_data, data_length)
         else:
-            raise ValueError(f"Unknown window_sampling_strategy: {self.window_sampling_strategy}")
+            raise ValueError(
+                "Unknown window_sampling_strategy: "
+                f"{self.window_sampling_strategy}"
+            )
 
-        # 对已切好的窗口逐个做归一化和加噪声
+        if not self.processed_data:
+            raise ValueError(
+                f"data ID {self.key!r} produced zero windows. Check "
+                "window_size, stride, num_window, and window_sampling_strategy."
+            )
+
         normalized_windows = []
         for window in self.processed_data:
-            w = self._normalize_window(window)
-            w = self._maybe_add_noise(w)
-            normalized_windows.append(w)
+            normalized = self._normalize_window(window)
+            normalized_windows.append(self._maybe_add_noise(normalized))
         self.processed_data = normalized_windows
 
     def _normalize_window(self, window: np.ndarray) -> np.ndarray:
-        """
-        对单个窗口执行归一化。支持与 args_data.normalization 相同的选项，
-        但按窗口级别进行统计（min/max 或 mean/std）。
-        """
-        norm = getattr(self.args_data, 'normalization', 'standardization')
-        if norm == 'minmax':
+        """Normalize one window using the configured per-window method."""
+        normalization = getattr(
+            self.args_data,
+            "normalization",
+            "standardization",
+        )
+        if normalization == "minmax":
             min_vals = np.min(window, axis=0)
             max_vals = np.max(window, axis=0)
             denominator = max_vals - min_vals
             denominator[denominator == 0] = 1
             return (window - min_vals) / denominator
-        elif norm == 'standardization':
+        if normalization == "standardization":
             mean_vals = np.mean(window, axis=0)
             std_vals = np.std(window, axis=0)
             return (window - mean_vals) / (std_vals + 1e-8)
-        elif norm == 'none':
+        if normalization == "none":
             return window
-        else:
-            raise ValueError(f"Unknown normalization method: {norm}")
+        raise ValueError(f"Unknown normalization method: {normalization}")
 
     def _maybe_add_noise(self, window: np.ndarray) -> np.ndarray:
-        """
-        根据 args_data.noise_snr 对单个窗口注入 AWGN。
-        若未设置 noise_snr 或计算失败，则返回原窗口。
-        """
-        noise_snr = getattr(self.args_data, 'noise_snr', None)
+        """Add AWGN only when ``data.noise_snr`` is explicitly configured."""
+        noise_snr = getattr(self.args_data, "noise_snr", None)
         if noise_snr is None:
             return window
         try:
@@ -180,49 +247,54 @@ class Default_dataset(Dataset): # THU_006or018_basic
             noise = np.random.normal(
                 loc=0.0,
                 scale=noise_std,
-                size=window.shape
+                size=window.shape,
             ).astype(window.dtype)
             return window + noise
         except Exception:
             return window
 
-
     def _split_data_for_mode(self):
-        """
-        根据当前模式划分数据集
-        """
+        """Select a non-overlapping split from one deterministic window list."""
         if not self.processed_data:
             return
-            
-        # 计算划分点
-        total_samples = len(self.processed_data)
-        train_size = int(self.train_ratio * total_samples)
-        
-        if self.mode == "train":
-            # 训练模式只保留训练数据
-            self.processed_data = self.processed_data[:train_size]
-        elif self.mode == "valid":
-            # 验证模式只保留验证数据
-            self.processed_data = self.processed_data[train_size:]
-        self.total_samples = len(self.processed_data)
-    
-    def __len__(self):
-        """返回数据集长度"""
-        return self.total_samples
-    
-    def __getitem__(self, idx):
-        """获取指定索引的样本"""
-        if idx >= self.total_samples:
-            raise IndexError(f"索引 {idx} 超出范围")
-        
-        sample = self.processed_data[idx]
-        # print(f"获取样本 {idx}，数据长度: {sample.shape}")
 
-        out = {
-            "x": sample,
-            "y": self.label # 所有的label
+        total_samples = len(self.processed_data)
+        train_end = int(round(self.train_ratio * total_samples))
+        val_end = int(
+            round((self.train_ratio + self.val_ratio) * total_samples)
+        )
+        test_end = int(
+            round(
+                (
+                    self.train_ratio
+                    + self.val_ratio
+                    + self.test_ratio
+                )
+                * total_samples
+            )
+        )
+        train_end = min(max(train_end, 0), total_samples)
+        val_end = min(max(val_end, train_end), total_samples)
+        test_end = min(max(test_end, val_end), total_samples)
+
+        if self.mode == "train":
+            self.processed_data = self.processed_data[:train_end]
+        elif self.mode == "val":
+            self.processed_data = self.processed_data[train_end:val_end]
+        elif self.mode == "test_holdout":
+            self.processed_data = self.processed_data[val_end:test_end]
+
+    def __len__(self):
+        return self.total_samples
+
+    def __getitem__(self, idx):
+        if idx < 0 or idx >= self.total_samples:
+            raise IndexError(f"索引 {idx} 超出范围")
+
+        return {
+            "x": self.processed_data[idx],
+            "y": self.label,
         }
-        return out
 
 
 class classification_dataset(Default_dataset):
@@ -234,9 +306,11 @@ class RUL_dataset(Default_dataset):
     def __init__(self, data, metadata, args_data, args_task, mode="train"):
         super().__init__(data, metadata, args_data, args_task, mode)
 
+
 class Anomaly_dataset(Default_dataset):
     def __init__(self, data, metadata, args_data, args_task, mode="train"):
         super().__init__(data, metadata, args_data, args_task, mode)
+
 
 class DigitalTwin_dataset(Default_dataset):
     def __init__(self, data, metadata, args_data, args_task, mode="train"):

--- a/src/data_factory/samplers/Get_sampler.py
+++ b/src/data_factory/samplers/Get_sampler.py
@@ -1,8 +1,21 @@
+"""Task-aware batch sampler selection."""
+
 from .Sampler import HierarchicalFewShotSampler, Same_system_Sampler
 
+
+def _evaluation_sampler(args_data, dataset):
+    """Keep every validation/test sample, including a final short batch."""
+    return Same_system_Sampler(
+        dataset=dataset,
+        batch_size=args_data.batch_size,
+        shuffle=False,
+        drop_last=False,
+    )
+
+
 def _get_gfs_sampler(args_task, args_data, dataset, mode):
-    if mode == 'train':
-        sampler = HierarchicalFewShotSampler(
+    if mode == "train":
+        return HierarchicalFewShotSampler(
             dataset=dataset,
             num_episodes=args_task.num_episodes,
             num_systems_per_episode=args_task.num_systems,
@@ -11,122 +24,46 @@ def _get_gfs_sampler(args_task, args_data, dataset, mode):
             num_support_per_label=args_task.num_support,
             num_query_per_label=args_task.num_query,
         )
-    elif mode == 'test' or mode == 'val':
-        sampler = Same_system_Sampler(
-            dataset=dataset,
-            batch_size=args_data.batch_size,
-            shuffle=False,
-            drop_last=True,
-        )
-    else:
-        raise ValueError(f"Unknown mode for GFS sampler: {mode}")
-    return sampler
+    if mode in {"val", "test"}:
+        return _evaluation_sampler(args_data, dataset)
+    raise ValueError(f"Unknown mode for GFS sampler: {mode}")
 
-def _get_cddg_sampler(args_data, dataset, mode):
-    if mode == 'train':
-        sampler = Same_system_Sampler(
+
+def _get_standard_sampler(args_data, dataset, mode, task_name):
+    if mode == "train":
+        return Same_system_Sampler(
             dataset=dataset,
             batch_size=args_data.batch_size,
             shuffle=True,
             drop_last=True,
         )
-    elif mode == 'val' or mode == 'test':
-        sampler = Same_system_Sampler(
-            dataset=dataset,
-            batch_size=args_data.batch_size,
-            shuffle=False,
-            drop_last=True
-        )
-    else:
-        raise ValueError(f"Unknown mode for CDDG sampler: {mode}")
-    return sampler
+    if mode in {"val", "test"}:
+        return _evaluation_sampler(args_data, dataset)
+    raise ValueError(f"Unknown mode for {task_name} sampler: {mode}")
 
-def _get_dg_sampler(args_data, dataset, mode):
-    if mode == 'train':
-        sampler = Same_system_Sampler(
-            dataset, 
-            batch_size=args_data.batch_size,
-            shuffle=True,
-            drop_last=True
-        )
-    elif mode == 'val' or mode == 'test':
-        sampler = Same_system_Sampler(
+
+def Get_sampler(args_task, args_data, dataset, mode="train"):
+    """Return the sampler for one explicit task type and split."""
+    task_type = args_task.type
+
+    if task_type == "GFS":
+        return _get_gfs_sampler(args_task, args_data, dataset, mode)
+    if task_type == "FS":
+        return _get_standard_sampler(args_data, dataset, mode, "FS")
+    if task_type in {"pretrain", "generative"}:
+        return _get_standard_sampler(args_data, dataset, mode, "Pretrain")
+    if task_type == "CDDG":
+        return _get_standard_sampler(args_data, dataset, mode, "CDDG")
+    if task_type == "DG":
+        return _get_standard_sampler(args_data, dataset, mode, "DG")
+    if task_type == "multi_task":
+        return _get_standard_sampler(args_data, dataset, mode, "multi_task")
+    if task_type == "In_distribution":
+        return _get_standard_sampler(
+            args_data,
             dataset,
-            batch_size=args_data.batch_size,
-            shuffle=False,
-            drop_last=True
+            mode,
+            "In_distribution",
         )
-    else:
-        raise ValueError(f"Unknown mode for DG sampler: {mode}")
-    return sampler
 
-def _get_pretrain_sampler(args_data, dataset, mode):
-    if mode == 'train':
-        sampler = Same_system_Sampler(
-            dataset=dataset,
-            batch_size=args_data.batch_size,
-            shuffle=True,
-            drop_last=True,
-        )
-    elif mode == 'val' or mode == 'test':
-        sampler = Same_system_Sampler(
-            dataset=dataset,
-            batch_size=args_data.batch_size,
-            shuffle=False,
-            drop_last=True
-        )
-    else:
-        raise ValueError(f"Unknown mode for Pretrain sampler: {mode}")
-    return sampler
-
-
-def Get_sampler(args_task, args_data, dataset, mode='train'):
-    """
-    Initializes and returns a sampler based on the task type and mode.
-
-    Args:
-        args_task: Task-specific arguments.
-        args_data: Data-specific arguments.
-        dataset: The dataset for which the sampler is to be created.
-        mode: 'train', 'val', or 'test'.
-
-    Returns:
-        A sampler instance or None for 'FS' type.
-    """
-    sampler = None # Initialize sampler to None
-    if args_task.type == 'GFS': # Generalized Few-Shot Learning
-        sampler = _get_gfs_sampler(args_task, args_data, dataset, mode)
-    elif args_task.type == 'FS':
-        # FS 视作单系统 few-shot 场景，先复用 Same_system_Sampler，
-        # 保持与 DG/CDDG 一致的按系统分组 batch 行为。
-        if mode == 'train':
-            sampler = Same_system_Sampler(
-                dataset=dataset,
-                batch_size=args_data.batch_size,
-                shuffle=True,
-                drop_last=True,
-            )
-        elif mode == 'val' or mode == 'test':
-            sampler = Same_system_Sampler(
-                dataset=dataset,
-                batch_size=args_data.batch_size,
-                shuffle=False,
-                drop_last=True,
-            )
-        else:
-            raise ValueError(f"Unknown mode for FS sampler: {mode}")
-    elif args_task.type in {'pretrain', 'generative'}:
-        sampler = _get_pretrain_sampler(args_data, dataset, mode)
-    elif args_task.type == 'CDDG':
-        sampler = _get_cddg_sampler(args_data, dataset, mode)
-    elif args_task.type == 'DG':
-        sampler = _get_dg_sampler(args_data, dataset, mode)
-    elif args_task.type == 'multi_task':
-        # Multi-task learning uses standard batch sampling
-        sampler = _get_pretrain_sampler(args_data, dataset, mode)  # Reuse pretrain sampler
-    elif args_task.type == 'In_distribution':
-        sampler = _get_pretrain_sampler(args_data, dataset, mode)
-    else:
-        raise ValueError(f"Unknown task type for sampler: {args_task.type}")
-        
-    return sampler
+    raise ValueError(f"Unknown task type for sampler: {task_type}")

--- a/test/test_classification_runtime.py
+++ b/test/test_classification_runtime.py
@@ -4,10 +4,14 @@ from argparse import Namespace
 from pathlib import Path
 from types import SimpleNamespace
 
+import numpy as np
 import pytest
 
 from phmfactory.config import ResolvedConfig
 from phmfactory.runtime import CompiledRunSpec
+from src.data_factory.dataset_task.Dataset_cluster import IdIncludedDataset
+from src.data_factory.dataset_task.Default_dataset import Default_dataset
+from src.data_factory.samplers.Get_sampler import Get_sampler
 from src.runtime import classification
 
 
@@ -47,6 +51,28 @@ def _args(tmp_path: Path, *, iterations: int = 1) -> Namespace:
         override=["trainer.num_epochs=99"],
         notes="",
     )
+
+
+def _window_args(**values) -> SimpleNamespace:
+    payload = {
+        "window_size": 4,
+        "stride": 4,
+        "num_window": 5,
+        "window_sampling_strategy": "sequential",
+        "window_sampling_seed": 0,
+        "train_ratio": 0.6,
+        "val_ratio": 0.2,
+        "test_ratio": 0.2,
+        "normalization": "none",
+        "dtype": "float32",
+        "batch_size": 4,
+    }
+    payload.update(values)
+    return SimpleNamespace(**payload)
+
+
+def _window_starts(dataset: Default_dataset) -> list[int]:
+    return [int(item["x"][0, 0]) for item in dataset]
 
 
 def test_compiled_config_bypasses_legacy_reparse(
@@ -115,10 +141,22 @@ def test_runtime_closes_data_and_lab_when_training_fails(
         "seed_everything",
         lambda seed: events.append(f"seed:{seed}"),
     )
-    monkeypatch.setattr(classification, "init_lab", lambda *args: events.append("lab-open"))
-    monkeypatch.setattr(classification, "close_lab", lambda: events.append("lab-close"))
+    monkeypatch.setattr(
+        classification,
+        "init_lab",
+        lambda *args: events.append("lab-open"),
+    )
+    monkeypatch.setattr(
+        classification,
+        "close_lab",
+        lambda: events.append("lab-close"),
+    )
     monkeypatch.setattr(classification, "build_data", lambda *args: DataFactory())
-    monkeypatch.setattr(classification, "build_model", lambda *args, **kwargs: object())
+    monkeypatch.setattr(
+        classification,
+        "build_model",
+        lambda *args, **kwargs: object(),
+    )
     monkeypatch.setattr(classification, "build_task", lambda **kwargs: object())
     monkeypatch.setattr(classification, "build_trainer", lambda *args: Trainer())
 
@@ -148,3 +186,68 @@ def test_pipeline_wrappers_only_select_hooks(monkeypatch: pytest.MonkeyPatch) ->
     assert pipeline_01.pipeline(marker) == []
     assert pipeline_05.pipeline(marker) == []
     assert calls == [("p01", marker), ("p05", marker, "ExplainabilityHooks")]
+
+
+def test_same_file_fewshot_windows_are_disjoint_across_splits() -> None:
+    raw = np.arange(40, dtype=np.float32).reshape(20, 2)
+    data = {1: raw}
+    metadata = {1: {"Label": 0}}
+    args_data = _window_args()
+    args_task = SimpleNamespace(type="FS")
+
+    train = Default_dataset(data, metadata, args_data, args_task, "train")
+    val = Default_dataset(data, metadata, args_data, args_task, "val")
+    test = Default_dataset(data, metadata, args_data, args_task, "test")
+
+    assert _window_starts(train) == [0, 8, 16]
+    assert _window_starts(val) == [24]
+    assert _window_starts(test) == [32]
+    assert set(_window_starts(train)).isdisjoint(_window_starts(val))
+    assert set(_window_starts(train)).isdisjoint(_window_starts(test))
+    assert set(_window_starts(val)).isdisjoint(_window_starts(test))
+
+
+def test_valid_alias_uses_the_validation_slice() -> None:
+    raw = np.arange(40, dtype=np.float32).reshape(20, 2)
+    data = {1: raw}
+    metadata = {1: {"Label": 0}}
+    args_data = _window_args()
+    args_task = SimpleNamespace(type="DG")
+
+    val = Default_dataset(data, metadata, args_data, args_task, "val")
+    valid = Default_dataset(data, metadata, args_data, args_task, "valid")
+
+    assert _window_starts(val) == _window_starts(valid) == [24]
+
+
+def test_evaluation_sampler_keeps_a_short_final_batch() -> None:
+    raw = np.arange(40, dtype=np.float32).reshape(20, 2)
+    data = {1: raw}
+    metadata = {1: {"Label": 0, "Dataset_id": 7}}
+    args_data = _window_args(batch_size=8)
+    args_task = SimpleNamespace(type="DG")
+    val_dataset = Default_dataset(data, metadata, args_data, args_task, "val")
+    clustered = IdIncludedDataset({1: val_dataset}, metadata)
+
+    sampler = Get_sampler(args_task, args_data, clustered, mode="val")
+
+    assert len(clustered) == 1
+    assert len(sampler) == 1
+    assert list(sampler) == [[0]]
+
+
+def test_short_signal_fails_with_actionable_message() -> None:
+    args_data = _window_args(window_size=16)
+    args_task = SimpleNamespace(type="DG")
+
+    with pytest.raises(
+        ValueError,
+        match="Reduce window_size or provide a longer signal",
+    ):
+        Default_dataset(
+            {1: np.zeros((8, 2), dtype=np.float32)},
+            {1: {"Label": 0}},
+            args_data,
+            args_task,
+            "train",
+        )


### PR DESCRIPTION
## User problem

Several maintained data paths could look successful while using incorrect split semantics:

- `data_factory` creates validation datasets with `mode="val"`, but `Default_dataset` only split `mode="valid"`, so validation reused all windows including training windows;
- FS/GFS/pretrain reuse the same file IDs for train and test, so the default test dataset reused the same window pool;
- validation and test samplers used `drop_last=True`, which could silently produce zero evaluation batches when a split was smaller than `data.batch_size`;
- signals shorter than `data.window_size` were printed and skipped instead of stopping with a repair instruction.

## First-principles contract

```text
same raw file
→ one deterministic window list
→ non-overlapping train / val / held-out test slices
```

For DG/CDDG paths whose test IDs are distinct, `mode="test"` still uses the complete test file. For FS/GFS/pretrain paths whose current ID selection reuses files, `mode="test"` selects the configured held-out window tail.

## Scope

- normalize `valid` to the public `val` spelling;
- validate train/val/test ratios;
- make random window selection deterministic through optional `data.window_sampling_seed` (default `0`) so separate split objects select the same source window list before slicing;
- keep FS/GFS/pretrain train, validation, and test windows mutually exclusive;
- preserve incomplete validation/test batches with `drop_last=False`;
- fail with the file ID, observed length, and repair action when a signal cannot produce a window;
- simplify sampler selection without changing GFS episodic training behavior.

## Tests

The existing shared classification runtime contract now checks:

- FS same-file train/val/test windows are disjoint;
- `val` and legacy `valid` select the same validation slice;
- an evaluation split smaller than batch size still yields one batch;
- a short signal fails with an actionable message.

The existing offline Dummy demo remains the end-to-end regression gate.

## Explicit non-goals

```text
no reader numerical changes
no cache rewrite
no dataset adapter registry change
no Pipeline 03/04 promotion
no new hash or manifest
no universal dataset schema
no benchmark-performance claim
```

## Review state

Draft pending Core quality gates and review of compatibility impact on existing dataset subclasses.