### PR TITLE
fix(data): expose actual split independence facts

### DIFF
--- a/.github/workflows/core-quality-gates.yml
+++ b/.github/workflows/core-quality-gates.yml
@@ -231,6 +231,7 @@ jobs:
           python -m py_compile \
             phmfactory/runtime/evidence.py \
             src/data_factory/explicit_data_factory.py \
+            src/data_factory/dataset_task/Default_dataset.py \
             src/model_factory/ISFM/system_utils.py \
             src/model_factory/ISFM/task_head/H_01_Linear_cla.py \
             src/task_factory/Default_task.py \
@@ -245,7 +246,8 @@ jobs:
             test/test_hse_objective_contract.py \
             test/test_per_sample_metadata.py \
             test/test_pipeline02_runtime.py \
-            test/test_runtime_evidence.py
+            test/test_runtime_evidence.py \
+            test/test_split_scientific_truth.py
           python -m pytest \
             test/test_classification_runtime.py \
             test/test_data_cache_contract.py \
@@ -253,6 +255,7 @@ jobs:
             test/test_per_sample_metadata.py \
             test/test_pipeline02_runtime.py \
             test/test_runtime_evidence.py \
+            test/test_split_scientific_truth.py \
             -vv --tb=long 2>&1 | tee runtime-contracts-pytest.log
 
       - name: Diagnose the installed environment

--- a/src/data_factory/dataset_task/Default_dataset.py
+++ b/src/data_factory/dataset_task/Default_dataset.py
@@ -16,6 +16,10 @@ class Default_dataset(Dataset):  # THU_006or018_basic
     the full file for tasks whose test IDs are distinct from training IDs. For
     FS/GFS/pretrain tasks, where the current ID search intentionally reuses the
     same files, ``mode="test"`` selects the held-out tail of the window sequence.
