### PR TITLE
fix(pipeline02): require completed finite evaluation for every stage

### DIFF
--- a/src/Pipeline_02_Pretraining_Few_Shot.py
+++ b/src/Pipeline_02_Pretraining_Few_Shot.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+from collections.abc import Mapping
+import math
+from numbers import Real
 from typing import Any
 
 from src.configs.config_utils import load_config
@@ -35,15 +38,82 @@ def _has_stages(config: Any) -> bool:
     return isinstance(stages, (list, tuple)) and bool(stages)
 
 
+def _metric_scalar(value: Any, *, stage_name: str, metric_name: str) -> float:
+    """Return one finite scalar metric without guessing non-scalar reductions."""
+
+    if hasattr(value, "item"):
+        try:
+            value = value.item()
+        except (RuntimeError, TypeError, ValueError) as exc:
+            raise RuntimeError(
+                f"Pipeline 02 stage {stage_name!r} metric {metric_name!r} must be "
+                "a scalar value."
+            ) from exc
+
+    if isinstance(value, bool) or not isinstance(value, Real):
+        raise RuntimeError(
+            f"Pipeline 02 stage {stage_name!r} metric {metric_name!r} must be "
+            f"a numeric scalar, got {type(value).__name__}."
+        )
+
+    scalar = float(value)
+    if not math.isfinite(scalar):
+        raise FloatingPointError(
+            f"Pipeline 02 stage {stage_name!r} metric {metric_name!r} is not finite: "
+            f"{scalar!r}."
+        )
+    return scalar
+
+
+def _require_completed_stage_evaluation(result: Any, mode: str) -> Any:
+    """Reject multi-stage success without finite evaluation metrics for every stage.
+
+    The current Pipeline 02 multi-stage contract always calls ``trainer.test`` after
+    each trained stage. Empty, non-scalar, or non-finite metrics therefore mean
+    evaluation did not complete successfully and the public run must fail.
+    """
+    if not isinstance(result, Mapping) or not result:
+        raise RuntimeError(
+            f"Pipeline 02 {mode} must return a non-empty stage result mapping."
+        )
+
+    stage_count = 0
+    for stage_name, stage_result in result.items():
+        if str(stage_name).startswith("_"):
+            continue
+        stage_count += 1
+        if not isinstance(stage_result, Mapping):
+            raise RuntimeError(
+                f"Pipeline 02 stage {stage_name!r} returned "
+                f"{type(stage_result).__name__}; expected a result mapping."
+            )
+        metrics = stage_result.get("metrics")
+        if not isinstance(metrics, Mapping) or not metrics:
+            raise RuntimeError(
+                f"Pipeline 02 stage {stage_name!r} did not complete evaluation: "
+                "expected a non-empty metrics mapping from trainer.test."
+            )
+        for metric_name, value in metrics.items():
+            _metric_scalar(
+                value,
+                stage_name=str(stage_name),
+                metric_name=str(metric_name),
+            )
+
+    if stage_count == 0:
+        raise RuntimeError(
+            f"Pipeline 02 {mode} returned no stage results."
+        )
+    return result
+
+
 def _run_unified_multistage(args: Any, config: Any, overrides: list[str]) -> Any:
     """Run the one supported multi-stage implementation without fallback."""
 
     print("[INFO] Pipeline 02 mode: unified_multistage")
     orchestrator = TwoStageOrchestrator(config, cli_overrides=overrides)
     result = orchestrator.run_complete()
-    if result is None:
-        raise RuntimeError("Pipeline 02 orchestrator returned None")
-    return result
+    return _require_completed_stage_evaluation(result, "unified_multistage")
 
 
 def _run_legacy_dual_yaml(args: Any) -> Any:
@@ -72,9 +142,7 @@ def _run_legacy_dual_yaml(args: Any) -> Any:
 
     print("[INFO] Pipeline 02 mode: legacy_dual_yaml")
     result = TwoStageOrchestrator(unified).run_complete()
-    if result is None:
-        raise RuntimeError("Pipeline 02 legacy orchestrator returned None")
-    return result
+    return _require_completed_stage_evaluation(result, "legacy_dual_yaml")
 
 
 def pipeline(args: Any) -> Any:
@@ -84,6 +152,7 @@ def pipeline(args: Any) -> Any:
     - a compiled config containing non-empty ``stages`` uses the unified orchestrator;
     - a config without ``stages`` uses the shared classification runtime.
 
