### PR TITLE
fix(data): make window and transform semantics explicit

### DIFF
--- a/.github/workflows/core-quality-gates.yml
+++ b/.github/workflows/core-quality-gates.yml
@@ -247,7 +247,8 @@ jobs:
             test/test_per_sample_metadata.py \
             test/test_pipeline02_runtime.py \
             test/test_runtime_evidence.py \
-            test/test_split_scientific_truth.py
+            test/test_split_scientific_truth.py \
+            test/test_transform_truth.py
           python -m pytest \
             test/test_classification_runtime.py \
             test/test_data_cache_contract.py \
@@ -256,6 +257,7 @@ jobs:
             test/test_pipeline02_runtime.py \
             test/test_runtime_evidence.py \
             test/test_split_scientific_truth.py \
+            test/test_transform_truth.py \
             -vv --tb=long 2>&1 | tee runtime-contracts-pytest.log
 
       - name: Diagnose the installed environment

--- a/configs/base/data/README.md
+++ b/configs/base/data/README.md
@@ -1,13 +1,17 @@
 # `configs/base/data/`
 
-## 1) What This Block Controls
+## What This Block Controls
 
 `data` controls:
-- where metadata lives (`data_dir`, `metadata_file`)
-- dataset windowing / normalization
-- dataloader worker settings
 
-## 2) Minimal Example (YAML Snippet)
+- metadata and raw-data locations;
+- window generation;
+- train/validation/test proportions;
+- per-window normalization;
+- explicit training augmentation or evaluation corruption;
+- DataLoader batch and worker settings.
+
+## Maintained Example
 
 ```yaml
 data:
@@ -15,21 +19,81 @@ data:
   metadata_file: "metadata.xlsx"
   batch_size: 256
   num_workers: 8
+
   window_size: 4096
-  stride: 5
+  window_sampling_strategy: "evenly_spaced"
+  num_window: 64
+
+  train_ratio: 0.8
+  val_ratio: 0.1
+  test_ratio: 0.1
+  unused_ratio: 0.0
+
+  normalization: "per_window_standardization"
+  train_noise_snr: null
+  evaluation_noise_snr: null
 ```
 
-## 3) Key Fields
+## Windowing
 
-| Field | Type | Notes |
-|---|---:|---|
-| `data.data_dir` | str | Root dir containing `metadata_file` and `raw/` (and optional caches). |
-| `data.metadata_file` | str | CSV/XLSX metadata filename. |
-| `data.window_size` | int | Sliding window length. |
-| `data.stride` | int | Sliding window stride. |
-| `data.num_workers` | int | PyTorch DataLoader workers. |
+| Field | Meaning |
+|---|---|
+| `window_size` | Number of raw samples in one window; must be positive. |
+| `num_window` | Maximum/generated window count; must be positive. |
+| `window_sampling_strategy` | `evenly_spaced`, `random`, or `sequential`. |
+| `stride` | Used only by `sequential`; it is invalid for other strategies. |
+| `window_sampling_seed` | Seed used by deterministic random window selection. |
 
-## 4) Typical Overrides
+`evenly_spaced` distributes `num_window` starts across the complete source file. It
+does not consume `stride`.
+
+## Split Proportions
+
+```text
+train_ratio + val_ratio + test_ratio + unused_ratio = 1
+```
+
+Use `unused_ratio` only when data is intentionally reserved. An unnamed remainder is
+not accepted.
+
+Window-list disjointness does not imply independent raw samples or independent files.
+The default data factory prints the actual raw-interval and file-overlap facts it can
+resolve.
+
+## Normalization
+
+`per_window_standardization` computes the mean and standard deviation from each window
+itself, including validation and test windows. This is test-sample adaptive
+preprocessing and removes absolute offset and scale information. It is not equivalent
+to train-fitted dataset normalization.
+
+Accepted maintained values:
+
+```text
+per_window_standardization
+per_window_minmax
+none
+```
+
+The historical names `standardization` and `minmax` remain implementation aliases for
+older configs, but maintained configs use the explicit per-window names.
+
+## Noise
+
+Noise is never applied through a shared ambiguous `noise_snr` field.
+
+```yaml
+data:
+  train_noise_snr: 20       # training windows only
+  evaluation_noise_snr: 10  # validation/test windows only
+  evaluation_noise_seed: 42 # deterministic evaluation corruption
+```
+
+Configure only the split whose scientific protocol requires noise. Invalid SNR values,
+non-finite signals, and zero-power signals with requested SNR augmentation fail at the
+data boundary instead of silently returning an unmodified window.
+
+## Typical Overrides
 
 ```bash
 python main.py --config <yaml> --override data.data_dir=/path/to/PHM-Vibench
@@ -37,21 +101,18 @@ python main.py --config <yaml> --override data.metadata_file=metadata.xlsx
 python main.py --config <yaml> --override data.num_workers=0
 ```
 