+
+    ``window_intervals`` records the raw ``[start, end)`` interval for every
+    retained window. It is used to report whether different splits share raw
+    samples; it does not change the sampling or split algorithm.
     """
 
     def __init__(self, data, metadata, args_data, args_task, mode="train"):
@@ -68,6 +72,7 @@ class Default_dataset(Dataset):  # THU_006or018_basic
         self._validate_split_ratios()
 
         self.processed_data = []
+        self.window_intervals: list[tuple[int, int]] = []
         self.prepare_data(metadata)
 
     def _validate_split_ratios(self) -> None:
@@ -99,6 +104,16 @@ class Default_dataset(Dataset):  # THU_006or018_basic
         self.total_samples = len(self.processed_data)
         self.label = metadata[self.key]["Label"]
 
+    def _append_window(
+        self,
+        sample_data: np.ndarray,
+        start_idx: int,
+        end_idx: int,
+    ) -> None:
+        """Append one window and its exact raw-sample interval."""
+        self.processed_data.append(sample_data[start_idx:end_idx])
+        self.window_intervals.append((int(start_idx), int(end_idx)))
+
     def _sequential_sampling(self, sample_data, data_length):
         """Create windows from left to right."""
         num_samples = max(
@@ -110,12 +125,12 @@ class Default_dataset(Dataset):  # THU_006or018_basic
         for index in range(num_samples):
             start_idx = index * self.stride
             end_idx = start_idx + self.window_size
-            self.processed_data.append(sample_data[start_idx:end_idx])
+            self._append_window(sample_data, start_idx, end_idx)
 
     def _random_sampling(self, sample_data, data_length):
         """Create a deterministic random window set shared by every split mode."""
         if data_length == self.window_size:
-            self.processed_data.append(sample_data)
+            self._append_window(sample_data, 0, self.window_size)
             return
 
         possible_starts = np.arange(data_length - self.window_size + 1)
@@ -132,18 +147,20 @@ class Default_dataset(Dataset):  # THU_006or018_basic
 
         for start_idx in selected_starts:
             end_idx = start_idx + self.window_size
-            self.processed_data.append(sample_data[start_idx:end_idx])
+            self._append_window(sample_data, int(start_idx), int(end_idx))
 
     def _evenly_spaced_sampling(self, sample_data, data_length):
         """Create windows distributed across the complete file."""
         if self.num_window == 0:
             return
         if data_length == self.window_size:
-            self.processed_data.append(sample_data)
+            self._append_window(sample_data, 0, self.window_size)
         elif self.num_window == 1:
             start_idx = (data_length - self.window_size) // 2
-            self.processed_data.append(
-                sample_data[start_idx : start_idx + self.window_size]
+            self._append_window(
+                sample_data,
+                start_idx,
+                start_idx + self.window_size,
             )
         else:
             effective_length = data_length - self.window_size
@@ -155,8 +172,10 @@ class Default_dataset(Dataset):  # THU_006or018_basic
                     int(round(index * step)),
                     data_length - self.window_size,
                 )
-                self.processed_data.append(
-                    sample_data[start_idx : start_idx + self.window_size]
+                self._append_window(
+                    sample_data,
+                    start_idx,
+                    start_idx + self.window_size,
                 )
 
     def _process_single_data(self, sample_data):
@@ -254,7 +273,7 @@ class Default_dataset(Dataset):  # THU_006or018_basic
             return window
 
     def _split_data_for_mode(self):
-        """Select a non-overlapping split from one deterministic window list."""
+        """Select a non-overlapping window-list split and retain its intervals."""
         if not self.processed_data:
             return
 
@@ -278,11 +297,14 @@ class Default_dataset(Dataset):  # THU_006or018_basic
         test_end = min(max(test_end, val_end), total_samples)
 
         if self.mode == "train":
-            self.processed_data = self.processed_data[:train_end]
+            selection = slice(None, train_end)
         elif self.mode == "val":
-            self.processed_data = self.processed_data[train_end:val_end]
-        elif self.mode == "test_holdout":
-            self.processed_data = self.processed_data[val_end:test_end]
+            selection = slice(train_end, val_end)
+        else:
+            selection = slice(val_end, test_end)
+
+        self.processed_data = self.processed_data[selection]
+        self.window_intervals = self.window_intervals[selection]
 
     def __len__(self):
         return self.total_samples

--- a/src/data_factory/explicit_data_factory.py
+++ b/src/data_factory/explicit_data_factory.py
@@ -6,6 +6,7 @@ import concurrent.futures
 import os
 from pathlib import Path
 import shutil
+from typing import Any
 
 import h5py
 from tqdm import tqdm
@@ -16,15 +17,150 @@ from .dataset_task.Dataset_cluster import IdIncludedDataset
 from .dataset_task.adapters import resolve_dataset_adapter
 
 
+def _plain_values(value: Any) -> set[Any]:
+    """Return scalar metadata values without imposing a new metadata schema."""
+    if hasattr(value, "tolist"):
+        value = value.tolist()
+    if isinstance(value, (list, tuple, set)):
+        values = value
+    else:
+        values = [value]
+
+    result: set[Any] = set()
+    for item in values:
+        if hasattr(item, "item"):
+            item = item.item()
+        result.add(item)
+    return result
+
+
+def _metadata_values(metadata: Any, file_ids: set[Any], field: str) -> set[Any]:
+    values: set[Any] = set()
+    for file_id in file_ids:
+        row = metadata[file_id]
+        try:
+            raw = row[field]
+        except (KeyError, TypeError, IndexError) as exc:
+            raise KeyError(
+                f"Cannot summarize data splits: metadata field {field!r} is "
+                f"missing for file_id={file_id!r}."
+            ) from exc
+        values.update(_plain_values(raw))
+    return values
+
+
+def _records(dataset_map: dict[Any, Any]) -> list[tuple[Any, int, int]] | None:
+    records: list[tuple[Any, int, int]] = []
+    for file_id, dataset in dataset_map.items():
+        intervals = getattr(dataset, "window_intervals", None)
+        if intervals is None:
+            return None
+        records.extend(
+            (file_id, int(start), int(end)) for start, end in intervals
+        )
+    return records
+
+
+def _raw_interval_overlap(
+    left: list[tuple[Any, int, int]] | None,
+    right: list[tuple[Any, int, int]] | None,
+) -> bool | None:
+    """Report raw-sample overlap for windows belonging to the same source file."""
+    if left is None or right is None:
+        return None
+
+    right_by_file: dict[Any, list[tuple[int, int]]] = {}
+    for file_id, start, end in right:
+        right_by_file.setdefault(file_id, []).append((start, end))
+
+    for file_id, left_start, left_end in left:
+        for right_start, right_end in right_by_file.get(file_id, ()):
+            if max(left_start, right_start) < min(left_end, right_end):
+                return True
+    return False
+
+
+def _summarize_split_assignments(
+    split_maps: dict[str, dict[Any, Any]],
+    metadata: Any,
+) -> dict[str, Any]:
+    """Summarize actual file/domain/class and raw-window relationships."""
+    split_files = {
+        split: set(dataset_map.keys())
+        for split, dataset_map in split_maps.items()
+    }
+    split_domains = {
+        split: _metadata_values(metadata, file_ids, "Domain_id")
+        for split, file_ids in split_files.items()
+    }
+    split_labels = {
+        split: _metadata_values(metadata, file_ids, "Label")
+        for split, file_ids in split_files.items()
+    }
+    split_records = {
+        split: _records(dataset_map)
+        for split, dataset_map in split_maps.items()
+    }
+
+    pairs = (("train", "val"), ("train", "test"), ("val", "test"))
+    raw_overlap = {
+        f"{left}_{right}": _raw_interval_overlap(
+            split_records[left],
+            split_records[right],
+        )
+        for left, right in pairs
+    }
+    file_overlap = {
+        f"{left}_{right}": sorted(
+            split_files[left] & split_files[right],
+            key=str,
+        )
+        for left, right in pairs
+    }
+    domain_overlap = {
+        f"{left}_{right}": sorted(
+            split_domains[left] & split_domains[right],
+            key=str,
+        )
+        for left, right in pairs
+    }
+
+    return {
+        "raw_interval_overlap": raw_overlap,
+        "file_overlap": file_overlap,
+        "domain_overlap": domain_overlap,
+        "classes": {
+            split: sorted(values, key=str)
+            for split, values in split_labels.items()
+        },
+        "test_classes_seen_in_train": split_labels["test"].issubset(
+            split_labels["train"]
+        ),
+    }
+
+
+def _format_split_summary(summary: dict[str, Any]) -> str:
+    raw = summary["raw_interval_overlap"]
+    files = summary["file_overlap"]
+    return (
+        "raw-overlap "
+        f"train/val={raw['train_val']}, "
+        f"train/test={raw['train_test']}, "
+        f"val/test={raw['val_test']}; "
+        "file-overlap "
+        f"train/val={files['train_val']}, "
+        f"train/test={files['train_test']}; "
+        "test-classes-seen-in-train="
+        f"{summary['test_classes_seen_in_train']}"
+    )
+
+
 class ExplicitDataFactory(data_factory):
     """Build data through explicit adapters and publish only usable data stacks.
 
     Reader behavior, ID selection, windowing, samplers and DataLoaders remain in
