### PR TITLE
fix(data): reject empty loaders before model construction

### DIFF
--- a/src/data_factory/contracts.py
+++ b/src/data_factory/contracts.py
@@ -1,0 +1,63 @@
+"""Small runtime contracts for user-visible PHMFactory data loaders."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from typing import Any
+
+
+def require_nonempty_dataloaders(
+    data_factory: Any,
+    args_task: Any,
+    args_data: Any,
+    splits: Iterable[str] = ("train", "val", "test"),
+) -> dict[str, int]:
+    """Return loader batch counts or fail before model construction.
+
+    The check uses ``len(loader)`` only. It does not consume a batch, change
+    sampler order, inspect tensors, or impose a universal batch schema.
+    """
+
+    task_type = str(getattr(args_task, "type", "unknown"))
+    task_name = str(getattr(args_task, "name", "unknown"))
+    batch_size = getattr(args_data, "batch_size", "unknown")
+    counts: dict[str, int] = {}
+
+    for split in splits:
+        loader = data_factory.get_dataloader(split)
+        if loader is None:
+            raise RuntimeError(
+                f"Data contract failed for {task_type}/{task_name}: "
+                f"{split} loader is None. Check the dataset adapter and sampler."
+            )
+        try:
+            batch_count = int(len(loader))
+        except (TypeError, ValueError) as exc:
+            raise RuntimeError(
+                f"Data contract failed for {task_type}/{task_name}: cannot "
+                f"determine the number of {split} batches from "
+                f"{type(loader).__name__}."
+            ) from exc
+
+        if batch_count <= 0:
+            raise RuntimeError(
+                f"Data contract failed for {task_type}/{task_name}: {split} "
+                f"loader has 0 batches. Check selected IDs, split ratios, "
+                f"data.window_size, data.num_window, and "
+                f"data.batch_size={batch_size}."
+            )
+        counts[str(split)] = batch_count
+
+    return counts
+
+
+def format_loader_summary(counts: dict[str, int]) -> str:
+    """Return a compact user-readable loader summary."""
+
+    return ", ".join(
+        f"{split}={count} batch{'es' if count != 1 else ''}"
+        for split, count in counts.items()
+    )
+
+
+__all__ = ["format_loader_summary", "require_nonempty_dataloaders"]

--- a/src/data_factory/explicit_data_factory.py
+++ b/src/data_factory/explicit_data_factory.py
@@ -10,20 +10,31 @@ import shutil
 import h5py
 from tqdm import tqdm
 
+from .contracts import format_loader_summary, require_nonempty_dataloaders
 from .data_factory import data_factory
 from .dataset_task.Dataset_cluster import IdIncludedDataset
 from .dataset_task.adapters import resolve_dataset_adapter
 
 
 class ExplicitDataFactory(data_factory):
-    """Build data through explicit adapters and publish only complete caches.
+    """Build data through explicit adapters and publish only usable data stacks.
 
     Reader behavior, ID selection, windowing, samplers and DataLoaders remain in
-    their existing modules. This class owns two user-visible boundaries:
+    their existing modules. This class owns three user-visible boundaries:
 
     - task-to-dataset selection is explicit;
-    - a cache path is replaced only after every requested ID is present.
+    - a cache path is replaced only after every requested ID is present;
+    - train, validation and test loaders must each contain at least one batch.
     """
+
+    def __init__(self, args_data, args_task):
+        super().__init__(args_data, args_task)
+        counts = require_nonempty_dataloaders(
+            self,
+            args_task,
+            args_data,
+        )
+        print(f"[SUCCESS] 数据加载器可用: {format_loader_summary(counts)}")
 
     def _update_name_cache(self, name, ids, args_data, max_workers):
         """Read all requested IDs and atomically update one dataset cache."""

--- a/test/test_data_cache_contract.py
+++ b/test/test_data_cache_contract.py
@@ -8,6 +8,11 @@ import numpy as np
 import pytest
 
 from src.data_factory import ExplicitDataFactory
+from src.data_factory.contracts import (
+    format_loader_summary,
+    require_nonempty_dataloaders,
+)
+from src.data_factory.data_factory import data_factory as BaseDataFactory
 
 
 def _factory(metadata):
