### PR TITLE
refactor(dx): align runtime and extension docs with factory contracts

### DIFF
--- a/src/data_factory/README.md
+++ b/src/data_factory/README.md
@@ -1,82 +1,148 @@
 # Data Factory (`src/data_factory/`)
 
-The Data Factory builds datasets and `DataLoader`s from `config.data` + `config.task`.
+The Data Factory converts a resolved `data` + `task` configuration into three usable `DataLoader`s:
 
-This README is the canonical “how to use” doc. For architecture/change guidance (extension rules, invariants), see
-[@CLAUDE.md].
+```text
+metadata + raw/prebuilt data
+→ complete cache
+→ explicit dataset adapter
+→ train / val / test datasets
+→ non-empty DataLoaders
+```
 
-## Purpose
+The public entry point is:
 
-- Select a dataset reader (`reader/`) based on metadata/config
-- Apply task-specific dataset wrappers (`dataset_task/`)
-- Create `DataLoader`s (optionally with custom samplers under `samplers/`)
+```python
+from src.data_factory import build_data
 
-## Module Structure
+data_factory = build_data(args_data, args_task)
+train_loader = data_factory.get_dataloader("train")
+```
 
-| File / Directory | Role |
-|---|---|
-| `__init__.py` | Public API (`build_data`, registry helpers) |
-| `data_factory.py` | Default factory implementation |
-| `id_data_factory.py` | ID-based (lazy/on-demand) factory implementation |
-| `H5DataDict.py` | H5-backed data access utilities |
-| `reader/` | Dataset readers (e.g. `RM_001_CWRU.py`) |
-| `dataset_task/` | Task-oriented dataset wrappers (DG/CDDG/FS/GFS/pretrain/ID/...) |
-| `samplers/` | Custom sampling strategies (e.g. episodic FS samplers) |
-| `ID/` | Utilities for querying/filtering sample IDs from metadata |
-| `data_utils.py` | Common preprocessing helpers |
-| `datainfo.py` | Helper to scan a raw directory and draft metadata |
+A successful call returns a usable factory. Missing data, unknown adapters, incomplete caches, and empty loaders raise at the data boundary with a repair message.
 
-## Configuration Interface
-
-The data factory is controlled by the `data` block in YAML.
-
-Key fields you will see across configs:
-- `data.factory_name`: `"default"` (eager) or `"id"` (lazy/on-demand)
-- `data.data_dir`: root data directory (often machine-local via `configs/local/local.yaml`)
-- `data.metadata_file`: metadata file name/path (Excel/CSV depending on dataset)
-- `data.batch_size`, `data.num_workers`, `data.pin_memory`: DataLoader settings
-
-Minimal example:
+## Maintained configuration
 
 ```yaml
 data:
   factory_name: "default"
-  data_dir: "/path/to/PHM-Vibench_data"
+  data_dir: "/path/to/phm-data"
   metadata_file: "metadata.xlsx"
   batch_size: 32
   num_workers: 4
+  window_size: 4096
+  stride: 128
+  num_window: 64
+  train_ratio: 0.8
+  val_ratio: 0.1
+  test_ratio: 0.1
+  normalization: "standardization"
 ```
 
-## Default vs ID-based Factory
-
-- `factory_name: "default"`: builds datasets up front (traditional eager loading)
-- `factory_name: "id"`: defers heavy work and can return ID-enriched batches for on-demand processing in tasks
-
-If you enable the ID-based path, ensure the corresponding task expects dictionary-style batches (e.g. `batch["x"]`,
-`batch["y"]`, and potentially `batch["file_id"]`).
-
-## Data Components (mental model)
-
-Most datasets in this benchmark can be thought of as:
-
-1. `metadata.xlsx` (or CSV): the sample index and labels; keyed by `Id`
-2. `*.h5`: signal cache keyed by `Id` (each item typically shaped `(L, C)`)
-3. (optional) `corpus.xlsx`: text annotations keyed by `Id`
-
-## Smoke Demo Note (`Dummy_Data`)
-
-The repo-shipped smoke config `configs/demo/00_smoke/dummy_dg.yaml` uses `Name=Dummy_Data`.
-For offline runs, `src/data_factory/reader/Dummy_Data.py` generates synthetic data if raw CSV files are not present
-under `data/raw/Dummy_Data/`.
-
-## Adding a New Dataset (quick checklist)
-
-1. Add raw files under `data/raw/<dataset_name>/` (or document how to obtain them).
-2. Implement a reader in `src/data_factory/reader/` (see existing `RM_*.py`).
-3. Register the reader (follow the patterns in `src/data_factory/data_factory.py` and/or package init exports).
-4. Add/update a smoke-friendly demo config under `configs/demo/` and validate it:
+Machine-specific values are applied only through an explicit local file:
 
 ```bash
-python -m scripts.config_inspect --config configs/demo/00_smoke/dummy_dg.yaml
-python -m scripts.validate_configs
+phmfactory preflight --config <yaml> --local-config /path/to/local.yaml
+phmfactory run --config <yaml> --local-config /path/to/local.yaml
 ```
