### PR TITLE
refactor(data): make dataset adapters explicit and extensible

### DIFF
--- a/src/data_factory/__init__.py
+++ b/src/data_factory/__init__.py
@@ -8,59 +8,53 @@ from .data_factory import (
     register_data_factory,
 )
 from .dataset_task.Dataset_cluster import IdIncludedDataset
+from .explicit_data_factory import ExplicitDataFactory
 from .id_data_factory import id_data_factory
 
 
-
-
 def resolve_data_factory_class(name: str):
-    """Return the factory class registered as ``name``.
+    """Return one explicit data factory class.
 
-    Parameters
-    ----------
-    name : str
-        Factory identifier from configuration.
-
-    Returns
-    -------
-    type
-        Data factory class corresponding to ``name``.
+    ``default`` uses :class:`ExplicitDataFactory`, which resolves the dataset
+    implementation from the registered ``(task.type, task.name)`` contract. Other
+    factory names must be present in ``DATA_FACTORY_REGISTRY``.
     """
+
+    requested = str(name)
+    if requested == "default":
+        return ExplicitDataFactory
+
     try:
-        return DATA_FACTORY_REGISTRY.get(name)
-    except KeyError:
-        # default fallback
-        if name == "default":
-            return data_factory
-        raise
+        return DATA_FACTORY_REGISTRY.get(requested)
+    except KeyError as exc:
+        available = sorted(
+            {
+                "default",
+                "department",
+                "id",
+            }
+        )
+        raise ValueError(
+            f"Unknown data.factory_name={requested!r}. "
+            f"Available factories: {', '.join(available)}"
+        ) from exc
 
 
 def build_data(args_data: Any, args_task: Any) -> Any:
-    """Instantiate a dataset using the configured factory.
+    """Instantiate the configured data factory for one task contract."""
 