-## 5) Coupling Notes
+## How to Extend
 
-- Metadata is loaded by `src/data_factory/data_factory.py:_init_metadata`.
-- Raw files are expected under `{data_dir}/raw/<Name>/<File>` where `Name` and `File` come from metadata.
+- Add a reader under `src/data_factory/reader/` whose module name matches metadata
+  `Name`.
+- Register the task-specific dataset adapter through `register_dataset_adapter(...)`.
+- Do not modify model, task, trainer, Pipeline, or CLI code for a compatible dataset.
 
-## 6) How to Extend
+## Common Failures
 
-- Add a new dataset reader under `src/data_factory/reader/` and ensure metadata `Name` matches the module name.
-- For custom data factories, register a new factory name in `src/data_factory/data_factory.py` and set `data.factory_name`.
-
-## 7) Common Pitfalls
-
-1) Metadata file missing → the loader may attempt network download (use local files for reproducibility).
-2) Wrong `Name` in metadata → `import src.data_factory.reader.<Name>` fails.
-3) Raw file path mismatch (`raw/<Name>/<File>`).
-4) `window_size` larger than signal length → zero samples.
-5) Too many `num_workers` on small datasets → slower or unstable.
-
+1. `window_size` exceeds the source signal length.
+2. `stride` is supplied for a non-sequential strategy.
+3. split ratios do not account for all data.
+4. metadata `Name` or raw file path does not resolve.
+5. reader output contains non-numeric, NaN, or Inf values.
+6. requested noise cannot be applied to a zero-power signal.

--- a/configs/base/data/base_classification.yaml
+++ b/configs/base/data/base_classification.yaml
@@ -6,9 +6,10 @@ data:
   train_ratio: 0.8
   val_ratio: 0.1
   test_ratio: 0.1
-  normalization: "standardization"
+  unused_ratio: 0.0
+  normalization: "per_window_standardization"
   window_size: 4096
-  stride: 5
+  window_sampling_strategy: "evenly_spaced"
   num_window: 64
   dtype: "float32"
   pin_memory: true

--- a/configs/base/data/base_cross_domain.yaml
+++ b/configs/base/data/base_cross_domain.yaml
@@ -6,9 +6,10 @@ data:
   train_ratio: 0.8
   val_ratio: 0.1
   test_ratio: 0.1
-  normalization: "standardization"
+  unused_ratio: 0.0
+  normalization: "per_window_standardization"
   window_size: 4096
-  stride: 5
+  window_sampling_strategy: "evenly_spaced"
   num_window: 64
   dtype: "float32"
   pin_memory: true

--- a/configs/base/data/base_cross_system.yaml
+++ b/configs/base/data/base_cross_system.yaml
@@ -6,9 +6,10 @@ data:
   train_ratio: 0.8
   val_ratio: 0.1
   test_ratio: 0.1
-  normalization: "standardization"
+  unused_ratio: 0.0
+  normalization: "per_window_standardization"
   window_size: 4096
-  stride: 5
+  window_sampling_strategy: "evenly_spaced"
   num_window: 64
   dtype: "float32"
   pin_memory: true

--- a/configs/base/data/base_cross_system_fewshot.yaml
+++ b/configs/base/data/base_cross_system_fewshot.yaml
@@ -6,9 +6,10 @@ data:
   train_ratio: 0.8
   val_ratio: 0.1
   test_ratio: 0.1
-  normalization: "standardization"
+  unused_ratio: 0.0
+  normalization: "per_window_standardization"
   window_size: 1024
-  stride: 5
+  window_sampling_strategy: "evenly_spaced"
   num_window: 32
   dtype: "float32"
   pin_memory: true

--- a/configs/base/data/base_fewshot.yaml
+++ b/configs/base/data/base_fewshot.yaml
@@ -6,9 +6,10 @@ data:
   train_ratio: 0.8
   val_ratio: 0.1
   test_ratio: 0.1
-  normalization: "standardization"
+  unused_ratio: 0.0
+  normalization: "per_window_standardization"
   window_size: 1024
-  stride: 5
+  window_sampling_strategy: "evenly_spaced"
   num_window: 32
   dtype: "float32"
   pin_memory: true

--- a/configs/default.yaml
+++ b/configs/default.yaml
@@ -22,9 +22,9 @@ data:
   batch_size: 32
   num_workers: 32
   train_ratio: 0.8
-  normalization: true
+  normalization: "per_window_standardization"
   window_size: 4096
-  stride: 5
+  window_sampling_strategy: "evenly_spaced"
   truncate_lenth: 100
   dtype: float32
   num_window: 64
@@ -84,7 +84,3 @@ trainer:
   early_stopping: true
   patience: 5
   device: 'cuda'
-
-
-
-

