### PR TITLE
fix(trainer): make device placement explicit and trainer-owned

### DIFF
--- a/.github/workflows/core-quality-gates.yml
+++ b/.github/workflows/core-quality-gates.yml
@@ -224,7 +224,7 @@ jobs:
       - name: Record smoke environment
         run: python -m pip freeze > offline-smoke-environment.txt
 
-      - name: Run shared runtime, data, evidence, and Pipeline 02 contract tests
+      - name: Run shared runtime, data, device, and Pipeline 02 contract tests
         shell: bash
         run: |
           set -o pipefail
@@ -236,6 +236,7 @@ jobs:
             src/model_factory/ISFM/task_head/H_01_Linear_cla.py \
             src/task_factory/Default_task.py \
             src/task_factory/task/pretrain/hse_contrastive.py \
+            src/trainer_factory/Default_trainer.py \
             src/runtime/classification.py \
             src/runtime/explainability.py \
             src/Pipeline_01_Fault_Diagnosis.py \
@@ -243,6 +244,7 @@ jobs:
             src/Pipeline_05_Explainable_Fault_Diagnosis.py \
             test/test_classification_runtime.py \
             test/test_data_cache_contract.py \
+            test/test_device_authority.py \
             test/test_hse_objective_contract.py \
             test/test_per_sample_metadata.py \
             test/test_pipeline02_runtime.py \
@@ -252,6 +254,7 @@ jobs:
           python -m pytest \
             test/test_classification_runtime.py \
             test/test_data_cache_contract.py \
+            test/test_device_authority.py \
             test/test_hse_objective_contract.py \
             test/test_per_sample_metadata.py \
             test/test_pipeline02_runtime.py \

--- a/configs/base/trainer/README.md
+++ b/configs/base/trainer/README.md
@@ -3,51 +3,103 @@
 ## 1) What This Block Controls
 
 `trainer` configures PyTorch Lightning trainer behavior:
-- device / accelerator selection
-- epoch count
-- callbacks (checkpointing / early stopping) via trainer_factory
 
-## 2) Minimal Example (YAML Snippet)
+- device and accelerator selection;
+- epoch count;
+- callbacks such as checkpointing and early stopping.
+
+The Trainer Factory is the only device-placement authority. Data, Model, and Task
+Factories must not move a model to CPU or CUDA during construction.
+
+## 2) Minimal Examples
+
+CPU:
 
 ```yaml
 trainer:
   name: "Default_trainer"
   num_epochs: 10
-  device: "cuda"   # set to "cpu" for CPU-only runs
-  gpus: 1          # Lightning devices field
+  device: "cpu"
+  gpus: 1
 ```
 
-## 3) Key Fields
+Explicit CUDA:
+
+```yaml
+trainer:
+  name: "Default_trainer"
+  num_epochs: 10
+  device: "cuda"
+  gpus: 1
+```
+
+Explicit automatic selection:
+
+```yaml
+trainer:
+  name: "Default_trainer"
+  num_epochs: 10
+  device: "auto"
+  gpus: 1
+```
+
+## 3) Device Contract
+
+| `trainer.device` | Runtime behavior |
+|---|---|
+| `cpu` | Passes `accelerator="cpu"` to Lightning. CUDA availability is irrelevant. |
+| `cuda` | Passes `accelerator="gpu"`; fails before Trainer construction when CUDA or the requested device count is unavailable. |
+| `auto` | Passes `accelerator="auto"` to Lightning. Automatic selection occurs only when the user explicitly writes `auto`. |
+
+There is no implicit `cuda -> cpu` fallback. A CUDA request that cannot be satisfied is
+an invalid run request and terminates with a corrective error.
+
+## 4) Key Fields
 
 | Field | Type | Notes |
 |---|---:|---|
 | `trainer.name` | str | Trainer implementation in `src/trainer_factory/`. |
-| `trainer.num_epochs` | int | Epoch count (override for smoke tests). |
-| `trainer.device` | str | `"cpu"` or `"cuda"` (used by Default_trainer). |
-| `trainer.gpus` | int | Lightning devices count (use `1` for cpu). |
+| `trainer.num_epochs` | int | Epoch count; override for bounded smoke tests. |
+| `trainer.device` | str | Required: `cpu`, `cuda`, or `auto`. |
+| `trainer.gpus` | positive int | Compatibility name for the Lightning device count. |
+| `trainer.devices` | positive int | Preferred device-count spelling when present; takes precedence over `gpus`. |
 