+    Multi-stage success requires non-empty finite evaluation metrics for every stage.
     No exception changes the selected mode or activates a second implementation.
     """
 

--- a/src/utils/training/two_stage_orchestrator.py
+++ b/src/utils/training/two_stage_orchestrator.py
@@ -11,6 +11,7 @@ Multi-Stage / Two-Stage Orchestrator
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from typing import Any, Dict, Optional
 from types import SimpleNamespace
 import logging
@@ -214,7 +215,7 @@ def _parse_value(value_str: str):
         return value_str.lower() == 'true'
     elif value_str.lower() in ['null', 'none']:
         return None
-    elif value_str.startswith(('\"', "'")) and value_str.endswith(('\"', "'")):
+    elif value_str.startswith(('"', "'")) and value_str.endswith(('"', "'")):
         return value_str[1:-1]  # 去掉引号
     else:
         return value_str  # 保持字符串
@@ -259,6 +260,31 @@ def apply_stage_overrides(stage_config, global_config, stage_overrides):
             merged_config = deep_merge(merged_config, stage_config.__dict__)
 
     return merged_config
+
+
+def _close_data_factory(data_factory: Any) -> None:
+    """Close the underlying data resource when the factory owns one."""
+
+    data = getattr(data_factory, "data", None)
+    close = getattr(data, "close", None)
+    if callable(close):
+        close()
+
+
+def _require_test_metrics(result: Any, stage_name: str) -> Dict[str, Any]:
+    """Return one non-empty test metric mapping or fail the stage."""
+
+    if (
+        not isinstance(result, (list, tuple))
+        or not result
+        or not isinstance(result[0], Mapping)
+        or not result[0]
+    ):
+        raise RuntimeError(
+            f"Pipeline 02 {stage_name} evaluation must return a non-empty "
+            "metrics mapping from trainer.test."
+        )
+    return deepcopy(dict(result[0]))
 
 
 class MultiStageOrchestrator:
@@ -405,30 +431,6 @@ class MultiStageOrchestrator:
             _validate_config_wrapper(stage_wrapped)
 
     # ------------------------ helpers ------------------------
-    def _ensure_trainer_attributes(self, trainer: Any, path: str) -> None:
-        """确保trainer配置包含所有必需的属性"""
-        if not hasattr(trainer, 'monitor'):
-            setattr(trainer, 'monitor', 'val_total_loss')
-        if not hasattr(trainer, 'save_dir'):
-            setattr(trainer, 'save_dir', path)
-
-        # 关键修复：处理device属性（Default_trainer需要）
-        if not hasattr(trainer, 'device'):
-            device = getattr(trainer, 'accelerator', 'cpu')
-            if device == 'gpu':
-                device = 'cuda'
-            setattr(trainer, 'device', device)
-
-        # 处理其他必需属性
-        if not hasattr(trainer, 'devices') and not hasattr(trainer, 'gpus'):
-            setattr(trainer, 'devices', 1)
-        if not hasattr(trainer, 'log_every_n_steps'):
-            setattr(trainer, 'log_every_n_steps', 50)
-
-        # 处理num_epochs/max_epochs
-        if not hasattr(trainer, 'num_epochs') and hasattr(trainer, 'max_epochs'):
-            setattr(trainer, 'num_epochs', trainer.max_epochs)
-
     def _stage_to_namespaces(self, stage_cfg: Any):
         # stage_cfg may be dict / ConfigWrapper / SimpleNamespace
         if isinstance(stage_cfg, dict):
@@ -449,11 +451,9 @@ class MultiStageOrchestrator:
     def run_pretrain(self, stage_cfg: Any, iteration: int = 0) -> Dict[str, Any]:
         env, data, model, task, trainer = self._stage_to_namespaces(stage_cfg)
 
-        # seed
         seed = getattr(env, 'seed', 42) + int(iteration)
         seed_everything(seed)
 
-        # path and logging（包含 environment，允许使用 environment.output_dir 控制结果根目录）
         cfg_for_path = ConfigWrapper(
             environment=env,
             data=data,
@@ -463,53 +463,73 @@ class MultiStageOrchestrator:
         )
         path, name = path_name(cfg_for_path)
         trainer.logger_name = name
-        init_lab(env, self.cfg, name)
 
-        # Ensure trainer has required attributes for build_trainer
-        self._ensure_trainer_attributes(trainer, path)
-
-        if self.dry_run:
-            close_lab()
-            return {'checkpoint_path': None, 'metrics': {'dry_run': True}, 'path': path}
-
-        # build
-        data_factory = build_data(data, task)
-        net = build_model(model, metadata=data_factory.get_metadata())
-        lightning_task = build_task(
-            args_task=task,
-            network=net,
-            args_data=data,
-            args_model=model,
-            args_trainer=trainer,
-            args_environment=env,
-            metadata=data_factory.get_metadata(),
-        )
-        pl_trainer = build_trainer(env, trainer, data, path)
-
-        # train
-        pl_trainer.fit(lightning_task, data_factory.get_dataloader('train'), data_factory.get_dataloader('val'))
-
-        # best ckpt
-        lightning_task = load_best_model_checkpoint(lightning_task, pl_trainer)
-        ckpt_path = None
-        for cb in pl_trainer.callbacks:
-            if isinstance(cb, ModelCheckpoint):
-                ckpt_path = cb.best_model_path
-                break
-
-        # optional test
-        test_metrics: Dict[str, Any] = {}
+        data_factory = None
+        lab_started = False
         try:
-            result = pl_trainer.test(lightning_task, data_factory.get_dataloader('test'))
-            if result:
-                test_metrics = deepcopy(result[0])
-        except Exception:
-            pass
+            init_lab(env, self.cfg, name)
+            lab_started = True
 
-        close_lab()
-        return {'checkpoint_path': ckpt_path, 'metrics': test_metrics, 'path': path}
+            if self.dry_run:
+                return {
+                    'checkpoint_path': None,
+                    'metrics': {'dry_run': True},
+                    'path': path,
+                }
 
-    def run_adapt(self, stage_cfg: Any, checkpoint_path: Optional[str] = None, iteration: int = 0) -> Dict[str, Any]:
+            data_factory = build_data(data, task)
+            metadata = data_factory.get_metadata()
+            net = build_model(model, metadata=metadata)
+            lightning_task = build_task(
+                args_task=task,
+                network=net,
+                args_data=data,
+                args_model=model,
+                args_trainer=trainer,
+                args_environment=env,
+                metadata=metadata,
+            )
+            pl_trainer = build_trainer(env, trainer, data, path)
+
+            pl_trainer.fit(
+                lightning_task,
+                data_factory.get_dataloader('train'),
+                data_factory.get_dataloader('val'),
+            )
+
+            lightning_task = load_best_model_checkpoint(lightning_task, pl_trainer)
+            ckpt_path = next(
+                (
+                    cb.best_model_path
+                    for cb in pl_trainer.callbacks
+                    if isinstance(cb, ModelCheckpoint)
+                ),
+                None,
+            )
+            test_metrics = _require_test_metrics(
+                pl_trainer.test(
+                    lightning_task,
+                    data_factory.get_dataloader('test'),
+                ),
+                "pretrain",
+            )
+            return {
+                'checkpoint_path': ckpt_path,
+                'metrics': test_metrics,
+                'path': path,
+            }
+        finally:
+            if data_factory is not None:
+                _close_data_factory(data_factory)
+            if lab_started:
+                close_lab()
+
+    def run_adapt(
+        self,
+        stage_cfg: Any,
+        checkpoint_path: Optional[str] = None,
+        iteration: int = 0,
+    ) -> Dict[str, Any]:
         env, data, model, task, trainer = self._stage_to_namespaces(stage_cfg)
 
         seed = getattr(env, 'seed', 42) + int(iteration)
@@ -524,50 +544,67 @@ class MultiStageOrchestrator:
         )
         path, name = path_name(cfg_for_path)
         trainer.logger_name = name
-        init_lab(env, self.cfg, name)
 
-        # Ensure trainer has required attributes for build_trainer
-        self._ensure_trainer_attributes(trainer, path)
-
-        if self.dry_run:
-            close_lab()
-            return {'checkpoint_path': checkpoint_path, 'metrics': {'dry_run': True}, 'path': path}
-
-        data_factory = build_data(data, task)
-        net = build_model(model, metadata=data_factory.get_metadata())
-        if checkpoint_path:
-            load_pretrained_weights(net, checkpoint_path, strict=False)
-        lightning_task = build_task(
-            args_task=task,
-            network=net,
-            args_data=data,
-            args_model=model,
-            args_trainer=trainer,
-            args_environment=env,
-            metadata=data_factory.get_metadata(),
-        )
-        pl_trainer = build_trainer(env, trainer, data, path)
-        pl_trainer.fit(lightning_task, data_factory.get_dataloader('train'), data_factory.get_dataloader('val'))
-
-        # best ckpt for this stage
-        lightning_task = load_best_model_checkpoint(lightning_task, pl_trainer)
-        ckpt_path = None
-        for cb in pl_trainer.callbacks:
-            if isinstance(cb, ModelCheckpoint):
-                ckpt_path = cb.best_model_path
-                break
-
-        # test
-        test_metrics: Dict[str, Any] = {}
+        data_factory = None
+        lab_started = False
         try:
-            result = pl_trainer.test(lightning_task, data_factory.get_dataloader('test'))
-            if result:
-                test_metrics = deepcopy(result[0])
-        except Exception:
-            pass
+            init_lab(env, self.cfg, name)
+            lab_started = True
 
-        close_lab()
-        return {'checkpoint_path': ckpt_path, 'metrics': test_metrics, 'path': path}
+            if self.dry_run:
+                return {
+                    'checkpoint_path': checkpoint_path,
+                    'metrics': {'dry_run': True},
+                    'path': path,
+                }
+
+            data_factory = build_data(data, task)
+            metadata = data_factory.get_metadata()
+            net = build_model(model, metadata=metadata)
+            if checkpoint_path:
+                load_pretrained_weights(net, checkpoint_path, strict=False)
+            lightning_task = build_task(
+                args_task=task,
+                network=net,
+                args_data=data,
+                args_model=model,
+                args_trainer=trainer,
+                args_environment=env,
+                metadata=metadata,
+            )
+            pl_trainer = build_trainer(env, trainer, data, path)
+            pl_trainer.fit(
+                lightning_task,
+                data_factory.get_dataloader('train'),
+                data_factory.get_dataloader('val'),
+            )
+
+            lightning_task = load_best_model_checkpoint(lightning_task, pl_trainer)
+            ckpt_path = next(
+                (
+                    cb.best_model_path
+                    for cb in pl_trainer.callbacks
+                    if isinstance(cb, ModelCheckpoint)
+                ),
+                None,
+            )
+            test_metrics = _require_test_metrics(
+                pl_trainer.test(
+                    lightning_task,
+                    data_factory.get_dataloader('test'),
+                ),
+                "adapt",
+            )
+            return {
+                'checkpoint_path': ckpt_path,
+                'metrics': test_metrics,
+                'path': path,
+            }
+        finally:
+            if data_factory is not None:
+                _close_data_factory(data_factory)
+            if lab_started:
+                close_lab()
 
     # ------------------------ orchestrator APIs ------------------------
     def run_all_stages(self) -> Dict[str, Any]:

--- a/test/test_pipeline02_metric_contract.py
+++ b/test/test_pipeline02_metric_contract.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import pytest
+import torch
+
+from src.Pipeline_02_Pretraining_Few_Shot import (
+    _require_completed_stage_evaluation,
+)
+
+
+def _stage_result(value):
+    return {
+        "stage_1": {
+            "checkpoint_path": "stage1.ckpt",
+            "metrics": {"test_metric": value},
+        }
+    }
+
+
+def test_completed_stage_accepts_finite_python_and_tensor_scalars() -> None:
+    result = {
+        "stage_1": {
+            "checkpoint_path": "stage1.ckpt",
+            "metrics": {
+                "test_loss": 0.25,
+                "test_accuracy": torch.tensor(0.75),
+            },
+        }
+    }
+
+    assert _require_completed_stage_evaluation(result, "test") is result
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        float("nan"),
+        float("inf"),
+        float("-inf"),
+        torch.tensor(float("nan")),
+    ],
+)
+def test_completed_stage_rejects_non_finite_metrics(value) -> None:
+    with pytest.raises(FloatingPointError, match="is not finite"):
+        _require_completed_stage_evaluation(_stage_result(value), "test")
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        True,
+        "0.5",
+        [0.5],
+        torch.tensor([0.25, 0.75]),
+    ],
+)
+def test_completed_stage_rejects_non_scalar_or_non_numeric_metrics(value) -> None:
+    with pytest.raises(RuntimeError, match="scalar"):
+        _require_completed_stage_evaluation(_stage_result(value), "test")

--- a/test/test_pipeline02_runtime.py
+++ b/test/test_pipeline02_runtime.py
@@ -91,6 +91,12 @@ def test_compiled_stages_select_one_unified_orchestrator(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     observed: dict[str, object] = {}
+    expected = {
+        "stage_1": {
+            "checkpoint_path": "stage1.ckpt",
+            "metrics": {"test_loss": 1.0},
+        }
+    }
 
     class Orchestrator:
         def __init__(self, config, cli_overrides):
@@ -98,7 +104,7 @@ def test_compiled_stages_select_one_unified_orchestrator(
             observed["overrides"] = cli_overrides
 
         def run_complete(self):
-            return {"stages": 2}
+            return expected
 
     monkeypatch.setattr(pipeline02, "TwoStageOrchestrator", Orchestrator)
     monkeypatch.setattr(
@@ -114,9 +120,26 @@ def test_compiled_stages_select_one_unified_orchestrator(
         ],
     )
 
-    assert pipeline02.pipeline(args) == {"stages": 2}
+    assert pipeline02.pipeline(args) == expected
     assert observed["overrides"] == []
     assert observed["config"]["stages"][0]["name"] == "pretrain"
+
+
+def test_multistage_rejects_stage_without_evaluation_metrics(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class Orchestrator:
+        def __init__(self, config, cli_overrides):
+            pass
+
+        def run_complete(self):
+            return {"stage_1": {"checkpoint_path": "stage1.ckpt", "metrics": {}}}
+
+    monkeypatch.setattr(pipeline02, "TwoStageOrchestrator", Orchestrator)
+
+    with pytest.raises(RuntimeError, match="did not complete evaluation"):
+        pipeline02.pipeline(_args(tmp_path, stages=[{"overrides": {}}]))
 
 
 def test_orchestrator_error_is_not_converted_to_single_stage(
@@ -161,13 +184,19 @@ def test_explicit_legacy_dual_yaml_uses_only_adapter_and_orchestrator(
         )
         or unified,
     )
+    expected = {
+        "stage_1": {
+            "checkpoint_path": "stage1.ckpt",
+            "metrics": {"test_loss": 1.0},
+        }
+    }
 
     class Orchestrator:
         def __init__(self, config):
             assert config is unified
 
         def run_complete(self):
-            return {"legacy": True}
+            return expected
 
     monkeypatch.setattr(pipeline02, "TwoStageOrchestrator", Orchestrator)
     args = _args(
@@ -178,7 +207,7 @@ def test_explicit_legacy_dual_yaml_uses_only_adapter_and_orchestrator(
         override=None,
     )
 
-    assert pipeline02.pipeline(args) == {"legacy": True}
+    assert pipeline02.pipeline(args) == expected
     assert observed == {
         "pretrain": str(tmp_path / "pipeline02.yaml"),
         "fewshot": "fewshot.yaml",
@@ -244,6 +273,142 @@ def test_load_ckpt_non_strict_rejects_zero_matches(tmp_path: Path) -> None:
         )
 
 
+def _stage_orchestrator(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    test_result=None,
+    test_error: Exception | None = None,
+):
+    orchestrator = orchestrator_module.MultiStageOrchestrator.__new__(
+        orchestrator_module.MultiStageOrchestrator
+    )
+    orchestrator.cfg = SimpleNamespace()
+    orchestrator.dry_run = False
+
+    env = SimpleNamespace(seed=1)
+    data = SimpleNamespace()
+    model = SimpleNamespace()
+    task = SimpleNamespace()
+    trainer_config = SimpleNamespace()
+    monkeypatch.setattr(
+        orchestrator,
+        "_stage_to_namespaces",
+        lambda stage_cfg: (env, data, model, task, trainer_config),
+    )
+    monkeypatch.setattr(
+        orchestrator_module,
+        "path_name",
+        lambda config: (str(tmp_path), "stage"),
+    )
+    monkeypatch.setattr(orchestrator_module, "seed_everything", lambda seed: None)
+
+    close_events: list[str] = []
+    monkeypatch.setattr(orchestrator_module, "init_lab", lambda *args: None)
+    monkeypatch.setattr(
+        orchestrator_module,
+        "close_lab",
+        lambda: close_events.append("lab"),
+    )
+
+    class DataResource:
+        def close(self):
+            close_events.append("data")
+
+    class DataFactory:
+        data = DataResource()
+
+        def get_metadata(self):
+            return None
+
+        def get_dataloader(self, split):
+            return split
+
+    monkeypatch.setattr(
+        orchestrator_module,
+        "build_data",
+        lambda args_data, args_task: DataFactory(),
+    )
+    monkeypatch.setattr(
+        orchestrator_module,
+        "build_model",
+        lambda args_model, metadata: TinyModel(),
+    )
+    monkeypatch.setattr(
+        orchestrator_module,
+        "build_task",
+        lambda **kwargs: SimpleNamespace(),
+    )
+
+    callback = ModelCheckpoint()
+    callback.best_model_path = str(tmp_path / "best.ckpt")
+
+    class Trainer:
+        callbacks = [callback]
+
+        def fit(self, *args):
+            return None
+
+        def test(self, *args):
+            if test_error is not None:
+                raise test_error
+            return test_result
+
+    monkeypatch.setattr(
+        orchestrator_module,
+        "build_trainer",
+        lambda *args: Trainer(),
+    )
+    monkeypatch.setattr(
+        orchestrator_module,
+        "load_best_model_checkpoint",
+        lambda lightning_task, trainer: lightning_task,
+    )
+    return orchestrator, close_events
+
+
+@pytest.mark.parametrize("method_name", ["run_pretrain", "run_adapt"])
+def test_stage_evaluation_error_propagates_and_resources_close(
+    method_name: str,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    orchestrator, close_events = _stage_orchestrator(
+        tmp_path,
+        monkeypatch,
+        test_error=RuntimeError("evaluation failed"),
+    )
+
+    method = getattr(orchestrator, method_name)
+    kwargs = (
+        {"stage_cfg": object()}
+        if method_name == "run_pretrain"
+        else {"stage_cfg": object(), "checkpoint_path": None}
+    )
+    with pytest.raises(RuntimeError, match="evaluation failed"):
+        method(**kwargs)
+
+    assert close_events == ["data", "lab"]
+
+
+@pytest.mark.parametrize("test_result", [[], [{}]])
+def test_stage_rejects_empty_test_metrics_and_resources_close(
+    test_result,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    orchestrator, close_events = _stage_orchestrator(
+        tmp_path,
+        monkeypatch,
+        test_result=test_result,
+    )
+
+    with pytest.raises(RuntimeError, match="non-empty metrics mapping"):
+        orchestrator.run_pretrain(stage_cfg=object())
+
+    assert close_events == ["data", "lab"]
+
+
 def test_pipeline02_adapt_uses_explicit_backbone_transfer(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -271,11 +436,6 @@ def test_pipeline02_adapt_uses_explicit_backbone_transfer(
         orchestrator,
         "_stage_to_namespaces",
         lambda stage_cfg: (env, data, model, task, trainer_config),
-    )
-    monkeypatch.setattr(
-        orchestrator,
-        "_ensure_trainer_attributes",
-        lambda trainer, path: None,
     )
     monkeypatch.setattr(
         orchestrator_module,


### PR DESCRIPTION
## Objective

Make Pipeline 02 success mean that every trained stage completed checkpoint restoration and returned a non-empty finite scalar evaluation mapping.

## Changes

- propagate `trainer.test()` exceptions instead of swallowing them;
- reject `[]`, `[{}]`, non-mapping, non-scalar, boolean, NaN, and Inf metrics;
- remove Pipeline-level repair of missing Trainer fields;
- close owned data resources and experiment loggers through `finally` without replacing the original exception;
- preserve explicit unified, legacy opt-in, and single-stage execution modes;
- add focused metric-contract and runtime/resource tests.

## Scientific invariant

```text
StageSuccess
=> FitSuccess
&& BestCheckpointRestored
&& EvaluationCompleted
&& MetricsNonempty
&& MetricsFinite
```

## Boundaries

- no hash/checksum/digest/receipt/ledger work;
- no new factory/manager/registry/schema layer;
- no fallback from a failed multi-stage run to a different execution mode;
- no unrelated model, data, or research-method changes.

## Validation requested

- Core quality gates
- PHMFactory public package
- Repository layout
- Submodule policy
- focused Pipeline 02 tests and maintained test suite

The branch was replayed directly onto the current `dev` head before opening this PR.