+
+PHMFactory does not auto-discover `configs/local/local.yaml`.
+
+## Runtime contracts
+
+### Explicit dataset adapter
+
+The default factory resolves exactly one adapter from:
+
+```text
+(task.type, task.name)
+```
+
+The runtime mapping lives in:
+
+```text
+src/data_factory/dataset_task/adapters.py
+```
+
+Unknown combinations fail. Import errors do not fall back to `Default_dataset`.
+
+### Complete cache
+
+Published `Name.h5` and `cache.h5` files contain every selected ID. A failed rebuild leaves the previous published cache unchanged. An already complete `cache.h5` is reused without copying the underlying data again.
+
+### Truthful splits
+
+- `val` and legacy `valid` refer to the same validation split.
+- DG/CDDG test IDs use their complete test files.
+- FS/GFS/pretrain tasks that reuse file IDs use disjoint train/val/test window slices.
+- Validation and test retain the final short batch.
+
+### Usable loaders
+
+The default factory checks `len(train_loader)`, `len(val_loader)`, and `len(test_loader)` before model construction. It does not consume a batch or impose a universal tensor schema.
+
+## Adding a new raw dataset
+
+1. Add a metadata row for every file. At minimum, current readers and tasks commonly use:
+
+```text
+Id, Dataset_id, Name, File, Label, Domain_id
+```
+
+2. Implement a reader:
+
+```python
+# src/data_factory/reader/MyDataset.py
+
+def read(file_path, args_data):
+    # Return a NumPy array shaped [length, channels].
+    ...
+```
+
+3. Set metadata `Name` to the reader module name, for example `MyDataset`.
+4. Use an existing task adapter or register a new one.
+5. Run a one-epoch smoke before adding the combination to the supported matrix.
+
+Reader numerical behavior is dataset-specific. Do not change channel order, axes, normalization, or source-field selection as part of unrelated cleanup.
+
+## Adding a task-specific dataset adapter
+
+Implement a dataset class with the historical constructor:
+
+```python
+class set_dataset:
+    def __init__(self, data, metadata, args_data, args_task, mode="train"):
+        ...
+```
+
+Register it explicitly:
+
+```python
+from src.data_factory import register_dataset_adapter
+
+register_dataset_adapter(
+    "MyTaskType",
+    "my_task",
+    "my_package.dataset_adapter",
+)
+```
+
+There is no filename guessing. Duplicate registrations fail immediately.
+
+## Factory choices
+
+- `factory_name: default`: maintained explicit-adapter path.
+- `factory_name: department`: compatibility subclass of the historical factory.
+- `factory_name: id`: compatibility research path; it is not part of the maintained release combination table.
+
+New development should use `default` unless the alternative path has its own reviewed smoke.
+
+## Validate an extension
+
+```bash
+python -m scripts.config_inspect --config <your-config.yaml> --dump targets
+python -m scripts.validate_configs
+python main.py --config <your-config.yaml> --override trainer.num_epochs=1 data.num_workers=0
+```
+
+A source file, registry entry, or importable reader is discoverable—not automatically release-supported. Add a `sanity_ok` demo only after the exact configuration completes its bounded smoke.