@@ -35,6 +40,24 @@ def _write_h5(path: Path, values: dict[str, float]) -> None:
 def _keys(path: Path) -> set[str]:
     with h5py.File(path, "r") as h5_file:
         return set(h5_file.keys())
+
+
+class _Loader:
+    def __init__(self, count: int) -> None:
+        self.count = count
+
+    def __len__(self) -> int:
+        return self.count
+
+
+class _LoaderFactory:
+    def __init__(self, **counts: int) -> None:
+        self.loaders = {
+            split: _Loader(count) for split, count in counts.items()
+        }
+
+    def get_dataloader(self, split: str):
+        return self.loaders[split]
 
 
 def test_failed_reader_does_not_publish_partial_dataset_cache(
@@ -165,3 +188,50 @@ def test_empty_task_selection_fails_before_cache_publication(
         factory._build_final_cache({}, _args(tmp_path), use_cache=True)
 
     assert not (tmp_path / "cache.h5").exists()
+
+
+def test_nonempty_loader_contract_returns_user_readable_counts() -> None:
+    factory = _LoaderFactory(train=3, val=1, test=2)
+    args_task = SimpleNamespace(type="DG", name="classification")
+    args_data = SimpleNamespace(batch_size=8)
+
+    counts = require_nonempty_dataloaders(factory, args_task, args_data)
+
+    assert counts == {"train": 3, "val": 1, "test": 2}
+    assert format_loader_summary(counts) == (
+        "train=3 batches, val=1 batch, test=2 batches"
+    )
+
+
+def test_zero_batch_loader_fails_with_actionable_configuration_fields() -> None:
+    factory = _LoaderFactory(train=3, val=0, test=2)
+    args_task = SimpleNamespace(type="FS", name="classification")
+    args_data = SimpleNamespace(batch_size=256)
+
+    with pytest.raises(
+        RuntimeError,
+        match=(
+            "FS/classification: val loader has 0 batches.*"
+            "window_size.*num_window.*batch_size=256"
+        ),
+    ):
+        require_nonempty_dataloaders(factory, args_task, args_data)
+
+
+def test_explicit_factory_checks_loaders_after_base_construction(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    def fake_base_init(self, args_data, args_task):
+        self.train_loader = _Loader(2)
+        self.val_loader = _Loader(1)
+        self.test_loader = _Loader(1)
+
+    monkeypatch.setattr(BaseDataFactory, "__init__", fake_base_init)
+    args_data = SimpleNamespace(batch_size=4)
+    args_task = SimpleNamespace(type="DG", name="classification")
+
+    ExplicitDataFactory(args_data, args_task)
+
+    output = capsys.readouterr().out
+    assert "train=2 batches, val=1 batch, test=1 batch" in output


### PR DESCRIPTION
## User problem

A selected dataset can produce zero train, validation, or test batches because of ID selection, split ratios, window size, window count, sampler grouping, or an oversized batch size. Without an explicit boundary, training may fail deep inside Lightning or appear to complete without meaningful evaluation.

## First-principles contract

```text
data factory constructed
⇒ train, val and test each contain at least one batch
```

## Scope

- add one small `require_nonempty_dataloaders(...)` helper;
- check `len(loader)` only, without consuming a batch or changing sampler order;
- run the check once at the end of the public default `ExplicitDataFactory` construction;
- stop before model construction when any maintained split has zero batches;
- include task type/name, failing split, batch size, and repair fields in the error;
- print one compact loader summary on success.

This single boundary covers Pipeline 01/05, Pipeline 02 single-stage and multistage paths, and other users of the public default factory without duplicating checks in every Pipeline.

## Validation

All workflows on the current head pass:

- loader contract unit tests;
- complete offline Dummy training and artifact verification;
- Pipeline 02 runtime contracts;
- Pipeline 06 shell contract;
- UXFD contract;
- configuration, layout and submodule gates.

## Explicit non-goals

```text
no batch consumption
no universal tensor schema
no sample-level validation pass
no new exception hierarchy
no manifest or hash
no changes to split, adapter, cache, reader, model or task algorithms
no claim that experimental Pipelines become release-supported
```

## Review state

Implementation and compatibility review complete; no blocking review threads.