### PR TITLE
fix(hse): make evaluation deterministic and reject invalid patches

### DIFF
--- a/src/model_factory/ISFM/embedding/E_01_HSE.py
+++ b/src/model_factory/ISFM/embedding/E_01_HSE.py
@@ -1,75 +1,88 @@
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
-from einops import rearrange, repeat
+from einops import rearrange
 from src.model_factory.ISFM.system_utils import normalize_fs
+
+
+def _deterministic_start_indices(
+    max_start: int,
+    batch_size: int,
+    num_patches: int,
+    device: torch.device,
+) -> torch.Tensor:
+    """Return the historical sequential patch grid for deterministic evaluation."""
+    step = max(
+        1,
+        max_start // (num_patches - 1) if num_patches > 1 else 1,
+    )
+    starts = torch.arange(
+        0,
+        min(max_start + 1, num_patches * step),
+        step,
+        device=device,
+    )
+    if len(starts) < num_patches:
+        repeats = (num_patches + len(starts) - 1) // len(starts)
+        starts = starts.repeat(repeats)[:num_patches]
+    return starts.unsqueeze(0).expand(batch_size, -1)
+
 
 class E_01_HSE(nn.Module):
     """
-    Randomly divides the input tensor along L (length) and C (channel) dimensions into patches,
-    then mixes these patches using linear layers. After the patches are selected, a time embedding
-    is added based on the sampling period, ensuring temporal information is preserved without
-    including the time axis in patch selection.
+    Divide an input signal into HSE patches and mix them with linear layers.
 
-    Args:
-        patch_size_L (int): Patch size along the L dimension.
-        patch_size_C (int): Patch size along the C dimension.
-        num_patches (int): Number of random patches to sample.
-        output_dim (int): Output feature dimension after linear mixing.
-        f_s (int): Sampling frequency, used to compute sampling period (T = 1/f_s).
+    Training samples patch starts randomly. Evaluation uses deterministic,
+    evenly-spaced starts unless an evaluator explicitly supplies starts. Inputs use
+    shape ``[B, L, C]``. Patch sizes larger than the observed signal are invalid;
+    HSE never repeats, pads, or duplicates scientific inputs.
     """
+
     def __init__(self, args):
         super(E_01_HSE, self).__init__()
-        self.patch_size_L = args.patch_size_L  # Patch size along L dimension
-        self.patch_size_C = args.patch_size_C  # Patch size along C dimension
-        self.num_patches = args.num_patches    # Number of patches to sample
-        self.output_dim =  args.output_dim
-        # self.args_d = args_d   
-        # self.f_s =  args_d.f_s  # Sampling frequency
-        # self.T = 1.0 /  args_d.f_s  # Sampling period
+        self.patch_size_L = args.patch_size_L
+        self.patch_size_C = args.patch_size_C
+        self.num_patches = args.num_patches
+        self.output_dim = args.output_dim
 
-
-        # Two linear layers for flatten + mixing
-        self.linear1 = nn.Linear(self.patch_size_L * (self.patch_size_C * 2), self.output_dim)
+        self.linear1 = nn.Linear(
+            self.patch_size_L * (self.patch_size_C * 2),
+            self.output_dim,
+        )
         self.linear2 = nn.Linear(self.output_dim, self.output_dim)
 
     def forward(self, x: torch.Tensor, fs, **kwargs) -> torch.Tensor:
-        """
-        Forward pass of RandomPatchMixer.
+        """Return HSE features with shape ``[B, num_patches, output_dim]``."""
+        if not torch.is_tensor(x) or x.ndim != 3:
+            observed = tuple(x.shape) if torch.is_tensor(x) else type(x).__name__
+            raise ValueError(f"HSE input must have shape [B,L,C], got {observed}")
 
-        Args:
-            x (torch.Tensor): Input tensor of shape (B, L, C),
-                              where B is batch size, L is length, C is channels.
-
-        Returns:
-            torch.Tensor: Output tensor of shape (B, num_patches, output_dim).
-        """
         B, L, C = x.size()
         device = x.device
-
-        # 归一化 fs → [B,1]
-        fs_tensor = normalize_fs(fs, batch_size=B, device=device, as_column=True)  # [B,1]
-        T = 1.0 / fs_tensor  # [B,1]
-
-        # Generate time axis 't' for each sample, shape: (B, L)
-        t = torch.arange(L, device=device, dtype=torch.float32).view(1, L)  # [1,L]
-        t = t * T  # 广播到 [B, L]
-
-        # If input is smaller than required patch size, repeat along L or C as needed
         if self.patch_size_L > L:
-            repeats_L = (self.patch_size_L + L - 1) // L  # Ceiling division
-            x = repeat(x, 'b l c -> b (l r) c', r=repeats_L)
-            t = repeat(t, 'b l -> b (l r)', r=repeats_L)
-            L = x.size(1)
-
+            raise ValueError(
+                "HSE patch_size_L exceeds the observed signal length: "
+                f"patch_size_L={self.patch_size_L}, L={L}. Reduce patch_size_L "
+                "or provide longer windows; HSE does not repeat or pad time."
+            )
         if self.patch_size_C > C:
