### PR TITLE
fix(core): enforce explicit experiment and data-population semantics

### DIFF
--- a/phmfactory/config.py
+++ b/phmfactory/config.py
@@ -140,7 +140,8 @@ def parse_overrides(values: Sequence[str] | None) -> dict[str, Any]:
     Raises
     ------
     ValueError
-        If a token is missing ``=`` or attempts to traverse a non-mapping field.
+        If a token is missing ``=``, has an empty key/value, contains malformed YAML,
+        or attempts to traverse a non-mapping field.
     """
 
     parsed: dict[str, Any] = {}
@@ -151,10 +152,18 @@ def parse_overrides(values: Sequence[str] | None) -> dict[str, Any]:
         key = key.strip()
         if not key:
             raise ValueError("Override key must be non-empty")
+        value_text = raw_value.strip()
+        if not value_text:
+            raise ValueError(
+                f"Override value for {key!r} must be non-empty. "
+                "Use `null` explicitly when a null value is intended."
+            )
         try:
-            value = yaml.safe_load(raw_value.strip())
-        except yaml.YAMLError:
-            value = raw_value.strip()
+            value = yaml.safe_load(value_text)
+        except yaml.YAMLError as exc:
+            raise ValueError(
+                f"Invalid YAML value for override {key!r}: {raw_value!r}"
+            ) from exc
         _set_dotted(parsed, key, value)
     return parsed
 
@@ -196,7 +205,7 @@ def analyze_config(
 
     Raises
     ------
-    FileNotFoundError, TypeError, ValueError, yaml.YAMLError
+    FileNotFoundError, TypeError, ValueError, UnicodeError, yaml.YAMLError
         The original configuration error is propagated; there is no fallback to another
         config or Pipeline.
     """