-    their existing modules. This class owns three user-visible boundaries:
-
-    - task-to-dataset selection is explicit;
-    - a cache path is replaced only after every requested ID is present;
-    - train, validation and test loaders must each contain at least one batch.
+    their existing modules. This class owns user-visible boundaries for explicit
+    adapters, complete caches, non-empty loaders, and observable split facts.
     """
 
     def __init__(self, args_data, args_task):
@@ -245,6 +381,16 @@ class ExplicitDataFactory(data_factory):
                 self.args_task,
                 "test",
             )
+
+        self.split_summary = _summarize_split_assignments(
+            {
+                "train": train_dataset,
+                "val": val_dataset,
+                "test": test_dataset,
+            },
+            self.target_metadata,
+        )
+        print(f"[DATA SPLIT] {_format_split_summary(self.split_summary)}")
 
         return (
             IdIncludedDataset(train_dataset, self.target_metadata),

--- a/src/data_factory/explicit_data_factory.py
+++ b/src/data_factory/explicit_data_factory.py
@@ -21,10 +21,7 @@ def _plain_values(value: Any) -> set[Any]:
     """Return scalar metadata values without imposing a new metadata schema."""
     if hasattr(value, "tolist"):
         value = value.tolist()
-    if isinstance(value, (list, tuple, set)):
-        values = value
-    else:
-        values = [value]
+    values = value if isinstance(value, (list, tuple, set)) else [value]
 
     result: set[Any] = set()
     for item in values:
@@ -34,17 +31,18 @@ def _plain_values(value: Any) -> set[Any]:
     return result
 
 
-def _metadata_values(metadata: Any, file_ids: set[Any], field: str) -> set[Any]:
+def _metadata_values(
+    metadata: Any,
+    file_ids: set[Any],
+    field: str,
+) -> set[Any] | None:
+    """Return split metadata values, or ``None`` when the optional fact is unavailable."""
     values: set[Any] = set()
     for file_id in file_ids:
-        row = metadata[file_id]
         try:
-            raw = row[field]
-        except (KeyError, TypeError, IndexError) as exc:
-            raise KeyError(
-                f"Cannot summarize data splits: metadata field {field!r} is "
-                f"missing for file_id={file_id!r}."
-            ) from exc
+            raw = metadata[file_id][field]
+        except (KeyError, TypeError, IndexError):
+            return None
         values.update(_plain_values(raw))
     return values
 
@@ -78,6 +76,15 @@ def _raw_interval_overlap(
             if max(left_start, right_start) < min(left_end, right_end):
                 return True
     return False
+
+
+def _set_overlap(
+    left: set[Any] | None,
+    right: set[Any] | None,
+) -> list[Any] | None:
+    if left is None or right is None:
+        return None
+    return sorted(left & right, key=str)
 
 
 def _summarize_split_assignments(
@@ -118,24 +125,30 @@ def _summarize_split_assignments(
         for left, right in pairs
     }
     domain_overlap = {
-        f"{left}_{right}": sorted(
-            split_domains[left] & split_domains[right],
-            key=str,
+        f"{left}_{right}": _set_overlap(
+            split_domains[left],
+            split_domains[right],
         )
         for left, right in pairs
     }
+    classes = {
+        split: None if values is None else sorted(values, key=str)
+        for split, values in split_labels.items()
+    }
+    train_labels = split_labels["train"]
+    test_labels = split_labels["test"]
+    test_classes_seen = (
+        None
+        if train_labels is None or test_labels is None
+        else test_labels.issubset(train_labels)
+    )
 
     return {
         "raw_interval_overlap": raw_overlap,
         "file_overlap": file_overlap,
         "domain_overlap": domain_overlap,
-        "classes": {
-            split: sorted(values, key=str)
-            for split, values in split_labels.items()
-        },
-        "test_classes_seen_in_train": split_labels["test"].issubset(
-            split_labels["train"]
-        ),
+        "classes": classes,
+        "test_classes_seen_in_train": test_classes_seen,
     }
 
 

--- a/test/test_split_scientific_truth.py
+++ b/test/test_split_scientific_truth.py
@@ -84,3 +84,28 @@ def test_distinct_files_and_unseen_test_class_are_reported():
         "test": [1],
     }
     assert summary["test_classes_seen_in_train"] is False
+
+
+def test_missing_optional_split_metadata_is_reported_as_unavailable():
+    metadata = {
+        1: {"Label": 0},
+        2: {"Label": 0},
+        3: {"Label": 0},
+    }
+    dataset = lambda interval: SimpleNamespace(window_intervals=[interval])
+
+    summary = _summarize_split_assignments(
+        {
+            "train": {1: dataset((0, 8))},
+            "val": {2: dataset((0, 8))},
+            "test": {3: dataset((0, 8))},
+        },
+        metadata,
+    )
+
+    assert summary["domain_overlap"] == {
+        "train_val": None,
+        "train_test": None,
+        "val_test": None,
+    }
+    assert summary["test_classes_seen_in_train"] is True

--- a/test/test_split_scientific_truth.py
+++ b/test/test_split_scientific_truth.py
@@ -1,0 +1,86 @@
+from types import SimpleNamespace
+
+import numpy as np
+
+from src.data_factory.dataset_task.Default_dataset import Default_dataset
+from src.data_factory.explicit_data_factory import _summarize_split_assignments
+
+
+def _data_args():
+    return SimpleNamespace(
+        window_size=8,
+        stride=1,
+        num_window=5,
+        window_sampling_strategy="evenly_spaced",
+        window_sampling_seed=0,
+        train_ratio=0.4,
+        val_ratio=0.2,
+        test_ratio=0.4,
+        normalization="none",
+        noise_snr=None,
+    )
+
+
+def test_same_file_split_reports_raw_sample_overlap():
+    metadata = {
+        1: {
+            "Label": 0,
+            "Domain_id": 0,
+        }
+    }
+    data = {1: np.arange(20, dtype=np.float32).reshape(-1, 1)}
+    task = SimpleNamespace(type="FS")
+
+    train = Default_dataset(data, metadata, _data_args(), task, "train")
+    val = Default_dataset(data, metadata, _data_args(), task, "val")
+    test = Default_dataset(data, metadata, _data_args(), task, "test")
+
+    assert train.window_intervals == [(0, 8), (3, 11)]
+    assert val.window_intervals == [(6, 14)]
+    assert test.window_intervals == [(9, 17), (12, 20)]
+
+    summary = _summarize_split_assignments(
+        {"train": {1: train}, "val": {1: val}, "test": {1: test}},
+        metadata,
+    )
+
+    assert summary["raw_interval_overlap"] == {
+        "train_val": True,
+        "train_test": True,
+        "val_test": True,
+    }
+    assert summary["file_overlap"]["train_test"] == [1]
+    assert summary["domain_overlap"]["train_test"] == [0]
+    assert summary["test_classes_seen_in_train"] is True
+
+
+def test_distinct_files_and_unseen_test_class_are_reported():
+    metadata = {
+        1: {"Label": 0, "Domain_id": 0},
+        2: {"Label": 0, "Domain_id": 1},
+        3: {"Label": 1, "Domain_id": 2},
+    }
+    dataset = lambda interval: SimpleNamespace(window_intervals=[interval])
+
+    summary = _summarize_split_assignments(
+        {
+            "train": {1: dataset((0, 8))},
+            "val": {2: dataset((0, 8))},
+            "test": {3: dataset((0, 8))},
+        },
+        metadata,
+    )
+
+    assert summary["raw_interval_overlap"] == {
+        "train_val": False,
+        "train_test": False,
+        "val_test": False,
+    }
+    assert summary["file_overlap"]["train_val"] == []
+    assert summary["domain_overlap"]["train_test"] == []
+    assert summary["classes"] == {
+        "train": [0],
+        "val": [0],
+        "test": [1],
+    }
+    assert summary["test_classes_seen_in_train"] is False


### PR DESCRIPTION
## User problem

PR #160 made train/validation/test window-list slices disjoint, but that does not prove statistical independence. Different windows from the same file can still share raw samples, validation can reuse training files and domains, and a test class may be absent from training.

The current run could therefore look scientifically separated while only proving that window indices differ.

## First-principles contract

```text
window-list disjointness
!=
raw-sample, file, domain, or class independence
```

PHMFactory must expose the split facts it actually knows rather than silently implying a stronger protocol.

## Scope

- retain each generated window's exact raw `[start, end)` interval;
- keep interval selection aligned with train/val/test window slicing;
- summarize raw-interval overlap for windows from the same file;
- summarize file overlap, domain overlap, class sets, and whether test classes appear in train;
- attach the summary as `data_factory.split_summary` and print one compact line;
- report optional unavailable facts as `None` instead of breaking existing custom adapters;
- add focused tests for same-file overlap, distinct-file independence, unseen test classes, and unavailable optional domain metadata;
- run the focused test inside the existing offline-smoke gate.

## Result

The current window-level compatibility path can now state facts such as:

```text
raw-overlap train/val=True
file-overlap train/val=[...]
test-classes-seen-in-train=False
```

This information does not automatically change protocol status or block an execution smoke.

## Explicit non-goals

```text
no split algorithm change
no file/domain/time-block split implementation
no benchmark promotion or automatic claim decision
no split manifest, hash, receipt, or protocol engine
no normalization or noise change
no universal dataset schema
no new workflow or exception hierarchy
```

## Validation

Focused tests prove:

- exact window intervals survive split slicing;
- disjoint window positions can still overlap in raw samples;
- distinct files report no raw or file overlap;
- an unseen test class is reported accurately;
- missing optional domain metadata produces an unavailable fact rather than changing runtime behavior.

Draft pending existing Core gates and real Dummy smoke.