-            repeats_C = (self.patch_size_C + C - 1) // C
-            x = repeat(x, 'b l c -> b l (c r)', r=repeats_C)
-            C = x.size(2)
+            raise ValueError(
+                "HSE patch_size_C exceeds the observed channel count: "
+                f"patch_size_C={self.patch_size_C}, C={C}. Reduce patch_size_C "
+                "or provide the requested channels; HSE does not duplicate or "
+                "pad channels."
+            )
 
-        # Randomly sample starting positions for patches unless an audited
-        # evaluator supplies manifest-keyed starts.  Explicit starts make one
-        # cached feature vector independent of arm order and global RNG state.
+        fs_tensor = normalize_fs(
+            fs,
+            batch_size=B,
+            device=device,
+            as_column=True,
+        )
+        T = 1.0 / fs_tensor
+        t = torch.arange(L, device=device, dtype=torch.float32).view(1, L)
+        t = t * T
+
         max_start_L = L - self.patch_size_L
         max_start_C = C - self.patch_size_C
         explicit_L = kwargs.get("start_indices_L")
@@ -78,20 +91,45 @@ class E_01_HSE(nn.Module):
             raise ValueError(
                 "start_indices_L and start_indices_C must be supplied together"
             )
+
         if explicit_L is None:
-            start_indices_L = torch.randint(
-                0, max_start_L + 1, (B, self.num_patches), device=device
-            )
-            start_indices_C = torch.randint(
-                0, max_start_C + 1, (B, self.num_patches), device=device
-            )
+            if self.training:
+                start_indices_L = torch.randint(
+                    0,
+                    max_start_L + 1,
+                    (B, self.num_patches),
+                    device=device,
+                )
+                start_indices_C = torch.randint(
+                    0,
+                    max_start_C + 1,
+                    (B, self.num_patches),
+                    device=device,
+                )
+            else:
+                start_indices_L = _deterministic_start_indices(
+                    max_start_L,
+                    B,
+                    self.num_patches,
+                    device,
+                )
+                start_indices_C = _deterministic_start_indices(
+                    max_start_C,
+                    B,
+                    self.num_patches,
+                    device,
+                )
         else:
             expected_shape = (B, self.num_patches)
             start_indices_L = torch.as_tensor(
-                explicit_L, dtype=torch.long, device=device
+                explicit_L,
+                dtype=torch.long,
+                device=device,
             )
             start_indices_C = torch.as_tensor(
-                explicit_C, dtype=torch.long, device=device
+                explicit_C,
+                dtype=torch.long,
+                device=device,
             )
             if tuple(start_indices_L.shape) != expected_shape:
                 raise ValueError(
@@ -103,267 +141,232 @@ class E_01_HSE(nn.Module):
                     "start_indices_C must have shape "
                     f"{expected_shape}, observed={tuple(start_indices_C.shape)}"
                 )
-            if (start_indices_L < 0).any() or (start_indices_L > max_start_L).any():
+            if (start_indices_L < 0).any() or (
+                start_indices_L > max_start_L
+            ).any():
                 raise ValueError("start_indices_L contains an out-of-range start")
-            if (start_indices_C < 0).any() or (start_indices_C > max_start_C).any():
+            if (start_indices_C < 0).any() or (
+                start_indices_C > max_start_C
+            ).any():
                 raise ValueError("start_indices_C contains an out-of-range start")
 
-        # Create offsets for patch sizes
         offsets_L = torch.arange(self.patch_size_L, device=device)
         offsets_C = torch.arange(self.patch_size_C, device=device)
+        idx_L = start_indices_L.unsqueeze(-1) + offsets_L
+        idx_C = start_indices_C.unsqueeze(-1) + offsets_C
 
-        # Compute actual indices
-        idx_L = (start_indices_L.unsqueeze(-1) + offsets_L) % L  # (B, num_patches, patch_size_L)
-        idx_C = (start_indices_C.unsqueeze(-1) + offsets_C) % C  # (B, num_patches, patch_size_C)
+        idx_L = idx_L.unsqueeze(-1)
+        idx_C = idx_C.unsqueeze(-2)
 
-        # Expand for advanced indexing
-        idx_L = idx_L.unsqueeze(-1)  # (B, num_patches, patch_size_L, 1)
-        idx_C = idx_C.unsqueeze(-2)  # (B, num_patches, 1, patch_size_C)
-
-        # Gather patches
         patches = x.unsqueeze(1).expand(-1, self.num_patches, -1, -1)
         patches = patches.gather(2, idx_L.expand(-1, -1, -1, C))
-        patches = patches.gather(3, idx_C.expand(-1, -1, self.patch_size_L, -1))
+        patches = patches.gather(
+            3,
+            idx_C.expand(-1, -1, self.patch_size_L, -1),
+        )
 
