### PR TITLE
feat(p05): add no-bypass F0 decision path

### DIFF
--- a/src/model_factory/X_model/TSPN.py
+++ b/src/model_factory/X_model/TSPN.py
@@ -42,6 +42,9 @@ class Model(nn.Module):
         self.signal_processing_modules, self.feature_extractor_modules = self.config_network(args)
         self.layer_num = len(self.signal_processing_modules)
         self.args = args
+        self.internal_instance_normalization = bool(
+            getattr(args, "internal_instance_normalization", True)
+        )
 
         self.init_signal_processing_layers()
         self.init_feature_extractor_layers()
@@ -82,8 +85,9 @@ class Model(nn.Module):
         for i in range(self.layer_num):
             self.signal_processing_layers.append(SignalProcessingLayer(self.signal_processing_modules[i],
                                                                        in_channels,
-                                                                         out_channels,
-                                                                         self.args.skip_connection).to(self.args.device))
+                                                                       out_channels,
+                                                                       self.args.skip_connection,
+                                                                       self.internal_instance_normalization).to(self.args.device))
             in_channels = out_channels 
             assert out_channels % self.signal_processing_layers[i].module_num == 0 
             # out_channels = int(out_channels * self.args.scale)
@@ -91,7 +95,12 @@ class Model(nn.Module):
 
     def init_feature_extractor_layers(self):
         print('# build feature extractor layers')
-        self.feature_extractor_layers = FeatureExtractorlayer(self.feature_extractor_modules,self.channel_for_feature,self.channel_for_feature).to(self.args.device)
+        self.feature_extractor_layers = FeatureExtractorlayer(
+            self.feature_extractor_modules,
+            self.channel_for_feature,
+            self.channel_for_feature,
+            self.internal_instance_normalization,
+        ).to(self.args.device)
         len_feature = len(self.feature_extractor_modules)
         self.channel_for_classifier = self.channel_for_feature * len_feature
 
@@ -146,9 +155,20 @@ class CustomBatchNorm(nn.Module):
 
 class SignalProcessingLayer(nn.Module):
     # TODO op first then weight connection -> attention
-    def __init__(self, signal_processing_modules, input_channels, output_channels,skip_connection=True):
+    def __init__(
+        self,
+        signal_processing_modules,
+        input_channels,
+        output_channels,
+        skip_connection=True,
+        internal_instance_normalization=True,
+    ):
         super(SignalProcessingLayer, self).__init__()
-        self.norm = nn.InstanceNorm1d(input_channels)
+        self.norm = (
+            nn.InstanceNorm1d(input_channels)
+            if internal_instance_normalization
+            else nn.Identity()
+        )
         self.weight_connection = nn.Linear(input_channels, output_channels)
         self.signal_processing_modules = signal_processing_modules
         self.module_num = len(signal_processing_modules)
@@ -163,9 +183,14 @@ class SignalProcessingLayer(nn.Module):
         normed_x = rearrange(normed_x, 'b c l -> b l c')
         # 通过线性层
         
