### PR TITLE
fix(metadata): preserve per-sample physical context

### DIFF
--- a/.github/workflows/core-quality-gates.yml
+++ b/.github/workflows/core-quality-gates.yml
@@ -231,6 +231,9 @@ jobs:
           python -m py_compile \
             phmfactory/runtime/evidence.py \
             src/data_factory/explicit_data_factory.py \
+            src/model_factory/ISFM/system_utils.py \
+            src/model_factory/ISFM/task_head/H_01_Linear_cla.py \
+            src/task_factory/Default_task.py \
             src/runtime/classification.py \
             src/runtime/explainability.py \
             src/Pipeline_01_Fault_Diagnosis.py \
@@ -238,11 +241,13 @@ jobs:
             src/Pipeline_05_Explainable_Fault_Diagnosis.py \
             test/test_classification_runtime.py \
             test/test_data_cache_contract.py \
+            test/test_per_sample_metadata.py \
             test/test_pipeline02_runtime.py \
             test/test_runtime_evidence.py
           python -m pytest \
             test/test_classification_runtime.py \
             test/test_data_cache_contract.py \
+            test/test_per_sample_metadata.py \
             test/test_pipeline02_runtime.py \
             test/test_runtime_evidence.py \
             -vv --tb=long 2>&1 | tee runtime-contracts-pytest.log