-        # Gather corresponding time embeddings
-        t_expanded = t.unsqueeze(1).expand(-1, self.num_patches, -1)  # (B, num_patches, L)
-        t_patches = t_expanded.gather(2, idx_L.squeeze(-1))           # (B, num_patches, patch_size_L)
-        t_patches = t_patches.unsqueeze(-1).expand(-1, -1, -1, self.patch_size_C)
+        t_expanded = t.unsqueeze(1).expand(-1, self.num_patches, -1)
+        t_patches = t_expanded.gather(2, idx_L.squeeze(-1))
+        t_patches = t_patches.unsqueeze(-1).expand(
+            -1,
+            -1,
+            -1,
+            self.patch_size_C,
+        )
 
-        # Concatenate time embedding to the end along channel dimension
-        patches = torch.cat([patches, t_patches], dim=-1)  # shape: (B, num_patches, patch_size_L, patch_size_C + 1)
-
-        # Flatten each patch and apply linear layers
-        patches = rearrange(patches, 'b p l c -> b p (l c)')
+        patches = torch.cat([patches, t_patches], dim=-1)
+        patches = rearrange(patches, "b p l c -> b p (l c)")
         out = self.linear1(patches)
         out = F.silu(out)
-        out = self.linear2(out)
-        return out
-    
-#%% 
-    
+        return self.linear2(out)
+
+
 class E_01_HSE_abalation(nn.Module):
     """
     Hierarchical Signal Embedding (HSE) module.
-    
-    支持多种消融实验参数:
-    - sampling_mode: 'random'或'sequential'采样模式
-    - apply_mixing: 是否对patch进行mixing处理
-    - linear_config: Linear层深度配置
-    - patch_scale: Patch参数放大倍数
-    - activation_type: 激活函数类型
-    
-    Args:
-        patch_size_L (int): Patch size along the L dimension.
-        patch_size_C (int): Patch size along the C dimension.
-        num_patches (int): Number of random patches to sample.
-        output_dim (int): Output feature dimension after linear mixing.
+
+    Supports configurable sampling, mixing, linear depth, patch scale, and
+    activation ablations while retaining the same no-repeat input boundary as
+    the maintained HSE implementation.
     """
+
     def __init__(self, args, args_d):
         super(E_01_HSE_abalation, self).__init__()
-        # 基本参数
-        self.patch_size_L = args.patch_size_L  # Patch size along L dimension
-        self.patch_size_C = args.patch_size_C  # Patch size along C dimension
-        self.num_patches = args.num_patches      # Number of patches to sample
+        self.patch_size_L = args.patch_size_L
+        self.patch_size_C = args.patch_size_C
+        self.num_patches = args.num_patches
         self.output_dim = args.output_dim
         self.args_d = args_d
-        
-        # 消融实验参数
-        self.sampling_mode = getattr(args, 'sampling_mode', 'random')  # 'random'或'sequential'
-        self.apply_mixing = getattr(args, 'apply_mixing', True)       # 是否混合patch
-        
-        # 获取线性层配置，默认为(1,1)
-        if hasattr(args, 'linear_config'):
-            if isinstance(args.linear_config, (list, tuple)) and len(args.linear_config) == 2:
-                self.linear_config = tuple(args.linear_config) 
+
+        self.sampling_mode = getattr(args, "sampling_mode", "random")
+        self.apply_mixing = getattr(args, "apply_mixing", True)
+
+        if hasattr(args, "linear_config"):
+            if (
+                isinstance(args.linear_config, (list, tuple))
+                and len(args.linear_config) == 2
+            ):
+                self.linear_config = tuple(args.linear_config)
             else:
                 self.linear_config = (1, 1)
         else:
             self.linear_config = (1, 1)
-        
-        # 获取patch缩放参数
-        if hasattr(args, 'patch_scale'):
-            if isinstance(args.patch_scale, (list, tuple)) and len(args.patch_scale) == 3:
+
+        if hasattr(args, "patch_scale"):
+            if (
+                isinstance(args.patch_scale, (list, tuple))
+                and len(args.patch_scale) == 3
+            ):
                 self.patch_scale = tuple(args.patch_scale)
             else:
                 self.patch_scale = (1, 1, 1)
         else:
             self.patch_scale = (1, 1, 1)
-            
-        # 应用patch缩放
+
         self.patch_size_L *= self.patch_scale[0]
         self.patch_size_C *= self.patch_scale[1]
         self.num_patches *= self.patch_scale[2]
-        
-        # 激活函数类型
-        self.activation_type = getattr(args, 'activation_type', 'silu')
+
+        self.activation_type = getattr(args, "activation_type", "silu")
         self.activation_fn = self._get_activation_fn(self.activation_type)
-        
-        # 创建线性层
         self._setup_linear_layers()
-        
+
     def _get_activation_fn(self, activation_type):
