### PR TITLE
fix(factory): raise task and trainer failures at the source

### DIFF
--- a/src/task_factory/__init__.py
+++ b/src/task_factory/__init__.py
@@ -1,8 +1,9 @@
-"""Public API for the task factory package."""
+"""Public API for task construction and registration."""
 
 from argparse import Namespace
 from typing import Any
 
+import pytorch_lightning as pl
 import torch.nn as nn
 
 from .task_factory import (
@@ -21,31 +22,9 @@ def build_task(
     args_trainer: Namespace,
     args_environment: Namespace,
     metadata: Any,
-) -> Any:
-    """Instantiate a task module using :mod:`task_factory`.
+) -> pl.LightningModule:
+    """Build one task; import and construction failures are raised."""
 
-    Parameters
-    ----------
-    args_task : Namespace
-        Task configuration namespace.
-    network : nn.Module
-        Model backbone to be wrapped by the task.
-    args_data : Namespace
-        Dataset related configuration.
-    args_model : Namespace
-        Model configuration namespace.
-    args_trainer : Namespace
-        Trainer configuration namespace.
-    args_environment : Namespace
-        Runtime environment configuration.
-    metadata : Any
-        Dataset metadata passed to the task.
-
-    Returns
-    -------
-    Any
-        Instantiated LightningModule or ``None`` on failure.
-    """
     return task_factory(
         args_task=args_task,
         network=network,
@@ -55,6 +34,7 @@ def build_task(
         args_environment=args_environment,
         metadata=metadata,
     )
+
 
 __all__ = [
     "build_task",

--- a/src/task_factory/task_factory.py
+++ b/src/task_factory/task_factory.py
@@ -4,20 +4,25 @@ from __future__ import annotations
 
 import importlib
 from argparse import Namespace
-from typing import Any, Optional
+from typing import Any
 
 import pytorch_lightning as pl
 import torch.nn as nn
+
 from ..utils.registry import Registry
 
 TASK_REGISTRY = Registry()
 
+
 def register_task(task_type: str, name: str):
     """Decorator to register a task implementation."""
+
     return TASK_REGISTRY.register(f"{task_type}.{name}")
 
+
 def resolve_task_module(args_task: Namespace) -> str:
-    """Return the Python import path for the task module."""
+    """Return the historical Python import path for one task configuration."""
+
     task_name = args_task.name
     task_type = args_task.type
     if task_type == "Default_task" or task_name == "Default_task":
@@ -28,6 +33,41 @@ def resolve_task_module(args_task: Namespace) -> str:
     return f"src.task_factory.task.{task_type}.{task_name}"
 
 
+def _resolve_task_class(args_task: Namespace):
+    """Resolve one task class from the registry or historical ``task`` symbol."""
+
+    key = f"{args_task.type}.{args_task.name}"
+    try:
+        return TASK_REGISTRY.get(key)
+    except KeyError:
+        pass
+
+    module_path = resolve_task_module(args_task)
+    try:
+        task_module = importlib.import_module(module_path)
+    except Exception as exc:
+        raise ImportError(
+            f"Cannot import task {key!r} from {module_path!r}: {exc}. "
+            "Check task.type, task.name, the module path, and optional "
+            "dependencies."
+        ) from exc
+
+    # Importing a module may execute its @register_task decorator.
+    try:
+        return TASK_REGISTRY.get(key)
+    except KeyError:
+        pass
+
+    task_class = getattr(task_module, "task", None)
+    if task_class is None:
+        raise AttributeError(
+            f"Task module {module_path!r} does not register {key!r} and does "
+            "not expose the historical class name 'task'. Register the class "
+            "with @register_task or export 'task'."
+        )
+    return task_class
+
+
 def task_factory(
     args_task: Namespace,
     network: nn.Module,
@@ -36,42 +76,13 @@ def task_factory(
     args_trainer: Namespace,
     args_environment: Namespace,
     metadata: Any,
-) -> Optional[pl.LightningModule]:
-    """Instantiate a task module using configuration namespaces."""
+) -> pl.LightningModule:
+    """Instantiate one task or raise at the task factory boundary."""
+
     key = f"{args_task.type}.{args_task.name}"
+    task_class = _resolve_task_class(args_task)
     try:
-        task_cls = TASK_REGISTRY.get(key)
-    except KeyError:
-        module_path = resolve_task_module(args_task)
-        try:
-            task_module = importlib.import_module(module_path)
-            # 智能检测类名，支持多种命名约定
-            task_cls = None
-
-            # 优先级1：查找与文件名相同的类名（如 hse_contrastive.py 中的 HseContrastiveTask）
-            class_name_from_file = module_path.split('.')[-1].replace('_', ' ').title().replace(' ', '')
-            if hasattr(task_module, class_name_from_file):
-                task_cls = getattr(task_module, class_name_from_file)
-
-            # 优先级2：查找标准化的类名（Task后缀）
-            task_name = args_task.name
-            standard_name = task_name.replace('_', ' ').title().replace(' ', '') + 'Task'
-            if hasattr(task_module, standard_name):
-                task_cls = getattr(task_module, standard_name)
-
-            # 优先级3：向后兼容 - 查找 'task' 类名
-            if hasattr(task_module, 'task'):
-                task_cls = getattr(task_module, 'task')
-
-            if task_cls is None:
-                raise AttributeError(f"No task class found in {module_path} (tried: {class_name_from_file}, {standard_name}, task)")
-
-        except Exception as exc:  # pragma: no cover - runtime safeguard
-            print(f"Failed to import task from {module_path}: {exc}")
-            return None
-
-    try:
-        return task_cls(
+        return task_class(
             network=network,
             args_data=args_data,
             args_model=args_model,
@@ -80,11 +91,17 @@ def task_factory(
             args_environment=args_environment,
             metadata=metadata,
         )
-    except Exception as exc:  # pragma: no cover - runtime safeguard
-        print(f"Failed to create task {key}: {exc}")
-        return None
+    except Exception as exc:
+        class_name = getattr(task_class, "__name__", type(task_class).__name__)
+        raise RuntimeError(
+            f"Cannot construct task {key!r} with {class_name}: {exc}. Check "
+            "the task configuration and constructor arguments."
+        ) from exc
 
 
-
-
-
+__all__ = [
+    "TASK_REGISTRY",
+    "register_task",
+    "resolve_task_module",
+    "task_factory",
+]

--- a/src/trainer_factory/__init__.py
+++ b/src/trainer_factory/__init__.py
@@ -1,7 +1,8 @@
-"""Public API for the trainer factory package."""
+"""Public API for trainer construction and registration."""
 
 from argparse import Namespace
-from typing import Any
+
+import pytorch_lightning as pl
 
 from .trainer_factory import (
     TRAINER_REGISTRY,
@@ -16,25 +17,9 @@ def build_trainer(
     args_trainer: Namespace,
     args_data: Namespace,
     path: str,
-) -> Any:
-    """Instantiate a trainer via :mod:`trainer_factory`.
+) -> pl.Trainer:
+    """Build one trainer; import and construction failures are raised."""
 
-    Parameters
-    ----------
-    args_environment : Namespace
-        Environment configuration.
-    args_trainer : Namespace
-        Trainer configuration namespace.
-    args_data : Namespace
-        Dataset configuration.
-    path : str
-        Output directory for checkpoints/logs.
-
-    Returns
-    -------
-    Any
-        Instantiated trainer object or ``None`` on failure.
-    """
     return trainer_factory(
         args_environment,
         args_trainer,
@@ -43,8 +28,6 @@ def build_trainer(
     )
 
 
-
-# public exports
 __all__ = [
     "build_trainer",
     "resolve_trainer_module",

--- a/src/trainer_factory/trainer_factory.py
+++ b/src/trainer_factory/trainer_factory.py
@@ -4,21 +4,67 @@ from __future__ import annotations
 
 import importlib
 from argparse import Namespace
-from typing import Any, Optional
 
 import pytorch_lightning as pl
+
 from ..utils.registry import Registry
 
 TRAINER_REGISTRY = Registry()
 
+
 def register_trainer(name: str):
     """Decorator to register a trainer implementation."""
+
     return TRAINER_REGISTRY.register(name)
 
+
 def resolve_trainer_module(args_trainer: Namespace) -> str:
-    """Return the Python import path for the trainer module."""
-    trainer_name = getattr(args_trainer, "trainer_name", "Default_trainer")
+    """Return the historical Python import path for one trainer configuration."""
+
+    trainer_name = getattr(
+        args_trainer,
+        "name",
+        getattr(args_trainer, "trainer_name", "Default_trainer"),
+    )
     return f"src.trainer_factory.{trainer_name}"
+
+
+def _resolve_trainer_function(args_trainer: Namespace):
+    """Resolve one trainer builder from the registry or module ``trainer`` symbol."""
+
+    name = getattr(
+        args_trainer,
+        "name",
+        getattr(args_trainer, "trainer_name", "Default_trainer"),
+    )
+    try:
+        return name, TRAINER_REGISTRY.get(name)
+    except KeyError:
+        pass
+
+    module_path = resolve_trainer_module(args_trainer)
+    try:
+        trainer_module = importlib.import_module(module_path)
+    except Exception as exc:
+        raise ImportError(
+            f"Cannot import trainer {name!r} from {module_path!r}: {exc}. "
+            "Check trainer.name, the module path, and optional dependencies."
+        ) from exc
+
+    # Importing a module may execute its @register_trainer decorator.
+    try:
+        return name, TRAINER_REGISTRY.get(name)
+    except KeyError:
+        pass
+
+    trainer_function = getattr(trainer_module, "trainer", None)
+    if trainer_function is None:
+        raise AttributeError(
+            f"Trainer module {module_path!r} does not register {name!r} and "
+            "does not expose the historical function name 'trainer'. Register "
+            "the builder with @register_trainer or export 'trainer'."
+        )
+    return name, trainer_function
 
 
 def trainer_factory(
@@ -26,27 +72,32 @@ def trainer_factory(
     args_trainer: Namespace,
     args_data: Namespace,
     path: str,
-) -> Optional[pl.Trainer]:
-    """Instantiate a trainer using configuration namespaces."""
-    name = getattr(args_trainer, "name", "Default_trainer")
-    try:
-        trainer_fn = TRAINER_REGISTRY.get(name)
-    except KeyError:
-        module_path = resolve_trainer_module(args_trainer)
-        try:
-            trainer_module = importlib.import_module(module_path)
-            trainer_fn = trainer_module.trainer
-        except Exception as exc:  # pragma: no cover - runtime safeguard
-            print(f"Failed to import trainer {module_path}: {exc}")
-            return None
+) -> pl.Trainer:
+    """Instantiate one trainer or raise at the trainer factory boundary."""
 
+    name, trainer_function = _resolve_trainer_function(args_trainer)
     try:
-        return trainer_fn(
+        return trainer_function(
             args_e=args_environment,
             args_t=args_trainer,
             args_d=args_data,
             path=path,
         )
-    except Exception as exc:  # pragma: no cover - runtime safeguard
-        print(f"Failed to create trainer {name}: {exc}")
-        return None
+    except Exception as exc:
+        function_name = getattr(
+            trainer_function,
+            "__name__",
+            type(trainer_function).__name__,
+        )
+        raise RuntimeError(
+            f"Cannot construct trainer {name!r} with {function_name}: {exc}. "
+            "Check trainer settings, device availability, and output path."
+        ) from exc
+
+
+__all__ = [
+    "TRAINER_REGISTRY",
+    "register_trainer",
+    "resolve_trainer_module",
+    "trainer_factory",
+]

--- a/test/test_classification_runtime.py
+++ b/test/test_classification_runtime.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from argparse import Namespace
+import importlib
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -18,6 +19,12 @@ from src.data_factory.dataset_task.adapters import (
 )
 from src.data_factory.samplers.Get_sampler import Get_sampler
 from src.runtime import classification
+
+
+task_factory_module = importlib.import_module("src.task_factory.task_factory")
+trainer_factory_module = importlib.import_module(
+    "src.trainer_factory.trainer_factory"
+)
 
 
 def _config(tmp_path: Path, *, iterations: int = 1) -> dict:
@@ -78,6 +85,14 @@ def _window_args(**values) -> SimpleNamespace:
 
 def _window_starts(dataset: Default_dataset) -> list[int]:
     return [int(item["x"][0, 0]) for item in dataset]
+
+
+def _raise_key_error(key):
+    raise KeyError(key)
+
+
+def _raise_module_not_found(message: str):
+    raise ModuleNotFoundError(message)
 
 
 def test_compiled_config_bypasses_legacy_reparse(
@@ -282,3 +297,154 @@ def test_unknown_dataset_adapter_fails_with_registered_combinations() -> None:
 def test_unknown_data_factory_name_fails_with_available_factories() -> None:
     with pytest.raises(ValueError, match="Unknown data.factory_name"):
         resolve_data_factory_class("auto_guess")
+
+
+def test_task_import_failure_preserves_requested_module_and_cause(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        task_factory_module.TASK_REGISTRY,
+        "get",
+        _raise_key_error,
+    )
+    monkeypatch.setattr(
+        task_factory_module.importlib,
+        "import_module",
+        lambda path: _raise_module_not_found("missing optional package"),
+    )
+    args_task = SimpleNamespace(type="DG", name="missing_task")
+
+    with pytest.raises(
+        ImportError,
+        match=(
+            "DG.missing_task.*src.task_factory.task.DG.missing_task.*"
+            "missing optional package"
+        ),
+    ) as captured:
+        task_factory_module.task_factory(
+            args_task=args_task,
+            network=object(),
+            args_data=SimpleNamespace(),
+            args_model=SimpleNamespace(),
+            args_trainer=SimpleNamespace(),
+            args_environment=SimpleNamespace(),
+            metadata={},
+        )
+
+    assert isinstance(captured.value.__cause__, ModuleNotFoundError)
+
+
+def test_task_module_requires_registration_or_task_symbol(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        task_factory_module.TASK_REGISTRY,
+        "get",
+        _raise_key_error,
+    )
+    monkeypatch.setattr(
+        task_factory_module.importlib,
+        "import_module",
+        lambda path: SimpleNamespace(),
+    )
+
+    with pytest.raises(
+        AttributeError,
+        match="does not register.*does not expose.*'task'",
+    ):
+        task_factory_module.task_factory(
+            args_task=SimpleNamespace(type="DG", name="empty_module"),
+            network=object(),
+            args_data=SimpleNamespace(),
+            args_model=SimpleNamespace(),
+            args_trainer=SimpleNamespace(),
+            args_environment=SimpleNamespace(),
+            metadata={},
+        )
+
+
+def test_task_construction_failure_is_raised_with_original_cause(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class BrokenTask:
+        def __init__(self, **kwargs):
+            raise ValueError("invalid task dimensions")
+
+    monkeypatch.setattr(
+        task_factory_module.TASK_REGISTRY,
+        "get",
+        lambda key: BrokenTask,
+    )
+
+    with pytest.raises(
+        RuntimeError,
+        match="Cannot construct task 'DG.classification'.*invalid task dimensions",
+    ) as captured:
+        task_factory_module.task_factory(
+            args_task=SimpleNamespace(type="DG", name="classification"),
+            network=object(),
+            args_data=SimpleNamespace(),
+            args_model=SimpleNamespace(),
+            args_trainer=SimpleNamespace(),
+            args_environment=SimpleNamespace(),
+            metadata={},
+        )
+
+    assert isinstance(captured.value.__cause__, ValueError)
+
+
+def test_trainer_import_failure_preserves_requested_module_and_cause(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        trainer_factory_module.TRAINER_REGISTRY,
+        "get",
+        _raise_key_error,
+    )
+    monkeypatch.setattr(
+        trainer_factory_module.importlib,
+        "import_module",
+        lambda path: _raise_module_not_found("trainer dependency missing"),
+    )
+
+    with pytest.raises(
+        ImportError,
+        match=(
+            "MissingTrainer.*src.trainer_factory.MissingTrainer.*"
+            "trainer dependency missing"
+        ),
+    ) as captured:
+        trainer_factory_module.trainer_factory(
+            args_environment=SimpleNamespace(),
+            args_trainer=SimpleNamespace(name="MissingTrainer"),
+            args_data=SimpleNamespace(),
+            path="results/run",
+        )
+
+    assert isinstance(captured.value.__cause__, ModuleNotFoundError)
+
+
+def test_trainer_construction_failure_is_raised_with_original_cause(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def broken_trainer(**kwargs):
+        raise OSError("output path is read-only")
+
+    monkeypatch.setattr(
+        trainer_factory_module.TRAINER_REGISTRY,
+        "get",
+        lambda key: broken_trainer,
+    )
+
+    with pytest.raises(
+        RuntimeError,
+        match="Cannot construct trainer 'Default_trainer'.*output path is read-only",
+    ) as captured:
+        trainer_factory_module.trainer_factory(
+            args_environment=SimpleNamespace(),
+            args_trainer=SimpleNamespace(name="Default_trainer"),
+            args_data=SimpleNamespace(),
+            path="results/run",
+        )
+
+    assert isinstance(captured.value.__cause__, OSError)


### PR DESCRIPTION
## User problem

Task and trainer factories previously caught import and construction errors, printed a message, and returned `None`. Callers then reported only `task factory returned None` or `trainer factory returned None`, losing the requested component, module and original cause.

## First-principles contract

```text
factory success → valid object
factory failure → exception with original cause
```

Factories never return `None` as an error value.

## Scope

### Task factory

- prefer an already registered `task.type/task.name` implementation;
- otherwise import the historical explicit module path;
- retry the registry after import so decorators work;
- retain only the historical exported class name `task` as compatibility fallback;
- remove filename-derived and `Task`-suffix class guessing;
- raise import, missing-entry and construction failures with task identity and repair action.

### Trainer factory

- prefer an already registered trainer builder;
- otherwise import `src.trainer_factory.<trainer.name>`;
- retry the registry after import;
- retain only the historical exported function `trainer` as compatibility fallback;
- raise import, missing-entry and construction failures with trainer identity and repair action.

Public `build_task` and `build_trainer` have non-optional return contracts.

## Validation

All workflows on the current head pass:

- task import failures preserve requested module and `ModuleNotFoundError` cause;
- task modules must register the key or expose `task`;
- task constructor failures preserve their cause;
- trainer import and constructor failures preserve their cause;
- complete offline Dummy training and artifact verification;
- Pipeline 02 and Pipeline 06 runtime contracts;
- UXFD, configuration, layout and submodule gates.

## Explicit non-goals

```text
no new exception hierarchy
no registry redesign
no model/data factory changes
no automatic module discovery
no broad Pipeline refactor
no hash, manifest, receipt or workflow
```

## Review state

Implementation and compatibility review complete; no blocking review threads.