--- a/configs/demo/00_smoke/dummy_dg.yaml
+++ b/configs/demo/00_smoke/dummy_dg.yaml
@@ -21,7 +21,6 @@ data:
   batch_size: 4
   num_workers: 0
   window_size: 128
-  stride: 16
   num_window: 8
 
 task:

--- a/configs/demo/06_pretrain_cddg/pretrain_hse_cddg.yaml
+++ b/configs/demo/06_pretrain_cddg/pretrain_hse_cddg.yaml
@@ -17,7 +17,7 @@ environment:
 
 data:
   train_ratio: 0.7
-  stride: 10
+  unused_ratio: 0.1
 
 # 模型配置全部由 base_configs.model (backbone_dlinear.yaml) 提供
 

--- a/configs/reference/experiment_7_cddg_noise.yaml
+++ b/configs/reference/experiment_7_cddg_noise.yaml
@@ -1,15 +1,18 @@
-# Experiment 7 (CDDG): Noise Robustness for Cross-Domain Classification
+# Experiment 7 reference: CDDG classification with explicit AWGN conditions.
 #
-# 说明：
-# - 本配置是 Experiment 7 的 CDDG 版本，研究噪声条件下 CDDG 任务的鲁棒性；
-# - 继承统一的噪声注入设计，仅将任务类型设置为 CDDG。
+# The maintained data path currently supports Gaussian noise through the split-specific
+# train_noise_snr and evaluation_noise_snr fields. Previous nested noise_injection,
+# model noise_robust_features, task noise_robustness, and robustness_score fields had
+# no runtime consumer and have been removed.
+
+pipeline: "Pipeline_01_Fault_Diagnosis"
 
 environment:
   VBENCH_HOME: "/home/user/LQ/B_Signal/Signal_foundation_model/Vbench"
   project: "experiment_7_cddg_noise_robustness"
   seed: 42
   output_dir: "paper/2025-10_foundation_model_0_metric/results/cddg/exp7_noise"
-  notes: "Experiment 7 (CDDG): HSE-Prompt robustness under noisy conditions (cross-domain classification)"
+  notes: "CDDG classification under explicit train/evaluation AWGN conditions"
   iterations: 1
 
 data:
@@ -20,39 +23,26 @@ data:
   train_ratio: 0.8
   val_ratio: 0.1
   test_ratio: 0.1
-  normalization: "standardization"
+  unused_ratio: 0.0
+  normalization: "per_window_standardization"
   window_size: 4096
-  stride: 5
+  window_sampling_strategy: "evenly_spaced"
   num_window: 64
   dtype: "float32"
   pin_memory: true
-
-  noise_injection:
-    enabled: true
-    noise_types: ["gaussian", "uniform", "colored"]
-    snr_levels: [20, 10, 5, 0, -5]
-    base_snr: 20
-    gaussian_noise:
-      mean: 0.0
-      std_range: [0.01, 0.1]
-    uniform_noise:
-      range_factor: 0.05
-    colored_noise:
-      colors: ["pink", "brown", "blue"]
-      filter_order: 4
+  train_noise_snr: 20
+  evaluation_noise_snr: 20
+  evaluation_noise_seed: 42
 
 model:
   name: "M_02_ISFM_Prompt"
   type: "ISFM_Prompt"
-
   embedding: "HSE_prompt"
   backbone: "B_04_Dlinear"
   task_head: "H_01_Linear_cla"
-
   input_dim: 1
   d_model: 256
   output_dim: 128
-
   num_heads: 8
   num_layers: 4
   e_layers: 4
@@ -60,54 +50,29 @@ model:
   dropout: 0.1
   activation: "relu"
   factor: 5
-
   patch_size_L: 64
   patch_size_C: 1
   num_patches: 64
-
   use_prompt: true
   prompt_dim: 128
   fusion_type: "attention"
   system_prompt_dim: 64
   sample_prompt_dim: 32
-
-  noise_robust_features:
-    enabled: true
-    spectral_filtering: true
-    denoising_prompts: true
-    adaptive_threshold: true
-    ensemble_predictions: true
-
   gradient_checkpointing: true
   mixed_precision: true
 
 task:
   name: "classification"
   type: "CDDG"
-
   target_system_id: [1, 13, 6, 12, 19]
   target_domain_num: 1
-
   optimizer: "adamw"
   lr: 0.0005
   weight_decay: 0.0001
   early_stopping: true
   es_patience: 15
-
   loss: "CE"
-  metrics: ["acc", "f1", "precision", "recall", "robustness_score"]
-
-  noise_robustness:
-    enabled: true
-    noise_augmentation:
-      enabled: true
-      noise_prob: 0.5
-      snr_range: [10, 20]
-      noise_types: ["gaussian", "uniform"]
-    test_time_augmentation:
-      enabled: true
-      num_augmentations: 5
-      voting_strategy: "majority"
+  metrics: ["acc", "f1", "precision", "recall"]
 
 trainer:
   name: "Default_trainer"