-        """获取激活函数"""
         activation_map = {
-            'silu': F.silu,
-            'relu': F.relu,
-            'gelu': F.gelu,
-            'leaky_relu': F.leaky_relu,
-            'tanh': torch.tanh,
-            'sigmoid': torch.sigmoid
+            "silu": F.silu,
+            "relu": F.relu,
+            "gelu": F.gelu,
+            "leaky_relu": F.leaky_relu,
+            "tanh": torch.tanh,
+            "sigmoid": torch.sigmoid,
         }
         return activation_map.get(activation_type.lower(), F.silu)
-        
+
     def _setup_linear_layers(self):
-        """设置线性层"""
         layer1_depth, layer2_depth = self.linear_config
-        
-        # 创建第一个线性变换
+
         if layer1_depth == 1:
-            self.linear1 = nn.Linear(self.patch_size_L * (self.patch_size_C * 2), self.output_dim)
+            self.linear1 = nn.Linear(
+                self.patch_size_L * (self.patch_size_C * 2),
+                self.output_dim,
+            )
         else:
-            layers = [nn.Linear(self.patch_size_L * (self.patch_size_C * 2), self.output_dim)]
+            layers = [
+                nn.Linear(
+                    self.patch_size_L * (self.patch_size_C * 2),
+                    self.output_dim,
+                )
+            ]
             for _ in range(layer1_depth - 1):
-                layers.extend([
-                    nn.LayerNorm(self.output_dim),
-                    # self.activation_fn,
-                    nn.Linear(self.output_dim, self.output_dim)
-                ])
+                layers.extend(
+                    [
+                        nn.LayerNorm(self.output_dim),
+                        nn.Linear(self.output_dim, self.output_dim),
+                    ]
+                )
             self.linear1 = nn.Sequential(*layers)
-        
-        # 创建第二个线性变换
+
         if not self.apply_mixing:
-            self.linear2 = nn.Identity()  # 如果不应用mixing，使用恒等映射
+            self.linear2 = nn.Identity()
         elif layer2_depth == 1:
             self.linear2 = nn.Linear(self.output_dim, self.output_dim)
         else:
             layers = [nn.Linear(self.output_dim, self.output_dim)]
             for _ in range(layer2_depth - 1):
-                layers.extend([
-                    nn.LayerNorm(self.output_dim),
-                    # self.activation_fn,
-                    nn.Linear(self.output_dim, self.output_dim)
-                ])
+                layers.extend(
+                    [
+                        nn.LayerNorm(self.output_dim),
+                        nn.Linear(self.output_dim, self.output_dim),
+                    ]
+                )
             self.linear2 = nn.Sequential(*layers)
 
     def forward(self, x: torch.Tensor, data_name) -> torch.Tensor:
-        """
-        Forward pass of HSE.
+        if not torch.is_tensor(x) or x.ndim != 3:
+            observed = tuple(x.shape) if torch.is_tensor(x) else type(x).__name__
+            raise ValueError(f"HSE input must have shape [B,L,C], got {observed}")
 
-        Args:
-            x (torch.Tensor): Input tensor of shape (B, L, C),
-                             where B is batch size, L is length, C is channels.
-            data_name (str): Dataset name for sampling frequency.
-
-        Returns:
-            torch.Tensor: Output tensor of shape (B, num_patches, output_dim).
-        """
         B, L, C = x.size()
         device = x.device
-        fs = self.args_d.task[data_name]['f_s']
-        T = 1.0 / fs
+        if self.patch_size_L > L:
+            raise ValueError(
+                "HSE patch_size_L exceeds the observed signal length: "
+                f"patch_size_L={self.patch_size_L}, L={L}. Reduce patch_size_L "
+                "or provide longer windows; HSE does not repeat or pad time."
+            )
+        if self.patch_size_C > C:
+            raise ValueError(
+                "HSE patch_size_C exceeds the observed channel count: "
+                f"patch_size_C={self.patch_size_C}, C={C}. Reduce patch_size_C "
+                "or provide the requested channels; HSE does not duplicate or "
+                "pad channels."
+            )
 
-        # 生成时间轴
+        fs = self.args_d.task[data_name]["f_s"]
+        T = 1.0 / fs
         t = torch.arange(L, device=device, dtype=torch.float32) * T
         t = t.unsqueeze(0).expand(B, -1)
 
-        # 处理尺寸不匹配
-        if self.patch_size_L > L:
-            repeats_L = (self.patch_size_L + L - 1) // L
-            x = repeat(x, 'b l c -> b (l r) c', r=repeats_L)
-            t = repeat(t, 'b l -> b (l r)', r=repeats_L)
-            L = x.size(1)
-
-        if self.patch_size_C > C:
-            repeats_C = (self.patch_size_C + C - 1) // C
-            x = repeat(x, 'b l c -> b l (c r)', r=repeats_C)
-            C = x.size(2)
-
-        # 根据采样模式选择处理方式
         max_start_L = L - self.patch_size_L
         max_start_C = C - self.patch_size_C