-        self.weight_connection.weight.data = F.softmax((1.0 / self.temperature) *
-                                                       self.weight_connection.weight.data, dim=0)
-        x = self.weight_connection(normed_x)
+        # Normalize for this forward without mutating the parameter. In-place
+        # ``weight.data`` replacement made consecutive interventions consume
+        # different backbones and bypassed autograd's actual parameter path.
+        normalized_weight = F.softmax(
+            self.weight_connection.weight / self.temperature,
+            dim=0,
+        )
+        x = F.linear(normed_x, normalized_weight, self.weight_connection.bias)
 
         # 按模块数拆分
         splits = torch.split(x, x.size(2) // self.module_num, dim=2)
@@ -183,14 +208,24 @@ class SignalProcessingLayer(nn.Module):
         return x
     
 class FeatureExtractorlayer(nn.Module):
-    def __init__(self, feature_extractor_modules,in_channels=1, out_channels=1):
+    def __init__(
+        self,
+        feature_extractor_modules,
+        in_channels=1,
+        out_channels=1,
+        internal_instance_normalization=True,
+    ):
         super(FeatureExtractorlayer, self).__init__()
         self.weight_connection = nn.Linear(in_channels, out_channels)
         self.feature_extractor_modules = feature_extractor_modules
         
         out_channels = int(len(feature_extractor_modules) * out_channels)
         
-        self.pre_norm = nn.InstanceNorm1d(in_channels)
+        self.pre_norm = (
+            nn.InstanceNorm1d(in_channels)
+            if internal_instance_normalization
+            else nn.Identity()
+        )
         self.norm = CustomBatchNorm(out_channels)
         
         # self.temperature = 1
@@ -213,7 +248,7 @@ class FeatureExtractorlayer(nn.Module):
         outputs = []
         for module in self.feature_extractor_modules.values():
             outputs.append(module(x))
-        res = torch.cat(outputs, dim=1).squeeze() # B,C
+        res = torch.cat(outputs, dim=1).squeeze(-1) # B,C
         return self.norm(res)
 
 class Classifier(nn.Module):

--- a/src/model_factory/X_model/TSPN_UXFD.py
+++ b/src/model_factory/X_model/TSPN_UXFD.py
@@ -13,7 +13,7 @@ Implementation note:
 
 from __future__ import annotations
 
-from dataclasses import asdict
+from dataclasses import asdict, dataclass
 from numbers import Integral
 from typing import Any, Dict, Optional
 
@@ -22,11 +22,43 @@ import torch.nn as nn
 
 from .TSPN import Model as _TSPNModel
 from .UXFD.fusion import FusionConfig, build_fusion
-from .UXFD.fuzzy import FuzzyConfig, FuzzyReasoner
+from .UXFD.fuzzy import (
+    FuzzyConfig,
+    FuzzyReasoner,
+    FuzzyTrace,
+    P05F0Decision,
+)
 from .UXFD.neurosymbolic import LogicConfig, LogicReasoner
 from .UXFD.operator_attention import OperatorAttention1D, OperatorAttentionConfig
 from .UXFD.signal_processing_2d import STFTTimeFrequency
 from .UXFD.signal_processing_2d.stft_tfr import STFTConfig
+
+
+@dataclass(frozen=True)
+class FuzzyTraceOutput:
+    """Complete same-forward reconstruction record for the additive control."""
+
+    logits: torch.Tensor
+    non_fuzzy_logits: torch.Tensor
+    fuzzy_scale: float
+    fuzzy_trace: FuzzyTrace
+
+    def scaled_rule_contributions(self) -> torch.Tensor:
+        return self.fuzzy_trace.rule_contributions * float(self.fuzzy_scale)
+
+    def reconstruct_logits(self) -> torch.Tensor:
+        return self.non_fuzzy_logits + self.scaled_rule_contributions().sum(dim=1)
+
+    def reconstruction_residual(self) -> torch.Tensor:
+        return self.logits - self.reconstruct_logits()
+
+
+@dataclass(frozen=True)
+class P05FeatureLogitOutput:
+    """Features and additive-control logits from one shared model forward."""
+
+    reduced_features: torch.Tensor
+    logits: torch.Tensor
 
 
 class Model(_TSPNModel):
@@ -106,30 +138,113 @@ class Model(_TSPNModel):
             self._uxfd_logic_scale = float(getattr(logic_cfg, "logit_scale", 1.0))
 
     def forward(self, x: torch.Tensor, data_id=None, task_id=None) -> torch.Tensor:
-        features_1d = self._forward_1d_features(x)  # (B, D)
-        features = features_1d
+        return self.forward_with_features(
+            x,
+            data_id=data_id,
+            task_id=task_id,
+        ).logits
 
-        if self._uxfd_enable_sp2d:
-            assert self._uxfd_sp2d is not None
-            assert self._uxfd_2d_proj is not None
-            assert self._uxfd_fusion is not None
+    def forward_with_features(
+        self,
+        x: torch.Tensor,
+        data_id=None,
+        task_id=None,
+    ) -> P05FeatureLogitOutput:
+        """Return the shared feature tensor and additive-control logits."""
 
-            x2d = self._uxfd_sp2d(x)  # (B, T, F, C) magnitude
-            pooled = x2d.mean(dim=(1, 2))  # (B, C)
-            proj = self._uxfd_2d_proj(pooled)  # (B, D)
-            features = self._uxfd_fusion(features_1d, proj)  # (B, D)
+        features = self._forward_features(x)
+        logits = self._forward_logits_from_features(features)
+        return P05FeatureLogitOutput(
+            reduced_features=features,
+            logits=logits,
+        )
 
-        base_logits = self.clf(features)
-        logits = base_logits
+    def _forward_logits_from_features(self, features: torch.Tensor) -> torch.Tensor:
+        logits = self._forward_non_fuzzy_logits(features)
         if self._uxfd_enable_fuzzy:
             assert self._uxfd_fuzzy is not None
             fuzzy_logits = self._uxfd_fuzzy(features)
             logits = logits + self._uxfd_fuzzy_scale * fuzzy_logits
+        return logits
+
+    def forward_with_fuzzy_trace(
+        self,
+        x: torch.Tensor,
+        *,
+        rule_mask: Optional[torch.Tensor] = None,
+        consequent_permutation: Optional[torch.Tensor] = None,
+        data_id=None,
+        task_id=None,
+    ) -> FuzzyTraceOutput:
+        """Return the additive-control prediction and exact fuzzy trace."""
+
+        if not self._uxfd_enable_fuzzy or self._uxfd_fuzzy is None:
+            raise RuntimeError(
+                "forward_with_fuzzy_trace requires model.uxfd.fuzzy.enable=true."
+            )
+        features = self._forward_features(x)
+        non_fuzzy_logits = self._forward_non_fuzzy_logits(features)
+        fuzzy_trace = self._uxfd_fuzzy.forward_with_trace(
+            features,
+            rule_mask=rule_mask,
+            consequent_permutation=consequent_permutation,
+        )
+        logits = non_fuzzy_logits + self._uxfd_fuzzy_scale * fuzzy_trace.fuzzy_logits
+        return FuzzyTraceOutput(
+            logits=logits,
+            non_fuzzy_logits=non_fuzzy_logits,
+            fuzzy_scale=float(self._uxfd_fuzzy_scale),
+            fuzzy_trace=fuzzy_trace,
+        )
+
+    def forward_f0(
+        self,
+        x: torch.Tensor,
+        *,
+        rule_to_class: torch.Tensor,
+        conflict_threshold: float,
+        rule_mask: Optional[torch.Tensor] = None,
+        consequent_override: Optional[torch.Tensor] = None,
+        data_id=None,
+        task_id=None,
+    ) -> P05F0Decision:
+        """Issue P05 F0 directly from memberships and minimum-t-norm rules.
+
+        The classifier and logic heads are deliberately not called. They remain
+        available to the additive control path used by B0/B1-style comparisons.
+        """
+
+        if not self._uxfd_enable_fuzzy or self._uxfd_fuzzy is None:
+            raise RuntimeError("forward_f0 requires model.uxfd.fuzzy.enable=true.")
+        features = self._forward_features(x)
+        return self._uxfd_fuzzy.forward_f0(
+            features,
+            rule_to_class=rule_to_class,
+            conflict_threshold=conflict_threshold,
+            rule_mask=rule_mask,
+            consequent_override=consequent_override,
+        )
+
+    def _forward_non_fuzzy_logits(self, features: torch.Tensor) -> torch.Tensor:
+        logits = self.clf(features)
         if self._uxfd_enable_logic:
             assert self._uxfd_logic is not None
             logic_logits = self._uxfd_logic(features)
             logits = logits + self._uxfd_logic_scale * logic_logits
         return logits
+
+    def _forward_features(self, x: torch.Tensor) -> torch.Tensor:
+        features_1d = self._forward_1d_features(x)
+        if not self._uxfd_enable_sp2d:
+            return features_1d
+
+        assert self._uxfd_sp2d is not None
+        assert self._uxfd_2d_proj is not None
+        assert self._uxfd_fusion is not None
+        x2d = self._uxfd_sp2d(x)
+        pooled = x2d.mean(dim=(1, 2))
+        projected = self._uxfd_2d_proj(pooled)
+        return self._uxfd_fusion(features_1d, projected)
 
     def _forward_1d_features(self, x: torch.Tensor) -> torch.Tensor:
         if self._uxfd_enable_operator_attention:

--- a/src/model_factory/X_model/UXFD/fuzzy/__init__.py
+++ b/src/model_factory/X_model/UXFD/fuzzy/__init__.py
@@ -1,8 +1,15 @@
 """Fuzzy logic operators (UXFD)."""
 
-from .fuzzy_reasoner import FuzzyConfig, FuzzyReasoner
+from .fuzzy_reasoner import (
+    FuzzyConfig,
+    FuzzyReasoner,
+    FuzzyTrace,
+    P05F0Decision,
+)
 
 __all__ = [
     "FuzzyConfig",
     "FuzzyReasoner",
+    "FuzzyTrace",
+    "P05F0Decision",
 ]

--- a/src/model_factory/X_model/UXFD/fuzzy/fuzzy_reasoner.py
+++ b/src/model_factory/X_model/UXFD/fuzzy/fuzzy_reasoner.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import math
 from dataclasses import dataclass
 from typing import Optional
 
@@ -10,62 +11,510 @@ import torch.nn.functional as F
 
 @dataclass(frozen=True)
 class FuzzyConfig:
-    num_fuzzy_features: int = 32
-    num_membership_functions: int = 3  # low/medium/high (Gaussian)
+    num_fuzzy_features: int = 8
+    num_membership_functions: int = 3
     num_rules: int = 10
     logit_scale: float = 1.0
+    antecedent_temperature: float = 1.0
+    min_width: float = 1.0e-4
+    firing_epsilon: float = 1.0e-12
+
+
+@dataclass(frozen=True)
+class FuzzyTrace:
+    """All tensors needed to reconstruct the additive fuzzy branch."""
+
+    reduced_features: torch.Tensor
+    membership_values: torch.Tensor
+    centers: torch.Tensor
+    widths: torch.Tensor
+    antecedent_probabilities: torch.Tensor
+    antecedent_memberships: torch.Tensor
+    log_rule_firing: torch.Tensor
+    rule_firing: torch.Tensor
+    normalized_rule_firing: torch.Tensor
+    rule_consequents: torch.Tensor
+    rule_contributions: torch.Tensor
+    fuzzy_logits: torch.Tensor
+    rule_mask: torch.Tensor
+    consequent_permutation: torch.Tensor
+
+    def reconstruct_fuzzy_logits(self) -> torch.Tensor:
+        return self.rule_contributions.sum(dim=1)
+
+    def reconstruction_residual(self) -> torch.Tensor:
+        return self.fuzzy_logits - self.reconstruct_fuzzy_logits()
+
+    def normalized_firing_entropy(self) -> torch.Tensor:
+        weights = self.normalized_rule_firing.clamp_min(
+            torch.finfo(self.fuzzy_logits.dtype).tiny
+        )
+        entropy = -(weights * weights.log()).sum(dim=1)
+        num_rules = int(weights.shape[1])
+        if num_rules <= 1:
+            return torch.zeros_like(entropy)
+        return entropy / math.log(num_rules)
+
+    def top_rule_share(self) -> torch.Tensor:
+        return self.normalized_rule_firing.max(dim=1).values
+
+
+@dataclass(frozen=True)
+class P05F0Decision:
+    """No-bypass F0 decision and the exact tensors it consumed.
+
+    ``issued_class`` uses ``-1`` for abstention. It is derived only from the
+    membership/rule path represented here; neural logits and learned vector
+    consequents are not inputs to this record.
+    """
+
+    reduced_features: torch.Tensor
+    membership_values: torch.Tensor
+    antecedent_probabilities: torch.Tensor
+    antecedent_memberships: torch.Tensor
+    rule_activations: torch.Tensor
+    rule_mask: torch.Tensor
+    rule_to_class: torch.Tensor
+    class_supports: torch.Tensor
+    top_support: torch.Tensor
+    second_support: torch.Tensor
+    conflict: torch.Tensor
+    candidate_class: torch.Tensor
+    accepted: torch.Tensor
+    issued_class: torch.Tensor
+    conflict_threshold: float
+
+    @property
+    def abstained(self) -> torch.Tensor:
+        return ~self.accepted
+
+
+@dataclass(frozen=True)
+class _AntecedentState:
+    reduced_features: torch.Tensor
+    membership_values: torch.Tensor
+    centers: torch.Tensor
+    widths: torch.Tensor
+    antecedent_probabilities: torch.Tensor
+    antecedent_memberships: torch.Tensor
 
 
 class FuzzyReasoner(nn.Module):
-    """A small fuzzy-rule head over a feature vector.
+    """Learned fuzzy terms with separate legacy and no-bypass decision heads.
 
-    Input:  (B, D)
-    Output: (B, num_classes) logits (to be added to a base classifier).
+    The additive head remains available for training and control baselines. F0
+    instead applies a minimum t-norm to the same antecedent memberships, keeps
+    raw rule activations unnormalized, aggregates support with a per-class max,
+    and abstains when support is absent or conflict exceeds the supplied
+    threshold.
     """
 
-    def __init__(self, dim_in: int, num_classes: int, cfg: Optional[FuzzyConfig] = None):
+    def __init__(
+        self,
+        dim_in: int,
+        num_classes: int,
+        cfg: Optional[FuzzyConfig] = None,
+    ):
         super().__init__()
         self.cfg = cfg or FuzzyConfig()
+        self._validate_config(dim_in=dim_in, num_classes=num_classes)
+        self.num_classes = int(num_classes)
 
-        self.feature_reducer = nn.Sequential(
-            nn.Linear(dim_in, int(self.cfg.num_fuzzy_features)),
-            nn.ReLU(inplace=True),
+        num_features = int(self.cfg.num_fuzzy_features)
+        num_memberships = int(self.cfg.num_membership_functions)
+        num_rules = int(self.cfg.num_rules)
+
+        if num_features == int(dim_in):
+            self.feature_reducer = nn.LayerNorm(num_features)
+        else:
+            self.feature_reducer = nn.Sequential(
+                nn.Linear(int(dim_in), num_features),
+                nn.LayerNorm(num_features),
+            )
+
+        initial_centers = (
+            torch.zeros(1)
+            if num_memberships == 1
+            else torch.linspace(-1.0, 1.0, steps=num_memberships)
+        )
+        initial_centers = initial_centers.repeat(num_features, 1)
+        self.center_origin = nn.Parameter(initial_centers[:, :1].clone())
+        if num_memberships > 1:
+            initial_gap = float(2.0 / (num_memberships - 1))
+            inverse_softplus_gap = math.log(math.expm1(initial_gap))
+            self.center_deltas_unconstrained = nn.Parameter(
+                torch.full(
+                    (num_features, num_memberships - 1),
+                    inverse_softplus_gap,
+                )
+            )
+        else:
+            self.register_parameter("center_deltas_unconstrained", None)
+
+        initial_width = 0.75
+        inverse_softplus_width = math.log(
+            math.expm1(max(initial_width - float(self.cfg.min_width), 1.0e-6))
+        )
+        self.widths_unconstrained = nn.Parameter(
+            torch.full(
+                (num_features, num_memberships),
+                inverse_softplus_width,
+            )
         )
 
-        f = int(self.cfg.num_fuzzy_features)
-        m = int(self.cfg.num_membership_functions)
-        r = int(self.cfg.num_rules)
-        k = int(num_classes)
+        antecedent_logits = torch.full(
+            (num_rules, num_features, num_memberships),
+            -2.0,
+        )
+        rule_index = torch.arange(num_rules).unsqueeze(1)
+        feature_index = torch.arange(num_features).unsqueeze(0)
+        initial_terms = (rule_index + feature_index) % num_memberships
+        antecedent_logits.scatter_(2, initial_terms.unsqueeze(-1), 2.0)
+        self.antecedent_logits = nn.Parameter(antecedent_logits)
 
-        self.centers = nn.Parameter(torch.randn(f, m) * 0.5)
-        self.widths = nn.Parameter(torch.ones(f, m) * 0.3)
-        self.rule_weights = nn.Parameter(torch.ones(r, f) / max(1, f))
-        self.rule_outputs = nn.Parameter(torch.randn(r, k) * 0.1)
-
-        self.classifier = nn.Sequential(
-            nn.Linear(k, 64),
-            nn.ReLU(inplace=True),
-            nn.Linear(64, k),
+        self.rule_consequents = nn.Parameter(
+            torch.randn(num_rules, self.num_classes) * 0.1
         )
 
     def forward(self, features: torch.Tensor) -> torch.Tensor:
-        reduced = self.feature_reducer(features)  # (B, F)
-        membership = self._compute_membership(reduced)  # (B, F, M)
-        fuzzy_logits = self._apply_rules(membership)  # (B, K)
-        return self.classifier(fuzzy_logits)
+        return self.forward_with_trace(features).fuzzy_logits
 
-    def _compute_membership(self, x: torch.Tensor) -> torch.Tensor:
-        x_expanded = x.unsqueeze(-1)  # (B, F, 1)
-        centers = self.centers.unsqueeze(0)  # (1, F, M)
-        widths = torch.abs(self.widths).unsqueeze(0).clamp_min(1e-6)  # (1, F, M)
-        return torch.exp(-((x_expanded - centers) ** 2) / (2.0 * widths**2))
+    def forward_with_trace(
+        self,
+        features: torch.Tensor,
+        *,
+        rule_mask: Optional[torch.Tensor] = None,
+        consequent_permutation: Optional[torch.Tensor] = None,
+    ) -> FuzzyTrace:
+        """Return the reconstructable additive control-head trace."""
 
-    def _apply_rules(self, membership: torch.Tensor) -> torch.Tensor:
-        aggregated = membership.mean(dim=2)  # (B, F)
-        activation = torch.sum(
-            aggregated.unsqueeze(1) * self.rule_weights.unsqueeze(0),
-            dim=2,
-        )  # (B, R)
-        activation = F.softmax(activation, dim=-1)
-        outputs = activation.unsqueeze(-1) * self.rule_outputs.unsqueeze(0)  # (B, R, K)
-        return outputs.sum(dim=1)
+        state = self._antecedent_state(features)
+        log_rule_firing = state.antecedent_memberships.clamp_min(
+            float(self.cfg.firing_epsilon)
+        ).log().mean(dim=-1)
+        rule_firing = log_rule_firing.exp()
+
+        normalized_mask = self._normalize_rule_mask(
+            rule_mask,
+            batch_size=int(features.shape[0]),
+            device=features.device,
+            require_support=True,
+        )
+        masked_log_firing = log_rule_firing.masked_fill(
+            ~normalized_mask,
+            -torch.inf,
+        )
+        normalized_rule_firing = F.softmax(masked_log_firing, dim=-1)
+
+        permutation = self._normalize_consequent_permutation(
+            consequent_permutation,
+            batch_size=int(features.shape[0]),
+            device=features.device,
+        )
+        if permutation.ndim == 1:
+            consequents = self.rule_consequents.index_select(0, permutation)
+            contribution_consequents = consequents.unsqueeze(0)
+        else:
+            consequents = self.rule_consequents[permutation]
+            contribution_consequents = consequents
+        rule_contributions = (
+            normalized_rule_firing.unsqueeze(-1) * contribution_consequents
+        )
+        fuzzy_logits = rule_contributions.sum(dim=1)
+
+        return FuzzyTrace(
+            reduced_features=state.reduced_features,
+            membership_values=state.membership_values,
+            centers=state.centers,
+            widths=state.widths,
+            antecedent_probabilities=state.antecedent_probabilities,
+            antecedent_memberships=state.antecedent_memberships,
+            log_rule_firing=log_rule_firing,
+            rule_firing=rule_firing,
+            normalized_rule_firing=normalized_rule_firing,
+            rule_consequents=consequents,
+            rule_contributions=rule_contributions,
+            fuzzy_logits=fuzzy_logits,
+            rule_mask=normalized_mask,
+            consequent_permutation=permutation,
+        )
+
+    def forward_f0(
+        self,
+        features: torch.Tensor,
+        *,
+        rule_to_class: torch.Tensor,
+        conflict_threshold: float,
+        rule_mask: Optional[torch.Tensor] = None,
+        consequent_override: Optional[torch.Tensor] = None,
+    ) -> P05F0Decision:
+        """Issue F0 class/abstention from the rule path only.
+
+        ``rule_to_class`` is the frozen training-only consequent mapping.
+        ``consequent_override`` is an explicit intervention mapping and never a
+        fallback. An all-false rule mask is valid and produces abstention.
+        """
+
+        threshold = self._validate_conflict_threshold(conflict_threshold)
+        state = self._antecedent_state(features)
+        batch_size = int(features.shape[0])
+        mask = self._normalize_rule_mask(
+            rule_mask,
+            batch_size=batch_size,
+            device=features.device,
+            require_support=False,
+        )
+        effective_mapping = self._normalize_rule_to_class(
+            consequent_override if consequent_override is not None else rule_to_class,
+            batch_size=batch_size,
+            device=features.device,
+        )
+
+        # This tensor is the F0 t-norm output. It is deliberately neither a
+        # geometric mean nor softmax-normalized.
+        raw_activations = state.antecedent_memberships.amin(dim=-1)
+        rule_activations = raw_activations.masked_fill(~mask, 0.0)
+
+        supports = []
+        for class_id in range(self.num_classes):
+            class_rule_activations = rule_activations.masked_fill(
+                effective_mapping.ne(class_id),
+                0.0,
+            )
+            supports.append(class_rule_activations.max(dim=1).values)
+        class_supports = torch.stack(supports, dim=1)
+
+        top_support, candidate_class = class_supports.max(dim=1)
+        second_support = class_supports.topk(k=2, dim=1).values[:, 1]
+        epsilon = float(self.cfg.firing_epsilon)
+        conflict = (second_support + epsilon) / (top_support + epsilon)
+        no_support = top_support <= 0.0
+        conflict = torch.where(no_support, torch.ones_like(conflict), conflict)
+        accepted = (~no_support) & (conflict <= threshold)
+        issued_class = torch.where(
+            accepted,
+            candidate_class,
+            torch.full_like(candidate_class, -1),
+        )
+
+        return P05F0Decision(
+            reduced_features=state.reduced_features,
+            membership_values=state.membership_values,
+            antecedent_probabilities=state.antecedent_probabilities,
+            antecedent_memberships=state.antecedent_memberships,
+            rule_activations=rule_activations,
+            rule_mask=mask,
+            rule_to_class=effective_mapping,
+            class_supports=class_supports,
+            top_support=top_support,
+            second_support=second_support,
+            conflict=conflict,
+            candidate_class=candidate_class,
+            accepted=accepted,
+            issued_class=issued_class,
+            conflict_threshold=threshold,
+        )
+
+    def _antecedent_state(self, features: torch.Tensor) -> _AntecedentState:
+        if features.ndim != 2:
+            raise ValueError(
+                "FuzzyReasoner expects features with shape (batch, dim), "
+                f"got {tuple(features.shape)}."
+            )
+        if int(features.shape[0]) <= 0:
+            raise ValueError("FuzzyReasoner requires a non-empty batch.")
+
+        reduced = self.feature_reducer(features)
+        centers = self._ordered_centers()
+        widths = F.softplus(self.widths_unconstrained) + float(self.cfg.min_width)
+        membership = self._compute_membership(
+            reduced,
+            centers=centers,
+            widths=widths,
+        )
+        temperature = float(self.cfg.antecedent_temperature)
+        antecedent_probabilities = F.softmax(
+            self.antecedent_logits / temperature,
+            dim=-1,
+        )
+        antecedent_memberships = torch.einsum(
+            "bfm,rfm->brf",
+            membership,
+            antecedent_probabilities,
+        )
+        return _AntecedentState(
+            reduced_features=reduced,
+            membership_values=membership,
+            centers=centers,
+            widths=widths,
+            antecedent_probabilities=antecedent_probabilities,
+            antecedent_memberships=antecedent_memberships,
+        )
+
+    def _ordered_centers(self) -> torch.Tensor:
+        if self.center_deltas_unconstrained is None:
+            return self.center_origin
+        positive_deltas = F.softplus(self.center_deltas_unconstrained)
+        return torch.cat(
+            (
+                self.center_origin,
+                self.center_origin + positive_deltas.cumsum(dim=1),
+            ),
+            dim=1,
+        )
+
+    @staticmethod
+    def _compute_membership(
+        x: torch.Tensor,
+        *,
+        centers: torch.Tensor,
+        widths: torch.Tensor,
+    ) -> torch.Tensor:
+        standardized = (
+            x.unsqueeze(-1) - centers.unsqueeze(0)
+        ) / widths.unsqueeze(0)
+        return torch.exp(-0.5 * standardized.square())
+
+    def _normalize_rule_mask(
+        self,
+        rule_mask: Optional[torch.Tensor],
+        *,
+        batch_size: int,
+        device: torch.device,
+        require_support: bool,
+    ) -> torch.Tensor:
+        num_rules = int(self.cfg.num_rules)
+        if rule_mask is None:
+            return torch.ones(
+                (batch_size, num_rules),
+                dtype=torch.bool,
+                device=device,
+            )
+
+        mask = torch.as_tensor(rule_mask, device=device)
+        if mask.ndim == 1:
+            if tuple(mask.shape) != (num_rules,):
+                raise ValueError(
+                    "rule_mask with one dimension must have shape "
+                    f"({num_rules},), got {tuple(mask.shape)}."
+                )
+            mask = mask.unsqueeze(0).expand(batch_size, -1)
+        elif tuple(mask.shape) != (batch_size, num_rules):
+            raise ValueError(
+                "rule_mask must have shape "
+                f"({num_rules},) or ({batch_size}, {num_rules}), "
+                f"got {tuple(mask.shape)}."
+            )
+
+        mask = mask.to(dtype=torch.bool)
+        if require_support and not bool(mask.any(dim=1).all()):
+            raise ValueError(
+                "rule_mask must retain at least one rule for every additive-head sample."
+            )
+        return mask
+
+    def _normalize_rule_to_class(
+        self,
+        mapping: torch.Tensor,
+        *,
+        batch_size: int,
+        device: torch.device,
+    ) -> torch.Tensor:
+        num_rules = int(self.cfg.num_rules)
+        raw_values = torch.as_tensor(mapping, device=device)
+        if raw_values.dtype == torch.bool:
+            raise TypeError("rule_to_class must contain integer class IDs, not booleans.")
+        if raw_values.is_floating_point():
+            if not bool(torch.isfinite(raw_values).all()) or not torch.equal(
+                raw_values,
+                raw_values.round(),
+            ):
+                raise ValueError("rule_to_class must contain finite integer class IDs.")
+        values = raw_values.to(dtype=torch.long)
+        if values.ndim == 1:
+            if tuple(values.shape) != (num_rules,):
+                raise ValueError(
+                    f"rule_to_class must have shape ({num_rules},), "
+                    f"got {tuple(values.shape)}."
+                )
+            values = values.unsqueeze(0).expand(batch_size, -1)
+        elif tuple(values.shape) != (batch_size, num_rules):
+            raise ValueError(
+                "rule_to_class must have shape "
+                f"({num_rules},) or ({batch_size}, {num_rules}), "
+                f"got {tuple(values.shape)}."
+            )
+        if bool(((values < 0) | (values >= self.num_classes)).any()):
+            raise ValueError(
+                "rule_to_class must map every rule to a class in "
+                f"[0, {self.num_classes})."
+            )
+        return values
+
+    def _normalize_consequent_permutation(
+        self,
+        consequent_permutation: Optional[torch.Tensor],
+        *,
+        batch_size: int,
+        device: torch.device,
+    ) -> torch.Tensor:
+        num_rules = int(self.cfg.num_rules)
+        if consequent_permutation is None:
+            return torch.arange(num_rules, dtype=torch.long, device=device)
+
+        permutation = torch.as_tensor(
+            consequent_permutation,
+            dtype=torch.long,
+            device=device,
+        )
+        valid_shape = tuple(permutation.shape) in {
+            (num_rules,),
+            (batch_size, num_rules),
+        }
+        if not valid_shape:
+            raise ValueError(
+                "consequent_permutation must have shape "
+                f"({num_rules},) or ({batch_size}, {num_rules}), "
+                f"got {tuple(permutation.shape)}."
+            )
+        expected = torch.arange(num_rules, dtype=torch.long, device=device)
+        sorted_permutation = permutation.sort(dim=-1).values
+        expected_permutation = (
+            expected
+            if permutation.ndim == 1
+            else expected.unsqueeze(0).expand(batch_size, -1)
+        )
+        if not torch.equal(sorted_permutation, expected_permutation):
+            raise ValueError(
+                "each consequent_permutation row must contain every rule index exactly once."
+            )
+        return permutation
+
+    @staticmethod
+    def _validate_conflict_threshold(value: float) -> float:
+        if isinstance(value, bool):
+            raise TypeError("conflict_threshold must be a finite float in [0, 1].")
+        threshold = float(value)
+        if not math.isfinite(threshold) or not 0.0 <= threshold <= 1.0:
+            raise ValueError("conflict_threshold must be a finite float in [0, 1].")
+        return threshold
+
+    def _validate_config(self, *, dim_in: int, num_classes: int) -> None:
+        integer_fields = {
+            "dim_in": dim_in,
+            "num_classes": num_classes,
+            "num_fuzzy_features": self.cfg.num_fuzzy_features,
+            "num_membership_functions": self.cfg.num_membership_functions,
+            "num_rules": self.cfg.num_rules,
+        }
+        for name, value in integer_fields.items():
+            if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+                raise ValueError(f"{name} must be a positive integer, got {value!r}.")
+        if int(num_classes) < 2:
+            raise ValueError("P05 F0 requires at least two classes.")
+        if float(self.cfg.antecedent_temperature) <= 0.0:
+            raise ValueError("antecedent_temperature must be positive.")
+        if float(self.cfg.min_width) <= 0.0:
+            raise ValueError("min_width must be positive.")
+        if not 0.0 < float(self.cfg.firing_epsilon) < 1.0:
+            raise ValueError("firing_epsilon must lie strictly between zero and one.")

--- a/test/test_p05_f0_no_bypass.py
+++ b/test/test_p05_f0_no_bypass.py
@@ -1,0 +1,181 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from src.model_factory.X_model.TSPN_UXFD import Model as TSPNUXFD
+from src.model_factory.X_model.UXFD.fuzzy import FuzzyConfig, FuzzyReasoner
+
+
+def _ns(**kwargs):  # type: ignore[no-untyped-def]
+    return SimpleNamespace(**kwargs)
+
+
+def _model_args() -> SimpleNamespace:
+    return _ns(
+        device="cpu",
+        num_classes=2,
+        in_channels=2,
+        out_channels=4,
+        scale=1,
+        skip_connection=True,
+        signal_processing_configs={"layer1": ["I"]},
+        feature_extractor_configs=["Mean", "Std"],
+        in_dim=128,
+        out_dim=128,
+        uxfd=_ns(
+            enable_sp2d=False,
+            fuzzy=_ns(
+                enable=True,
+                num_fuzzy_features=4,
+                num_membership_functions=3,
+                num_rules=4,
+                logit_scale=1.0,
+            ),
+            neural_residual=_ns(enable=False),
+            anfis=_ns(enable=False),
+            operator_attention=_ns(enable=False),
+            logic=_ns(enable=False),
+        ),
+    )
+
+
+def _reasoner() -> FuzzyReasoner:
+    torch.manual_seed(20260801)
+    return FuzzyReasoner(
+        dim_in=3,
+        num_classes=2,
+        cfg=FuzzyConfig(
+            num_fuzzy_features=3,
+            num_membership_functions=2,
+            num_rules=4,
+        ),
+    )
+
+
+def test_f0_consumes_logged_minimum_activations_and_max_class_supports() -> None:
+    reasoner = _reasoner()
+    features = torch.tensor(
+        [[0.1, -0.3, 0.7], [1.0, -1.0, 0.0]],
+        dtype=torch.float32,
+    )
+    mapping = torch.tensor([0, 1, 0, 1])
+
+    decision = reasoner.forward_f0(
+        features,
+        rule_to_class=mapping,
+        conflict_threshold=1.0,
+    )
+
+    expected_activations = decision.antecedent_memberships.amin(dim=-1)
+    assert torch.equal(decision.rule_activations, expected_activations)
+    for class_id in (0, 1):
+        expected_support = expected_activations.masked_fill(
+            decision.rule_to_class.ne(class_id),
+            0.0,
+        ).max(dim=1).values
+        assert torch.equal(decision.class_supports[:, class_id], expected_support)
+    assert torch.equal(decision.top_support, decision.class_supports.max(dim=1).values)
+    assert decision.accepted.all()
+    assert (decision.issued_class >= 0).all()
+
+
+def test_f0_all_rule_removal_abstains_without_fallback() -> None:
+    reasoner = _reasoner()
+    decision = reasoner.forward_f0(
+        torch.zeros(2, 3),
+        rule_to_class=torch.tensor([0, 1, 0, 1]),
+        conflict_threshold=1.0,
+        rule_mask=torch.zeros(4, dtype=torch.bool),
+    )
+
+    assert torch.equal(decision.rule_activations, torch.zeros_like(decision.rule_activations))
+    assert torch.equal(decision.class_supports, torch.zeros_like(decision.class_supports))
+    assert torch.equal(decision.conflict, torch.ones_like(decision.conflict))
+    assert not decision.accepted.any()
+    assert torch.equal(decision.issued_class, torch.full((2,), -1))
+
+
+def test_f0_does_not_consume_neural_or_learned_vector_consequents() -> None:
+    torch.manual_seed(20260801)
+    model = TSPNUXFD(_model_args()).eval()
+    x = torch.randn(3, 128, 2)
+    mapping = torch.tensor([0, 1, 0, 1])
+
+    with torch.no_grad():
+        # The legacy TSPN backbone normalizes a weight tensor in-place on each
+        # forward. Freeze its output explicitly so this intervention changes
+        # only the neural and learned-vector consequent heads.
+        fixed_features = model._forward_features(x)
+        model._forward_features = lambda _x: fixed_features  # type: ignore[method-assign]
+        logits_before = model._forward_non_fuzzy_logits(fixed_features)
+        decision_before = model.forward_f0(
+            x,
+            rule_to_class=mapping,
+            conflict_threshold=1.0,
+        )
+        for parameter in model.clf.parameters():
+            parameter.add_(5.0 * torch.randn_like(parameter))
+        assert model._uxfd_fuzzy is not None
+        model._uxfd_fuzzy.rule_consequents.add_(
+            5.0 * torch.randn_like(model._uxfd_fuzzy.rule_consequents)
+        )
+        logits_after = model._forward_non_fuzzy_logits(fixed_features)
+        decision_after = model.forward_f0(
+            x,
+            rule_to_class=mapping,
+            conflict_threshold=1.0,
+        )
+
+    assert not torch.allclose(logits_before, logits_after)
+    assert torch.equal(decision_before.rule_activations, decision_after.rule_activations)
+    assert torch.equal(decision_before.class_supports, decision_after.class_supports)
+    assert torch.equal(decision_before.conflict, decision_after.conflict)
+    assert torch.equal(decision_before.issued_class, decision_after.issued_class)
+
+
+def test_f0_consequent_and_threshold_directions_are_explicit() -> None:
+    reasoner = _reasoner()
+    features = torch.tensor([[0.2, -0.4, 0.6]], dtype=torch.float32)
+    mapping = torch.tensor([0, 1, 0, 1])
+    flipped = 1 - mapping
+
+    original = reasoner.forward_f0(
+        features,
+        rule_to_class=mapping,
+        conflict_threshold=1.0,
+    )
+    intervened = reasoner.forward_f0(
+        features,
+        rule_to_class=mapping,
+        consequent_override=flipped,
+        conflict_threshold=1.0,
+    )
+    strict = reasoner.forward_f0(
+        features,
+        rule_to_class=mapping,
+        conflict_threshold=0.0,
+    )
+
+    assert torch.equal(intervened.class_supports, original.class_supports.flip(dims=(1,)))
+    assert torch.all(strict.accepted <= original.accepted)
+    assert original.accepted.all()
+
+
+@pytest.mark.parametrize(
+    "mapping",
+    [
+        torch.tensor([0, 1, 0]),
+        torch.tensor([0, 1, 0, 2]),
+        torch.tensor([0.0, 1.0, 0.5, 1.0]),
+    ],
+)
+def test_f0_rejects_missing_or_invalid_rule_mapping(mapping: torch.Tensor) -> None:
+    with pytest.raises((TypeError, ValueError), match="rule_to_class"):
+        _reasoner().forward_f0(
+            torch.zeros(1, 3),
+            rule_to_class=mapping,
+            conflict_threshold=0.5,
+        )

--- a/test/test_p05_f0_no_bypass.py
+++ b/test/test_p05_f0_no_bypass.py
@@ -21,6 +21,7 @@ def _model_args() -> SimpleNamespace:
         out_channels=4,
         scale=1,
         skip_connection=True,
+        internal_instance_normalization=False,
         signal_processing_configs={"layer1": ["I"]},
         feature_extractor_configs=["Mean", "Std"],
         in_dim=128,
@@ -179,3 +180,27 @@ def test_f0_rejects_missing_or_invalid_rule_mapping(mapping: torch.Tensor) -> No
             rule_to_class=mapping,
             conflict_threshold=0.5,
         )
+
+
+def test_p05_backbone_forward_is_non_mutating_and_gradients_are_finite() -> None:
+    torch.manual_seed(20260801)
+    model = TSPNUXFD(_model_args()).train()
+    x = torch.randn(4, 128, 2)
+    y = torch.tensor([0, 1, 0, 1])
+    parameters_before = {
+        name: parameter.detach().clone()
+        for name, parameter in model.named_parameters()
+    }
+
+    logits = model(x)
+    torch.nn.functional.cross_entropy(logits, y).backward()
+
+    for name, parameter in model.named_parameters():
+        assert torch.equal(parameter, parameters_before[name]), name
+    gradients = [
+        parameter.grad
+        for parameter in model.parameters()
+        if parameter.grad is not None
+    ]
+    assert gradients
+    assert all(torch.isfinite(gradient).all() for gradient in gradients)


### PR DESCRIPTION
Implements the focused P05-G050 dev integration without importing the divergent legacy Pipeline/data stack.\n\nChanges:\n- derive F0 from logged memberships -> minimum t-norm raw activations -> frozen rule-to-class consequents -> per-class max support -> conflict -> acceptance\n- abstain with issued_class=-1 when support is absent\n- keep neural logits and learned vector consequents outside F0\n- make the TSPN connection normalization non-mutating and honor internal_instance_normalization=false so real P05 gradients remain finite\n\nVerification:\n- targeted semantic/model tests: 17 passed, 1 CUDA-only skip in restricted pytest\n- public config inspection and validation: 7/7 configs passed\n- real XJTU grouped GPU6 smoke: forward/backward PASS; 17/17 gradient tensors finite; F0 activation/support reconstruction error 0; all-rule removal abstains\n- repository suite: 414 passed, 1 skipped, 4 pre-existing failures in unchanged CLI/config/sampler paths (branch diff to origin/dev is zero for those paths)\n\nThe untracked local data/Rotor_simulation directory was not staged or pushed.