@@ -117,21 +82,16 @@ trainer:
   device: "cuda"
   accelerator: "gpu"
   precision: 16
-
   auto_select_gpus: true
   progress_bar_refresh_rate: 20
   check_val_every_n_epoch: 5
   deterministic: true
   gradient_clip_val: 1.0
   accumulate_grad_batches: 1
-
   use_wandb: true
   save_checkpoints: true
   log_every_n_steps: 10
   save_dir: "results/experiment_7_cddg_noise_robustness"
-
   early_stopping: true
   patience: 15
   wandb: false
-
-# 推荐 pipeline：Pipeline_01_Fault_Diagnosis（CDDG 单阶段分类）

--- a/configs/reference/experiment_7_cddg_noise_twostage.yaml
+++ b/configs/reference/experiment_7_cddg_noise_twostage.yaml
@@ -1,8 +1,9 @@
 # Experiment 7 (CDDG, Two-Stage): Noise Robustness with HSE-Prompt
 #
 # 说明：
-# - Stage1：在固定 SNR 条件下进行 HSE-Prompt 对比预训练（通过 data.noise_snr 控制 AWGN）；
-# - Stage2：在不同 SNR 条件下进行 CDDG 分类评估，用于量化噪声鲁棒性。
+# - Stage1：在固定 SNR 条件下进行 HSE-Prompt 对比预训练；
+# - Stage2：在不同 SNR 条件下进行 CDDG 分类评估；
+# - train_noise_snr 与 evaluation_noise_snr 分别控制训练增强和评估污染。
 
 environment:
   VBENCH_HOME: "/home/user/LQ/B_Signal/Signal_foundation_model/Vbench"
@@ -20,9 +21,10 @@ data:
   train_ratio: 0.8
   val_ratio: 0.1
   test_ratio: 0.1
-  normalization: "standardization"
+  unused_ratio: 0.0
+  normalization: "per_window_standardization"
   window_size: 4096
-  stride: 5
+  window_sampling_strategy: "evenly_spaced"
   num_window: 64
   dtype: "float32"
   pin_memory: true
@@ -91,7 +93,7 @@ trainer:
 
 stages:
   - name: "pretraining"
-    description: "Stage1: HSE-Prompt 对比预训练（固定 SNR，例如 20dB AWGN）"
+    description: "Stage1: HSE-Prompt 对比预训练（训练与评估均使用固定 20dB AWGN）"
     overrides:
       task:
         type: "pretrain"
@@ -109,11 +111,12 @@ stages:
         early_stopping: false
       data:
         num_window: 64
-        stride: 5
-        noise_snr: 20  # 默认预训练使用 20dB AWGN，可通过 CLI override 修改
+        train_noise_snr: 20
+        evaluation_noise_snr: 20
+        evaluation_noise_seed: 42
 
   - name: "finetuning"
-    description: "Stage2: CDDG 分类微调，在不同 SNR 条件下评估噪声鲁棒性"
+    description: "Stage2: CDDG 分类微调，在显式训练/评估 SNR 条件下量化鲁棒性"
     overrides:
       task:
         type: "CDDG"
@@ -131,9 +134,9 @@ stages:
         patience: 10
       data:
         num_window: 64
-        stride: 5
-        noise_snr: 20  # 将在脚本中通过 CLI override 设置为 20/10/5/0 等不同值
+        train_noise_snr: 20
+        evaluation_noise_snr: 20
+        evaluation_noise_seed: 42
 
 pipeline:
   name: "Pipeline_02_Pretraining_Few_Shot"
-

--- a/src/data_factory/dataset_task/Default_dataset.py
+++ b/src/data_factory/dataset_task/Default_dataset.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import math
+
 import numpy as np
 from torch.utils.data import Dataset
 
@@ -47,16 +49,16 @@ class Default_dataset(Dataset):  # THU_006or018_basic
         self.mode = requested_mode
 
         self.window_size = int(args_data.window_size)
-        self.stride = int(args_data.stride)
         self.num_window = int(args_data.num_window)
-        self.window_sampling_strategy = getattr(
-            args_data,
-            "window_sampling_strategy",
-            "evenly_spaced",
-        )
+        self.window_sampling_strategy = str(
+            getattr(args_data, "window_sampling_strategy", "evenly_spaced")
+        ).lower()
+        raw_stride = getattr(args_data, "stride", None)
+        self.stride = None if raw_stride is None else int(raw_stride)
         self.window_sampling_seed = int(
             getattr(args_data, "window_sampling_seed", 0)
         )
+        self._validate_window_config(raw_stride)
 
         self.train_ratio = float(getattr(args_data, "train_ratio", 0.8))
         self.val_ratio = float(
@@ -69,30 +71,93 @@ class Default_dataset(Dataset):  # THU_006or018_basic
                 max(0.0, 1.0 - self.train_ratio - self.val_ratio),
             )
         )
