### PR TITLE
feat(data): prove compatible CSV dataset extension

### DIFF
--- a/src/data_factory/reader/CSV_Signal.py
+++ b/src/data_factory/reader/CSV_Signal.py
@@ -1,0 +1,74 @@
+"""Reader for headered CSV files with explicitly configured signal columns."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+
+
+def read(file_path, args_data):
+    """Read selected numeric CSV columns as a ``[length, channels]`` array.
+
+    Required data configuration:
+
+    ```yaml
+    data:
+      csv_signal_columns: [sensor_a, sensor_b]
+    ```
+
+    Columns are never guessed. Index, time, label, or metadata columns remain excluded
+    unless the user explicitly lists them as signal channels.
+    """
+    path = Path(file_path)
+    if not path.is_file():
+        raise FileNotFoundError(f"CSV signal file not found: {path}")
+
+    columns = getattr(args_data, "csv_signal_columns", None)
+    if not isinstance(columns, (list, tuple)) or not columns:
+        raise ValueError(
+            "CSV_Signal requires data.csv_signal_columns as a non-empty list "
+            "of header names."
+        )
+    column_names = [str(column) for column in columns]
+    if len(set(column_names)) != len(column_names):
+        raise ValueError(
+            "data.csv_signal_columns contains duplicate column names: "
+            f"{column_names}."
+        )
+
+    delimiter = str(getattr(args_data, "csv_delimiter", ","))
+    frame = pd.read_csv(path, sep=delimiter)
+    missing = [column for column in column_names if column not in frame.columns]
+    if missing:
+        raise ValueError(
+            f"CSV signal file {path} is missing configured column(s) {missing}. "
+            f"Available columns: {list(frame.columns)}."
+        )
+
+    selected = frame.loc[:, column_names]
+    try:
+        numeric = selected.apply(pd.to_numeric, errors="raise")
+    except (TypeError, ValueError) as exc:
+        raise ValueError(
+            f"Configured CSV signal columns must be numeric: {column_names}."
+        ) from exc
+
+    dtype_name = str(getattr(args_data, "dtype", "float32"))
+    if dtype_name not in {"float32", "float64"}:
+        raise ValueError(
+            "CSV_Signal supports data.dtype 'float32' or 'float64', "
+            f"got {dtype_name!r}."
+        )
+    array = numeric.to_numpy(dtype=np.dtype(dtype_name), copy=True)
+    if array.ndim != 2 or array.shape[0] == 0 or array.shape[1] == 0:
+        raise ValueError(
+            f"CSV signal file {path} produced invalid shape {array.shape}; "
+            "at least one row and one configured channel are required."
+        )
+    if not np.isfinite(array).all():
+        raise FloatingPointError(
+            f"CSV signal file {path} contains NaN or Inf in {column_names}."
+        )
+    return array

--- a/test/test_data_cache_contract.py
+++ b/test/test_data_cache_contract.py
@@ -7,12 +7,13 @@ import h5py
 import numpy as np
 import pytest
 
-from src.data_factory import ExplicitDataFactory
+from src.data_factory import ExplicitDataFactory, build_data
 from src.data_factory.contracts import (
     format_loader_summary,
     require_nonempty_dataloaders,
 )
 from src.data_factory.data_factory import data_factory as BaseDataFactory
+from src.data_factory.reader.CSV_Signal import read as read_csv_signal
 
 
 def _factory(metadata):
@@ -235,3 +236,86 @@ def test_explicit_factory_checks_loaders_after_base_construction(
 
     output = capsys.readouterr().out
     assert "train=2 batches, val=1 batch, test=1 batch" in output
+
+
+def _write_signal_csv(path: Path, offset: float) -> None:
+    rows = ["time,sensor_a,sensor_b"]
+    for index in range(16):
+        rows.append(f"{index},{offset + index},{offset + 2 * index}")
+    path.write_text("\n".join(rows) + "\n", encoding="utf-8")
+
+
+def test_csv_signal_reader_requires_explicit_numeric_columns(tmp_path: Path) -> None:
+    signal_path = tmp_path / "signal.csv"
+    _write_signal_csv(signal_path, 0.0)
+    args_data = SimpleNamespace(
+        csv_signal_columns=["sensor_a", "sensor_b"],
+        csv_delimiter=",",
+        dtype="float32",
+    )
+
+    signal = read_csv_signal(signal_path, args_data)
+    assert signal.shape == (16, 2)
+    assert signal.dtype == np.float32
+    assert np.array_equal(signal[0], np.array([0.0, 0.0], dtype=np.float32))
+
+    args_data.csv_signal_columns = ["sensor_a", "missing"]
+    with pytest.raises(ValueError, match="missing configured column"):
+        read_csv_signal(signal_path, args_data)
+
+
+def test_compatible_csv_dataset_uses_existing_data_and_task_contracts(
+    tmp_path: Path,
+) -> None:
+    raw_dir = tmp_path / "raw" / "CSV_Signal"
+    raw_dir.mkdir(parents=True)
+    _write_signal_csv(raw_dir / "source.csv", 0.0)
+    _write_signal_csv(raw_dir / "target.csv", 100.0)
+    (tmp_path / "metadata.csv").write_text(
+        "Id,Name,File,Dataset_id,Domain_id,Label,Sample_Rate\n"
+        "1,CSV_Signal,source.csv,0,0,0,1000\n"
+        "2,CSV_Signal,target.csv,0,1,0,1000\n",
+        encoding="utf-8",
+    )
+
+    args_data = SimpleNamespace(
+        factory_name="default",
+        data_dir=str(tmp_path),
+        metadata_file="metadata.csv",
+        batch_size=1,
+        num_workers=0,
+        train_ratio=0.5,
+        val_ratio=0.25,
+        test_ratio=0.25,
+        unused_ratio=0.0,
+        normalization="none",
+        window_size=4,
+        window_sampling_strategy="evenly_spaced",
+        num_window=4,
+        window_sampling_seed=0,
+        dtype="float32",
+        pin_memory=False,
+        csv_signal_columns=["sensor_a", "sensor_b"],
+    )
+    args_task = SimpleNamespace(
+        type="DG",
+        name="classification",
+        target_system_id=[0],
+        source_domain_id=[0],
+        target_domain_id=[1],
+    )
+
+    factory = build_data(args_data, args_task)
+    try:
+        train_batch = next(iter(factory.train_loader))
+        val_batch = next(iter(factory.val_loader))
+        test_batch = next(iter(factory.test_loader))
+
+        assert train_batch["x"].shape == (1, 4, 2)
+        assert val_batch["x"].shape == (1, 4, 2)
+        assert test_batch["x"].shape == (1, 4, 2)
+        assert train_batch["file_id"].tolist() == [1]
+        assert test_batch["file_id"].tolist() == [2]
+        assert factory.split_summary["file_overlap"]["train_test"] == []
+    finally:
+        factory.data.close()


### PR DESCRIPTION
## Developer problem

PHMFactory should not create a ReaderPlugin framework unless a compatible dataset cannot be added through the existing reader name and explicit dataset-adapter paths without changing learning or runtime code.

This experiment tests that extension seam directly.

## Measurable contract

```text
add one compatible CSV dataset
→ no model/task/trainer/Pipeline/runtime changes
→ existing DG/classification adapter is reused
→ train/val/test DataLoaders are built
```

## Scope

- add `reader/CSV_Signal.py` for headered CSV files;
- require explicit `data.csv_signal_columns`, with no automatic column guessing;
- reject missing, duplicate, non-numeric, empty, or non-finite signal columns;
- build a temporary source/target-domain dataset through the public default data factory;
- reuse the existing `DG/classification` dataset adapter, split, cache, sampler, and DataLoader contracts;
- verify two channels and source/target file IDs reach the loaders;
- extend the already executed data-cache contract test.

## Modification surface

```text
added:
  src/data_factory/reader/CSV_Signal.py
modified:
  test/test_data_cache_contract.py

unchanged:
  runtime
  CLI
  Pipeline
  model
  task
  trainer
  dataset adapter registry
```

## Architectural result

A compatible dataset can already be added by supplying a reader and metadata `Name`, while reusing the existing task adapter. This PR therefore does **not** add `ReaderPlugin`, a second registry, a dataset card system, or a universal data schema.

## Explicit non-goals

```text
no automatic signal-column discovery
no index/time-column guessing
no reader registry redesign
no new dataset adapter
no model/task/trainer changes
no new workflow, manifest, hash or policy
no claim that arbitrary CSV layouts are supported
```

## Validation

The existing offline data contract group proves:

- explicit signal columns produce a numeric `[length, channels]` array;
- a missing configured column fails with available columns;
- metadata using `Name=CSV_Signal` resolves the reader without runtime changes;
- the existing DG adapter produces non-empty train/val/test loaders;
- batches have shape `[B, L, 2]`;
- source and target file IDs remain distinct;
- split summary reports no train/test file overlap.

Draft pending current Core gates and full Dummy smoke.