-## 4) Typical Overrides
+## 5) Typical Overrides
 
 ```bash
 python main.py --config <yaml> --override trainer.num_epochs=1
-python main.py --config <yaml> --override trainer.device=cpu --override trainer.gpus=1
+python main.py --config <yaml> \
+  --override trainer.device=cpu \
+  --override trainer.gpus=1
 ```
 
-## 5) Coupling Notes
+A GPU run must be requested explicitly:
+
+```bash
+python main.py --config <yaml> \
+  --override trainer.device=cuda \
+  --override trainer.gpus=1
+```
+
+## 6) Coupling Notes
 
 - Built by `src/trainer_factory/__init__.py:build_trainer`.
-- `Default_trainer` maps `trainer.device` to Lightning `accelerator`.
+- `Default_trainer` maps the explicit device request to the Lightning accelerator.
+- Task constructors preserve the model returned by Model Factory and do not inspect
+  CUDA availability.
 
-## 6) How to Extend
+## 7) How to Extend
 
-1) Add a new trainer implementation under `src/trainer_factory/`.
-2) Point configs at it via `trainer.name`.
+1. Add a trainer implementation under `src/trainer_factory/`.
+2. Point configs at it through `trainer.name`.
+3. Keep hardware selection in the trainer implementation; do not add `.cuda()` calls to
+   Tasks or Models.
 
-## 7) Common Pitfalls
+## 8) Common Failures
 
-1) Leaving `trainer.device=cuda` on a CPU-only machine.
-2) Setting `trainer.gpus=0` (Lightning expects `devices>=1` in this repo’s wrapper).
-3) Using DDP settings with `gpus=1`.
-4) Conflicting early stopping monitor names.
-5) Forgetting to override `num_epochs` for smoke tests.
-
+1. `trainer.device` is absent or not one of `cpu`, `cuda`, `auto`.
+2. `trainer.device=cuda` is requested on a host without CUDA.
+3. The requested CUDA device count exceeds `torch.cuda.device_count()`.
+4. `trainer.gpus` or `trainer.devices` is zero, boolean, non-integral, or negative.
+5. DDP is requested indirectly with more devices than the host provides.
+6. Early-stopping and checkpoint monitor names do not match logged metrics.

--- a/src/task_factory/Default_task.py
+++ b/src/task_factory/Default_task.py
@@ -45,30 +45,9 @@ class Default_task(pl.LightningModule):
         """
         super().__init__()
 
-        # 兼容旧配置：为 gpus 提供合理默认值，避免缺少属性导致崩溃
-        gpus = getattr(args_trainer, "gpus", None)
-        if gpus is None:
-            gpus = getattr(args_trainer, "devices", 1)
-            setattr(args_trainer, "gpus", gpus)
-
-        # 将网络移动到 GPU（仅在配置明确请求 CUDA/GPU 且 CUDA 可用时）。
-        # ``gpus`` 在旧配置里也被 Lightning 当作 CPU devices 使用，因此
-        # 不能仅凭其非零就覆盖 ``trainer.device: cpu``。
-        requested_device = str(getattr(args_trainer, "device", "cpu")).lower()
-        use_cuda = (
-            requested_device in {"cuda", "gpu"}
-            and bool(gpus)
-            and torch.cuda.is_available()
-        )
-        if requested_device in {"cuda", "gpu"} and bool(gpus) and not use_cuda:
-            raise RuntimeError(
-                "CUDA was explicitly requested but is unavailable; evidence-bearing "
-                "runs must not fall back to CPU"
-            )
-        if use_cuda and hasattr(network, "cuda"):
-            self.network = network.cuda()
-        else:
-            self.network = network  # 在当前环境（无 GPU）下保持 CPU 训练
+        # Device placement belongs exclusively to the Lightning Trainer.  Task
+        # construction must preserve the model exactly as returned by Model Factory.
+        self.network = network
         self.args_task = args_task
         self.args_model = args_model
         self.args_data = args_data

--- a/src/trainer_factory/Default_trainer.py
+++ b/src/trainer_factory/Default_trainer.py
@@ -1,6 +1,8 @@
 import os
+from numbers import Integral
 
 import pytorch_lightning as pl
+import torch
 from pytorch_lightning.callbacks import EarlyStopping, ModelCheckpoint, ModelPruning
 from pytorch_lightning.loggers import CSVLogger, WandbLogger
 from torch.utils.tensorboard.writer import SummaryWriter
@@ -20,6 +22,51 @@ if "LOCAL_RANK" in os.environ:
     is_main_process = local_rank == 0
 
 
+DEVICE_MODES = ("cpu", "cuda", "auto")
+
+
+def _resolve_device_request(args_t):
+    """Resolve the explicit trainer device request without hardware fallback."""
+
+    if not hasattr(args_t, "device"):
+        raise ValueError(
+            "trainer.device is required and must be one of: cpu, cuda, auto"
+        )
+    requested = str(args_t.device).strip().lower()
+    if requested not in DEVICE_MODES:
+        raise ValueError(
+            f"unsupported trainer.device {args_t.device!r}; expected one of: "
+            + ", ".join(DEVICE_MODES)
+        )
+
+    devices = getattr(args_t, "devices", getattr(args_t, "gpus", 1))
+    if isinstance(devices, bool) or not isinstance(devices, Integral) or devices < 1:
+        raise ValueError(
+            "trainer.devices/trainer.gpus must be a positive integer, "
+            f"got {devices!r}"
+        )
+    devices = int(devices)
+
+    if requested == "cpu":
+        return "cpu", devices
+    if requested == "auto":
+        return "auto", devices
+
+    if not torch.cuda.is_available():
+        raise RuntimeError(
+            "trainer.device='cuda' was requested, but CUDA is unavailable. "
+            "Set trainer.device=cpu or repair the CUDA runtime; no CPU fallback "
+            "was applied."
+        )
+    available_devices = int(torch.cuda.device_count())
+    if devices > available_devices:
+        raise RuntimeError(
+            "trainer.device='cuda' requested more devices than are available: "
+            f"requested={devices}, available={available_devices}."
+        )
+    return "gpu", devices
+
+
 @register_trainer("Default_trainer")
 def trainer(args_e, args_t, args_d, path):
     """