--- a/src/model_factory/ISFM/system_utils.py
+++ b/src/model_factory/ISFM/system_utils.py
@@ -29,30 +29,29 @@ def resolve_batch_metadata(
     - file_id_batch 为单个 id、list/tuple、或 torch.Tensor；
     - metadata[file_id] 返回标量或 pandas.Series。
     """
-    # 收集每个样本对应的 metadata 行
     if isinstance(file_id_batch, (list, tuple)):
-        rows = [metadata[fid] for fid in file_id_batch]
+        file_ids = list(file_id_batch)
     elif isinstance(file_id_batch, torch.Tensor):
-        rows = [metadata[fid.item()] for fid in file_id_batch.view(-1)]
+        file_ids = [fid.item() for fid in file_id_batch.view(-1)]
     else:
-        # 单个 file_id，广播到整个 batch
-        rows = [metadata[file_id_batch]]
+        file_ids = [file_id_batch]
 
-    B = len(rows)
+    if not file_ids:
+        raise ValueError("file_id_batch must contain at least one file ID.")
+
+    rows = [metadata[fid] for fid in file_ids]
     dataset_ids: List[int] = []
     sample_rates: List[float] = []
 
     for row in rows:
         ds = row["Dataset_id"]
-        if isinstance(row, dict): # 大小写问题
+        if isinstance(row, dict):
             fs = row.get("Sample_rate")
             if fs is None:
-                # Backward/format compatibility: allow common variants used in metadata files.
                 fs = row.get("Sample_Rate", row.get("sample_rate", row.get("sample_rate_hz")))
             if fs is None:
                 raise KeyError("Sample_rate")
         else:
-            # pandas.Series / similar
             fs = row.get("Sample_rate")
             if fs is None:
                 fs = row.get("Sample_Rate", row.get("sample_rate", row.get("sample_rate_hz")))
@@ -74,11 +73,6 @@ def resolve_batch_metadata(
 
     system_ids_tensor = torch.as_tensor(dataset_ids, dtype=torch.long, device=device)
     sample_f_tensor = torch.as_tensor(sample_rates, dtype=torch.float32, device=device)
-
-    if system_ids_tensor.shape[0] == 1 and B > 1:
-        system_ids_tensor = system_ids_tensor.expand(B)
-        sample_f_tensor = sample_f_tensor.expand(B)
-
     return system_ids_tensor, sample_f_tensor
 
 
@@ -93,21 +87,26 @@ def normalize_fs(
     - [B] (as_column=False) 或
     - [B, 1] (as_column=True)
 
-    支持:
-      - 标量 (int/float)
-      - list/tuple/np.ndarray/torch.Tensor
-      - pandas.Series
+    标量或单值输入可显式广播；逐样本输入必须恰好为长度 B。
     """
+    if batch_size <= 0:
+        raise ValueError(f"batch_size must be positive, got {batch_size}.")
+
     if isinstance(fs, (list, tuple, np.ndarray, torch.Tensor)):
         fs_tensor = torch.as_tensor(fs, dtype=torch.float32, device=device).view(-1)
     elif isinstance(fs, pd.Series):
         fs_tensor = torch.as_tensor(fs.values, dtype=torch.float32, device=device).view(-1)
     else:
-        fs_tensor = torch.full((batch_size,), float(fs), device=device)
+        fs_tensor = torch.as_tensor([float(fs)], dtype=torch.float32, device=device)
 
-    if fs_tensor.shape[0] != batch_size:
-        # 回退：若长度不匹配，广播第一个值
-        fs_tensor = fs_tensor[0:1].expand(batch_size)
+    count = fs_tensor.shape[0]
+    if count == 1:
+        fs_tensor = fs_tensor.expand(batch_size)
+    elif count != batch_size:
+        raise ValueError(
+            "Sampling-rate metadata must be a scalar, one value, or one value per sample: "
+            f"received {count} values for batch_size={batch_size}."
+        )
 
     if as_column:
         fs_tensor = fs_tensor.view(-1, 1)
@@ -123,9 +122,6 @@ def normalize_system_ids(system_id: Any, batch_size: int, device: torch.device) 
     - 标量 int/str: 整批使用同一个 system_id；
     - list/tuple/tensor: 每个样本一个 system_id。
     """
-    # Debug: Print the actual type and value
-    # print(f"[DEBUG] normalize_system_ids: system_id={system_id}, type={type(system_id)}, batch_size={batch_size}")
-
     if isinstance(system_id, (int, str)):
         sid = int(system_id)
         return torch.full((batch_size,), sid, dtype=torch.long, device=device)
@@ -134,12 +130,13 @@ def normalize_system_ids(system_id: Any, batch_size: int, device: torch.device) 
     if isinstance(system_id, (list, tuple)):
         vals = [int(v) for v in system_id]
         return torch.as_tensor(vals, dtype=torch.long, device=device)
-    # Handle numpy scalar types
-    import numpy as np
     if isinstance(system_id, (np.int64, np.int32, np.int16, np.int8)):
         sid = int(system_id)
         return torch.full((batch_size,), sid, dtype=torch.long, device=device)
-    raise ValueError(f"system_id must be scalar or per-sample list/tensor, got {type(system_id)} with value {system_id}")
+    raise ValueError(
+        f"system_id must be scalar or per-sample list/tensor, got {type(system_id)} "
+        f"with value {system_id}"
+    )
 
 
 def group_forward_by_system(
@@ -160,12 +157,18 @@ def group_forward_by_system(
         键为 str(Dataset_id)，值为对应的线性分类 head。
     """
     if x.ndim == 3:
-        x = x.mean(dim=1)  # [B, D]
+        x = x.mean(dim=1)
     B, _ = x.shape
 
-    sid = normalize_system_ids(system_id, batch_size=B, device=x.device)  # [B]
+    sid = normalize_system_ids(system_id, batch_size=B, device=x.device)
+    if sid.numel() == 1 and B > 1:
+        sid = sid.expand(B)
+    elif sid.numel() != B:
+        raise ValueError(
+            f"system_id must contain one value or batch_size values; received "
+            f"{sid.numel()} for batch_size={B}."
+        )
 
-    # uniq: [K], inv: [B]，inv[b] = 当前样本属于第几个唯一 system
     uniq, inv = torch.unique(sid, sorted=True, return_inverse=True)
 
     if len(head_dict) == 0:
@@ -181,11 +184,9 @@ def group_forward_by_system(
             raise KeyError(f"Missing head for system_id '{key}'.")
         head = head_dict[key]
 
-        mask = inv == k  # [B] bool
+        mask = inv == k
         if not mask.any():
             continue
-        xs = x[mask]  # [B_k, D]
-        ys = head(xs)  # [B_k, out_dim]
-        logits[mask] = ys
+        logits[mask] = head(x[mask])
 
     return logits

--- a/src/model_factory/ISFM/task_head/H_01_Linear_cla.py
+++ b/src/model_factory/ISFM/task_head/H_01_Linear_cla.py
@@ -9,34 +9,41 @@ class H_01_Linear_cla(nn.Module):
         self.mutiple_fc = nn.ModuleDict()
         num_classes = args.num_classes
         for data_name, n_class in num_classes.items():
-            # data_name 一般为 Dataset_id，对外统一使用 str(key)
             self.mutiple_fc[str(data_name)] = nn.Linear(args.output_dim, n_class)
 
     def forward(self, x, system_id=False, return_feature=False, **kwargs):
-        """
-        多系统线性分类头（当前假设一个 batch 只包含单一系统）。
-
-        - x: [B, T, D] or [B, D]，先对时间维做平均池化；
-        - system_id:
-          * 标量 int/str：整批同一系统；
-          * list/tuple/tensor：若传入 per-sample ID，当前实现会取第一个，假设 batch 内已按 Dataset_id 分组。
-        - return_feature: 是否返回特征（除了logits外）。
-        """
+        """Apply the classification head for one explicitly homogeneous system batch."""
         if x.ndim == 3:
-            x = x.mean(dim=1)  # [B, D]
+            x = x.mean(dim=1)
 
-        B = x.size(0)
-        sid_tensor = normalize_system_ids(system_id, batch_size=B, device=x.device)
-        sid = int(sid_tensor[0].item())
-        key = str(sid)
+        batch_size = x.size(0)
+        sid_tensor = normalize_system_ids(
+            system_id,
+            batch_size=batch_size,
+            device=x.device,
+        )
+        if sid_tensor.numel() == 1 and batch_size > 1:
+            sid_tensor = sid_tensor.expand(batch_size)
+        elif sid_tensor.numel() != batch_size:
+            raise ValueError(
+                "H_01_Linear_cla requires one system ID or one ID per sample: "
+                f"received {sid_tensor.numel()} IDs for batch_size={batch_size}."
+            )
+
+        unique_systems = torch.unique(sid_tensor)
+        if unique_systems.numel() != 1:
+            values = [int(value) for value in unique_systems.tolist()]
+            raise ValueError(
+                "H_01_Linear_cla requires a single Dataset_id per batch, "
+                f"but received {values}. Use a system-homogeneous sampler or a "
+                "head that explicitly supports mixed-system batches."
+            )
+
+        key = str(int(unique_systems[0].item()))
         if key not in self.mutiple_fc:
             raise KeyError(f"Missing head for system_id '{key}' in H_01_Linear_cla.")
 
-        head = self.mutiple_fc[key]
-        logits = head(x)  # [B, num_classes_for_this_system]
-
-        # 支持return_feature参数
+        logits = self.mutiple_fc[key](x)
         if return_feature:
             return logits, x
-        else:
-            return logits
+        return logits

--- a/src/task_factory/Default_task.py
+++ b/src/task_factory/Default_task.py
@@ -134,19 +134,32 @@ class Default_task(pl.LightningModule):
         通用处理步骤 (已重构)
         期望 batch 格式: ((x, y), data_name)
         """
-        try:
-            # x, y, id = batch['x'], batch['y'], batch['id']
-            # Ensure a default task identifier if not provided
-            batch.setdefault('task_id', 'classification')
-            # Convert tensor-based ID to a Python int for indexing metadata
-            file_id = batch['file_id'][0].item()
-            data_name = self.metadata[file_id]['Name']# .values
-            # dataset_id = self.metadata[file_id]['Dataset_id'].item() 
-            batch.update({'file_id': file_id})
-        except (ValueError, TypeError) as e:
-            raise ValueError(f" Error: {e}")
+        batch.setdefault('task_id', 'classification')
 
-        # 1. 前向传播
+        batch_size = int(batch['x'].shape[0])
+        raw_file_ids = batch['file_id']
+        if isinstance(raw_file_ids, torch.Tensor):
+            file_ids = [value.item() for value in raw_file_ids.view(-1)]
+        elif isinstance(raw_file_ids, (list, tuple)):
+            file_ids = list(raw_file_ids)
+        else:
+            file_ids = [raw_file_ids]
+
+        if len(file_ids) not in (1, batch_size):
+            raise ValueError(
+                "batch['file_id'] must contain one ID or one ID per sample: "
+                f"received {len(file_ids)} IDs for batch_size={batch_size}."
+            )
+
+        first_file_id = file_ids[0]
+        try:
+            data_name = self.metadata[first_file_id]['Name']
+        except (KeyError, IndexError, TypeError) as exc:
+            raise KeyError(
+                f"Unable to resolve metadata Name for file_id={first_file_id!r}."
+            ) from exc
+
+        # 1. 前向传播。保留原始逐样本 file_id，不得用首个文件覆盖整批。
         y_hat = self.forward(batch)
 
         # 2. 计算任务损失

--- a/test/test_per_sample_metadata.py
+++ b/test/test_per_sample_metadata.py
@@ -1,0 +1,119 @@
+from types import SimpleNamespace
+
+import pytest
+import torch
+import torch.nn.functional as F
+
+from src.model_factory.ISFM.system_utils import normalize_fs, resolve_batch_metadata
+from src.model_factory.ISFM.task_head.H_01_Linear_cla import H_01_Linear_cla
+from src.task_factory.Default_task import Default_task
+
+
+_METADATA = {
+    101: {
+        "Name": "Dummy",
+        "Dataset_id": 1,
+        "Domain_id": 0,
+        "Sample_Rate": 12_000,
+    },
+    102: {
+        "Name": "Dummy",
+        "Dataset_id": 1,
+        "Domain_id": 1,
+        "Sample_Rate": 48_000,
+    },
+}
+
+
+class _TaskHarness:
+    metadata = _METADATA
+
+    def __init__(self):
+        self.seen_file_ids = None
+        self.seen_sample_rates = None
+
+    def forward(self, batch):
+        self.seen_file_ids = batch["file_id"].clone()
+        _, sample_rates = resolve_batch_metadata(
+            self.metadata,
+            batch["file_id"],
+            device=batch["x"].device,
+        )
+        self.seen_sample_rates = sample_rates
+        return torch.tensor(
+            [[2.0, -1.0], [-1.0, 2.0]],
+            dtype=torch.float32,
+            requires_grad=True,
+        )
+
+    @staticmethod
+    def _compute_loss(y_hat, y):
+        return F.cross_entropy(y_hat, y)
+
+    @staticmethod
+    def _compute_metrics(y_hat, y, data_name, stage):
+        return {}
+
+    @staticmethod
+    def _compute_regularization():
+        return {"total": torch.tensor(0.0)}
+
+
+def test_default_task_preserves_per_sample_file_ids_and_sampling_rates():
+    task = _TaskHarness()
+    batch = {
+        "x": torch.zeros(2, 8, 1),
+        "y": torch.tensor([0, 1]),
+        "file_id": torch.tensor([101, 102]),
+    }
+
+    metrics = Default_task._shared_step(task, batch, "train")
+
+    assert torch.equal(batch["file_id"], torch.tensor([101, 102]))
+    assert torch.equal(task.seen_file_ids, torch.tensor([101, 102]))
+    assert torch.equal(task.seen_sample_rates, torch.tensor([12_000.0, 48_000.0]))
+    assert metrics["train_total_loss"].requires_grad
+
+
+def test_default_task_rejects_partial_file_id_vectors():
+    task = _TaskHarness()
+    batch = {
+        "x": torch.zeros(3, 8, 1),
+        "y": torch.tensor([0, 1, 0]),
+        "file_id": torch.tensor([101, 102]),
+    }
+
+    with pytest.raises(ValueError, match="one ID or one ID per sample"):
+        Default_task._shared_step(task, batch, "train")
+
+
+def test_normalize_fs_preserves_vectors_and_rejects_wrong_lengths():
+    fs = normalize_fs(
+        torch.tensor([12_000.0, 48_000.0]),
+        batch_size=2,
+        device=torch.device("cpu"),
+    )
+    assert torch.equal(fs, torch.tensor([12_000.0, 48_000.0]))
+
+    with pytest.raises(ValueError, match="received 2 values for batch_size=3"):
+        normalize_fs(
+            torch.tensor([12_000.0, 48_000.0]),
+            batch_size=3,
+            device=torch.device("cpu"),
+        )
+
+
+def test_linear_head_requires_one_system_per_batch():
+    head = H_01_Linear_cla(
+        SimpleNamespace(
+            num_classes={1: 2, 2: 2},
+            output_dim=4,
+        )
+    )
+    features = torch.randn(2, 4)
+
+    logits = head(features, system_id=torch.tensor([1, 1]))
+    assert logits.shape == (2, 2)
+
+    with pytest.raises(ValueError, match="single Dataset_id per batch"):
+        head(features, system_id=torch.tensor([1, 2]))


### PR DESCRIPTION
## User problem

The maintained classification task collapsed a batch of file IDs to the first ID and overwrote `batch["file_id"]`. ISFM then resolved one sampling rate and the HSE embedding could broadcast it across the batch. The classification head also selected the first system head without proving that the batch was system-homogeneous.

A run could therefore complete while some samples used another file's physical time scale or the wrong system assumption.

## First-principles contract

```text
for every sample i in a batch:
metadata_i = metadata[file_id_i]
```

A scalar or one-value sampling rate may be explicitly broadcast. A per-sample vector must contain exactly `batch_size` values. The current linear classification head continues to require one `Dataset_id` per batch and now verifies that requirement.

## Scope

- keep the original per-sample `file_id` value through `Default_task.forward`;
- use the first file only for the existing metric/logging name, without mutating the batch;
- reject partial file-ID vectors;
- preserve per-sample sampling-rate vectors and reject other length mismatches instead of broadcasting the first value;
- reject mixed-system batches in `H_01_Linear_cla` before choosing a head;
- add focused tests for the task-to-metadata path, sampling-rate length contract, and homogeneous-system head contract.

## Validation

The focused tests cover:

```text
[file_id 101, file_id 102]
+ [12 kHz, 48 kHz]
→ both IDs survive the task boundary
→ both sampling rates reach metadata resolution
```

They also cover partial metadata vectors and mixed-system classification batches.

Existing repository workflows are expected to provide the full offline Dummy regression and maintained runtime contracts.

## Explicit non-goals

```text
no BatchContext or universal batch schema
no MetadataStore abstraction
no sampler redesign
no mixed-system multi-head implementation
no model/task/trainer architecture rewrite
no new registry, manifest, hash, policy or workflow
no HSE loss/objective change
```

## Review state

Draft pending CI and adversarial review of compatibility with maintained classification paths.