@@ -225,12 +234,17 @@ def analyze_config(
     _deep_merge(data, overrides)
     _mark_leaf_sources(sources, overrides, "cli:--override")
 
-    raw_pipeline = data.get("pipeline", DEFAULT_PIPELINE)
+    if "pipeline" not in data:
+        raise ValueError(
+            "The effective configuration must declare `pipeline`. Add it to the "
+            "selected YAML, an explicit --local-config file, or an explicit "
+            "--override pipeline=<canonical-name>."
+        )
+    raw_pipeline = data["pipeline"]
     if not isinstance(raw_pipeline, str) or not raw_pipeline.strip():
         raise ValueError("pipeline must be a non-empty string")
     pipeline = canonical_pipeline_name(raw_pipeline.strip())
     data["pipeline"] = pipeline
-    sources.setdefault("pipeline", "default:Pipeline_01_Fault_Diagnosis")
 
     effective = _json_compatible(deepcopy(data))
     return ConfigAnalysis(
@@ -375,11 +389,12 @@ def _load_recursive_with_sources(
 
 def _read_yaml_mapping(path: Path) -> dict[str, Any]:
     try:
-        payload = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
-    except UnicodeDecodeError:
-        payload = yaml.safe_load(
-            path.read_text(encoding="gb18030", errors="ignore")
-        ) or {}
+        text = path.read_text(encoding="utf-8")
+    except UnicodeDecodeError as exc:
+        raise UnicodeError(
+            f"Configuration file must be valid UTF-8: {path}"
+        ) from exc
+    payload = yaml.safe_load(text) or {}
     if not isinstance(payload, dict):
         raise TypeError(f"Top-level YAML object must be a mapping: {path}")
     return payload

--- a/src/data_factory/ID/Get_id.py
+++ b/src/data_factory/ID/Get_id.py
@@ -1,167 +1,220 @@
+from __future__ import annotations
+
+from collections.abc import Iterable
+from typing import Any
+
 import pandas as pd
 
-def remove_invalid_labels(df, label_column='Label'):
-    """
-    从DataFrame中删除指定列值为-1的行
-    
-    Args:
-        df (pd.DataFrame): 输入的DataFrame
-        label_column (str): 标签列名，默认为'Label'
-    
-    Returns:
-        pd.DataFrame: 删除指定条件行后的新DataFrame
-    """
-    # 检查列是否存在
-    if label_column not in df.columns:
-        raise ValueError(f"列 '{label_column}' 不存在于DataFrame中")
-    
-    # 删除Label为-1的行
-    filtered_df = df[df[label_column] != -1].copy()
-    
-    # 重置索引（可选）
-    filtered_df.reset_index(drop=True, inplace=True)
-    
-    return filtered_df
+
+def _declared_values(value: Any, name: str) -> list[Any]:
+    """Return one explicit non-empty configuration value list."""
+
+    if value is None:
+        raise ValueError(f"{name} must be declared.")
+    if isinstance(value, (str, bytes)):
+        values = [value]
+    elif isinstance(value, Iterable):
+        values = list(value)
+    else:
+        values = [value]
+    if not values:
+        raise ValueError(f"{name} must contain at least one value.")
+    if any(pd.isna(item) for item in values):
+        raise ValueError(f"{name} must not contain null values: {values!r}.")
+    return values
+
+
+def _require_valid_classification_labels(df: pd.DataFrame) -> pd.DataFrame:
+    """Reject invalid supervised labels instead of deleting metadata rows."""
+
+    if "Label" not in df.columns:
+        raise ValueError("Supervised classification metadata must contain 'Label'.")
+
+    invalid = df[df["Label"].isna() | (df["Label"] == -1)]
+    if not invalid.empty:
+        invalid_ids = (
+            invalid["Id"].tolist() if "Id" in invalid.columns else invalid.index.tolist()
+        )
+        raise ValueError(
+            "Supervised classification metadata contains missing or -1 labels for "
+            f"ID(s) {invalid_ids}. Fix the metadata instead of dropping rows."
+        )
+    return df.copy()
+
+
+def _available_domains(df: pd.DataFrame, context: str) -> list[Any]:
+    """Return sorted, fully declared domains for one selected population."""
+
+    if "Domain_id" not in df.columns:
+        raise ValueError(f"{context} metadata must contain 'Domain_id'.")
+    invalid = df[df["Domain_id"].isna()]
+    if not invalid.empty:
+        invalid_ids = (
+            invalid["Id"].tolist() if "Id" in invalid.columns else invalid.index.tolist()
+        )
+        raise ValueError(
+            f"{context} metadata contains missing Domain_id for ID(s) {invalid_ids}."
+        )
+    domains = sorted(df["Domain_id"].unique().tolist())
+    if not domains:
+        raise ValueError(f"{context} metadata contains no domains.")
+    return domains
+
+
+def _require_nonempty_split(train_df: pd.DataFrame, test_df: pd.DataFrame, context: str) -> None:
+    if train_df.empty:
+        raise ValueError(f"{context} produced an empty training/validation population.")
+    if test_df.empty:
+        raise ValueError(f"{context} produced an empty test population.")
+
 
 def Get_DG_ids(metadata_accessor, args_task):
-    """
-    Retrieves training/validation and test IDs for Domain Generalization (DG) tasks.
-    If target_domain_num is specified, it will be used to dynamically split domains.
-    Otherwise, it falls back to using source_domain_id and target_domain_id.
-    """
-    # Filter by the target system(s) first
+    """Return IDs for one executable domain-generalization protocol."""
+
+    target_systems = _declared_values(
+        getattr(args_task, "target_system_id", None),
+        "task.target_system_id",
+    )
+    if "Dataset_id" not in metadata_accessor.df.columns:
+        raise ValueError("DG metadata must contain 'Dataset_id'.")
+
     system_df = metadata_accessor.df[
-        metadata_accessor.df['Dataset_id'].isin(args_task.target_system_id)
-    ]
-    system_df = remove_invalid_labels(system_df)
+        metadata_accessor.df["Dataset_id"].isin(target_systems)
+    ].copy()
+    if system_df.empty:
+        raise ValueError(
+            f"DG target_system_id={target_systems!r} matched no metadata rows."
+        )
+    system_df = _require_valid_classification_labels(system_df)
+    all_domains = _available_domains(system_df, "DG")
 
-    # Check if target_domain_num is specified for dynamic splitting
-    if hasattr(args_task, 'target_domain_num') and args_task.target_domain_num > 0:
-        # Dynamic splitting based on target_domain_num
-        all_domains = sorted(system_df['Domain_id'].unique())
-        all_domains = [d for d in all_domains if not pd.isna(d)]
+    raw_target_count = getattr(args_task, "target_domain_num", 0)
+    target_count = int(raw_target_count or 0)
+    if target_count < 0:
+        raise ValueError(
+            f"task.target_domain_num must be non-negative, got {raw_target_count!r}."
+        )
 
-        if not all_domains:
-            train_domains, test_domains = [], []
-        else:
-            # Keep at least one domain for training whenever possible
-            max_testable = max(len(all_domains) - 1, 0)
-            if args_task.target_domain_num > 0:
-                test_count = min(args_task.target_domain_num, max_testable)
-            else:
-                test_count = 0
-
-            if test_count == 0 and len(all_domains) > 0 and args_task.target_domain_num > 0:
-                print("[WARNING] Not enough domains to allocate test split. Falling back to train-only for this dataset.")
-
-            train_domains = all_domains[:-test_count] if test_count > 0 else all_domains
-            test_domains = all_domains[-test_count:] if test_count > 0 else []
-
-        train_df = system_df[system_df['Domain_id'].isin(train_domains)]
-        test_df = system_df[system_df['Domain_id'].isin(test_domains)]
-
-        print(f"DG划分 - 使用 target_domain_num={args_task.target_domain_num} 进行动态划分")
-        print(f"  - 训练域: {train_domains}")
-        print(f"  - 测试域: {test_domains}")
-
+    if target_count > 0:
+        if len(all_domains) <= target_count:
+            raise ValueError(
+                "DG target_domain_num cannot be satisfied: requested "
+                f"{target_count} test domain(s), but available domains are "
+                f"{all_domains}. At least one source domain must remain for training."
+            )
+        train_domains = all_domains[:-target_count]
+        test_domains = all_domains[-target_count:]
     else:
-        # Original logic using predefined source/target domains
-        train_df = system_df[system_df['Domain_id'].isin(args_task.source_domain_id)]
-        test_df = system_df[system_df['Domain_id'].isin(args_task.target_domain_id)]
-        
-        print(f"DG划分 - 使用预定义的 source_domain 和 target_domain")
-        print(f"  - 训练域: {getattr(args_task, 'source_domain_id', 'N/A')}")
-        print(f"  - 测试域: {getattr(args_task, 'target_domain_id', 'N/A')}")
+        source_domains = _declared_values(
+            getattr(args_task, "source_domain_id", None),
+            "task.source_domain_id",
+        )
+        target_domains = _declared_values(
+            getattr(args_task, "target_domain_id", None),
+            "task.target_domain_id",
+        )
+        overlap = sorted(set(source_domains) & set(target_domains))
+        if overlap:
+            raise ValueError(
+                f"DG source and target domains must be disjoint; overlap={overlap}."
+            )
+        missing = sorted(
+            (set(source_domains) | set(target_domains)) - set(all_domains),
+            key=str,
+        )
+        if missing:
+            raise ValueError(
+                f"DG requested domain(s) {missing} are absent; available={all_domains}."
+            )
+        train_domains = source_domains
+        test_domains = target_domains
 
-    train_val_ids = list(train_df['Id'])
-    test_ids = list(test_df['Id'])
-    
+    train_df = system_df[system_df["Domain_id"].isin(train_domains)]
+    test_df = system_df[system_df["Domain_id"].isin(test_domains)]
+    _require_nonempty_split(train_df, test_df, "DG")
+
+    train_val_ids = train_df["Id"].tolist()
+    test_ids = test_df["Id"].tolist()
+    if set(train_val_ids) & set(test_ids):
+        raise ValueError("DG produced overlapping train and test IDs.")
+
+    print("DG划分 - 使用显式可执行域协议")
+    print(f"  - 训练域: {train_domains}")
+    print(f"  - 测试域: {test_domains}")
     print(f"训练/验证样本数: {len(train_val_ids)}")
     print(f"测试样本数: {len(test_ids)}")
-    
     return train_val_ids, test_ids
 
-# def Get_GFS_ids(metadata_accessor, args_task):
-#     。。
-
-# def Get_pretrain_ids(metadata_accessor, args_task):
-#     """
-#     Retrieves training/validation and test IDs for pretraining tasks.
-    
-#     output:
-#         train_val_ids (list): List of IDs for training/validation set.
-#         test_ids (list): List of IDs for test set.
-#     """
-#     # For pretraining, we typically use all available IDs
-#     train_val_ids = list(metadata_accessor.df['Id'])
-#     test_ids = list(metadata_accessor.df['Id'])
-    
-#     print(f"Pretrain划分 - 使用全部数据集ID")
-#     print(f"训练/验证样本数: {len(train_val_ids)}")
-#     print(f"测试样本数: {len(test_ids)}")
-    
-#     return train_val_ids, test_ids
 
 def Get_CDDG_ids(metadata_accessor, args_task):
-    """
-    Retrieves training/validation and test IDs for Cross-Domain Domain Generalization (CDDG) tasks.
+    """Return IDs for a per-system cross-domain generalization protocol."""
 
-    output:
-        train_val_ids (list): List of IDs for source domain for different systems.
-        test_ids (list): List of IDs for test set.
-    """
-    filtered_df = metadata_accessor.df[metadata_accessor.df['Dataset_id'].isin(args_task.target_system_id)]
-    filtered_df = remove_invalid_labels(filtered_df)
-    
-    dataset_domains = {}
-    for dataset_id in args_task.target_system_id:
-        dataset_df = filtered_df[filtered_df['Dataset_id'] == dataset_id]
-        domains = sorted(dataset_df['Domain_id'].unique())
-        # Filter out NaN values from domains
-        domains = [d for d in domains if not pd.isna(d)]
-        dataset_domains[dataset_id] = domains
-    
-    train_domains = {}
-    test_domains = {}
-    for dataset_id, domains in dataset_domains.items():
-        if not domains:
-            train_domains[dataset_id], test_domains[dataset_id] = [], []
-            continue
+    target_systems = _declared_values(
+        getattr(args_task, "target_system_id", None),
+        "task.target_system_id",
+    )
+    raw_target_count = getattr(args_task, "target_domain_num", None)
+    if raw_target_count is None:
+        raise ValueError("CDDG requires task.target_domain_num.")
+    target_count = int(raw_target_count)
+    if target_count <= 0:
+        raise ValueError(
+            f"CDDG task.target_domain_num must be positive, got {raw_target_count!r}."
+        )
+    if "Dataset_id" not in metadata_accessor.df.columns:
+        raise ValueError("CDDG metadata must contain 'Dataset_id'.")
 
-        max_testable = max(len(domains) - 1, 0)
-        if args_task.target_domain_num > 0:
-            test_count = min(args_task.target_domain_num, max_testable)
-        else:
-            test_count = 0
+    filtered_df = metadata_accessor.df[
+        metadata_accessor.df["Dataset_id"].isin(target_systems)
+    ].copy()
+    if filtered_df.empty:
+        raise ValueError(
+            f"CDDG target_system_id={target_systems!r} matched no metadata rows."
+        )
+    filtered_df = _require_valid_classification_labels(filtered_df)
 
-        if test_count == 0 and len(domains) > 0 and args_task.target_domain_num > 0:
-            print(f"[WARNING] 数据集 {dataset_id} 仅包含 {len(domains)} 个域，无法按照 target_domain_num 分配测试域，已全部用于训练。")
+    train_domains: dict[Any, list[Any]] = {}
+    test_domains: dict[Any, list[Any]] = {}
+    train_val_ids: list[Any] = []
+    test_ids: list[Any] = []
 
-        train_domains[dataset_id] = domains[:-test_count] if test_count > 0 else domains
-        test_domains[dataset_id] = domains[-test_count:] if test_count > 0 else []
-    
-    train_val_ids = []
-    test_ids = []
-    for dataset_id_val in args_task.target_system_id:
-        # Training set rows
-        for domain_id in train_domains[dataset_id_val]:
-            train_val_ids.extend(
-                filtered_df[(filtered_df['Dataset_id'] == dataset_id_val) & 
-                            (filtered_df['Domain_id'] == domain_id)]['Id'].tolist()
+    for dataset_id in target_systems:
+        dataset_df = filtered_df[filtered_df["Dataset_id"] == dataset_id]
+        if dataset_df.empty:
+            raise ValueError(
+                f"CDDG target system {dataset_id!r} matched no metadata rows."
             )
-        # Test set rows
-        for domain_id in test_domains[dataset_id_val]:
-            test_ids.extend(
-                filtered_df[(filtered_df['Dataset_id'] == dataset_id_val) & 
-                            (filtered_df['Domain_id'] == domain_id)]['Id'].tolist()
+        domains = _available_domains(dataset_df, f"CDDG dataset {dataset_id!r}")
+        if len(domains) <= target_count:
+            raise ValueError(
+                f"CDDG dataset {dataset_id!r} cannot reserve {target_count} test "
+                f"domain(s) from available domains {domains}; at least one training "
+                "domain must remain."
             )
-    
-    print(f"CDGD划分 - 选择每个数据集的最后{args_task.target_domain_num}个domain作为测试集")
-    for dataset_id_print in args_task.target_system_id:
-        print(f"数据集 {dataset_id_print}:")
-        print(f"  - 训练域: {train_domains[dataset_id_print]}")
-        print(f"  - 测试域: {test_domains[dataset_id_print]}")
+
+        train_domains[dataset_id] = domains[:-target_count]
+        test_domains[dataset_id] = domains[-target_count:]
+
+        train_rows = dataset_df[
+            dataset_df["Domain_id"].isin(train_domains[dataset_id])
+        ]
+        test_rows = dataset_df[
+            dataset_df["Domain_id"].isin(test_domains[dataset_id])
+        ]
+        _require_nonempty_split(train_rows, test_rows, f"CDDG dataset {dataset_id!r}")
+        train_val_ids.extend(train_rows["Id"].tolist())
+        test_ids.extend(test_rows["Id"].tolist())
+
+    if set(train_val_ids) & set(test_ids):
+        raise ValueError("CDDG produced overlapping train and test IDs.")
+
+    print(
+        f"CDDG划分 - 每个数据集保留最后 {target_count} 个 domain 作为测试集"
+    )
+    for dataset_id in target_systems:
+        print(f"数据集 {dataset_id}:")
+        print(f"  - 训练域: {train_domains[dataset_id]}")
+        print(f"  - 测试域: {test_domains[dataset_id]}")
     print(f"训练/验证样本数: {len(train_val_ids)}")
     print(f"测试样本数: {len(test_ids)}")
-    
     return train_val_ids, test_ids

--- a/src/data_factory/ID/Id_searcher.py
+++ b/src/data_factory/ID/Id_searcher.py
@@ -1,69 +1,113 @@
-import pandas as pd
+from __future__ import annotations
+
 from ..data_utils import MetadataAccessor
-from .Get_id import Get_DG_ids, Get_CDDG_ids # ,Get_GFS_ids
+from .Get_id import Get_CDDG_ids, Get_DG_ids
+
+
+_ALL_ID_TASK_TYPES = frozenset(
+    {
+        "FS",
+        "GFS",
+        "pretrain",
+        "Pretrain",
+        "generative",
+        "multi_task",
+        "In_distribution",
+    }
+)
+_TASKS_ALLOWING_ALL_SYSTEMS = frozenset({"pretrain", "Pretrain", "generative"})
+_SUPERVISED_TASK_TYPES = frozenset(
+    {"DG", "CDDG", "FS", "GFS", "multi_task", "In_distribution"}
+)
 
 
 def search_ids_for_task(metadata_accessor, args_task):
-    """
-    根据任务参数从元数据中搜索训练/验证和测试ID。
-    """
-    train_val_ids = []
-    test_ids = []
+    """Return the exact train/validation and test IDs for one known task type."""
 
-    if args_task.target_system_id is not None:
-        if args_task.type == 'DG':
-            train_val_ids, test_ids = Get_DG_ids(metadata_accessor, args_task)
-        elif args_task.type == 'CDDG':
-            train_val_ids, test_ids = Get_CDDG_ids(metadata_accessor, args_task)
-        elif args_task.type == 'FS':
-            # Few-shot 学习：在筛选出的目标系统范围内，直接使用全部 ID
-            train_val_ids, test_ids = list(metadata_accessor.keys()), list(metadata_accessor.keys())
-        elif args_task.type == 'GFS':
-            train_val_ids, test_ids = list(metadata_accessor.keys()), list(metadata_accessor.keys())
-        elif args_task.type in ['pretrain', 'Pretrain']:
-            # 对于预训练任务，通常使用全部可用 ID
-            train_val_ids, test_ids = list(metadata_accessor.keys()), list(metadata_accessor.keys())
-        # Add other task types here if needed
-        # elif args_task.type == 'SOME_OTHER_TYPE':
-        #     train_val_ids, test_ids = get_some_other_type_ids(metadata_accessor, args_task)
-        else:
-            # Default or error handling if task type is unknown or not specified for ID searching
-            print(f"Warning: Task type {args_task.type} not specifically handled for ID searching. Defaulting to all keys.")
-            train_val_ids, test_ids = list(metadata_accessor.keys()), list(metadata_accessor.keys())
+    task_type = str(getattr(args_task, "type", "") or "").strip()
+    if not task_type:
+        raise ValueError("task.type must be a non-empty string before selecting data IDs.")
 
+    target_system_id = getattr(args_task, "target_system_id", None)
+    if not target_system_id and task_type not in _TASKS_ALLOWING_ALL_SYSTEMS:
+        raise ValueError(
+            f"task.type={task_type!r} requires a non-empty task.target_system_id. "
+            "Declare the intended system population instead of using all metadata rows."
+        )
+
+    if task_type == "DG":
+        train_val_ids, test_ids = Get_DG_ids(metadata_accessor, args_task)
+    elif task_type == "CDDG":
+        train_val_ids, test_ids = Get_CDDG_ids(metadata_accessor, args_task)
+    elif task_type in _ALL_ID_TASK_TYPES:
+        # These maintained compatibility paths intentionally reuse the selected
+        # metadata population. Their scientific support/query semantics are reviewed
+        # separately; this function must not invent another split.
+        selected_ids = list(metadata_accessor.keys())
+        train_val_ids, test_ids = selected_ids, list(selected_ids)
     else:
-        train_val_ids, test_ids = list(metadata_accessor.keys()), list(metadata_accessor.keys())
-    
+        supported = sorted({"DG", "CDDG", *_ALL_ID_TASK_TYPES})
+        raise ValueError(
+            f"Unknown task.type={task_type!r} for data ID selection. "
+            f"Supported task types: {', '.join(supported)}."
+        )
+
+    if not train_val_ids:
+        raise ValueError(
+            f"task.type={task_type!r} selected no training/validation IDs. "
+            "Check target_system_id, domain settings, labels, and metadata."
+        )
+    if task_type in {"DG", "CDDG"} and not test_ids:
+        raise ValueError(
+            f"task.type={task_type!r} selected no test IDs. "
+            "The requested domain protocol cannot be executed."
+        )
+
     return train_val_ids, test_ids
 
+
 def search_target_dataset_metadata(metadata_accessor, args_task):
-    """
-    根据任务参数筛选目标数据集的元数据。
-    """
-    # 某些任务（如部分 pretrain 配置）可能未显式指定 target_system_id，此时直接返回全部元数据
-    if not hasattr(args_task, 'target_system_id') or not args_task.target_system_id:
-        print("未指定目标数据集ID，返回全部元数据")
-        return metadata_accessor
-    
+    """Select the declared system population without dropping invalid rows silently."""
+
+    task_type = str(getattr(args_task, "type", "") or "").strip()
+    target_system_id = getattr(args_task, "target_system_id", None)
+
+    if not target_system_id:
+        if task_type in _TASKS_ALLOWING_ALL_SYSTEMS:
+            return metadata_accessor
+        raise ValueError(
+            f"task.type={task_type!r} requires task.target_system_id before metadata "
+            "selection."
+        )
+
+    if "Dataset_id" not in metadata_accessor.df.columns:
+        raise ValueError("Metadata must contain a 'Dataset_id' column.")
+
     filtered_df = metadata_accessor.df[
-        metadata_accessor.df['Dataset_id'].isin(args_task.target_system_id)].copy()
-    
+        metadata_accessor.df["Dataset_id"].isin(target_system_id)
+    ].copy()
 
-    # 检查Label是否有空值 
-    filtered_df = filtered_df[filtered_df['Label'].notna()]
+    if filtered_df.empty:
+        raise ValueError(
+            f"task.target_system_id={list(target_system_id)!r} matched no metadata rows."
+        )
 
-    # 检查Label是否有-1
-    filtered_df = filtered_df[filtered_df['Label'] != -1]
+    if task_type in _SUPERVISED_TASK_TYPES:
+        if "Label" not in filtered_df.columns:
+            raise ValueError(
+                f"Supervised task.type={task_type!r} requires metadata column 'Label'."
+            )
+        invalid = filtered_df[filtered_df["Label"].isna() | (filtered_df["Label"] == -1)]
+        if not invalid.empty:
+            invalid_ids = (
+                invalid["Id"].tolist()
+                if "Id" in invalid.columns
+                else invalid.index.tolist()
+            )
+            raise ValueError(
+                "Supervised metadata contains missing or -1 labels for ID(s) "
+                f"{invalid_ids}. Fix the metadata instead of dropping rows."
+            )
 
-    # # 检查是否visiable？
-    # filtered_df = filtered_df[filtered_df['Visible'] == True]
-
-    print(f"筛选前元数据行数: {len(metadata_accessor.df)}")
-    print(f"筛选后元数据行数: {len(filtered_df)}")
-    
-    if len(filtered_df) == 0:
-        print(f"警告: 目标数据集ID {args_task.target_system_id} 没有匹配的记录")
-    
     filtered_df.reset_index(drop=True, inplace=True)
-    target_metadata = MetadataAccessor(filtered_df, key_column=metadata_accessor.key_column)
-    return target_metadata
+    return MetadataAccessor(filtered_df, key_column=metadata_accessor.key_column)

--- a/src/data_factory/dataset_task/Dataset_cluster.py
+++ b/src/data_factory/dataset_task/Dataset_cluster.py
@@ -1,85 +1,71 @@
-import torch
+from __future__ import annotations
+
+from collections.abc import Mapping
+
 from torch.utils.data import Dataset
-# Reference:UniTS
 
 
 class IdIncludedDataset(Dataset):
-    def __init__(self, dataset_dict, metadata=None):
-        """
-        包装一个 PyTorch Dataset 字典，使得每个样本都包含其原始ID。
+    """Flatten per-file datasets while preserving every sample's source file ID."""
 
-        Args:
-            dataset_dict (dict): 一个字典，键是字符串ID，值是 PyTorch Dataset 对象。
-                                 例如：{'id1': train_dataset_for_id1, 'id2': train_dataset_for_id2}
-                                 其中 train_dataset_for_id1 等实例的 __getitem__ 返回 (x, y)。
-        """
-        self.dataset_dict = dataset_dict # 保存对原始数据集字典的引用
-        self.file_windows_list = [] # 用于全局索引到 (id, 原始数据集中的索引) 的映射
-        self.metadata = metadata # 保存元数据，可能包含数据集的其他信息
+    def __init__(self, dataset_dict, metadata=None):
+        if not isinstance(dataset_dict, Mapping) or not dataset_dict:
+            raise ValueError(
+                "IdIncludedDataset requires a non-empty mapping of file IDs to datasets."
+            )
+
+        self.dataset_dict = dict(dataset_dict)
+        self.file_windows_list: list[dict[str, object]] = []
+        self.metadata = metadata
+
         for file_id, original_dataset in self.dataset_dict.items():
             if original_dataset is None:
-                print(f"警告: ID '{file_id}' 对应的 dataset 为 None，已跳过。")
-                continue
-            if len(original_dataset) == 0:
-                print(f"警告: ID '{file_id}' 对应的 dataset 为空，已跳过。")
-                continue
-            # if not isinstance(file_id,str):
-            #     print(f"警告: ID '{file_id}' 不是字符串，已跳过。")
-            #     continue
-            
-            for window_id in range(len(original_dataset)): # 数据集id ，样本id； 样本id 当前数据集的id
-                self.file_windows_list.append({'file_id': file_id, 'window_id': window_id}) # 1,2,3 | 1,2,3,4 ~ 1,2,3,4,5,6,7
-        
-        self._total_samples = len(self.file_windows_list) # 计算所有原始数据集的样本总数
+                raise ValueError(
+                    f"Selected file_id={file_id!r} has no dataset object. "
+                    "Fix dataset construction instead of skipping the file."
+                )
+            sample_count = len(original_dataset)
+            if sample_count == 0:
+                raise ValueError(
+                    f"Selected file_id={file_id!r} produced zero samples. "
+                    "Fix windowing or split configuration instead of skipping the file."
+                )
+
+            for window_id in range(sample_count):
+                self.file_windows_list.append(
+                    {"file_id": file_id, "window_id": window_id}
+                )
+
+        self._total_samples = len(self.file_windows_list)
+        if self._total_samples == 0:
+            raise ValueError("IdIncludedDataset produced zero samples.")
 
     def __len__(self):
-        """
-        返回所有原始数据集中样本的总数。
-        """
         return self._total_samples
+
     def get_file_windows_list(self):
-        """
-        获取文件窗口列表。
-
-        Returns:
-            list: 包含所有样本的文件窗口列表，每个元素是一个字典，包含 'file_id' 和 'Window_id'。
-        """
         return self.file_windows_list
+
     def get_file_id(self, global_idx):
-        """
-        根据全局索引获取文件ID。
-
-        Args:
-            global_idx (int): 全局样本索引。
-
-        Returns:
-            str: 文件ID。
-        """
-        return self.file_windows_list[global_idx]['file_id']
+        return self.file_windows_list[global_idx]["file_id"]
 
     def __getitem__(self, global_idx):
-        """
-        根据全局索引获取样本，并返回 (id, (x, y))。
-
-        Args:
-            global_idx (int): 全局样本索引。
-
-        Returns:
-            tuple: (str, tuple), 即 (id, (x, y))
-                   其中 x 是特征数据, y 是标签。
-        """
         if global_idx < 0 or global_idx >= self._total_samples:
-            raise IndexError(f"全局索引 {global_idx} 超出范围 (总样本数: {self._total_samples})")
+            raise IndexError(
+                f"Global index {global_idx} is outside [0, {self._total_samples})."
+            )
 
         sample_info = self.file_windows_list[global_idx]
+        file_id = sample_info["file_id"]
+        window_id = sample_info["window_id"]
+        original_dataset = self.dataset_dict[file_id]
+        output = original_dataset[window_id]
+        if not isinstance(output, dict):
+            raise TypeError(
+                f"Dataset for file_id={file_id!r} must return a mapping, "
+                f"got {type(output).__name__}."
+            )
 
-        file_id = sample_info['file_id']
-        # dataset_id = self.metadata[data_id]['Dataset_id'] # 获取数据集的ID
-        window_id_in_original_dataset = sample_info['window_id']
-
-        # 从原始数据集中获取 (x, y)
-        original_dataset_instance = self.dataset_dict[file_id]
-        out = original_dataset_instance[window_id_in_original_dataset] # may be (x, y) or (x, y, z)
-
-        out.update({"file_id": file_id}) # 添加 id 信息
-        return  out
+        result = dict(output)
+        result["file_id"] = file_id
+        return result

--- a/src/data_factory/samplers/Get_sampler.py
+++ b/src/data_factory/samplers/Get_sampler.py
@@ -3,6 +3,37 @@
 from .Sampler import HierarchicalFewShotSampler, Same_system_Sampler
 
 
+def _require_metadata_coverage(dataset) -> None:
+    """Require every selected sample to resolve one explicit Dataset_id."""
+
+    windows = getattr(dataset, "file_windows_list", None)
+    if not isinstance(windows, list) or not windows:
+        raise ValueError("Sampler requires a non-empty IdIncludedDataset population.")
+    metadata = getattr(dataset, "metadata", None)
+    if metadata is None:
+        raise ValueError("Sampler requires metadata for every selected file ID.")
+
+    selected_file_ids = {item["file_id"] for item in windows}
+    missing_rows = [file_id for file_id in selected_file_ids if file_id not in metadata]
+    if missing_rows:
+        raise ValueError(
+            "Sampler metadata is missing selected file ID(s) "
+            f"{sorted(missing_rows, key=str)}."
+        )
+
+    missing_systems = [
+        file_id
+        for file_id in selected_file_ids
+        if "Dataset_id" not in metadata[file_id]
+        or metadata[file_id]["Dataset_id"] is None
+    ]
+    if missing_systems:
+        raise ValueError(
+            "Sampler metadata is missing Dataset_id for selected file ID(s) "
+            f"{sorted(missing_systems, key=str)}."
+        )
+
+
 def _evaluation_sampler(args_data, dataset):
     """Keep every validation/test sample, including a final short batch."""
     return Same_system_Sampler(
@@ -35,7 +66,7 @@ def _get_standard_sampler(args_data, dataset, mode, task_name):
             dataset=dataset,
             batch_size=args_data.batch_size,
             shuffle=True,
-            drop_last=True,
+            drop_last=False,
         )
     if mode in {"val", "test"}:
         return _evaluation_sampler(args_data, dataset)
@@ -43,7 +74,9 @@ def _get_standard_sampler(args_data, dataset, mode, task_name):
 
 
 def Get_sampler(args_task, args_data, dataset, mode="train"):
-    """Return the sampler for one explicit task type and split."""
+    """Return the sampler for one explicit task type and complete sample population."""
+
+    _require_metadata_coverage(dataset)
     task_type = args_task.type
 
     if task_type == "GFS":

--- a/src/data_factory/samplers/Get_sampler.py
+++ b/src/data_factory/samplers/Get_sampler.py
@@ -1,6 +1,19 @@
 """Task-aware batch sampler selection."""
 
+from collections.abc import Mapping
+
+import pandas as pd
+
 from .Sampler import HierarchicalFewShotSampler, Same_system_Sampler
+
+
+def _missing_dataset_id(metadata_entry) -> bool:
+    if not isinstance(metadata_entry, Mapping) or "Dataset_id" not in metadata_entry:
+        return True
+    value = metadata_entry["Dataset_id"]
+    if isinstance(value, (list, tuple, set, dict)):
+        return True
+    return bool(pd.isna(value))
 
 
 def _require_metadata_coverage(dataset) -> None:
@@ -24,8 +37,7 @@ def _require_metadata_coverage(dataset) -> None:
     missing_systems = [
         file_id
         for file_id in selected_file_ids
-        if "Dataset_id" not in metadata[file_id]
-        or metadata[file_id]["Dataset_id"] is None
+        if _missing_dataset_id(metadata[file_id])
     ]
     if missing_systems:
         raise ValueError(

--- a/test/test_phmfactory_config_resolver.py
+++ b/test/test_phmfactory_config_resolver.py
@@ -4,7 +4,6 @@ from pathlib import Path
 
 import pytest
 from phmfactory.config import (
-    DEFAULT_PIPELINE,
     MAINTAINED_PRESETS,
     load_config_dict,
     parse_overrides,
@@ -22,6 +21,16 @@ def test_parse_overrides_expands_dotted_keys_and_yaml_types() -> None:
         "task": {"enabled": True},
         "labels": [1, 2],
     }
+
+
+def test_parse_overrides_rejects_malformed_yaml_value() -> None:
+    with pytest.raises(ValueError, match="Invalid YAML value"):
+        parse_overrides(["labels=[1, 2"])
+
+
+def test_parse_overrides_rejects_empty_value() -> None:
+    with pytest.raises(ValueError, match="must be non-empty"):
+        parse_overrides(["trainer.device="])
 
 
 def test_recursive_base_config_merge_is_ordered(tmp_path: Path) -> None:
@@ -68,6 +77,37 @@ def test_resolve_config_canonicalizes_pipeline_and_applies_override(
     assert resolved.path == config.resolve()
 
 
+def test_explicit_config_requires_pipeline(tmp_path: Path) -> None:
+    config = tmp_path / "config.yaml"
+    config.write_text("trainer:\n  max_epochs: 1\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="must declare `pipeline`"):
+        resolve_config(config)
+
+
+def test_pipeline_may_be_supplied_by_explicit_override(tmp_path: Path) -> None:
+    config = tmp_path / "config.yaml"
+    config.write_text("trainer:\n  max_epochs: 1\n", encoding="utf-8")
+
+    resolved = resolve_config(
+        config,
+        override_values=["pipeline=Pipeline_01_Fault_Diagnosis"],
+    )
+
+    assert resolved.pipeline == "Pipeline_01_Fault_Diagnosis"
+    assert resolved.data["pipeline"] == "Pipeline_01_Fault_Diagnosis"
+
+
+def test_non_utf8_config_fails_without_encoding_fallback(tmp_path: Path) -> None:
+    config = tmp_path / "config.yaml"
+    config.write_bytes(
+        b"pipeline: Pipeline_01_Fault_Diagnosis\nnotes: \xff\n"
+    )
+
+    with pytest.raises(UnicodeError, match="must be valid UTF-8"):
+        resolve_config(config)
+
+
 def test_resolve_config_rejects_missing_source(tmp_path: Path) -> None:
     with pytest.raises(FileNotFoundError):
         resolve_config(tmp_path / "missing.yaml")
@@ -83,7 +123,6 @@ def test_maintained_presets_point_to_tracked_configs(
     assert resolve_config_path(preset) == expected
 
 
-
 def test_installed_style_resolution_works_outside_repository(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -95,6 +134,7 @@ def test_installed_style_resolution_works_outside_repository(
     assert resolved.data["data"]["metadata_file"] == "metadata_dummy.csv"
     assert resolved.data["trainer"]["device"] == "cpu"
 
+
 def test_cycle_detection(tmp_path: Path) -> None:
     first = tmp_path / "first.yaml"
     second = tmp_path / "second.yaml"
@@ -103,9 +143,3 @@ def test_cycle_detection(tmp_path: Path) -> None:
 
     with pytest.raises(ValueError, match="Cyclic base_configs"):
         load_config_dict(first)
-
-
-def test_pipeline_defaults_when_omitted(tmp_path: Path) -> None:
-    config = tmp_path / "config.yaml"
-    config.write_text("trainer:\n  max_epochs: 1\n", encoding="utf-8")
-    assert resolve_config(config).pipeline == DEFAULT_PIPELINE

--- a/test/test_protocol_selection_truth.py
+++ b/test/test_protocol_selection_truth.py
@@ -1,0 +1,164 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pandas as pd
+import pytest
+
+from src.data_factory.ID.Get_id import Get_CDDG_ids, Get_DG_ids
+from src.data_factory.ID.Id_searcher import (
+    search_ids_for_task,
+    search_target_dataset_metadata,
+)
+from src.data_factory.data_utils import MetadataAccessor
+
+
+def _metadata(rows) -> MetadataAccessor:
+    return MetadataAccessor(pd.DataFrame(rows).copy(), key_column="Id")
+
+
+def _single_system_rows():
+    return [
+        {"Id": 1, "Dataset_id": 10, "Domain_id": 0, "Label": 0},
+        {"Id": 2, "Dataset_id": 10, "Domain_id": 1, "Label": 1},
+        {"Id": 3, "Dataset_id": 10, "Domain_id": 2, "Label": 0},
+    ]
+
+
+def test_unknown_task_type_does_not_default_to_all_ids() -> None:
+    metadata = _metadata(_single_system_rows())
+    args = SimpleNamespace(type="unknown", target_system_id=[10])
+
+    with pytest.raises(ValueError, match="Unknown task.type"):
+        search_ids_for_task(metadata, args)
+
+
+def test_supervised_task_requires_explicit_target_system() -> None:
+    metadata = _metadata(_single_system_rows())
+    args = SimpleNamespace(type="DG", target_system_id=None)
+
+    with pytest.raises(ValueError, match="requires task.target_system_id"):
+        search_target_dataset_metadata(metadata, args)
+
+
+def test_pretrain_may_explicitly_use_complete_metadata_population() -> None:
+    metadata = _metadata(_single_system_rows())
+    args = SimpleNamespace(type="pretrain", target_system_id=None)
+
+    assert search_target_dataset_metadata(metadata, args) is metadata
+
+
+def test_target_system_must_match_metadata_rows() -> None:
+    metadata = _metadata(_single_system_rows())
+    args = SimpleNamespace(type="DG", target_system_id=[999])
+
+    with pytest.raises(ValueError, match="matched no metadata rows"):
+        search_target_dataset_metadata(metadata, args)
+
+
+@pytest.mark.parametrize("invalid_label", [None, -1])
+def test_supervised_metadata_rejects_invalid_labels(invalid_label) -> None:
+    rows = _single_system_rows()
+    rows[1]["Label"] = invalid_label
+    metadata = _metadata(rows)
+    args = SimpleNamespace(type="DG", target_system_id=[10])
+
+    with pytest.raises(ValueError, match="Fix the metadata instead of dropping rows"):
+        search_target_dataset_metadata(metadata, args)
+
+
+def test_valid_dynamic_dg_split_keeps_one_source_domain() -> None:
+    metadata = _metadata(_single_system_rows())
+    args = SimpleNamespace(
+        type="DG",
+        target_system_id=[10],
+        target_domain_num=1,
+    )
+
+    train_ids, test_ids = Get_DG_ids(metadata, args)
+
+    assert train_ids == [1, 2]
+    assert test_ids == [3]
+
+
+def test_impossible_dynamic_dg_request_fails_instead_of_train_only() -> None:
+    metadata = _metadata(
+        [{"Id": 1, "Dataset_id": 10, "Domain_id": 0, "Label": 0}]
+    )
+    args = SimpleNamespace(
+        type="DG",
+        target_system_id=[10],
+        target_domain_num=1,
+    )
+
+    with pytest.raises(ValueError, match="cannot be satisfied"):
+        Get_DG_ids(metadata, args)
+
+
+def test_explicit_dg_domains_must_be_disjoint_and_available() -> None:
+    metadata = _metadata(_single_system_rows())
+
+    overlapping = SimpleNamespace(
+        type="DG",
+        target_system_id=[10],
+        target_domain_num=0,
+        source_domain_id=[0, 1],
+        target_domain_id=[1, 2],
+    )
+    with pytest.raises(ValueError, match="must be disjoint"):
+        Get_DG_ids(metadata, overlapping)
+
+    missing = SimpleNamespace(
+        type="DG",
+        target_system_id=[10],
+        target_domain_num=0,
+        source_domain_id=[0, 1],
+        target_domain_id=[99],
+    )
+    with pytest.raises(ValueError, match="are absent"):
+        Get_DG_ids(metadata, missing)
+
+
+def test_valid_cddg_reserves_each_systems_last_domain() -> None:
+    rows = []
+    next_id = 1
+    for dataset_id in (10, 20):
+        for domain_id in (0, 1, 2):
+            rows.append(
+                {
+                    "Id": next_id,
+                    "Dataset_id": dataset_id,
+                    "Domain_id": domain_id,
+                    "Label": domain_id % 2,
+                }
+            )
+            next_id += 1
+    metadata = _metadata(rows)
+    args = SimpleNamespace(
+        type="CDDG",
+        target_system_id=[10, 20],
+        target_domain_num=1,
+    )
+
+    train_ids, test_ids = Get_CDDG_ids(metadata, args)
+
+    assert train_ids == [1, 2, 4, 5]
+    assert test_ids == [3, 6]
+
+
+def test_cddg_fails_when_any_system_cannot_keep_a_training_domain() -> None:
+    metadata = _metadata(
+        [
+            {"Id": 1, "Dataset_id": 10, "Domain_id": 0, "Label": 0},
+            {"Id": 2, "Dataset_id": 20, "Domain_id": 0, "Label": 0},
+            {"Id": 3, "Dataset_id": 20, "Domain_id": 1, "Label": 1},
+        ]
+    )
+    args = SimpleNamespace(
+        type="CDDG",
+        target_system_id=[10, 20],
+        target_domain_num=1,
+    )
+
+    with pytest.raises(ValueError, match="at least one training domain must remain"):
+        Get_CDDG_ids(metadata, args)

--- a/test/test_sampler_population_truth.py
+++ b/test/test_sampler_population_truth.py
@@ -53,8 +53,12 @@ def test_sampler_rejects_missing_metadata_row() -> None:
         Get_sampler(args_task, args_data, dataset, mode="train")
 
 
-def test_sampler_rejects_missing_dataset_id() -> None:
-    dataset = IdIncludedDataset({1: DictDataset(2)}, metadata={1: {}})
+@pytest.mark.parametrize("dataset_id", [None, float("nan"), [10]])
+def test_sampler_rejects_missing_or_non_scalar_dataset_id(dataset_id) -> None:
+    dataset = IdIncludedDataset(
+        {1: DictDataset(2)},
+        metadata={1: {"Dataset_id": dataset_id}},
+    )
     args_task, args_data = _args()
 
     with pytest.raises(ValueError, match="missing Dataset_id"):

--- a/test/test_sampler_population_truth.py
+++ b/test/test_sampler_population_truth.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+from torch.utils.data import Dataset
+
+from src.data_factory.dataset_task.Dataset_cluster import IdIncludedDataset
+from src.data_factory.samplers.Get_sampler import Get_sampler
+
+
+class DictDataset(Dataset):
+    def __init__(self, size: int) -> None:
+        self.size = size
+
+    def __len__(self) -> int:
+        return self.size
+
+    def __getitem__(self, index: int):
+        return {"x": index, "y": index % 2}
+
+
+def _args(batch_size: int = 2):
+    return (
+        SimpleNamespace(type="DG"),
+        SimpleNamespace(batch_size=batch_size),
+    )
+
+
+def test_id_included_dataset_rejects_empty_population() -> None:
+    with pytest.raises(ValueError, match="non-empty mapping"):
+        IdIncludedDataset({}, metadata={})
+
+
+def test_id_included_dataset_rejects_missing_dataset_object() -> None:
+    with pytest.raises(ValueError, match="has no dataset object"):
+        IdIncludedDataset({1: None}, metadata={1: {"Dataset_id": 10}})
+
+
+def test_id_included_dataset_rejects_zero_sample_file() -> None:
+    with pytest.raises(ValueError, match="produced zero samples"):
+        IdIncludedDataset(
+            {1: DictDataset(0)},
+            metadata={1: {"Dataset_id": 10}},
+        )
+
+
+def test_sampler_rejects_missing_metadata_row() -> None:
+    dataset = IdIncludedDataset({1: DictDataset(2)}, metadata={})
+    args_task, args_data = _args()
+
+    with pytest.raises(ValueError, match="missing selected file ID"):
+        Get_sampler(args_task, args_data, dataset, mode="train")
+
+
+def test_sampler_rejects_missing_dataset_id() -> None:
+    dataset = IdIncludedDataset({1: DictDataset(2)}, metadata={1: {}})
+    args_task, args_data = _args()
+
+    with pytest.raises(ValueError, match="missing Dataset_id"):
+        Get_sampler(args_task, args_data, dataset, mode="train")
+
+
+def test_training_sampler_keeps_final_short_batch() -> None:
+    dataset = IdIncludedDataset(
+        {1: DictDataset(3)},
+        metadata={1: {"Dataset_id": 10}},
+    )
+    args_task, args_data = _args(batch_size=2)
+
+    batches = list(Get_sampler(args_task, args_data, dataset, mode="train"))
+
+    assert sorted(len(batch) for batch in batches) == [1, 2]
+    assert sorted(index for batch in batches for index in batch) == [0, 1, 2]
+
+
+def test_sampler_represents_every_selected_system() -> None:
+    dataset = IdIncludedDataset(
+        {
+            1: DictDataset(1),
+            2: DictDataset(2),
+        },
+        metadata={
+            1: {"Dataset_id": 10},
+            2: {"Dataset_id": 20},
+        },
+    )
+    args_task, args_data = _args(batch_size=4)
+
+    batches = list(Get_sampler(args_task, args_data, dataset, mode="train"))
+    represented_file_ids = {
+        dataset.get_file_id(index)
+        for batch in batches
+        for index in batch
+    }
+
+    assert represented_file_ids == {1, 2}
+    assert sum(len(batch) for batch in batches) == len(dataset)


### PR DESCRIPTION
## Goal

Make the maintained configuration and ordinary classification data path execute exactly the user-declared experiment population.

## Scientific invariants

```text
explicit experiment -> explicit pipeline
requested IDs = selected IDs = materialized dataset IDs = sampler population
requested domain protocol = executed domain protocol
```

## Changes

- reject explicit configs that do not declare `pipeline`;
- reject malformed or empty CLI override values instead of converting them to strings;
- reject non-UTF-8 configuration files instead of lossy decoding;
- reject unknown task types and missing target-system declarations;
- reject missing/-1 supervised labels instead of silently deleting rows;
- reject impossible DG/CDDG target-domain requests instead of shrinking the request or producing train-only runs;
- reject empty or missing per-file datasets instead of skipping selected files;
- require metadata and scalar `Dataset_id` coverage for every selected file;
- keep final short training batches so selected small systems are not silently removed.

## Focused tests added/updated

```text
test/test_phmfactory_config_resolver.py
test/test_protocol_selection_truth.py
test/test_sampler_population_truth.py
```

## Explicit non-goals

- no hash/checksum/digest/receipt/ledger/integrity machinery;
- no new Factory/Manager/Adapter/Registry/Schema layer;
- no model, loss, Trainer, Pipeline 02, UI, release, or external-dataset changes;
- no claim that MFPT/SEU/PU/CWRU numerical experiments have been executed.

## Acceptance commands

```bash
python -m pytest -q \
  test/test_phmfactory_config_resolver.py \
  test/test_protocol_selection_truth.py \
  test/test_sampler_population_truth.py \
  test/test_data_cache_contract.py \
  test/test_split_scientific_truth.py \
  test/test_transform_truth.py

python -m phmfactory preflight --config smoke
python -m phmfactory demo
```

## Review basis

Derived from the 140-review synthesis in `reviews/2026-08-11`, especially CFG-01/02 and DATA-06/07/08/10/11.