### PR TITLE
fix(p05): normalize float32 firing before risk evaluation

### DIFF
--- a/src/explain_factory/p05_selective_risk.py
+++ b/src/explain_factory/p05_selective_risk.py
@@ -105,8 +105,12 @@ def trace_risk_features(logits: np.ndarray, firing: np.ndarray) -> np.ndarray:
     if np.any(firing_values < 0.0):
         raise ValueError("normalized rule firing cannot be negative")
     row_sums = firing_values.sum(axis=1)
-    if not np.allclose(row_sums, 1.0, rtol=0.0, atol=1e-10):
+    # The registered trace is emitted in float32 and converted to float64 for
+    # offline statistics.  Accept only its frozen reconstruction tolerance,
+    # then remove harmless float32 row-sum drift before entropy is evaluated.
+    if not np.allclose(row_sums, 1.0, rtol=1e-6, atol=1e-6):
         raise ValueError("rule firing rows must sum to one")
+    firing_values = firing_values / row_sums[:, None]
     entropy = -np.sum(
         firing_values
         * np.log(np.clip(firing_values, np.finfo(np.float64).tiny, 1.0)),

--- a/test/test_p05_selective_risk.py
+++ b/test/test_p05_selective_risk.py
@@ -10,6 +10,7 @@ from src.explain_factory.p05_selective_risk import (
     operational_wording_gate,
     retrospective_selective_metrics,
     select_validation_threshold,
+    trace_risk_features,
 )
 
 
@@ -67,6 +68,28 @@ def test_validation_bundle_fits_all_registered_scores_without_test_inputs():
     assert set(bundle.thresholds) == {"trace", "R0", "R1", "R2", "R3"}
     assert 0.05 <= bundle.temperature <= 20.0
     assert all(np.isfinite(value) for value in bundle.thresholds.values())
+
+
+def test_trace_risk_accepts_and_normalizes_float32_softmax_row_drift():
+    logits = np.asarray([[1.0, 0.0], [0.0, 1.0]], dtype=np.float32)
+    firing = np.asarray(
+        [
+            [0.10000001, 0.20000002, 0.70000005],
+            [0.33333334, 0.33333334, 0.33333334],
+        ],
+        dtype=np.float32,
+    )
+    features = trace_risk_features(logits, firing)
+    assert features.shape == (2, 3)
+    assert np.isfinite(features).all()
+
+
+def test_trace_risk_still_rejects_materially_unnormalized_firing():
+    with pytest.raises(ValueError, match="sum to one"):
+        trace_risk_features(
+            np.asarray([[1.0, 0.0]], dtype=np.float32),
+            np.asarray([[0.2, 0.2, 0.2]], dtype=np.float32),
+        )
 
 
 def test_validation_threshold_includes_all_exact_score_ties():


### PR DESCRIPTION
## Summary
- accept only registered 1e-6 float32 row-sum drift in normalized rule firing
- renormalize in float64 before entropy-based selective-risk statistics
- retain fail-closed rejection for materially invalid firing

## Validation
- targeted P05 trace/intervention/risk: 32 passed, 1 skipped
- full maintained test suite: 868 passed, 2 skipped

This fixes a real GPU6 G050 smoke failure without changing model logits, training, risk features, or scientific thresholds.