-    Parameters
-    ----------
-    args_data : Any
-        Data related configuration namespace.
-    args_task : Any
-        Task configuration used during dataset creation.
-
-    Returns
-    -------
-    Any
-        Instantiated dataset factory.
-    """
     name = getattr(args_data, "factory_name", "default")
     factory_cls = resolve_data_factory_class(name)
     return factory_cls(args_data, args_task)
 
 
-# public exports
 __all__ = [
     "build_data",
     "resolve_data_factory_class",
     "register_data_factory",
     "DATA_FACTORY_REGISTRY",
+    "data_factory",
+    "ExplicitDataFactory",
     "IdIncludedDataset",
     "id_data_factory",
 ]

--- a/src/data_factory/__init__.py
+++ b/src/data_factory/__init__.py
@@ -1,4 +1,4 @@
-"""Public API for the data factory package."""
+"""Public API for PHMFactory data construction and dataset extensions."""
 
 from typing import Any
 
@@ -8,6 +8,11 @@ from .data_factory import (
     register_data_factory,
 )
 from .dataset_task.Dataset_cluster import IdIncludedDataset
+from .dataset_task.adapters import (
+    DATASET_ADAPTERS,
+    register_dataset_adapter,
+    resolve_dataset_adapter,
+)
 from .explicit_data_factory import ExplicitDataFactory
 from .id_data_factory import id_data_factory
 
@@ -27,13 +32,7 @@ def resolve_data_factory_class(name: str):
     try:
         return DATA_FACTORY_REGISTRY.get(requested)
     except KeyError as exc:
-        available = sorted(
-            {
-                "default",
-                "department",
-                "id",
-            }
-        )
+        available = ["default", "department", "id"]
         raise ValueError(
             f"Unknown data.factory_name={requested!r}. "
             f"Available factories: {', '.join(available)}"
@@ -55,6 +54,9 @@ __all__ = [
     "DATA_FACTORY_REGISTRY",
     "data_factory",
     "ExplicitDataFactory",
+    "DATASET_ADAPTERS",
+    "register_dataset_adapter",
+    "resolve_dataset_adapter",
     "IdIncludedDataset",
     "id_data_factory",
 ]

--- a/src/data_factory/dataset_task/adapters.py
+++ b/src/data_factory/dataset_task/adapters.py
@@ -1,0 +1,137 @@
+"""Explicit dataset adapter registry keyed by ``(task.type, task.name)``."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import importlib
+from typing import Any
+
+
+@dataclass(frozen=True)
+class DatasetAdapterSpec:
+    """Import location for one dataset implementation."""
+
+    module: str
+    attribute: str = "set_dataset"
+
+
+DATASET_ADAPTERS: dict[tuple[str, str], DatasetAdapterSpec] = {
+    ("Default_task", "Default_task"): DatasetAdapterSpec(
+        "src.data_factory.dataset_task.Default_dataset",
+        "Default_dataset",
+    ),
+    ("Default_task", "ID_task"): DatasetAdapterSpec(
+        "src.data_factory.dataset_task.ID.Classification_dataset"
+    ),
+    ("DG", "classification"): DatasetAdapterSpec(
+        "src.data_factory.dataset_task.DG.Classification_dataset"
+    ),
+    ("CDDG", "classification"): DatasetAdapterSpec(
+        "src.data_factory.dataset_task.CDDG.classification_dataset"
+    ),
+    ("FS", "classification"): DatasetAdapterSpec(
+        "src.data_factory.dataset_task.FS.Classification_dataset"
+    ),
+    ("FS", "prototypical_network"): DatasetAdapterSpec(
+        "src.data_factory.dataset_task.FS.Classification_dataset"
+    ),
+    ("FS", "matching_network"): DatasetAdapterSpec(
+        "src.data_factory.dataset_task.FS.Classification_dataset"
+    ),
+    ("FS", "knn_feature"): DatasetAdapterSpec(
+        "src.data_factory.dataset_task.FS.Classification_dataset"
+    ),
+    ("FS", "finetuning"): DatasetAdapterSpec(
+        "src.data_factory.dataset_task.FS.Classification_dataset"
+    ),
+    ("GFS", "classification"): DatasetAdapterSpec(
+        "src.data_factory.dataset_task.GFS.Classification_dataset"
+    ),
+    ("GFS", "matching"): DatasetAdapterSpec(
+        "src.data_factory.dataset_task.GFS.Classification_dataset"
+    ),
+    ("pretrain", "classification"): DatasetAdapterSpec(
+        "src.data_factory.dataset_task.Pretrain.Classification_dataset"
+    ),
+    ("pretrain", "hse_contrastive"): DatasetAdapterSpec(
+        "src.data_factory.dataset_task.Pretrain.Classification_dataset"
+    ),
+    ("pretrain", "masked_reconstruction"): DatasetAdapterSpec(
+        "src.data_factory.dataset_task.Pretrain.Classification_dataset"
+    ),
+    ("pretrain", "prediction"): DatasetAdapterSpec(
+        "src.data_factory.dataset_task.Pretrain.Classification_dataset"
+    ),
+    ("pretrain", "classification_prediction"): DatasetAdapterSpec(
+        "src.data_factory.dataset_task.Pretrain.Classification_dataset"
+    ),
+    ("generative", "conditional_flow_matching"): DatasetAdapterSpec(
+        "src.data_factory.dataset_task.Default_dataset",
+        "Default_dataset",
+    ),
+    ("In_distribution", "multi_task_phm"): DatasetAdapterSpec(
+        "src.data_factory.dataset_task.Default_dataset",
+        "Default_dataset",
+    ),
+}
+
+
+def register_dataset_adapter(
+    task_type: str,
+    task_name: str,
+    module: str,
+    attribute: str = "set_dataset",
+) -> None:
+    """Register one explicit dataset adapter for an extension package."""
+
+    key = (str(task_type), str(task_name))
+    if key in DATASET_ADAPTERS:
+        raise ValueError(f"dataset adapter already registered for {key!r}")
+    DATASET_ADAPTERS[key] = DatasetAdapterSpec(module, attribute)
+
+
+def resolve_dataset_adapter(task_type: Any, task_name: Any):
+    """Return the dataset class for one exact task combination.
+
+    Unknown combinations fail with the supported keys. Import errors retain their
+    original cause instead of falling back to ``Default_dataset``.
+    """
+
+    key = (str(task_type), str(task_name))
+    spec = DATASET_ADAPTERS.get(key)
+    if spec is None:
+        supported = ", ".join(
+            f"{item_type}/{item_name}"
+            for item_type, item_name in sorted(DATASET_ADAPTERS)
+        )
+        raise ValueError(
+            f"No dataset adapter is registered for task {key[0]}/{key[1]}. "
+            f"Registered combinations: {supported}. Add an explicit adapter "
+            "before running this task."
+        )
+
+    try:
+        module = importlib.import_module(spec.module)
+    except ImportError as exc:
+        raise ImportError(
+            f"Dataset adapter for {key[0]}/{key[1]} could not import "
+            f"{spec.module}: {exc}"
+        ) from exc
+
+    try:
+        dataset_class = getattr(module, spec.attribute)
+    except AttributeError as exc:
+        raise ImportError(
+            f"Dataset adapter for {key[0]}/{key[1]} expected "
+            f"{spec.module}.{spec.attribute}, but that attribute does not exist."
+        ) from exc
+
+    return dataset_class
+
+
+__all__ = [
+    "DATASET_ADAPTERS",
+    "DatasetAdapterSpec",
+    "register_dataset_adapter",
+    "resolve_dataset_adapter",
+]