@@ -33,13 +80,13 @@ def trainer(args_e, args_t, args_d, path):
     返回:
     - trainer: 训练器对象
     """
-    # 为兼容旧配置，填充 num_epochs / gpus / pruning 的合理默认值
+    # 为兼容旧配置，填充 num_epochs / pruning 的合理默认值
     if not hasattr(args_t, "num_epochs"):
         setattr(args_t, "num_epochs", getattr(args_t, "max_epochs", 1))
-    if not hasattr(args_t, "gpus"):
-        setattr(args_t, "gpus", getattr(args_t, "devices", 1))
     if not hasattr(args_t, "pruning"):
         setattr(args_t, "pruning", 0.0)
+
+    accelerator, devices = _resolve_device_request(args_t)
 
     # 获取回调列表
     callback_list = call_backs(args_t, path)
@@ -63,22 +110,19 @@ def trainer(args_e, args_t, args_d, path):
         swanlab_logger = SwanLabLogger(project=args_e.project)
         log_list.append(swanlab_logger)
 
-    # 设置设备类型：CPU 或自动选择
-    accelerate_type = "cpu" if args_t.device == "cpu" else "auto"
-
     # 如果不存在log_every_n_steps，使用默认值50 # TODO @liq22
     if not getattr(args_t, "log_every_n_steps", None):
         args_t.log_every_n_steps = 50
 
-    # 初始化训练器
+    # 初始化训练器。Lightning Trainer 是唯一的设备放置 authority。
     trainer = pl.Trainer(
         callbacks=callback_list,
-        accelerator=accelerate_type,
+        accelerator=accelerator,
         max_epochs=args_t.num_epochs,
-        devices=args_t.gpus,
+        devices=devices,
         logger=log_list,
         log_every_n_steps=args_t.log_every_n_steps,
-        strategy="ddp_find_unused_parameters_true" if args_t.gpus > 1 else "auto",
+        strategy="ddp_find_unused_parameters_true" if devices > 1 else "auto",
         deterministic=getattr(args_t, "deterministic", None),
     )
     return trainer
@@ -141,7 +185,7 @@ def call_backs(args, path):
 
 def Prune_callback(args):
     """
-    根据训练配置，返回模型修剪回调函数。
+    根据训练配置，返回训练器的模型修剪回调。
 
     参数:
     - args: 包含训练配置的对象