+        self.unused_ratio = float(getattr(args_data, "unused_ratio", 0.0))
         self._validate_split_ratios()
+
+        legacy_noise = getattr(args_data, "noise_snr", None)
+        if legacy_noise is not None:
+            raise ValueError(
+                "data.noise_snr is ambiguous because it affects every split. "
+                "Use data.train_noise_snr for training augmentation and/or "
+                "data.evaluation_noise_snr for an explicit evaluation corruption."
+            )
+        self.train_noise_snr = self._optional_finite_float(
+            getattr(args_data, "train_noise_snr", None),
+            "train_noise_snr",
+        )
+        self.evaluation_noise_snr = self._optional_finite_float(
+            getattr(args_data, "evaluation_noise_snr", None),
+            "evaluation_noise_snr",
+        )
+        self.evaluation_noise_seed = int(
+            getattr(args_data, "evaluation_noise_seed", 0)
+        )
+        self._evaluation_noise_rng = np.random.default_rng(
+            self.evaluation_noise_seed
+        )
 
         self.processed_data = []
         self.window_intervals: list[tuple[int, int]] = []
         self.prepare_data(metadata)
+
+    def _validate_window_config(self, raw_stride) -> None:
+        if self.window_size <= 0:
+            raise ValueError(
+                f"data.window_size must be positive, got {self.window_size}."
+            )
+        if self.num_window <= 0:
+            raise ValueError(
+                f"data.num_window must be positive, got {self.num_window}."
+            )
+        allowed = {"sequential", "random", "evenly_spaced"}
+        if self.window_sampling_strategy not in allowed:
+            raise ValueError(
+                "Unknown window_sampling_strategy "
+                f"{self.window_sampling_strategy!r}; choose one of "
+                f"{', '.join(sorted(allowed))}."
+            )
+        if self.window_sampling_strategy == "sequential":
+            if self.stride is None or self.stride <= 0:
+                raise ValueError(
+                    "data.stride must be a positive integer when "
+                    "window_sampling_strategy='sequential'."
+                )
+        elif raw_stride is not None:
+            raise ValueError(
+                "data.stride is only consumed by "
+                "window_sampling_strategy='sequential'. Remove stride or select "
+                "the sequential strategy."
+            )
+
+    @staticmethod
+    def _optional_finite_float(value, name: str):
+        if value is None:
+            return None
+        result = float(value)
+        if not math.isfinite(result):
+            raise ValueError(f"data.{name} must be finite, got {value!r}.")
+        return result
 
     def _validate_split_ratios(self) -> None:
         ratios = {
             "train_ratio": self.train_ratio,
             "val_ratio": self.val_ratio,
             "test_ratio": self.test_ratio,
+            "unused_ratio": self.unused_ratio,
         }
         invalid = {
             name: value
             for name, value in ratios.items()
-            if not 0 <= value <= 1
+            if not math.isfinite(value) or not 0 <= value <= 1
         }
         if invalid:
             raise ValueError(f"data split ratios must be within [0, 1]: {invalid}")
         total = sum(ratios.values())
-        if total > 1.0 + 1e-8:
+        if not math.isclose(total, 1.0, abs_tol=1e-8):
             raise ValueError(
-                "data split ratios must sum to at most 1.0; "
-                f"got train+val+test={total:.6f}"
+                "data train_ratio + val_ratio + test_ratio + unused_ratio "
+                f"must equal 1.0; got {total:.6f}. Declare unused_ratio "
+                "explicitly when reserving data."
             )
 
     def prepare_data(self, metadata=None):
@@ -151,8 +216,6 @@ class Default_dataset(Dataset):  # THU_006or018_basic
 
     def _evenly_spaced_sampling(self, sample_data, data_length):
         """Create windows distributed across the complete file."""
-        if self.num_window == 0:
-            return
         if data_length == self.window_size:
             self._append_window(sample_data, 0, self.window_size)
         elif self.num_window == 1:
@@ -196,6 +259,17 @@ class Default_dataset(Dataset):  # THU_006or018_basic
                 f"data ID {self.key!r} must be rank 1 or 2 after reader output; "
                 f"got shape {sample_data.shape}"
             )
+        try:
+            finite_input = np.isfinite(sample_data).all()
+        except TypeError as exc:
+            raise ValueError(
+                f"data ID {self.key!r} must contain numeric signal values; "
+                f"got dtype {sample_data.dtype}."
+            ) from exc
+        if not finite_input:
+            raise FloatingPointError(
+                f"data ID {self.key!r} contains NaN or Inf values after reading."
+            )
 
         data_length = len(sample_data)
         if data_length < self.window_size:
@@ -209,13 +283,8 @@ class Default_dataset(Dataset):  # THU_006or018_basic
             self._sequential_sampling(sample_data, data_length)
         elif self.window_sampling_strategy == "random":
             self._random_sampling(sample_data, data_length)