--- a/src/data_factory/explicit_data_factory.py
+++ b/src/data_factory/explicit_data_factory.py
@@ -1,0 +1,71 @@
+"""Default data factory with explicit task-to-dataset adapter resolution."""
+
+from __future__ import annotations
+
+from tqdm import tqdm
+
+from .data_factory import data_factory
+from .dataset_task.Dataset_cluster import IdIncludedDataset
+from .dataset_task.adapters import resolve_dataset_adapter
+
+
+class ExplicitDataFactory(data_factory):
+    """Build datasets only from registered task adapters.
+
+    Cache construction, ID selection, samplers, and DataLoader creation remain in
+    the historical ``data_factory`` implementation. This subclass replaces only
+    the ambiguous dataset-module lookup and its silent fallback.
+    """
+
+    def _init_dataset(self):
+        task_type = str(self.args_task.type)
+        task_name = str(self.args_task.name)
+        dataset_cls = resolve_dataset_adapter(task_type, task_name)
+
+        train_dataset = {}
+        val_dataset = {}
+        test_dataset = {}
+        train_val_ids, test_ids = self.search_id()
+
+        print(
+            "Initializing datasets with explicit adapter "
+            f"{dataset_cls.__module__}.{dataset_cls.__name__} "
+            f"for {task_type}/{task_name}."
+        )
+        for file_id in tqdm(
+            train_val_ids,
+            desc="Creating train/val datasets",
+        ):
+            file_data = {file_id: self.data[file_id]}
+            train_dataset[file_id] = dataset_cls(
+                file_data,
+                self.target_metadata,
+                self.args_data,
+                self.args_task,
+                "train",
+            )
+            val_dataset[file_id] = dataset_cls(
+                file_data,
+                self.target_metadata,
+                self.args_data,
+                self.args_task,
+                "val",
+            )
+
+        for file_id in tqdm(test_ids, desc="Creating test datasets"):
+            test_dataset[file_id] = dataset_cls(
+                {file_id: self.data[file_id]},
+                self.target_metadata,
+                self.args_data,
+                self.args_task,
+                "test",
+            )
+
+        return (
+            IdIncludedDataset(train_dataset, self.target_metadata),
+            IdIncludedDataset(val_dataset, self.target_metadata),
+            IdIncludedDataset(test_dataset, self.target_metadata),
+        )
+
+
+__all__ = ["ExplicitDataFactory"]

--- a/test/test_classification_runtime.py
+++ b/test/test_classification_runtime.py
@@ -9,8 +9,13 @@ import pytest
 
 from phmfactory.config import ResolvedConfig
 from phmfactory.runtime import CompiledRunSpec
+from src.data_factory import ExplicitDataFactory, resolve_data_factory_class
 from src.data_factory.dataset_task.Dataset_cluster import IdIncludedDataset
 from src.data_factory.dataset_task.Default_dataset import Default_dataset
+from src.data_factory.dataset_task.adapters import (
+    DATASET_ADAPTERS,
+    resolve_dataset_adapter,
+)
 from src.data_factory.samplers.Get_sampler import Get_sampler
 from src.runtime import classification
 
@@ -251,3 +256,29 @@ def test_short_signal_fails_with_actionable_message() -> None:
             args_task,
             "train",
         )
+
+
+def test_default_data_factory_uses_explicit_adapter_resolution() -> None:
+    assert resolve_data_factory_class("default") is ExplicitDataFactory
+
+
+@pytest.mark.parametrize("task_type,task_name", sorted(DATASET_ADAPTERS))
+def test_every_registered_dataset_adapter_imports(
+    task_type: str,
+    task_name: str,
+) -> None:
+    dataset_class = resolve_dataset_adapter(task_type, task_name)
+    assert isinstance(dataset_class, type)
+
+
+def test_unknown_dataset_adapter_fails_with_registered_combinations() -> None:
+    with pytest.raises(
+        ValueError,
+        match="No dataset adapter is registered.*Add an explicit adapter",
+    ):
+        resolve_dataset_adapter("unknown", "task")
+
+
+def test_unknown_data_factory_name_fails_with_available_factories() -> None:
+    with pytest.raises(ValueError, match="Unknown data.factory_name"):
+        resolve_data_factory_class("auto_guess")


### PR DESCRIPTION
## User problem

Dataset selection previously guessed a Python module from `task.type` and `task.name`. On Linux, case mismatches could trigger `ImportError`, after which the runtime silently switched to `Default_dataset`. A user could therefore request one dataset adapter while running another.

## First-principles contract

```text
task.type + task.name
→ one registered dataset adapter
→ that adapter loads successfully
```

Unknown combinations and broken adapters fail at construction with the requested task, expected module, original cause, and a repair action.

## Scope

- add one central `(task.type, task.name) -> module/class` registry;
- register current maintained combinations and existing explicit experimental task entries;
- route the public default data factory through exact adapter resolution;
- preserve cache construction, ID selection, windowing, samplers and DataLoaders;
- expose `register_dataset_adapter(...)` through `src.data_factory` as the extension point;
- reject duplicate registrations, unknown combinations, missing modules and missing adapter classes;
- reject unknown `data.factory_name` instead of guessing.

## Developer path

```python
from src.data_factory import register_dataset_adapter

register_dataset_adapter(
    "MyTaskType",
    "my_task",
    "my_package.dataset_adapter",
)
```

No filename convention, module guessing or fallback is required.

## Validation

All workflows on the current head pass:

- Core quality gates, including every registered adapter import and the full offline Dummy user path;
- Repository layout;
- Submodule policy;
- Pipeline 02, Pipeline 06 and UXFD focused contracts.

## Explicit non-goals

```text
no cache rewrite
no reader numerical changes
no universal batch schema
no Pipeline 03/04 promotion
no automatic adapter discovery
no module-name guessing
no new hash, manifest, policy or workflow
```

## Review state

Implementation and compatibility review complete; no blocking review threads.