--- a/test/test_device_authority.py
+++ b/test/test_device_authority.py
@@ -1,0 +1,192 @@
+from __future__ import annotations
+
+from argparse import Namespace
+import importlib
+
+import pytest
+import torch
+import torch.nn as nn
+
+
+def _default_task_module():
+    return importlib.import_module("src.task_factory.Default_task")
+
+
+def _default_trainer_module():
+    return importlib.import_module("src.trainer_factory.Default_trainer")
+
+
+class TrackingNetwork(nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.linear = nn.Linear(2, 2)
+        self.cuda_calls = 0
+
+    def cuda(self, *args, **kwargs):
+        del args, kwargs
+        self.cuda_calls += 1
+        raise AssertionError("Task construction must not call network.cuda()")
+
+    def forward(self, x, file_id, task_id):
+        del file_id, task_id
+        return self.linear(x)
+
+
+def test_default_task_preserves_model_device_and_trainer_config(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = _default_task_module()
+    monkeypatch.setattr(module, "get_loss_fn", lambda name: nn.CrossEntropyLoss())
+    monkeypatch.setattr(module, "get_metrics", lambda metrics, metadata: {})
+    monkeypatch.setattr(
+        module.torch.cuda,
+        "is_available",
+        lambda: pytest.fail("Task construction must not inspect CUDA availability"),
+    )
+
+    network = TrackingNetwork()
+    args_trainer = Namespace(device="cuda", gpus=1)
+    trainer_config_before = vars(args_trainer).copy()
+
+    task = module.Default_task(
+        network=network,
+        args_data=Namespace(),
+        args_model=Namespace(),
+        args_task=Namespace(
+            loss="CE",
+            metrics=[],
+            optimizer="adam",
+            lr=1e-3,
+        ),
+        args_trainer=args_trainer,
+        args_environment=Namespace(),
+        metadata={0: {"Name": "dummy", "Label": 0}},
+    )
+
+    assert task.network is network
+    assert network.cuda_calls == 0
+    assert next(task.network.parameters()).device.type == "cpu"
+    assert vars(args_trainer) == trainer_config_before
+
+
+@pytest.mark.parametrize(
+    ("device", "devices", "expected"),
+    [
+        ("cpu", 1, ("cpu", 1)),
+        ("cpu", 3, ("cpu", 3)),
+    ],
+)
+def test_device_resolver_honors_explicit_cpu(
+    device: str,
+    devices: int,
+    expected: tuple[str, int],
+) -> None:
+    module = _default_trainer_module()
+    assert module._resolve_device_request(
+        Namespace(device=device, gpus=devices)
+    ) == expected
+
+
+def test_device_resolver_uses_auto_only_when_explicit(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = _default_trainer_module()
+    monkeypatch.setattr(
+        module.torch.cuda,
+        "is_available",
+        lambda: pytest.fail("explicit auto must be delegated to Lightning"),
+    )
+
+    assert module._resolve_device_request(
+        Namespace(device="auto", devices=2)
+    ) == ("auto", 2)
+
+
+def test_device_resolver_rejects_unavailable_cuda_without_cpu_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = _default_trainer_module()
+    monkeypatch.setattr(module.torch.cuda, "is_available", lambda: False)
+    monkeypatch.setattr(
+        module.torch.cuda,
+        "device_count",
+        lambda: pytest.fail("device_count is irrelevant when CUDA is unavailable"),
+    )
+
+    with pytest.raises(RuntimeError, match="no CPU fallback"):
+        module._resolve_device_request(Namespace(device="cuda", gpus=1))
+
+
+def test_device_resolver_accepts_available_cuda(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = _default_trainer_module()
+    monkeypatch.setattr(module.torch.cuda, "is_available", lambda: True)
+    monkeypatch.setattr(module.torch.cuda, "device_count", lambda: 2)
+
+    assert module._resolve_device_request(
+        Namespace(device="cuda", gpus=2)
+    ) == ("gpu", 2)
+
+
+def test_device_resolver_rejects_excess_cuda_devices(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = _default_trainer_module()
+    monkeypatch.setattr(module.torch.cuda, "is_available", lambda: True)
+    monkeypatch.setattr(module.torch.cuda, "device_count", lambda: 1)
+
+    with pytest.raises(RuntimeError, match="requested=2, available=1"):
+        module._resolve_device_request(Namespace(device="cuda", gpus=2))
+
+
+@pytest.mark.parametrize(
+    "args_trainer",
+    [
+        Namespace(gpus=1),
+        Namespace(device="gpu", gpus=1),
+        Namespace(device="cuda", gpus=0),
+        Namespace(device="cpu", devices=True),
+    ],
+)
+def test_device_resolver_rejects_ambiguous_or_invalid_requests(
+    args_trainer: Namespace,
+) -> None:
+    module = _default_trainer_module()
+    with pytest.raises(ValueError):
+        module._resolve_device_request(args_trainer)
+
+
+def test_default_trainer_passes_resolved_cpu_request_to_lightning(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    module = _default_trainer_module()
+    observed: dict[str, object] = {}
+
+    monkeypatch.setattr(module, "call_backs", lambda args, path: [])
+    monkeypatch.setattr(module, "CSVLogger", lambda *args, **kwargs: object())
+    monkeypatch.setattr(
+        module.pl,
+        "Trainer",
+        lambda **kwargs: observed.update(kwargs) or kwargs,
+    )
+
+    result = module.trainer(
+        args_e=Namespace(wandb=False, swanlab=False),
+        args_t=Namespace(
+            device="cpu",
+            gpus=1,
+            num_epochs=1,
+            pruning=0.0,
+            monitor="val_loss",
+            log_every_n_steps=1,
+        ),
+        args_d=Namespace(),
+        path=str(tmp_path),
+    )
+
+    assert result["accelerator"] == "cpu"
+    assert result["devices"] == 1
+    assert result["strategy"] == "auto"
+    assert observed["accelerator"] == "cpu"

--- a/test/test_per_sample_metadata.py
+++ b/test/test_per_sample_metadata.py
@@ -237,17 +237,27 @@ def test_default_task_forwards_explicit_physical_vectors_to_decisive_model():
     }
 
 
-def test_default_task_rejects_cuda_fallback(monkeypatch):  # type: ignore[no-untyped-def]
-    monkeypatch.setattr(torch.cuda, "is_available", lambda: False)
-    with pytest.raises(RuntimeError, match="must not fall back to CPU"):
-        Default_task(
-            network=torch.nn.Linear(2, 2),
-            args_data=SimpleNamespace(normalization="none"),
-            args_model=SimpleNamespace(type="test", name="cuda_required"),
-            args_task=SimpleNamespace(
-                loss="CE", metrics=["acc"], optimizer="adam", lr=1e-3
-            ),
-            args_trainer=SimpleNamespace(device="cuda", gpus=1),
-            args_environment=SimpleNamespace(project="p04_cuda_fail_fast"),
-            metadata={0: {"Name": "Dummy", "Label": 0}},
-        )
+def test_default_task_delegates_cuda_validation_to_trainer(monkeypatch):  # type: ignore[no-untyped-def]
+    monkeypatch.setattr(
+        torch.cuda,
+        "is_available",
+        lambda: pytest.fail("Task construction must not inspect CUDA availability"),
+    )
+    network = torch.nn.Linear(2, 2)
+    args_trainer = SimpleNamespace(device="cuda", gpus=1)
+
+    task = Default_task(
+        network=network,
+        args_data=SimpleNamespace(normalization="none"),
+        args_model=SimpleNamespace(type="test", name="cuda_required"),
+        args_task=SimpleNamespace(
+            loss="CE", metrics=["acc"], optimizer="adam", lr=1e-3
+        ),
+        args_trainer=args_trainer,
+        args_environment=SimpleNamespace(project="p04_cuda_fail_fast"),
+        metadata={0: {"Name": "Dummy", "Label": 0}},
+    )
+
+    assert task.network is network
+    assert next(task.network.parameters()).device.type == "cpu"
+    assert vars(args_trainer) == {"device": "cuda", "gpus": 1}


### PR DESCRIPTION
## Objective

Make the Trainer Factory the sole device-placement authority for the maintained PHMFactory classification path.

## Scientific/runtime invariant

```text
requested device == executed device
```

More precisely:

```text
trainer.device=cpu  -> Lightning accelerator=cpu
trainer.device=cuda -> Lightning accelerator=gpu, or fail before training
trainer.device=auto -> Lightning auto selection only after explicit user request
```

Task and Model construction must preserve the model device and must not inspect or repair hardware configuration.

## Changes

- remove `network.cuda()` and CUDA availability checks from `Default_task`;
- stop mutating `args_trainer.gpus` during Task construction;
- add one explicit `cpu/cuda/auto` resolver to `Default_trainer`;
- reject missing, ambiguous, non-integral, zero, and excessive device requests;
- fail on unavailable CUDA without falling back to CPU;
- document the user-facing device contract;
- add focused tests and execute them inside the maintained offline smoke job.

## Boundaries

- no Data Factory, Model Factory, Pipeline, objective, metric, or experiment-protocol changes;
- no hash/checksum/digest/receipt/ledger/attestation work;
- no new manager, registry, adapter, or schema layer;
- experimental Pipeline 03 multitask implementations remain outside this maintained-surface PR.

## Validation

Requested checks:

- Core quality gates, including `test/test_device_authority.py` and the offline Dummy demo;
- Repository layout;
- Submodule policy;
- documentation and maintained-config validation.