-        elif self.window_sampling_strategy == "evenly_spaced":
-            self._evenly_spaced_sampling(sample_data, data_length)
         else:
-            raise ValueError(
-                "Unknown window_sampling_strategy: "
-                f"{self.window_sampling_strategy}"
-            )
+            self._evenly_spaced_sampling(sample_data, data_length)
 
         if not self.processed_data:
             raise ValueError(
@@ -223,54 +292,82 @@ class Default_dataset(Dataset):  # THU_006or018_basic
                 "window_size, stride, num_window, and window_sampling_strategy."
             )
 
-        normalized_windows = []
+        transformed_windows = []
         for window in self.processed_data:
             normalized = self._normalize_window(window)
-            normalized_windows.append(self._maybe_add_noise(normalized))
-        self.processed_data = normalized_windows
+            transformed = self._maybe_add_noise(normalized)
+            if not np.isfinite(transformed).all():
+                raise FloatingPointError(
+                    f"data ID {self.key!r} produced NaN or Inf during "
+                    f"{self.mode} preprocessing."
+                )
+            transformed_windows.append(transformed)
+        self.processed_data = transformed_windows
 
     def _normalize_window(self, window: np.ndarray) -> np.ndarray:
-        """Normalize one window using the configured per-window method."""
-        normalization = getattr(
-            self.args_data,
-            "normalization",
-            "standardization",
-        )
-        if normalization == "minmax":
+        """Normalize one window using an explicitly per-window method."""
+        normalization = str(
+            getattr(
+                self.args_data,
+                "normalization",
+                "per_window_standardization",
+            )
+        ).lower()
+        if normalization in {"minmax", "per_window_minmax"}:
             min_vals = np.min(window, axis=0)
             max_vals = np.max(window, axis=0)
-            denominator = max_vals - min_vals
-            denominator[denominator == 0] = 1
-            return (window - min_vals) / denominator
-        if normalization == "standardization":
+            denominator = np.where(max_vals - min_vals == 0, 1, max_vals - min_vals)
+            result = (window - min_vals) / denominator
+        elif normalization in {
+            "standardization",
+            "per_window_standardization",
+        }:
             mean_vals = np.mean(window, axis=0)
             std_vals = np.std(window, axis=0)
-            return (window - mean_vals) / (std_vals + 1e-8)
-        if normalization == "none":
-            return window
-        raise ValueError(f"Unknown normalization method: {normalization}")
+            result = (window - mean_vals) / (std_vals + 1e-8)
+        elif normalization == "none":
+            result = window
+        else:
+            raise ValueError(
+                "Unknown normalization method "
+                f"{normalization!r}; use per_window_standardization, "
+                "per_window_minmax, or none."
+            )
+
+        if not np.isfinite(result).all():
+            raise FloatingPointError(
+                f"data ID {self.key!r} produced NaN or Inf during "
+                f"normalization={normalization!r}."
+            )
+        return result
 
     def _maybe_add_noise(self, window: np.ndarray) -> np.ndarray:
-        """Add AWGN only when ``data.noise_snr`` is explicitly configured."""
-        noise_snr = getattr(self.args_data, "noise_snr", None)
-        if noise_snr is None:
+        """Apply split-specific AWGN only when explicitly configured."""
+        if self.mode == "train":
+            snr_db = self.train_noise_snr
+            rng = np.random
+        else:
+            snr_db = self.evaluation_noise_snr
+            rng = self._evaluation_noise_rng
+        if snr_db is None:
             return window
-        try:
-            snr_db = float(noise_snr)
-            signal_power = np.mean(window.astype(np.float64) ** 2)
-            if signal_power <= 0:
-                return window
-            snr_linear = 10.0 ** (snr_db / 10.0)
-            noise_power = signal_power / snr_linear
-            noise_std = np.sqrt(noise_power)
-            noise = np.random.normal(
-                loc=0.0,
-                scale=noise_std,
-                size=window.shape,
-            ).astype(window.dtype)
-            return window + noise
-        except Exception:
-            return window
+
+        signal_power = float(np.mean(window.astype(np.float64) ** 2))
+        if not math.isfinite(signal_power) or signal_power <= 0:
+            raise ValueError(
+                f"Cannot apply {snr_db} dB AWGN to data ID {self.key!r}: "
+                "signal power must be finite and positive."
+            )
+        snr_linear = 10.0 ** (snr_db / 10.0)
+        if not math.isfinite(snr_linear) or snr_linear <= 0:
+            raise ValueError(f"Invalid AWGN SNR value: {snr_db!r} dB.")
+        noise_std = math.sqrt(signal_power / snr_linear)
+        noise = rng.normal(
+            loc=0.0,
+            scale=noise_std,
+            size=window.shape,
+        ).astype(window.dtype)
+        return window + noise
 
     def _split_data_for_mode(self):
         """Select a non-overlapping window-list split and retain its intervals."""