-        
-        if self.sampling_mode == 'random':
-            # 随机采样
-            start_indices_L = torch.randint(0, max(1, max_start_L + 1), (B, self.num_patches), device=device)
-            start_indices_C = torch.randint(0, max(1, max_start_C + 1), (B, self.num_patches), device=device)
-        else:
-            # 顺序采样
-            step_L = max(1, max_start_L // (self.num_patches - 1) if self.num_patches > 1 else 1)
-            step_C = max(1, max_start_C // (self.num_patches - 1) if self.num_patches > 1 else 1)
-            
-            # 生成等距起始点
-            start_L_seq = torch.arange(0, min(max_start_L+1, self.num_patches * step_L), step_L, device=device)
-            start_C_seq = torch.arange(0, min(max_start_C+1, self.num_patches * step_C), step_C, device=device)
-            
-            # 确保有足够的起始点
-            if len(start_L_seq) < self.num_patches:
-                start_L_seq = start_L_seq.repeat((self.num_patches + len(start_L_seq) - 1) // len(start_L_seq))
-                start_L_seq = start_L_seq[:self.num_patches]
-            
-            if len(start_C_seq) < self.num_patches:
-                start_C_seq = start_C_seq.repeat((self.num_patches + len(start_C_seq) - 1) // len(start_C_seq))
-                start_C_seq = start_C_seq[:self.num_patches]
-            
-            # 扩展到批次维度
-            start_indices_L = start_L_seq.unsqueeze(0).expand(B, -1)
-            start_indices_C = start_C_seq.unsqueeze(0).expand(B, -1)
 
-        # 创建偏移量
+        if self.sampling_mode == "random" and self.training:
+            start_indices_L = torch.randint(
+                0,
+                max_start_L + 1,
+                (B, self.num_patches),
+                device=device,
+            )
+            start_indices_C = torch.randint(
+                0,
+                max_start_C + 1,
+                (B, self.num_patches),
+                device=device,
+            )
+        else:
+            start_indices_L = _deterministic_start_indices(
+                max_start_L,
+                B,
+                self.num_patches,
+                device,
+            )
+            start_indices_C = _deterministic_start_indices(
+                max_start_C,
+                B,
+                self.num_patches,
+                device,
+            )
+
         offsets_L = torch.arange(self.patch_size_L, device=device)
         offsets_C = torch.arange(self.patch_size_C, device=device)
+        idx_L = start_indices_L.unsqueeze(-1) + offsets_L
+        idx_C = start_indices_C.unsqueeze(-1) + offsets_C
 
-        # 计算实际索引
-        idx_L = (start_indices_L.unsqueeze(-1) + offsets_L) % L  # (B, num_patches, patch_size_L)
-        idx_C = (start_indices_C.unsqueeze(-1) + offsets_C) % C  # (B, num_patches, patch_size_C)
+        idx_L = idx_L.unsqueeze(-1)
+        idx_C = idx_C.unsqueeze(-2)
 
-        # 扩展用于高级索引
-        idx_L = idx_L.unsqueeze(-1)  # (B, num_patches, patch_size_L, 1)
-        idx_C = idx_C.unsqueeze(-2)  # (B, num_patches, 1, patch_size_C)
-
-        # 收集patches
         patches = x.unsqueeze(1).expand(-1, self.num_patches, -1, -1)
         patches = patches.gather(2, idx_L.expand(-1, -1, -1, C))
-        patches = patches.gather(3, idx_C.expand(-1, -1, self.patch_size_L, -1))
+        patches = patches.gather(
+            3,
+            idx_C.expand(-1, -1, self.patch_size_L, -1),
+        )
 
-        # 收集对应的时间嵌入
         t_expanded = t.unsqueeze(1).expand(-1, self.num_patches, -1)
         t_patches = t_expanded.gather(2, idx_L.squeeze(-1))
-        t_patches = t_patches.unsqueeze(-1).expand(-1, -1, -1, self.patch_size_C)
+        t_patches = t_patches.unsqueeze(-1).expand(
+            -1,
+            -1,
+            -1,
+            self.patch_size_C,
+        )
 
-        # 沿通道维度连接时间嵌入
         patches = torch.cat([patches, t_patches], dim=-1)
-
-        # 展平每个patch并应用线性层
-        patches = rearrange(patches, 'b p l c -> b p (l c)')
+        patches = rearrange(patches, "b p l c -> b p (l c)")
         out = self.linear1(patches)
-        
+
         if self.apply_mixing:
             out = self.activation_fn(out)
             out = self.linear2(out)
-            
+
         return out
-
-if __name__ == '__main__':
-    # Testing the RandomPatchMixer class
-    def test_random_patch_mixer():
-        B = 2  # Batch size
-        L_list = [1024, 2048]  # Variable sequence lengths
-        C_list = [8, 3]   # Variable channel dimensions
-
-        patch_size_L = 128   # Patch size along L dimension
-        patch_size_C = 5   # Patch size along C dimension
-        num_patches = 100   # Number of patches to sample
-        output_dim = 16    # Output dimension after mixing
-        f_s = 100  # Sampling frequency
-
-        model = E_01_HSE(patch_size_L, patch_size_C, num_patches, output_dim, f_s)
-
-        for C in C_list:
-            for L in L_list:
-                x = torch.randn(B, L, C)
-                y = model(x)
-                print(f'Input shape: {x.shape}, Output shape: {y.shape}')
-
-    # Run the test
-    test_random_patch_mixer()

--- a/src/model_factory/ISFM/embedding/README.md
+++ b/src/model_factory/ISFM/embedding/README.md
@@ -24,6 +24,19 @@ The presence of a Python file alone does not imply release support. Maintained c
 
 Exact constructor arguments and module paths are recorded in `../isfm_components.csv`. Runtime metadata requirements, such as sampling-rate or system identifiers, are documented in `../README.md` and the selected configuration.
 
+## HSE runtime contract
+
+`E_01_HSE` consumes signals with shape `[B, L, C]`.
+
+- Training mode samples valid patch starts randomly.
+- Evaluation mode uses a deterministic, evenly spaced patch grid.
+- Explicit `start_indices_L` and `start_indices_C` may be supplied together by a controlled evaluator.
+- `patch_size_L > L` is invalid and fails before feature construction.
+- `patch_size_C > C` is invalid and fails before feature construction.
+- HSE never repeats or pads the time axis and never duplicates or pads channels to satisfy a patch request.
+
+This distinction keeps training stochastic while ensuring repeated validation and test passes evaluate the same finite input representation.
+
 ## Adding or changing an embedding
 
 A public embedding change should keep the following surfaces synchronized:

--- a/src/task_factory/task/pretrain/README.md
+++ b/src/task_factory/task/pretrain/README.md
@@ -34,6 +34,24 @@ Base fields live in `configs/base/task/pretrain.yaml`; demo files may override
 `task.name`, contrastive weights, augmentation settings, and stage-specific
 fields.
 
+## HSE contrastive evaluation contract
+
+Configured HSE augmentation remains stochastic during training. Validation and
+test augmentation use a local generator derived from:
+
+```text
+environment.seed + evaluation stage + batch index
+```
+
+Consequently, repeated evaluation of the same checkpoint, ordered loader, and
+configuration produces the same augmented feature view without consuming or
+depending on the process-wide random-number state. Validation and test use
+different stage offsets, so they remain distinct evaluation streams.
+
+This contract does not change the training objective or augmentation family. It
+only prevents validation and test metrics from changing because unrelated code
+advanced the global RNG.
+
 ## Boundaries
 
 - This README does not promote every registered pretrain module to

--- a/src/task_factory/task/pretrain/hse_contrastive.py
+++ b/src/task_factory/task/pretrain/hse_contrastive.py
@@ -17,6 +17,11 @@ logger = logging.getLogger(__name__)
 class task(Default_task):
     """Feature-level HSE contrastive learning with an optional CE objective."""
 
+    _EVAL_AUGMENTATION_STAGE_OFFSETS = {
+        "val": 1_000_003,
+        "test": 2_000_003,
+    }
+
     def __init__(
         self,
         network,
@@ -40,6 +45,7 @@ class task(Default_task):
         self.args_task = args_task
         self.args_model = args_model
         self.args_data = args_data
+        self.args_environment = args_environment
         self.metadata = metadata
 
         self.contrast_weight = self._validated_weight(
@@ -144,7 +150,12 @@ class task(Default_task):
 
         contrastive_loss = x.new_zeros(())
         if self.contrast_weight > 0:
-            contrastive_loss = self._run_contrastive_flow(features, y)
+            contrastive_loss = self._run_contrastive_flow(
+                features,
+                y,
+                stage=stage,
+                batch_idx=batch_idx,
+            )
             self._require_valid_loss(contrastive_loss, "contrastive objective", stage)
 
         total_loss = (
@@ -291,6 +302,9 @@ class task(Default_task):
         self,
         features: torch.Tensor,
         y: torch.Tensor,
+        *,
+        stage: str = "train",
+        batch_idx: int = 0,
     ) -> torch.Tensor:
         if self.strategy_manager is None:
             raise RuntimeError(
@@ -327,7 +341,11 @@ class task(Default_task):
             labels_ext = torch.cat([y, y], dim=0)
 
         z1 = features
-        z2 = self._create_augmented_view(features)
+        z2 = self._create_augmented_view(
+            features,
+            stage=stage,
+            batch_idx=batch_idx,
+        )
         z = torch.cat([z1, z2], dim=0)
 
         result = self.strategy_manager.compute_loss(
@@ -343,7 +361,41 @@ class task(Default_task):
             )
         return result["loss"]
 
-    def _create_augmented_view(self, features: torch.Tensor) -> torch.Tensor:
+    def _augmentation_generator(
+        self,
+        features: torch.Tensor,
+        *,
+        stage: str,
+        batch_idx: int,
+    ) -> Optional[torch.Generator]:
+        if stage == "train":
+            return None
+        if stage not in self._EVAL_AUGMENTATION_STAGE_OFFSETS:
+            raise ValueError(
+                f"unsupported HSE stage {stage!r}; expected train, val, or test"
+            )
+        if isinstance(batch_idx, bool) or int(batch_idx) != batch_idx or batch_idx < 0:
+            raise ValueError(
+                f"HSE evaluation batch_idx must be a non-negative integer, got {batch_idx!r}"
+            )
+
+        base_seed = int(getattr(self.args_environment, "seed", 0))
+        seed = (
+            base_seed
+            + self._EVAL_AUGMENTATION_STAGE_OFFSETS[stage]
+            + int(batch_idx)
+        ) % (2**63 - 1)
+        generator = torch.Generator(device=features.device)
+        generator.manual_seed(seed)
+        return generator
+
+    def _create_augmented_view(
+        self,
+        features: torch.Tensor,
+        *,
+        stage: str = "train",
+        batch_idx: int = 0,
+    ) -> torch.Tensor:
         aug_type = str(getattr(self.args_task, "augmentation_type", "noise")).lower()
         allowed = {"none", "noise", "scaling", "dropout", "mixed"}
         if aug_type not in allowed:
@@ -362,31 +414,57 @@ class task(Default_task):
         if not math.isfinite(dropout_p) or not 0 <= dropout_p < 1:
             raise ValueError("task.augmentation_dropout_p must satisfy 0 <= p < 1.")
 
+        generator = self._augmentation_generator(
+            features,
+            stage=stage,
+            batch_idx=batch_idx,
+        )
         if aug_type == "none":
             augmented = features.clone()
         else:
             if aug_type == "mixed":
                 candidates = ("noise", "scaling", "dropout")
-                index = torch.randint(len(candidates), (1,), device=features.device).item()
+                index = torch.randint(
+                    len(candidates),
+                    (1,),
+                    device=features.device,
+                    generator=generator,
+                ).item()
                 aug_type = candidates[index]
 
             if aug_type == "dropout":
                 if dropout_p == 0:
                     augmented = features.clone()
                 else:
-                    mask = (torch.rand_like(features) >= dropout_p).to(features.dtype)
-                    augmented = features * mask
+                    mask = torch.rand(
+                        features.shape,
+                        device=features.device,
+                        dtype=features.dtype,
+                        generator=generator,
+                    )
+                    augmented = features * (mask >= dropout_p).to(features.dtype)
             elif aug_type == "scaling":
                 if scale_std == 0:
                     augmented = features.clone()
                 else:
-                    scale = 1.0 + torch.randn_like(features) * scale_std
+                    scale = 1.0 + torch.randn(
+                        features.shape,
+                        device=features.device,
+                        dtype=features.dtype,
+                        generator=generator,
+                    ) * scale_std
                     augmented = features * scale
             else:
                 if noise_std == 0:
                     augmented = features.clone()
                 else:
-                    augmented = features + torch.randn_like(features) * noise_std
+                    noise = torch.randn(
+                        features.shape,
+                        device=features.device,
+                        dtype=features.dtype,
+                        generator=generator,
+                    )
+                    augmented = features + noise * noise_std
 
         if not torch.isfinite(augmented).all():
             raise FloatingPointError("HSE augmentation produced NaN or Inf values.")

--- a/test/test_hse_objective_contract.py
+++ b/test/test_hse_objective_contract.py
@@ -5,6 +5,8 @@ import pytest
 import torch
 import torch.nn.functional as F
 
+from src.model_factory.ISFM.embedding.E_01_HSE import E_01_HSE
+
 
 hse_module = importlib.import_module(
     "src.task_factory.task.pretrain.hse_contrastive"
@@ -36,8 +38,20 @@ def _new_task_for_methods():
     instance = HSETask.__new__(HSETask)
     torch.nn.Module.__init__(instance)
     instance.args_task = _task_args()
+    instance.args_environment = SimpleNamespace(seed=17)
     instance.ce_loss_fn = F.cross_entropy
     return instance
+
+
+def _embedding_args(**overrides):
+    values = {
+        "patch_size_L": 4,
+        "patch_size_C": 2,
+        "num_patches": 5,
+        "output_dim": 8,
+    }
+    values.update(overrides)
+    return SimpleNamespace(**values)
 
 
 def test_hse_requires_at_least_one_enabled_objective(monkeypatch):
@@ -165,3 +179,113 @@ def test_invalid_augmentation_is_not_silently_rewritten():
     instance.args_task = _task_args(augmentation_dropout_p=1.2)
     with pytest.raises(ValueError, match="0 <= p < 1"):
         instance._create_augmented_view(features)
+
+
+def test_hse_embedding_rejects_oversized_time_patch_without_repetition():
+    model = E_01_HSE(_embedding_args(patch_size_L=9))
+    x = torch.randn(2, 8, 3)
+
+    with pytest.raises(ValueError, match="does not repeat or pad time"):
+        model(x, fs=torch.tensor([12_000.0, 48_000.0]))
+
+
+def test_hse_embedding_rejects_oversized_channel_patch_without_duplication():
+    model = E_01_HSE(_embedding_args(patch_size_C=4))
+    x = torch.randn(2, 8, 3)
+
+    with pytest.raises(ValueError, match="does not duplicate or pad channels"):
+        model(x, fs=torch.tensor([12_000.0, 48_000.0]))
+
+
+def test_hse_embedding_eval_is_deterministic_and_does_not_sample_random_starts(
+    monkeypatch,
+):
+    model = E_01_HSE(_embedding_args())
+    model.eval()
+    x = torch.arange(2 * 12 * 3, dtype=torch.float32).reshape(2, 12, 3)
+    fs = torch.tensor([12_000.0, 48_000.0])
+
+    def fail_random_start(*args, **kwargs):
+        pytest.fail("evaluation must not call torch.randint for HSE patch starts")
+
+    monkeypatch.setattr(torch, "randint", fail_random_start)
+    first = model(x, fs=fs)
+    torch.manual_seed(999)
+    second = model(x, fs=fs)
+
+    assert torch.equal(first, second)
+
+
+def test_hse_embedding_training_keeps_random_patch_sampling(monkeypatch):
+    model = E_01_HSE(_embedding_args())
+    model.train()
+    x = torch.randn(2, 12, 3)
+    calls = []
+
+    def fixed_random_start(low, high, size, *, device):
+        calls.append((low, high, size, device))
+        return torch.zeros(size, dtype=torch.long, device=device)
+
+    monkeypatch.setattr(torch, "randint", fixed_random_start)
+    output = model(x, fs=12_000.0)
+
+    assert output.shape == (2, 5, 8)
+    assert len(calls) == 2
+
+
+def test_hse_eval_augmentation_is_deterministic_and_rng_independent():
+    instance = _new_task_for_methods()
+    instance.args_task = _task_args(
+        augmentation_type="noise",
+        augmentation_noise_std=0.2,
+    )
+    features = torch.arange(24, dtype=torch.float32).reshape(4, 6)
+
+    torch.manual_seed(123)
+    rng_before = torch.random.get_rng_state()
+    first = instance._create_augmented_view(
+        features,
+        stage="val",
+        batch_idx=3,
+    )
+    rng_after = torch.random.get_rng_state()
+    assert torch.equal(rng_before, rng_after)
+
+    torch.manual_seed(999)
+    second = instance._create_augmented_view(
+        features,
+        stage="val",
+        batch_idx=3,
+    )
+    test_view = instance._create_augmented_view(
+        features,
+        stage="test",
+        batch_idx=3,
+    )
+
+    assert torch.equal(first, second)
+    assert not torch.equal(first, test_view)
+
+
+def test_hse_training_augmentation_remains_stochastic():
+    instance = _new_task_for_methods()
+    instance.args_task = _task_args(
+        augmentation_type="noise",
+        augmentation_noise_std=0.2,
+    )
+    features = torch.arange(24, dtype=torch.float32).reshape(4, 6)
+
+    torch.manual_seed(1)
+    first = instance._create_augmented_view(
+        features,
+        stage="train",
+        batch_idx=0,
+    )
+    torch.manual_seed(2)
+    second = instance._create_augmented_view(
+        features,
+        stage="train",
+        batch_idx=0,
+    )
+
+    assert not torch.equal(first, second)


### PR DESCRIPTION
## Objective

Make HSE evaluation a deterministic estimator and reject input shapes that cannot satisfy the configured patch contract without fabricating signal content.

## Runtime invariant

```text
train:
  random valid patch starts
  stochastic configured contrastive augmentation

val/test:
  deterministic valid patch grid
  deterministic configured contrastive augmentation

invalid patch request:
  fail before feature construction
```

More precisely:

```text
patch_size_L > L -> ValueError
patch_size_C > C -> ValueError
```

HSE does not repeat or pad time and does not duplicate or pad channels.

## Changes

- replace implicit time/channel repetition with actionable shape errors;
- preserve random patch sampling in training mode;
- use an evenly spaced deterministic patch grid in evaluation mode;
- preserve explicit evaluator-provided patch starts with range validation;
- make validation/test contrastive augmentation use a local generator derived from `environment.seed`, stage, and batch index;
- keep training augmentation stochastic and unchanged in family/parameters;
- add focused tests for shape boundaries, patch determinism, RNG isolation, and stochastic training behavior;
- document the HSE embedding and contrastive evaluation contracts.

## Boundaries

- no Data Factory, Trainer Factory, Pipeline, checkpoint, metric, label, or estimator aggregation changes;
- no `task_id` cleanup in this PR; that remains the next Task/Metric P0;
- no hash/checksum/digest/receipt/ledger/attestation work;
- no new manager, wrapper, adapter, registry, or schema layer;
- no automatic patch resizing, padding, signal repetition, or channel duplication.

## Validation

Requested checks:

- Core quality gates, including the focused HSE objective contract and offline Dummy demo;
- PHMFactory public package;
- Repository layout;
- Submodule policy;
- maintained configuration and documentation validation.
