### PR TITLE
fix(data): publish caches only when complete

### DIFF
--- a/.github/workflows/core-quality-gates.yml
+++ b/.github/workflows/core-quality-gates.yml
@@ -224,22 +224,25 @@ jobs:
       - name: Record smoke environment
         run: python -m pip freeze > offline-smoke-environment.txt
 
-      - name: Run shared runtime, evidence, and Pipeline 02 contract tests
+      - name: Run shared runtime, data, evidence, and Pipeline 02 contract tests
         shell: bash
         run: |
           set -o pipefail
           python -m py_compile \
             phmfactory/runtime/evidence.py \
+            src/data_factory/explicit_data_factory.py \
             src/runtime/classification.py \
             src/runtime/explainability.py \
             src/Pipeline_01_Fault_Diagnosis.py \
             src/Pipeline_02_Pretraining_Few_Shot.py \
             src/Pipeline_05_Explainable_Fault_Diagnosis.py \
             test/test_classification_runtime.py \
+            test/test_data_cache_contract.py \
             test/test_pipeline02_runtime.py \
             test/test_runtime_evidence.py
           python -m pytest \
             test/test_classification_runtime.py \
+            test/test_data_cache_contract.py \
             test/test_pipeline02_runtime.py \
             test/test_runtime_evidence.py \
             -vv --tb=long 2>&1 | tee runtime-contracts-pytest.log

--- a/src/data_factory/explicit_data_factory.py
+++ b/src/data_factory/explicit_data_factory.py
@@ -112,9 +112,7 @@ class ExplicitDataFactory(data_factory):
             raise
 
     def _build_final_cache(self, task_meta, args_data, use_cache):
-        """Build the current task cache completely, then publish it atomically."""
-        del use_cache  # The final cache is rebuilt from validated dataset caches.
-
+        """Reuse a complete task cache or rebuild it before atomic publication."""
         expected_ids = list(task_meta.keys())
         if not expected_ids:
             raise ValueError(
@@ -122,9 +120,22 @@ class ExplicitDataFactory(data_factory):
                 "domain selection, labels, and metadata."
             )
 
+        expected_keys = {str(file_id) for file_id in expected_ids}
         cache_path = Path(args_data.data_dir) / "cache.h5"
         temp_path = cache_path.with_name(".cache.h5.tmp")
         cache_path.parent.mkdir(parents=True, exist_ok=True)
+
+        if use_cache and cache_path.is_file():
+            try:
+                with h5py.File(cache_path, "r") as published_cache:
+                    if expected_keys.issubset(published_cache.keys()):
+                        return str(cache_path)
+            except OSError as exc:
+                raise RuntimeError(
+                    f"Existing cache cannot be opened: {cache_path}. Delete this "
+                    "cache and rerun so PHMFactory can rebuild it."
+                ) from exc
+
         temp_path.unlink(missing_ok=True)
         missing = []
 

--- a/src/data_factory/explicit_data_factory.py
+++ b/src/data_factory/explicit_data_factory.py
@@ -1,7 +1,13 @@
-"""Default data factory with explicit task-to-dataset adapter resolution."""
+"""Default data factory with explicit adapters and atomic cache publication."""
 
 from __future__ import annotations
 
+import concurrent.futures
+import os
+from pathlib import Path
+import shutil
+
+import h5py
 from tqdm import tqdm
 
 from .data_factory import data_factory
@@ -10,12 +16,169 @@ from .dataset_task.adapters import resolve_dataset_adapter
 
 
 class ExplicitDataFactory(data_factory):
-    """Build datasets only from registered task adapters.
+    """Build data through explicit adapters and publish only complete caches.
 