--- a/test/test_split_scientific_truth.py
+++ b/test/test_split_scientific_truth.py
@@ -9,15 +9,16 @@ from src.data_factory.explicit_data_factory import _summarize_split_assignments
 def _data_args():
     return SimpleNamespace(
         window_size=8,
-        stride=1,
         num_window=5,
         window_sampling_strategy="evenly_spaced",
         window_sampling_seed=0,
         train_ratio=0.4,
         val_ratio=0.2,
         test_ratio=0.4,
+        unused_ratio=0.0,
         normalization="none",
-        noise_snr=None,
+        train_noise_snr=None,
+        evaluation_noise_snr=None,
     )
 
 

--- a/test/test_transform_truth.py
+++ b/test/test_transform_truth.py
@@ -1,0 +1,174 @@
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+
+from src.data_factory.dataset_task.Default_dataset import Default_dataset
+
+
+_METADATA = {1: {"Label": 0}}
+_TASK = SimpleNamespace(type="DG")
+_DATA = {1: np.arange(1, 17, dtype=np.float32).reshape(-1, 1)}
+
+
+def _args(**overrides):
+    values = {
+        "window_size": 8,
+        "num_window": 2,
+        "window_sampling_strategy": "evenly_spaced",
+        "window_sampling_seed": 0,
+        "train_ratio": 0.5,
+        "val_ratio": 0.25,
+        "test_ratio": 0.25,
+        "unused_ratio": 0.0,
+        "normalization": "none",
+        "dtype": "float32",
+        "train_noise_snr": None,
+        "evaluation_noise_snr": None,
+        "evaluation_noise_seed": 7,
+    }
+    values.update(overrides)
+    return SimpleNamespace(**values)
+
+
+def test_stride_is_only_valid_for_sequential_sampling():
+    with pytest.raises(ValueError, match="stride is only consumed"):
+        Default_dataset(
+            _DATA,
+            _METADATA,
+            _args(stride=2),
+            _TASK,
+            "train",
+        )
+
+    with pytest.raises(ValueError, match="stride must be a positive integer"):
+        Default_dataset(
+            _DATA,
+            _METADATA,
+            _args(window_sampling_strategy="sequential"),
+            _TASK,
+            "train",
+        )
+
+    dataset = Default_dataset(
+        _DATA,
+        _METADATA,
+        _args(window_sampling_strategy="sequential", stride=2),
+        _TASK,
+        "train",
+    )
+    assert dataset.window_intervals == [(0, 8)]
+
+
+def test_split_ratios_require_explicit_unused_data():
+    with pytest.raises(ValueError, match="must equal 1.0"):
+        Default_dataset(
+            _DATA,
+            _METADATA,
+            _args(test_ratio=0.0),
+            _TASK,
+            "train",
+        )
+
+    dataset = Default_dataset(
+        _DATA,
+        _METADATA,
+        _args(test_ratio=0.0, unused_ratio=0.25),
+        _TASK,
+        "train",
+    )
+    assert len(dataset) == 1
+
+
+def test_non_finite_reader_output_fails_at_data_boundary():
+    bad_data = {1: np.array([1.0, 2.0, np.nan, 4.0, 5.0, 6.0, 7.0, 8.0])}
+    with pytest.raises(FloatingPointError, match="contains NaN or Inf"):
+        Default_dataset(bad_data, _METADATA, _args(num_window=1), _TASK, "test")
+
+
+def test_per_window_standardization_is_named_and_finite():
+    dataset = Default_dataset(
+        _DATA,
+        _METADATA,
+        _args(
+            num_window=1,
+            normalization="per_window_standardization",
+            train_ratio=1.0,
+            val_ratio=0.0,
+            test_ratio=0.0,
+        ),
+        _TASK,
+        "train",
+    )
+    window = dataset.processed_data[0]
+    assert np.isfinite(window).all()
+    assert np.allclose(window.mean(axis=0), 0.0, atol=1e-6)
+    assert np.allclose(window.std(axis=0), 1.0, atol=1e-6)
+
+
+def test_noise_is_split_specific_and_evaluation_noise_is_deterministic():
+    clean_eval = Default_dataset(
+        _DATA,
+        _METADATA,
+        _args(num_window=1),
+        _TASK,
+        "test",
+    )
+    train_noisy = Default_dataset(
+        _DATA,
+        _METADATA,
+        _args(
+            num_window=1,
+            train_noise_snr=20,
+            train_ratio=1.0,
+            val_ratio=0.0,
+            test_ratio=0.0,
+        ),
+        _TASK,
+        "train",
+    )
+    assert not np.array_equal(
+        train_noisy.processed_data[0],
+        clean_eval.processed_data[0],
+    )
+
+    eval_args = _args(num_window=1, evaluation_noise_snr=20)
+    noisy_eval_a = Default_dataset(_DATA, _METADATA, eval_args, _TASK, "test")
+    noisy_eval_b = Default_dataset(_DATA, _METADATA, eval_args, _TASK, "test")
+    assert np.array_equal(
+        noisy_eval_a.processed_data[0],
+        noisy_eval_b.processed_data[0],
+    )
+    assert not np.array_equal(
+        noisy_eval_a.processed_data[0],
+        clean_eval.processed_data[0],
+    )
+
+
+def test_legacy_ambiguous_noise_setting_fails_with_repair_path():
+    with pytest.raises(ValueError, match="train_noise_snr"):
+        Default_dataset(
+            _DATA,
+            _METADATA,
+            _args(noise_snr=20),
+            _TASK,
+            "test",
+        )
+
+
+def test_requested_noise_cannot_silently_skip_zero_power_signal():
+    zero_data = {1: np.zeros((8, 1), dtype=np.float32)}
+    with pytest.raises(ValueError, match="signal power must be finite and positive"):
+        Default_dataset(
+            zero_data,
+            _METADATA,
+            _args(
+                num_window=1,
+                evaluation_noise_snr=20,
+                train_ratio=0.0,
+                val_ratio=0.0,
+                test_ratio=1.0,
+            ),
+            _TASK,
+            "test",
+        )