--- a/src/runtime/classification.py
+++ b/src/runtime/classification.py
@@ -223,14 +223,10 @@ def run_classification_pipeline(
 
             print("[INFO] 构建数据工厂...")
             context.data_factory = build_data(args_data, args_task)
-            if context.data_factory is None:
-                raise RuntimeError("data factory returned None")
             metadata = context.data_factory.get_metadata()
 
             print("[INFO] 构建模型...")
             context.model = build_model(args_model, metadata=metadata)
-            if context.model is None:
-                raise RuntimeError("model factory returned None")
 
             print("[INFO] 构建任务...")
             context.task = build_task(
@@ -242,8 +238,6 @@ def run_classification_pipeline(
                 args_environment=args_environment,
                 metadata=metadata,
             )
-            if context.task is None:
-                raise RuntimeError("task factory returned None")
 
             print("[INFO] 构建训练器...")
             context.trainer = build_trainer(
@@ -252,8 +246,6 @@ def run_classification_pipeline(
                 args_data,
                 str(path),
             )
-            if context.trainer is None:
-                raise RuntimeError("trainer factory returned None")
 
             hooks.after_stack_built(context)
 

--- a/src/task_factory/README.md
+++ b/src/task_factory/README.md
@@ -1,33 +1,32 @@
-
 # Task Factory (`src/task_factory/`)
 
-The Task Factory builds the training “task module” (a PyTorch Lightning `LightningModule`) from:
+The Task Factory wraps a model in the PyTorch Lightning task selected by `task.type` and `task.name`.
 
-- a model from `src/model_factory/`
-- data from `src/data_factory/`
-- the `task` section in your YAML config
+```text
+resolved task config + model + metadata
+→ one task class
+→ configured LightningModule
+```
 
-This README is the canonical “how to use” doc. For architecture/change guidance, see [@CLAUDE.md].
+The public contract is simple:
 
-## Module Structure
+```python
+from src.task_factory import build_task
 
-| File / Directory | Role |
-|---|---|
-| `task_factory.py` | Entry point; resolves and instantiates a task |
-| `task_registry.csv` | SSOT for `task.type` + `task.name` → Python path + notes |
-| `Default_task.py` | Default single-task wrapper (baseline LightningModule) |
-| `task/` | Concrete task families (e.g. `DG/`, `CDDG/`, `FS/`, `GFS/`, `pretrain/`, `ID/`, `MT/`) |
-| `Components/` | Reusable losses/metrics/regularizers |
+task = build_task(
+    args_task=args_task,
+    network=model,
+    args_data=args_data,
+    args_model=args_model,
+    args_trainer=args_trainer,
+    args_environment=args_environment,
+    metadata=metadata,
+)
+```
 
-## Configuration Interface (YAML)
+A successful call returns a `LightningModule`. Import and constructor failures raise with the requested task, module path, original cause, and repair guidance. The factory does not print an error and return `None`.
 
-The task is selected by `task.type` + `task.name`.
-
-- `task.type`: matches a subfolder under `src/task_factory/task/` (e.g. `DG`, `CDDG`, `FS`, `pretrain`)
-- `task.name`: matches the Python file inside that folder (e.g. `classification.py` → `name: "classification"`)
-- additional fields under `task` are task-specific hyperparameters
-
-Minimal example:
+## Configuration
 
 ```yaml
 task:
@@ -35,35 +34,91 @@ task:
   name: "classification"
   loss: "CE"
   metrics: ["acc"]
-  lr: 1e-4
+  optimizer: "adamw"
+  lr: 0.001
 ```
 
-## Task Registry (SSOT)
-
-The authoritative list of supported tasks is `src/task_factory/task_registry.csv`.
-
-If you see an import error (“cannot import task …”), inspect the registry row and confirm `task.type`/`task.name`
-matches the implementation.
-
-## Workflow (high-level)
-
-1. Pipeline creates the model via the Model Factory.
-2. `task_factory(...)` looks up `task.type`/`task.name`, imports the corresponding module, and instantiates the task.
-3. The task consumes dict-style batches from the Data Factory (e.g. `batch["x"]`, `batch["y"]`, and sometimes
-   `batch["file_id"]` depending on dataset wrapper).
-
-## Troubleshooting
-
-- “Which values are actually used?”: `python -m scripts.config_inspect --config <yaml>`
-- “Which module will be instantiated?”: `python -m scripts.config_inspect --config <yaml> --dump targets`
-
-## Adding a New Task (checklist)
-
-1. Implement a LightningModule under `src/task_factory/task/<TYPE>/<name>.py`.
-2. Add a row to `src/task_factory/task_registry.csv` documenting its import path and expected args/batch format.
-3. Add (or update) a demo config under `configs/demo/` and run:
+Inspect the final target before running:
 
 ```bash
-python -m scripts.config_inspect --config <your_demo.yaml> --override trainer.num_epochs=1
-python -m scripts.validate_configs
+python -m scripts.config_inspect --config <yaml> --dump targets
 ```
+
+## Resolution order
+
+For key `DG.classification`, the factory:
+
+1. checks `TASK_REGISTRY`;
+2. imports the explicit historical path `src.task_factory.task.DG.classification`;
+3. checks the registry again so module decorators can register the class;
+4. accepts the historical exported class name `task` when the module is not decorator-registered.
+
+It does not guess a class from the filename or try arbitrary `*Task` names.
+
+## Adding a task
+
+Preferred implementation:
+
+```python
+from src.task_factory import register_task
+from src.task_factory.Default_task import Default_task
+
+
+@register_task("MyTaskType", "my_task")
+class MyTask(Default_task):
+    def training_step(self, batch, batch_idx):
+        ...
+```
+
+Place the module at the path implied by the configuration:
+
+```text
+src/task_factory/task/MyTaskType/my_task.py
+```
+
+For historical compatibility, the module may instead export:
+
+```python
+class task(Default_task):
+    ...
+```
+
+Do not implement both unless compatibility requires it.
+
+## Dataset contract
+
+A task must document the batch fields it actually consumes, such as:
+
+```text
+x, y, file_id, domain_id, mask
+```
+
+When the task needs a new dataset wrapper, register the matching dataset adapter explicitly:
+
+```python
+from src.data_factory import register_dataset_adapter
+
+register_dataset_adapter(
+    "MyTaskType",
+    "my_task",
+    "my_package.dataset_adapter",
+)
+```
+
+Do not rely on `ImportError → Default_dataset` fallback; that behavior is intentionally removed.
+
+## Minimal validation
+
+```bash
+python -m scripts.validate_configs
+python main.py --config <your-config.yaml> \
+  --override trainer.num_epochs=1 data.num_workers=0
+```
+
+A task becomes release-supported only when an exact config is listed as `sanity_ok`. A class, registry row, or successful import alone is not a support claim.
+
+## Failure examples
+
+- `Cannot import task ...`: verify `task.type`, `task.name`, module path, and optional dependencies.
+- `does not register ... and does not expose 'task'`: add `@register_task(...)` or export the historical `task` class.
+- `Cannot construct task ...`: inspect the preserved original exception and the task-specific configuration.

--- a/src/trainer_factory/README.md
+++ b/src/trainer_factory/README.md
@@ -1,58 +1,111 @@
-
 # Trainer Factory (`src/trainer_factory/`)
 
-The Trainer Factory constructs a `pytorch_lightning.Trainer` from `config.trainer` + `config.environment`.
+The Trainer Factory builds the `pytorch_lightning.Trainer` selected by `trainer.name`.
 
-This README is the canonical “how to use” doc. For architecture/change guidance, see [@CLAUDE.md].
+```text
+resolved environment + trainer + data config + run path
+→ one trainer builder
+→ configured pl.Trainer
+```
 
-## Purpose
+The public contract is:
 
-- Centralize callbacks (checkpointing, early stopping, pruning)
-- Centralize loggers (CSV always, plus optional WandB / SwanLab / TensorBoard)
-- Centralize hardware settings (CPU/GPU, strategy, precision)
+```python
+from src.trainer_factory import build_trainer
 
-## Module Structure
+trainer = build_trainer(
+    args_environment,
+    args_trainer,
+    args_data,
+    run_path,
+)
+```
 
-| File | Role |
-|---|---|
-| `trainer_factory.py` | Entry point; resolves the trainer implementation and returns a `pl.Trainer` |
-| `Default_trainer.py` | Default trainer builder (callbacks/loggers/hardware wiring) |
+A successful call returns `pl.Trainer`. Import and construction failures raise with the requested trainer, module path, original cause, and repair guidance. The factory does not print an error and return `None`.
 
-## Configuration (YAML)
-
-The trainer implementation is selected by `trainer.name`.
-
-Minimal example (aligned with `configs/base/trainer/default_single_gpu.yaml`):
+## Configuration
 
 ```yaml
-environment:
-  project: "demo"
-
 trainer:
   name: "Default_trainer"
   num_epochs: 10
+  device: "cpu"
   gpus: 1
-  device: "cuda"
   monitor: "val_loss"
   early_stopping: true
   patience: 5
 ```
 
-### Note on `trainer.trainer_name` (legacy/import fallback)
+`trainer.name` is the maintained selector. `trainer.trainer_name` remains a compatibility fallback only when `name` is absent.
 
-Internally, `src/trainer_factory/trainer_factory.py` will:
+## Resolution order
 
-- Prefer `trainer.name` (registry / default implementation name)
-- If needed, fall back to importing a module named by `trainer.trainer_name` (defaults to `Default_trainer`)
+For `Default_trainer`, the factory:
 
-In normal configs you should set only `trainer.name`.
+1. checks `TRAINER_REGISTRY`;
+2. imports `src.trainer_factory.Default_trainer`;
+3. checks the registry again so module decorators can register the builder;
+4. accepts the historical exported function name `trainer` when the module is not decorator-registered.
 
-## Workflow (high-level)
+It does not scan the package or guess alternative builder names.
 
-1. Pipeline loads YAML and builds `args_trainer` / `args_environment`.
-2. `trainer_factory(...)` resolves the trainer function.
-3. The trainer function configures callbacks/loggers/hardware and returns `pl.Trainer`.
+## Adding a trainer
 
-## Output
+Preferred implementation:
 
-Returns a configured `pytorch_lightning.Trainer` ready for `.fit(...)` / `.test(...)`.
+```python
+from src.trainer_factory import register_trainer
+
+
+@register_trainer("MyTrainer")
+def build_my_trainer(*, args_e, args_t, args_d, path):
+    ...
+    return trainer
+```
+
+Place it at:
+
+```text
+src/trainer_factory/MyTrainer.py
+```
+
+A historical module may instead export:
+
+```python
+def trainer(*, args_e, args_t, args_d, path):
+    ...
+```
+
+The builder must either return a valid `pl.Trainer` or raise. It must not catch a construction failure and return `None`.
+
+## Developer expectations
+
+A trainer builder owns:
+
+- device and accelerator selection;
+- callbacks such as checkpointing and early stopping;
+- loggers;
+- output/checkpoint paths;
+- Lightning `Trainer` options.
+
+It should not reinterpret the experiment YAML, replace the selected task/model, or silently switch hardware after an error.
+
+## Minimal validation
+
+```bash
+python -m scripts.config_inspect --config <yaml> --dump targets
+python main.py --config <yaml> \
+  --override trainer.num_epochs=1 trainer.device=cpu data.num_workers=0
+```
+
+Use the repository-shipped Dummy demo as the final compatibility check:
+
+```bash
+phmfactory demo
+```
+
+## Failure examples
+
+- `Cannot import trainer ...`: verify `trainer.name`, module path, and optional dependencies.
+- `does not register ... and does not expose 'trainer'`: add `@register_trainer(...)` or export the historical `trainer` function.
+- `Cannot construct trainer ...`: inspect the preserved cause, device availability, callback settings, and output path permissions.


### PR DESCRIPTION
## User problem

After task and trainer factories became non-optional, the maintained classification runtime still contained unreachable `factory returned None` branches. Component READMEs also described old behavior: hidden local configuration, filename/class guessing, silent dataset fallback, personal Agent documentation, and an ID path as though it were maintained.

## Scope

- remove unreachable data/model/task/trainer `None` guards from the maintained classification assembly path;
- keep cleanup guards that remain necessary when construction raises before assignment;
- rewrite the existing Data Factory README around the actual maintained path: complete cache, explicit adapter, truthful splits, non-empty loaders;
- document explicit `--local-config` use and remove hidden-local guidance;
- document the public `register_dataset_adapter(...)` extension point;
- rewrite Task Factory guidance around registry-first resolution plus the explicit historical `task` symbol;
- rewrite Trainer Factory guidance around registry-first resolution plus the explicit historical `trainer` symbol;
- state the support boundary clearly: discoverable/importable is not automatically `sanity_ok` or release-supported.

## Developer result

```text
new data task wrapper → register_dataset_adapter(...)
new task             → @register_task(...) or historical task symbol
new trainer          → @register_trainer(...) or historical trainer symbol
```

Factories return valid objects or raise. Maintained callers do not implement `None` fallback logic.

## Validation

All workflows on the current head pass:

- documentation validation and generated support authority;
- complete offline Dummy training and artifact verification;
- shared runtime, data and Pipeline 02 contracts;
- Pipeline 06 shell and UXFD contracts;
- repository layout and submodule policy.

## Explicit non-goals

```text
no new documentation file
no new registry or abstraction
no Pipeline algorithm change
no reader/cache/split behavior change
no hash, manifest, policy, receipt or workflow
```

## Review state

Implementation and documentation review complete; no blocking review threads.