-    Cache construction, ID selection, samplers, and DataLoader creation remain in
-    the historical ``data_factory`` implementation. This subclass replaces only
-    the ambiguous dataset-module lookup and its silent fallback.
+    Reader behavior, ID selection, windowing, samplers and DataLoaders remain in
+    their existing modules. This class owns two user-visible boundaries:
+
+    - task-to-dataset selection is explicit;
+    - a cache path is replaced only after every requested ID is present.
     """
+
+    def _update_name_cache(self, name, ids, args_data, max_workers):
+        """Read all requested IDs and atomically update one dataset cache."""
+        if not ids:
+            return
+
+        id_meta_pairs = []
+        missing_metadata = []
+        for file_id in ids:
+            meta = self.metadata[file_id]
+            if not meta.get("File"):
+                missing_metadata.append(str(file_id))
+                continue
+            id_meta_pairs.append((file_id, meta))
+
+        if missing_metadata:
+            raise RuntimeError(
+                f"Cannot build cache for dataset {name!r}: metadata is missing "
+                f"File for ID(s) {', '.join(missing_metadata)}. Fix the metadata "
+                "before rerunning."
+            )
+
+        results = []
+        with concurrent.futures.ThreadPoolExecutor(
+            max_workers=max_workers
+        ) as executor:
+            futures = [
+                executor.submit(
+                    self._read_single_data,
+                    file_id,
+                    meta,
+                    args_data,
+                )
+                for file_id, meta in id_meta_pairs
+            ]
+            for future in tqdm(
+                concurrent.futures.as_completed(futures),
+                total=len(futures),
+                desc=f"并行读取 {name}",
+            ):
+                results.append(future.result())
+
+        failures = [
+            (str(file_id), error or "reader returned no data")
+            for file_id, data, error in results
+            if data is None
+        ]
+        if failures:
+            details = "; ".join(
+                f"ID {file_id}: {reason}" for file_id, reason in failures
+            )
+            raise RuntimeError(
+                f"Cannot publish cache for dataset {name!r}; raw-data reading "
+                f"failed. {details}"
+            )
+
+        cache_path = Path(args_data.data_dir) / f"{name}.h5"
+        temp_path = cache_path.with_name(f".{cache_path.name}.tmp")
+        cache_path.parent.mkdir(parents=True, exist_ok=True)
+        temp_path.unlink(missing_ok=True)
+
+        try:
+            if cache_path.is_file():
+                shutil.copy2(cache_path, temp_path)
+            with h5py.File(temp_path, "a") as h5_file:
+                for file_id, data, _ in results:
+                    key = str(file_id)
+                    if key in h5_file:
+                        del h5_file[key]
+                    h5_file.create_dataset(key, data=data)
+
+                missing_ids = [
+                    str(file_id)
+                    for file_id in ids
+                    if str(file_id) not in h5_file
+                ]
+                if missing_ids:
+                    raise RuntimeError(
+                        f"Temporary cache {temp_path} is missing ID(s) "
+                        f"{', '.join(missing_ids)}."
+                    )
+
+            os.replace(temp_path, cache_path)
+        except Exception:
+            temp_path.unlink(missing_ok=True)
+            raise
+
+    def _build_final_cache(self, task_meta, args_data, use_cache):
+        """Build the current task cache completely, then publish it atomically."""
+        del use_cache  # The final cache is rebuilt from validated dataset caches.
+
+        expected_ids = list(task_meta.keys())
+        if not expected_ids:
+            raise ValueError(
+                "The selected task contains no data IDs. Check task.target_system_id, "
+                "domain selection, labels, and metadata."
+            )
+
+        cache_path = Path(args_data.data_dir) / "cache.h5"
+        temp_path = cache_path.with_name(".cache.h5.tmp")
+        cache_path.parent.mkdir(parents=True, exist_ok=True)
+        temp_path.unlink(missing_ok=True)
+        missing = []
+
+        try:
+            with h5py.File(temp_path, "w") as output_cache:
+                for file_id in tqdm(
+                    expected_ids,
+                    desc="整合 cache.h5",
+                ):
+                    meta = self.metadata[file_id]
+                    dataset_name = meta.get("Name")
+                    if not dataset_name:
+                        missing.append(
+                            (str(file_id), "metadata field Name is missing")
+                        )
+                        continue
+
+                    source_path = (
+                        Path(args_data.data_dir) / f"{dataset_name}.h5"
+                    )
+                    if not source_path.is_file():
+                        missing.append(
+                            (str(file_id), f"dataset cache not found: {source_path}")
+                        )
+                        continue
+
+                    key = str(file_id)
+                    with h5py.File(source_path, "r") as source_cache:
+                        if key not in source_cache:
+                            missing.append(
+                                (
+                                    key,
+                                    f"ID is absent from dataset cache {source_path}",
+                                )
+                            )
+                            continue
+                        source_cache.copy(key, output_cache, name=key)
+
+            if missing:
+                details = "; ".join(
+                    f"ID {file_id}: {reason}"
+                    for file_id, reason in missing
+                )
+                raise RuntimeError(
+                    "Cannot publish cache.h5 because the selected data is "
+                    f"incomplete. {details}"
+                )
+
+            os.replace(temp_path, cache_path)
+        except Exception:
+            temp_path.unlink(missing_ok=True)
+            raise
+
+        return str(cache_path)
 
     def _init_dataset(self):
         task_type = str(self.args_task.type)

--- a/test/test_data_cache_contract.py
+++ b/test/test_data_cache_contract.py
@@ -93,6 +93,28 @@ def test_successful_dataset_cache_replaces_only_after_all_ids_exist(
     assert not (tmp_path / ".Demo.h5.tmp").exists()
 
 
+def test_complete_published_cache_is_reused_without_source_cache(
+    tmp_path: Path,
+) -> None:
+    metadata = {
+        1: {"Name": "Demo", "File": "one.csv"},
+        2: {"Name": "Demo", "File": "two.csv"},
+    }
+    factory = _factory(metadata)
+    final_cache = tmp_path / "cache.h5"
+    _write_h5(final_cache, {"1": 1.0, "2": 2.0, "extra": 3.0})
+
+    result = factory._build_final_cache(
+        metadata,
+        _args(tmp_path),
+        use_cache=True,
+    )
+
+    assert result == str(final_cache)
+    assert _keys(final_cache) == {"1", "2", "extra"}
+    assert not (tmp_path / "Demo.h5").exists()
+
+
 def test_incomplete_final_cache_keeps_previous_published_file(tmp_path: Path) -> None:
     metadata = {
         1: {"Name": "Demo", "File": "one.csv"},
@@ -126,7 +148,7 @@ def test_complete_final_cache_atomically_replaces_previous_file(tmp_path: Path) 
     result = factory._build_final_cache(
         metadata,
         _args(tmp_path),
-        use_cache=True,
+        use_cache=False,
     )
 
     assert result == str(final_cache)

--- a/test/test_data_cache_contract.py
+++ b/test/test_data_cache_contract.py
@@ -1,0 +1,145 @@
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import h5py
+import numpy as np
+import pytest
+
+from src.data_factory import ExplicitDataFactory
+
+
+def _factory(metadata):
+    factory = ExplicitDataFactory.__new__(ExplicitDataFactory)
+    factory.metadata = metadata
+    return factory
+
+
+def _args(tmp_path: Path) -> SimpleNamespace:
+    return SimpleNamespace(
+        data_dir=str(tmp_path),
+        metadata_file="metadata.csv",
+    )
+
+
+def _write_h5(path: Path, values: dict[str, float]) -> None:
+    with h5py.File(path, "w") as h5_file:
+        for key, value in values.items():
+            h5_file.create_dataset(
+                key,
+                data=np.full((2, 1), value, dtype=np.float32),
+            )
+
+
+def _keys(path: Path) -> set[str]:
+    with h5py.File(path, "r") as h5_file:
+        return set(h5_file.keys())
+
+
+def test_failed_reader_does_not_publish_partial_dataset_cache(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    metadata = {
+        1: {"Name": "Demo", "File": "one.csv"},
+        2: {"Name": "Demo", "File": "two.csv"},
+    }
+    factory = _factory(metadata)
+    cache_path = tmp_path / "Demo.h5"
+    _write_h5(cache_path, {"stable": 9.0})
+
+    def read_one(file_id, meta, args_data):
+        if file_id == 1:
+            return file_id, np.ones((4, 1), dtype=np.float32), None
+        return file_id, None, "raw file is unreadable"
+
+    monkeypatch.setattr(factory, "_read_single_data", read_one)
+
+    with pytest.raises(
+        RuntimeError,
+        match="Cannot publish cache.*ID 2: raw file is unreadable",
+    ):
+        factory._update_name_cache("Demo", [1, 2], _args(tmp_path), 1)
+
+    assert _keys(cache_path) == {"stable"}
+    assert not (tmp_path / ".Demo.h5.tmp").exists()
+
+
+def test_successful_dataset_cache_replaces_only_after_all_ids_exist(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    metadata = {
+        1: {"Name": "Demo", "File": "one.csv"},
+        2: {"Name": "Demo", "File": "two.csv"},
+    }
+    factory = _factory(metadata)
+
+    monkeypatch.setattr(
+        factory,
+        "_read_single_data",
+        lambda file_id, meta, args_data: (
+            file_id,
+            np.full((4, 1), file_id, dtype=np.float32),
+            None,
+        ),
+    )
+
+    factory._update_name_cache("Demo", [1, 2], _args(tmp_path), 1)
+
+    cache_path = tmp_path / "Demo.h5"
+    assert _keys(cache_path) == {"1", "2"}
+    assert not (tmp_path / ".Demo.h5.tmp").exists()
+
+
+def test_incomplete_final_cache_keeps_previous_published_file(tmp_path: Path) -> None:
+    metadata = {
+        1: {"Name": "Demo", "File": "one.csv"},
+        2: {"Name": "Demo", "File": "two.csv"},
+    }
+    factory = _factory(metadata)
+    _write_h5(tmp_path / "Demo.h5", {"1": 1.0})
+    final_cache = tmp_path / "cache.h5"
+    _write_h5(final_cache, {"stable": 9.0})
+
+    with pytest.raises(
+        RuntimeError,
+        match="Cannot publish cache.h5.*ID 2",
+    ):
+        factory._build_final_cache(metadata, _args(tmp_path), use_cache=True)
+
+    assert _keys(final_cache) == {"stable"}
+    assert not (tmp_path / ".cache.h5.tmp").exists()
+
+
+def test_complete_final_cache_atomically_replaces_previous_file(tmp_path: Path) -> None:
+    metadata = {
+        1: {"Name": "Demo", "File": "one.csv"},
+        2: {"Name": "Demo", "File": "two.csv"},
+    }
+    factory = _factory(metadata)
+    _write_h5(tmp_path / "Demo.h5", {"1": 1.0, "2": 2.0})
+    final_cache = tmp_path / "cache.h5"
+    _write_h5(final_cache, {"stale": 9.0})
+
+    result = factory._build_final_cache(
+        metadata,
+        _args(tmp_path),
+        use_cache=True,
+    )
+
+    assert result == str(final_cache)
+    assert _keys(final_cache) == {"1", "2"}
+    assert not (tmp_path / ".cache.h5.tmp").exists()
+
+
+def test_empty_task_selection_fails_before_cache_publication(
+    tmp_path: Path,
+) -> None:
+    factory = _factory({})
+
+    with pytest.raises(ValueError, match="contains no data IDs"):
+        factory._build_final_cache({}, _args(tmp_path), use_cache=True)
+
+    assert not (tmp_path / "cache.h5").exists()


### PR DESCRIPTION
## User problem

The default data path could skip failed raw-data IDs, still write partial `Name.h5` / `cache.h5` files, print completion, and continue with fewer samples than the selected task requested.

## First-principles contract

```text
published cache
⇒ every selected ID is present
```

A cache update either completes and replaces the prior file, or fails while leaving the prior published cache unchanged.

## Scope

- read all requested raw-data IDs before touching a published dataset cache;
- aggregate reader failures with ID and original reason;
- update `Name.h5` through a same-directory temporary file and `os.replace`;
- reuse an existing `cache.h5` immediately when it already contains every selected ID;
- otherwise rebuild the current task cache from validated dataset caches and publish atomically;
- refuse publication when task selection is empty or any ID is missing;
- remove temporary files on failure;
- keep the previous published file unchanged when a rebuild fails;
- apply this contract to the public default `ExplicitDataFactory` path.

## Validation

All workflows on the current head pass. The existing Core quality gate covers:

- one reader failure does not publish a partial dataset cache;
- all successful IDs produce a complete dataset cache;
- a complete prebuilt cache is reused without copying source caches;
- an incomplete final cache leaves the previous file unchanged;
- a complete rebuild atomically replaces stale content;
- an empty task selection fails before publication;
- the full offline Dummy command still trains and produces the expected run artifacts.

Repository layout, submodule policy, Pipeline 02, Pipeline 06 and UXFD contracts also pass.

## Explicit non-goals

```text
no file hashes
no cache signatures
no lock server
no database transaction layer
no multi-process recovery protocol
no reader numerical changes
no dataset split or adapter changes
no repair of legacy department/id factories in this slice
```

## Review state

Implementation and compatibility review complete; no blocking review threads.