--- a/test/test_transform_truth.py
+++ b/test/test_transform_truth.py
@@ -3,6 +3,7 @@ from types import SimpleNamespace
 import numpy as np
 import pytest
 
+from phmfactory.config import resolve_config
 from src.data_factory.dataset_task.Default_dataset import Default_dataset
 
 
@@ -29,6 +30,21 @@ def _args(**overrides):
     }
     values.update(overrides)
     return SimpleNamespace(**values)
+
+
+def test_maintained_smoke_declares_consumed_transform_fields():
+    data = resolve_config("configs/demo/00_smoke/dummy_dg.yaml").data["data"]
+
+    assert data["window_sampling_strategy"] == "evenly_spaced"
+    assert "stride" not in data
+    assert data["normalization"] == "per_window_standardization"
+    assert (
+        data["train_ratio"]
+        + data["val_ratio"]
+        + data["test_ratio"]
+        + data["unused_ratio"]
+        == 1.0
+    )
 
 
 def test_stride_is_only_valid_for_sequential_sampling():


### PR DESCRIPTION
## User problem

The maintained data path exposed configuration that did not match computation:

- the default `evenly_spaced` strategy ignored `stride`, although every maintained base displayed `stride: 5`;
- `standardization` actually used each individual train/validation/test window's own statistics;
- `noise_snr` affected every split and swallowed invalid settings by returning the clean window;
- non-finite reader or transformed values could propagate into the model;
- split ratios could leave unnamed unused data.

A run could therefore succeed with different transforms than a user reasonably inferred from the config.

## First-principles contract

```text
configured windowing / normalization / noise
=
executed transform for the declared split
```

## Scope

- require positive `window_size` and `num_window`;
- make `stride` valid only for `window_sampling_strategy=sequential`;
- update maintained configs to declare `evenly_spaced` and remove ignored stride;
- rename maintained normalization to `per_window_standardization` while retaining historical aliases;
- require split ratios plus explicit `unused_ratio` to equal one;
- separate `train_noise_snr` from deterministic `evaluation_noise_snr`;
- reject ambiguous legacy `noise_snr` with a repair path;
- reject non-numeric, NaN, Inf, invalid SNR, and zero-power requested-noise inputs at the data boundary;
- remove unconsumed noise robustness blocks from the current Experiment 7 reference configs;
- add focused transform tests to the existing offline-smoke gate.

## Result

Maintained data configs now state exactly what is consumed:

```yaml
data:
  window_sampling_strategy: evenly_spaced
  normalization: per_window_standardization
  train_noise_snr: null
  evaluation_noise_snr: null
  unused_ratio: 0.0
```

Evaluation corruption is reproducible through `evaluation_noise_seed`.

## Explicit non-goals

```text
no train-fitted normalization implementation
no file/domain split implementation
no new augmentation framework
no uniform/colored noise implementation
no transform manifest, hash, receipt, or policy engine
no model/task/trainer/Pipeline algorithm change
no new workflow or exception hierarchy
```

## Validation

Focused tests cover:

- maintained smoke config contains only consumed transform fields;
- stride is accepted only for sequential sampling;
- unnamed unused data is rejected;
- non-finite reader output fails at the data boundary;
- per-window standardization is finite and has its stated semantics;
- training noise does not contaminate evaluation;
- evaluation noise is deterministic;
- legacy ambiguous noise and zero-power requested noise fail clearly.

Draft pending current config/docs gates and full offline Dummy training.