### PR TITLE
docs(readme): refresh the PHMFactory project homepage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,37 +1,104 @@
 # PHMFactory
 
 <div align="center">
-  <img src="pic/PHM-Vibench.png" alt="PHMFactory logo" width="280"/>
+  <img src="pic/PHM-Vibench.png" alt="PHMFactory logo" width="300"/>
 
   <p>
     <a href="README.md"><strong>English</strong></a> |
     <a href="README_CN.md">中文</a>
   </p>
 
-  <p><strong>A configuration-first framework for reproducible PHM experiments on industrial signals.</strong></p>
+  <p><strong>Configuration-first, fail-fast PHM experiments for industrial signals.</strong></p>
+  <p><em>One configuration from data selection to evaluation, without hidden scientific fallbacks.</em></p>
 
   <p>
     <img src="https://img.shields.io/badge/status-alpha-orange" alt="Status: alpha"/>
-    <img src="https://img.shields.io/badge/v0.3-pre--release-blue" alt="v0.3 pre-release"/>
+    <img src="https://img.shields.io/badge/version-0.3.0.dev0-blue" alt="Version 0.3.0.dev0"/>
+    <img src="https://img.shields.io/badge/Python-%3E%3D3.10-3776AB" alt="Python 3.10 or newer"/>
     <a href="https://github.com/PHMbench/PHM-Vibench/actions/workflows/core-quality-gates.yml"><img src="https://github.com/PHMbench/PHM-Vibench/actions/workflows/core-quality-gates.yml/badge.svg" alt="Core quality gates"/></a>
     <img src="https://img.shields.io/badge/license-Apache%202.0-green" alt="Apache 2.0 license"/>
   </p>
+
+  <p>
+    <a href="#quick-start">Quick start</a> •
+    <a href="#why-phmfactory">Why PHMFactory</a> •
+    <a href="#how-it-works">How it works</a> •
+    <a href="#choose-your-path">Documentation</a> •
+    <a href="#support-boundary">Support boundary</a> •
+    <a href="#contributing-and-citation">Contribute</a>
+  </p>
 </div>
 
-> **Current repository identity.** The project and Python package are named
-> **PHMFactory**, while the GitHub repository remains
-> [`PHMbench/PHM-Vibench`](https://github.com/PHMbench/PHM-Vibench) during the v0.3
-> pre-release. Use the repository URL shown here until an eventual rename is completed.
+---
 
-PHMFactory connects data loading, model construction, task logic, training, evaluation,
-and run records through one configuration-first interface. You select a maintained
-configuration, override only the values that differ on your machine, and run the same
-contract from the command line, Python module, or compatibility launcher.
+> **Repository identity.** The project and Python package are named
+> **PHMFactory**. During the v0.3 pre-release, the GitHub repository remains
+> [`PHMbench/PHM-Vibench`](https://github.com/PHMbench/PHM-Vibench). Use this
+> repository URL until a future rename is explicitly announced.
 
-## Start with the offline demo
+PHMFactory is a modular research framework for fault diagnosis and related PHM
+experiments on industrial signals. A single resolved configuration connects the data,
+model, task objective, trainer, checkpoint, evaluation, and user-visible results.
 
-The following path uses repository-shipped synthetic data and does not download an
-external dataset.
+The governing invariant is:
+
+```text
+requested experiment = executed experiment
+```
+
+A run must fail clearly when its requested data, task, device, objective, checkpoint, or
+evaluation cannot be executed as declared. PHMFactory does not silently replace the
+experiment with an easier one.
+
+## Why PHMFactory
+
+Industrial PHM repositories often contain strong algorithms but weak experimental
+boundaries. The resulting code may run while executing a different data split, task,
+device, objective, or estimator than the user intended.
+
+| Common failure in PHM experimentation | PHMFactory response |
+| --- | --- |
+| Configuration defaults silently change the experiment | Explicit configuration resolution and fail-fast validation |
+| Data, model, task, and trainer logic are entangled | Four factories with narrow, reviewable responsibilities |
+| Evaluation depends on uncontrolled random sampling | Deterministic validation and test behavior on maintained paths |
+| A source file is mistaken for a supported capability | Generated support tables distinguish discovery, execution, and maintained evidence |
+| Replacing one component requires editing the runtime | Component selection remains configuration-first |
+
+Two practical design rules follow:
+
+```text
+Replace one module
+→ change that module and its configuration
+```
+
+```text
+Training may be stochastic
+→ evaluation must still be a defined estimator
+```
+
+<details>
+<summary><strong>What PHMFactory is—and is not</strong></summary>
+
+PHMFactory is intended to provide:
+
+- one public configuration-first execution path;
+- explicit data, model, task, and trainer boundaries;
+- actionable failures rather than silent fallback;
+- maintained smoke configurations and generated support documentation;
+- a common runtime for CLI and optional Streamlit usage.
+
+PHMFactory does not claim that every implementation in the repository is mutually
+compatible, benchmark-valid, state of the art, or ready for redistribution. Those claims
+require an explicitly maintained configuration and a scientifically closed protocol.
+
+</details>
+
+## Quick start
+
+The first run is fully offline. It uses repository-shipped synthetic data and does not
+download an external dataset.
+
+### 1. Install
 
 ```bash
 git clone https://github.com/PHMbench/PHM-Vibench.git
@@ -41,64 +108,124 @@ python -m venv .venv
 source .venv/bin/activate          # Windows: .venv\Scripts\activate
 python -m pip install --upgrade pip
 python -m pip install -e .
+```
 
+Python 3.10 or newer is required. CPU-only and GPU-specific installation notes are in
+[Installation](docs/installation.md).
+
+### 2. Diagnose, preflight, and run
+
+```bash
 phmfactory doctor
 phmfactory preflight --config smoke
 phmfactory demo
 ```
 
-A successful first run should:
+The three commands have separate purposes:
 
-- report every required `doctor` check as `PASS`;
-- print `status=passed` during `preflight` without starting training;
-- complete one CPU Dummy experiment through data → model → task → trainer;
-- print the path to `run_manifest.json`;
-- write results below `results/demo/dummy_dg_smoke/`;
-- exit with status code `0` for all three commands.
+```text
+doctor
+→ checks the installed environment and repository resources
 
-If a command fails, keep the complete terminal output and follow the relevant section in
-[Quickstart](docs/quickstart.md). Installation variants, including CPU-only PyTorch, are
-covered in [Installation](docs/installation.md).
+preflight
+→ resolves and validates the exact configuration without training
 
-## Choose your next task
+demo
+→ executes one bounded CPU experiment through data → model → task → trainer
+```
 
-| Goal | Start here |
+A successful run writes below:
+
+```text
+results/demo/dummy_dg_smoke/
+```
+
+and prints the location of the run record. For expected output and failure diagnosis, see
+[Quickstart](docs/quickstart.md).
+
+### What the offline demo proves
+
+It proves that the package can be installed and that the maintained public runtime can
+complete one bounded experiment. It does **not** prove real-data benchmark validity,
+algorithm superiority, or universal compatibility across repository components.
+
+## How it works
+
+```text
+YAML or preset
+    ↓
+resolved configuration
+    ↓
+canonical Pipeline
+    ↓
+Data Factory → Model Factory → Task Factory → Trainer Factory
+    ↓
+fit → best checkpoint → evaluation → finite metrics
+    ↓
+user-visible result path
+```
+
+### Factory responsibilities
+
+| Boundary | Owns | Must not do |
+| --- | --- | --- |
+| **Data Factory** | readers, metadata, selected IDs, datasets, samplers, loaders | repair model or task configuration |
+| **Model Factory** | model identity, construction, explicitly requested weights | select data splits or move the model to a device |
+| **Task Factory** | task identity, objective, metric lifecycle | control hardware or rewrite the requested task |
+| **Trainer Factory** | device, callbacks, checkpoints, loggers, training and evaluation lifecycle | invent missing task or data semantics |
+| **Pipeline** | orchestration, success gating, result location | silently repair any factory input |
+
+This division is deliberately narrow. New datasets, models, tasks, and trainers should
+normally extend their own factory rather than add special cases to `main.py`.
+
+## Core capabilities
+
+| Capability | User-visible behavior |
+| --- | --- |
+| **Configuration-first execution** | The same resolved configuration drives CLI, module, and compatibility entrypoints. |
+| **Fail-fast scientific semantics** | Invalid labels, unavailable devices, impossible splits, missing checkpoints, and invalid metrics stop the run. |
+| **Deterministic evaluation boundaries** | Maintained validation and test paths do not depend on uncontrolled patch or augmentation randomness. |
+| **Offline first-run path** | `doctor`, `preflight`, and `demo` work without downloading an external dataset. |
+| **Modular replacement** | Data, model, task, and trainer choices remain explicit and independently reviewable. |
+| **One runtime, optional interfaces** | The CLI is authoritative; Streamlit adapts the same command rather than creating a second training system. |
+
+## Choose your path
+
+| Your goal | Start here |
 | --- | --- |
 | Understand the first run and its outputs | [Quickstart](docs/quickstart.md) |
 | Install on CPU, GPU, Linux, macOS, or Windows | [Installation](docs/installation.md) |
-| Use an existing maintained experiment | [Configuration guide](configs/README.md) |
+| Run an existing maintained experiment | [Configuration guide](configs/README.md) |
 | Connect local PHM data | [Data layout](data/README.md) and [custom dataset guide](docs/custom_dataset.md) |
 | Select or add a model | [Model Factory](src/model_factory/README.md) |
 | Select or add a task | [Task Factory](src/task_factory/README.md) |
-| Use the browser interface | [Streamlit workspace](apps/streamlit/README.md) |
+| Use the browser workspace | [Streamlit workspace](apps/streamlit/README.md) |
 | Extend or maintain the framework | [Developer guide](docs/developer_guide.md) |
-| Check the exact maintained surface | [Supported combinations](SUPPORTED_COMBINATIONS.md) |
+| Inspect the exact maintained surface | [Supported combinations](SUPPORTED_COMBINATIONS.md) |
 
 The complete documentation map is in [docs/index.md](docs/index.md).
 
-## The configuration model
+## Configuration contract
 
-Maintained configurations use five logical blocks:
+Maintained experiments use a top-level `pipeline` and five logical blocks:
 
 ```yaml
-environment:  # output location, seed, repeat count, process-level settings
+pipeline: "Pipeline_01_Fault_Diagnosis"
+
+environment:  # output path, seed, repeat count, process-level settings
   ...
 data:         # metadata, raw data root, windows, workers, sampling policy
   ...
 model:        # model family and model-specific parameters
   ...
-task:         # diagnosis, domain generalization, few-shot, or pretraining logic
+task:         # diagnosis, generalization, few-shot, or pretraining objective
   ...
-trainer:      # device, epochs, precision, logging, and checkpoint behavior
+trainer:      # device, epochs, precision, logging, checkpoint behavior
   ...
 ```
 
-A top-level `pipeline` selects the orchestration path. New datasets, models, tasks, and
-trainers should normally extend their factory instead of adding special cases to
-`main.py`.
-
 Start from the nearest maintained file under `configs/demo/`. Put research variants under
-`configs/experiments/`, and pass machine-specific values explicitly:
+`configs/experiments/`, and pass machine-specific paths explicitly:
 
 ```bash
 phmfactory preflight \
@@ -108,7 +235,7 @@ phmfactory preflight \
   --override trainer.num_epochs=1
 ```
 
-After preflight passes, remove the word `preflight` to execute the same configuration:
+After preflight succeeds, execute the same configuration:
 
 ```bash
 phmfactory \
@@ -118,10 +245,10 @@ phmfactory \
   --override trainer.num_epochs=1
 ```
 
-The exact composition and precedence rules are defined in
-[configs/README.md](configs/README.md).
+Composition and precedence rules are defined in [configs/README.md](configs/README.md).
 
-## Public entrypoints
+<details>
+<summary><strong>Public entrypoints</strong></summary>
 
 The following process entrypoints share the same configuration and exit-status semantics:
 
@@ -131,9 +258,8 @@ python -m phmfactory --config <yaml> [--override key=value ...]
 python main.py --config <yaml> [--override key=value ...]
 ```
 
-Use the installed `phmfactory` command in normal work. `python main.py` remains a
-repository compatibility launcher. Python callers that need the structured command or
-Pipeline result may import `phmfactory.cli.main` directly.
+Use the installed `phmfactory` command for normal work. `python main.py` remains a
+repository compatibility launcher.
 
 Useful bounded commands:
 
@@ -144,9 +270,11 @@ phmfactory demo
 phmfactory data --help
 ```
 
-## Maintained support boundary
+</details>
 
-PHMFactory distinguishes three claims:
+## Support boundary
+
+PHMFactory distinguishes three levels:
 
 ```text
 discoverable  = an implementation or registry entry exists
@@ -160,34 +288,34 @@ The required relation is:
 supported ⊆ runnable ⊆ discoverable
 ```
 
-A source file, model registry row, or successful import is not by itself a support claim.
-The current maintained surface is generated from the configuration registry and current
-runtime descriptors:
+A file, registry row, or successful import is not a support claim. Current maintained
+surfaces are generated from repository configuration and runtime descriptors:
 
 - [Supported components](SUPPORTED_COMPONENTS.md)
 - [Supported combinations](SUPPORTED_COMBINATIONS.md)
 - [Configuration registry](configs/config_registry.csv)
 - [Configuration Atlas](docs/CONFIG_ATLAS.md)
 
-`sanity_ok` means bounded functional evidence exists. It does not mean state-of-the-art
-performance, universal component compatibility, or permission to redistribute an
-external dataset.
+`sanity_ok` means bounded functional evidence exists. It does not mean benchmark-valid
+performance, state-of-the-art results, unrestricted dataset redistribution, or arbitrary
+Cartesian-product compatibility.
 
 ## Optional Streamlit workspace
 
-The web workspace is an adapter around the same public CLI, not a second training system:
+The browser workspace adapts the same public CLI:
 
 ```bash
 python -m pip install -r apps/streamlit/requirements.txt
 streamlit run apps/streamlit/app.py
 ```
 
-Start with **Use safe CPU smoke defaults**. The UI can prepare a configuration, validate
-it, launch the public command, and display logs and artifacts. See
-[apps/streamlit/README.md](apps/streamlit/README.md) for its single-worker scope and
-troubleshooting.
+Start with **Use safe CPU smoke defaults**. The interface can prepare a configuration,
+validate it, launch the public command, and display logs and outputs. Its single-worker
+scope and troubleshooting are documented in
+[apps/streamlit/README.md](apps/streamlit/README.md).
 
-## Architecture for developers
+<details>
+<summary><strong>Developer architecture and repository map</strong></summary>
 
 ```text
 phmfactory command / python -m phmfactory / main.py
@@ -202,11 +330,11 @@ phmfactory command / python -m phmfactory / main.py
 
 Primary paths:
 
-- `phmfactory/` — public package, commands, config resolver, Pipeline descriptors, and run control plane;
+- `phmfactory/` — public package, commands, configuration resolver, Pipeline descriptors, and run control;
 - `configs/` — reusable blocks, maintained demos, research experiments, and registry;
 - `src/data_factory/` — metadata, readers, datasets, samplers, and data assembly;
 - `src/model_factory/` — model families and model construction;
-- `src/task_factory/` — tasks, losses, metrics, and task construction;
+- `src/task_factory/` — tasks, objectives, metrics, and task construction;
 - `src/trainer_factory/` — trainer construction and extensions;
 - `apps/streamlit/` — optional browser workspace;
 - `test/` — maintained pytest suite;
@@ -224,25 +352,18 @@ git diff --exit-code SUPPORTED_COMPONENTS.md SUPPORTED_COMBINATIONS.md
 python -m pytest test/ -q
 ```
 
-See [docs/testing.md](docs/testing.md) for focused gates and evidence terminology.
+See [docs/testing.md](docs/testing.md) for focused gates and test terminology.
 
-## Branch policy
-
-`main` is the user-facing stable branch and the default branch. `dev` is the integration
-branch. Routine feature, fix, documentation, test, CI, cleanup, and migration pull
-requests target `dev` and start from the latest `dev`.
-
-Only an explicitly authorized release-promotion pull request or emergency hotfix may
-target `main`. A hotfix must be synchronized back to `dev`. See
-[CONTRIBUTING.md](CONTRIBUTING.md) for the full workflow.
+</details>
 
 ## Current pre-release limits
 
-PHMFactory remains an alpha `0.3.0.dev0` source release. In particular:
+PHMFactory remains an alpha `0.3.0.dev0` source release:
 
 - only the Dummy demo is fully offline and repository-shipped;
-- most real-data demos require local metadata and raw data;
-- CWRU provider revisions and required-file hashes are not yet finalized;
+- most real-data configurations require local metadata and raw signals;
+- no real-data configuration has yet been promoted as the first scientifically closed `baseline_valid` reference;
+- CWRU provider, reader, and final acceptance conditions are still being finalized;
 - the GitHub repository has not been renamed;
 - no final `v0.3.0` tag or package publication is claimed;
 - experimental Pipelines and unlisted model/task combinations are not release-supported.
@@ -251,17 +372,26 @@ Read [Known limitations](KNOWN_LIMITATIONS.md) and the
 [v0.3 release-readiness page](docs/PHMFACTORY_V0_3_RELEASE_READINESS.md) before making a
 release or benchmark claim.
 
-## Contributing, support, and citation
+## Branch policy
 
-Read [CONTRIBUTING.md](CONTRIBUTING.md) before opening an issue or pull request. Report the
-exact commit, configuration, overrides, environment, data source, and complete error
-output.
+`main` is the user-facing stable default branch. `dev` is the integration branch. Routine
+feature, fix, documentation, test, CI, cleanup, and migration pull requests start from
+the latest `dev` and target `dev`.
+
+Only an explicitly authorized release-promotion pull request or emergency hotfix may
+target `main`. See [CONTRIBUTING.md](CONTRIBUTING.md) for the full workflow.
+
+## Contributing and citation
+
+Read [CONTRIBUTING.md](CONTRIBUTING.md) before opening an issue or pull request. A useful
+problem report includes the exact commit, configuration, overrides, environment, data
+source, and complete terminal output.
 
 - Bugs and feature requests: [GitHub Issues](https://github.com/PHMbench/PHM-Vibench/issues)
-- Security reports: [SECURITY.md](SECURITY.md)
-- Development workflow: [docs/developer_guide.md](docs/developer_guide.md)
-- Release readiness: [docs/PHMFACTORY_V0_3_RELEASE_READINESS.md](docs/PHMFACTORY_V0_3_RELEASE_READINESS.md)
+- Development workflow: [Developer guide](docs/developer_guide.md)
+- Release readiness: [v0.3 release status](docs/PHMFACTORY_V0_3_RELEASE_READINESS.md)
+- Software citation metadata: [CITATION.cff](CITATION.cff)
+- License: [Apache License 2.0](LICENSE)
 
-PHMFactory is licensed under the [Apache License 2.0](LICENSE). Dataset and model artifacts
-may have separate source licenses. Use [CITATION.cff](CITATION.cff) for software citation
-metadata, and cite the exact commit or release used for each experiment.
+Dataset and model artifacts may have separate source licenses. Cite the exact commit or
+release used for each experiment.

--- a/README_CN.md
+++ b/README_CN.md
@@ -1,35 +1,101 @@
 # PHMFactory
 
 <div align="center">
-  <img src="pic/PHM-Vibench.png" alt="PHMFactory 标志" width="280"/>
+  <img src="pic/PHM-Vibench.png" alt="PHMFactory 标志" width="300"/>
 
   <p>
     <a href="README.md">English</a> |
     <a href="README_CN.md"><strong>中文</strong></a>
   </p>
 
-  <p><strong>面向工业信号、强调可复现性的配置优先 PHM 实验框架。</strong></p>
+  <p><strong>配置优先、失败即停的工业信号 PHM 实验框架。</strong></p>
+  <p><em>用一份配置贯通数据、模型、任务、训练与评价，不用隐式兜底改变实验。</em></p>
 
   <p>
     <img src="https://img.shields.io/badge/状态-alpha-orange" alt="状态：alpha"/>
-    <img src="https://img.shields.io/badge/v0.3-预发布-blue" alt="v0.3 预发布"/>
+    <img src="https://img.shields.io/badge/版本-0.3.0.dev0-blue" alt="版本 0.3.0.dev0"/>
+    <img src="https://img.shields.io/badge/Python-%3E%3D3.10-3776AB" alt="Python 3.10 或更高版本"/>
     <a href="https://github.com/PHMbench/PHM-Vibench/actions/workflows/core-quality-gates.yml"><img src="https://github.com/PHMbench/PHM-Vibench/actions/workflows/core-quality-gates.yml/badge.svg" alt="核心质量门禁"/></a>
     <img src="https://img.shields.io/badge/许可-Apache%202.0-green" alt="Apache 2.0 许可"/>
   </p>
+
+  <p>
+    <a href="#快速开始">快速开始</a> •
+    <a href="#为什么是-phmfactory">为什么使用</a> •
+    <a href="#运行机制">运行机制</a> •
+    <a href="#按任务选择文档">使用文档</a> •
+    <a href="#支持边界">支持边界</a> •
+    <a href="#贡献与引用">参与贡献</a>
+  </p>
 </div>
 
-> **当前仓库身份。** 项目名称和 Python 包名已经统一为 **PHMFactory**，但在
-> v0.3 预发布阶段，GitHub 仓库仍是
-> [`PHMbench/PHM-Vibench`](https://github.com/PHMbench/PHM-Vibench)。正式改名前请始终
-> 使用这里给出的真实仓库地址。
+---
 
-PHMFactory 用一个配置优先入口连接数据加载、模型构建、任务逻辑、训练、评估和
-运行记录。用户选择一个维护中的配置，只覆盖本机路径或实验参数，即可通过命令行、
-Python 模块或兼容入口执行同一份实验语义。
+> **当前仓库身份。** 项目名称和 Python 包名已经统一为 **PHMFactory**。在 v0.3
+> 预发布阶段，GitHub 仓库仍为
+> [`PHMbench/PHM-Vibench`](https://github.com/PHMbench/PHM-Vibench)。在后续改名被明确
+> 公布之前，请始终使用这里给出的真实仓库地址。
 
-## 先运行完全离线的示例
+PHMFactory 面向工业信号故障诊断及相关 PHM 实验，提供模块化、配置驱动的研究运行
+框架。一份解析完成的配置直接连接数据、模型、任务目标、训练器、checkpoint、评价与
+用户可见结果。
 
-下面的路径只使用仓库自带的合成数据，不下载外部数据集：
+仓库的核心不变量是：
+
+```text
+用户声明的实验 = 程序实际执行的实验
+```
+
+当请求的数据、任务、设备、目标函数、checkpoint 或评价无法按配置执行时，程序应给出
+明确错误并停止，不得偷偷换成更容易运行的另一套实验。
+
+## 为什么是 PHMFactory
+
+工业 PHM 仓库常常拥有较强的算法，却缺少清晰的实验边界。结果可能是代码成功退出，
+但真实执行的数据划分、任务、设备、目标函数或估计量已经偏离用户声明。
+
+| PHM 实验中的常见问题 | PHMFactory 的处理方式 |
+| --- | --- |
+| 默认值在不知情时改变实验 | 显式解析配置，并在不满足条件时立即失败 |
+| 数据、模型、任务和训练器彼此耦合 | 四个 Factory 分工清晰，责任可以独立审查 |
+| 评价结果受无约束随机采样影响 | 维护路径中的验证与测试采用确定性边界 |
+| 源码文件存在就被误认为“已支持” | 自动生成支持表，区分可发现、可运行和维护证据 |
+| 替换一个组件需要修改运行时 | 组件选择保持配置优先 |
+
+由此形成两条直接的设计规则：
+
+```text
+替换一个模块
+→ 只修改该模块及其配置
+```
+
+```text
+训练可以具有随机性
+→ 评价仍必须对应一个定义明确的估计量
+```
+
+<details>
+<summary><strong>PHMFactory 是什么，也不是什么</strong></summary>
+
+PHMFactory 主要提供：
+
+- 一条统一的配置优先运行路径；
+- 清晰的数据、模型、任务与训练器边界；
+- 可执行的错误提示，而不是静默兜底；
+- 维护中的冒烟配置和自动生成的支持文档；
+- CLI 与可选 Streamlit 共用的同一运行时。
+
+PHMFactory 不宣称仓库中的所有实现都可以任意组合，也不因源码存在、import 成功或一次
+运行成功就宣称结果已经达到 benchmark-valid、SOTA 或允许重新分发。此类结论必须建立
+在明确维护的配置和科学闭合的协议上。
+
+</details>
+
+## 快速开始
+
+首次运行完全离线，只使用仓库自带的合成数据，不下载外部数据集。
+
+### 1. 安装
 
 ```bash
 git clone https://github.com/PHMbench/PHM-Vibench.git
@@ -39,61 +105,121 @@ python -m venv .venv
 source .venv/bin/activate          # Windows：.venv\Scripts\activate
 python -m pip install --upgrade pip
 python -m pip install -e .
+```
 
+项目要求 Python 3.10 或更高版本。CPU-only PyTorch、GPU 和不同操作系统的安装方式见
+[安装指南](docs/installation.md)。
+
+### 2. 检查、预检与运行
+
+```bash
 phmfactory doctor
 phmfactory preflight --config smoke
 phmfactory demo
 ```
 
-首次运行成功时，应满足：
+三条命令分别承担不同责任：
 
-- `doctor` 的必需检查全部显示 `PASS`；
-- `preflight` 打印 `status=passed`，且不会启动训练；
-- `demo` 在 CPU 上完成一次 Dummy 数据的 data → model → task → trainer 链路；
-- 终端打印 `run_manifest.json` 的路径；
-- 结果写入 `results/demo/dummy_dg_smoke/`；
-- 三条命令的进程退出码均为 `0`。
+```text
+doctor
+→ 检查安装环境和仓库必需资源
 
-命令失败时请保留完整终端输出，并根据[快速开始](docs/quickstart.md)中的对应故障
-处理。CPU-only PyTorch、GPU 和不同操作系统的安装方式见[安装指南](docs/installation.md)。
+preflight
+→ 解析并验证同一份配置，但不启动训练
 
-## 根据任务选择文档
+demo
+→ 在 CPU 上执行 data → model → task → trainer 的完整受控链路
+```
+
+成功运行后，结果位于：
+
+```text
+results/demo/dummy_dg_smoke/
+```
+
+终端会打印运行记录的位置。预期输出和故障排查见[快速开始](docs/quickstart.md)。
+
+### 离线示例能够证明什么
+
+它能够证明软件已正确安装，并且维护中的公共运行时可以完成一次边界明确的实验。它不
+证明真实数据 benchmark 已经有效，也不证明算法性能优越或仓库内任意组件都可以组合。
+
+## 运行机制
+
+```text
+YAML 或 preset
+    ↓
+解析完成的配置
+    ↓
+canonical Pipeline
+    ↓
+Data Factory → Model Factory → Task Factory → Trainer Factory
+    ↓
+fit → best checkpoint → evaluation → finite metrics
+    ↓
+用户可见结果路径
+```
+
+### Factory 责任边界
+
+| 边界 | 负责 | 不应负责 |
+| --- | --- | --- |
+| **Data Factory** | reader、metadata、selected IDs、dataset、sampler、loader | 修复模型或任务配置 |
+| **Model Factory** | 模型身份、构造、显式请求的外部权重 | 选择数据划分或移动模型设备 |
+| **Task Factory** | 任务身份、目标函数、指标生命周期 | 控制硬件或改写用户任务 |
+| **Trainer Factory** | 设备、callback、checkpoint、logger、训练与评价生命周期 | 补齐缺失的任务或数据语义 |
+| **Pipeline** | 编排、成功门控、结果位置 | 静默修复任何 Factory 输入 |
+
+这些边界刻意保持简洁。新增数据集、模型、任务和训练器时，通常应扩展对应 Factory，
+而不是在 `main.py` 中增加项目专用分支。
+
+## 核心能力
+
+| 能力 | 用户可观察行为 |
+| --- | --- |
+| **配置优先运行** | CLI、Python 模块和兼容入口使用同一份解析配置。 |
+| **科学语义 fail-fast** | 非法标签、不可用设备、不可能的数据划分、缺失 checkpoint 和非法指标会终止运行。 |
+| **确定性评价边界** | 维护中的验证与测试不依赖无约束的 patch 或增强随机性。 |
+| **离线首次运行** | `doctor`、`preflight` 和 `demo` 不需要下载外部数据。 |
+| **模块化替换** | 数据、模型、任务和训练器的选择显式且可以独立审查。 |
+| **单一运行时** | CLI 是权威入口；Streamlit 只是同一命令的界面适配。 |
+
+## 按任务选择文档
 
 | 你的目标 | 从这里开始 |
 | --- | --- |
 | 理解第一次运行及其输出 | [快速开始](docs/quickstart.md) |
 | 在 CPU、GPU、Linux、macOS 或 Windows 上安装 | [安装指南](docs/installation.md) |
-| 运行一个已有的维护实验 | [配置系统](configs/README.md) |
+| 运行已有的维护实验 | [配置系统](configs/README.md) |
 | 接入本地 PHM 数据 | [数据目录](data/README.md)和[自定义数据集](docs/custom_dataset.md) |
 | 选择或新增模型 | [模型工厂](src/model_factory/README_CN.md) |
 | 选择或新增任务 | [任务工厂](src/task_factory/README.md) |
-| 使用浏览器界面 | [Streamlit 工作区](apps/streamlit/README.md) |
+| 使用浏览器工作区 | [Streamlit 工作区](apps/streamlit/README.md) |
 | 扩展或维护框架 | [开发者指南](docs/developer_guide.md) |
-| 核对当前真正支持的组合 | [支持组合](SUPPORTED_COMBINATIONS.md) |
+| 核对真正维护的组合 | [支持组合](SUPPORTED_COMBINATIONS.md) |
 
 完整文档地图见 [docs/index.md](docs/index.md)。
 
-## 配置的五个逻辑块
+## 配置合同
 
-维护中的配置统一使用：
+维护实验统一使用一个顶层 `pipeline` 和五个逻辑块：
 
 ```yaml
+pipeline: "Pipeline_01_Fault_Diagnosis"
+
 environment:  # 输出路径、随机种子、重复次数和进程级设置
   ...
-data:         # metadata、原始数据根目录、窗口和 worker
+data:         # metadata、原始数据根目录、窗口、worker 和采样策略
   ...
 model:        # 模型家族及模型专有参数
   ...
-task:         # 诊断、域泛化、小样本或预训练逻辑
+task:         # 诊断、泛化、小样本或预训练目标
   ...
-trainer:      # 设备、epoch、精度、日志和 checkpoint
+trainer:      # 设备、epoch、精度、日志和 checkpoint 行为
   ...
 ```
 
-顶层 `pipeline` 只负责选择编排路径。新增数据集、模型、任务和训练器时，原则上应扩展
-对应 factory，不应在 `main.py` 中加入项目专用分支。
-
-本地实验从 `configs/demo/` 中最接近的维护配置开始，研究变体放到
+本地实验从 `configs/demo/` 中最接近的维护配置开始，研究变体放入
 `configs/experiments/`，本机路径通过显式 override 传入：
 
 ```bash
@@ -104,7 +230,7 @@ phmfactory preflight \
   --override trainer.num_epochs=1
 ```
 
-预检通过后，去掉 `preflight` 即可执行同一份配置：
+预检通过后，执行同一份配置：
 
 ```bash
 phmfactory \
@@ -114,9 +240,10 @@ phmfactory \
   --override trainer.num_epochs=1
 ```
 
-配置组合和优先级的权威说明位于 [configs/README.md](configs/README.md)。
+配置组合与优先级的权威说明见 [configs/README.md](configs/README.md)。
 
-## 公开入口
+<details>
+<summary><strong>公共入口</strong></summary>
 
 以下三个进程入口具有相同的配置和退出码语义：
 
@@ -126,10 +253,9 @@ python -m phmfactory --config <yaml> [--override key=value ...]
 python main.py --config <yaml> [--override key=value ...]
 ```
 
-正常使用时推荐安装后的 `phmfactory` 命令；`python main.py` 只作为仓库兼容入口保留。
-需要直接读取结构化 Python 返回值的调用者可以导入 `phmfactory.cli.main`。
+正常使用推荐安装后的 `phmfactory` 命令；`python main.py` 只作为仓库兼容入口保留。
 
-常用的轻量命令：
+常用轻量命令：
 
 ```bash
 phmfactory doctor
@@ -138,14 +264,16 @@ phmfactory demo
 phmfactory data --help
 ```
 
-## 如何理解“支持”
+</details>
 
-PHMFactory 明确区分：
+## 支持边界
+
+PHMFactory 明确区分三个层级：
 
 ```text
 discoverable  = 源码或注册表条目存在
-runnable      = 已建立可审查的执行路径
-supported     = 维护配置具有当前的功能冒烟结果
+runnable      = 已建立经过审查的执行路径
+supported     = 维护配置具有当前功能冒烟证据
 ```
 
 必须满足：
@@ -154,31 +282,32 @@ supported     = 维护配置具有当前的功能冒烟结果
 supported ⊆ runnable ⊆ discoverable
 ```
 
-源码文件、模型注册表条目或 import 成功都不自动等于“已支持”。当前维护范围由配置注册表
-和运行时 descriptor 生成：
+源码文件、注册表行或 import 成功都不是支持声明。当前维护范围由仓库配置和运行时描述
+自动生成：
 
 - [支持组件](SUPPORTED_COMPONENTS.md)
 - [支持组合](SUPPORTED_COMBINATIONS.md)
 - [配置注册表](configs/config_registry.csv)
 - [配置图谱](docs/CONFIG_ATLAS.md)
 
-`sanity_ok` 只表示已有边界明确的功能冒烟，不表示达到 SOTA、任意组件都可组合，也不
-表示外部数据可以重新分发。
+`sanity_ok` 只表示已有边界明确的功能冒烟，不表示 benchmark-valid、SOTA、允许任意重分发
+外部数据，或任意组件笛卡尔积都能组合。
 
 ## 可选 Streamlit 工作区
 
-Web 工作区只是同一公共 CLI 的适配层，不是第二套训练框架：
+浏览器工作区适配同一条公共 CLI：
 
 ```bash
 python -m pip install -r apps/streamlit/requirements.txt
 streamlit run apps/streamlit/app.py
 ```
 
-首次使用选择 **Use safe CPU smoke defaults**。界面可以准备配置、验证、启动公共命令，
-并查看日志和产物。其单 worker 边界和故障处理见
+首次使用选择 **Use safe CPU smoke defaults**。界面可以准备配置、验证、启动公共命令并
+显示日志和输出。单 worker 边界和故障处理见
 [apps/streamlit/README.md](apps/streamlit/README.md)。
 
-## 开发者架构
+<details>
+<summary><strong>开发者架构与仓库地图</strong></summary>
 
 ```text
 phmfactory 命令 / python -m phmfactory / main.py
@@ -193,17 +322,17 @@ phmfactory 命令 / python -m phmfactory / main.py
 
 主要目录：
 
-- `phmfactory/`：公开包、命令、配置解析、Pipeline descriptor 和运行控制层；
+- `phmfactory/`：公开包、命令、配置解析、Pipeline descriptor 和运行控制；
 - `configs/`：复用块、维护 demo、研究实验和配置注册表；
 - `src/data_factory/`：metadata、reader、dataset、sampler 和数据装配；
 - `src/model_factory/`：模型家族和模型构造；
-- `src/task_factory/`：任务、损失、指标和任务构造；
+- `src/task_factory/`：任务、目标函数、指标和任务构造；
 - `src/trainer_factory/`：训练器构造和扩展；
 - `apps/streamlit/`：可选浏览器工作区；
 - `test/`：维护中的 pytest 测试；
 - `docs/`：用户、扩展、开发、发布和历史文档。
 
-提交 PR 前运行：
+提交审阅前运行：
 
 ```bash
 python -m scripts.validate_docs
@@ -215,39 +344,42 @@ git diff --exit-code SUPPORTED_COMPONENTS.md SUPPORTED_COMBINATIONS.md
 python -m pytest test/ -q
 ```
 
-聚焦测试和验证术语见 [docs/testing.md](docs/testing.md)。
+聚焦测试和术语说明见 [docs/testing.md](docs/testing.md)。
 
-## 分支策略
+</details>
 
-`main` 是面向用户的稳定默认分支，`dev` 是集成分支。常规功能、修复、文档、测试、CI、
-清理和迁移 PR 都应以最新 `dev` 为起点并合入 `dev`。
-
-只有明确授权的发布提升 PR 或紧急 hotfix 可以指向 `main`；hotfix 必须同步回 `dev`。
-完整流程见 [CONTRIBUTING_CN.md](CONTRIBUTING_CN.md)。
-
-## 当前预发布限制
+## 当前预发布边界
 
 PHMFactory 仍是 alpha 阶段的 `0.3.0.dev0` 源码版本：
 
 - 只有 Dummy demo 完全离线并随仓库提供；
-- 大部分真实数据 demo 需要本地 metadata 和原始数据；
-- CWRU provider revision 和必需文件 hash 尚未最终冻结；
+- 大部分真实数据配置需要本地 metadata 和原始信号；
+- 尚无真实数据配置被提升为首个科学闭合的 `baseline_valid` 参考实验；
+- CWRU provider、reader 和最终 acceptance 条件仍在收敛；
 - GitHub 仓库尚未改名；
-- 当前不宣称已有最终 `v0.3.0` tag 或包发布；
+- 当前不宣称已有最终 `v0.3.0` tag 或正式包发布；
 - experimental Pipeline 和未列出的模型/任务组合不属于发布支持范围。
 
 进行发布或 benchmark 声明前，请阅读[已知限制](KNOWN_LIMITATIONS.md)和
 [v0.3 发布就绪状态](docs/PHMFACTORY_V0_3_RELEASE_READINESS.md)。
 
-## 贡献、支持与引用
+## 分支策略
 
-提交 Issue 或 PR 前请阅读 [CONTRIBUTING_CN.md](CONTRIBUTING_CN.md)。问题报告应包含
-准确 commit、配置、override、环境、数据来源和完整错误输出。
+`main` 是面向用户的稳定默认分支，`dev` 是集成分支。常规功能、修复、文档、测试、CI、
+清理和迁移 PR 都从最新 `dev` 开始并指向 `dev`。
+
+只有明确授权的 release promotion PR 或紧急 hotfix 可以指向 `main`。完整流程见
+[CONTRIBUTING_CN.md](CONTRIBUTING_CN.md)。
+
+## 贡献与引用
+
+提交 Issue 或 PR 前请阅读 [CONTRIBUTING_CN.md](CONTRIBUTING_CN.md)。有效的问题报告应
+包含准确 commit、配置、override、环境、数据来源和完整终端输出。
 
 - Bug 与功能建议：[GitHub Issues](https://github.com/PHMbench/PHM-Vibench/issues)
-- 安全问题：[SECURITY.md](SECURITY.md)
-- 开发流程：[docs/developer_guide.md](docs/developer_guide.md)
-- 发布状态：[docs/PHMFACTORY_V0_3_RELEASE_READINESS.md](docs/PHMFACTORY_V0_3_RELEASE_READINESS.md)
+- 开发流程：[开发者指南](docs/developer_guide.md)
+- 发布状态：[v0.3 发布状态](docs/PHMFACTORY_V0_3_RELEASE_READINESS.md)
+- 软件引用信息：[CITATION.cff](CITATION.cff)
+- 许可：[Apache License 2.0](LICENSE)
 
-PHMFactory 使用 [Apache License 2.0](LICENSE)。数据集和模型产物可能适用独立来源许可。
-软件引用信息见 [CITATION.cff](CITATION.cff)，每次实验应记录并引用准确的 commit 或 tag。
+数据集和模型产物可能适用独立来源许可。每次实验应记录并引用准确的 commit 或 tag。


### PR DESCRIPTION
## Objective

Refresh the English and Chinese repository homepages by combining the stronger visual hierarchy of the earlier PHM-Vibench README with the current PHMFactory runtime and scientific boundaries.

## Changes

- restore a product-style hero section with language switcher, accurate badges, and direct navigation;
- add a concise `Why PHMFactory` section grounded in current fail-fast and Factory responsibilities;
- make the offline first-run path visually prominent and explain what it proves and does not prove;
- add an explicit runtime flow and Factory responsibility table;
- reorganize documentation links around user goals;
- retain the current five-block configuration contract, public entrypoints, support boundary, Streamlit adapter, branch policy, and pre-release limits;
- move developer-heavy content into expandable sections so the homepage remains readable;
- remove the homepage's outdated hash-based release-blocker wording and replace it with provider/reader/protocol acceptance language;
- keep English and Chinese pages structurally aligned.

## Boundaries

- documentation only;
- no runtime, configuration, Factory, test, CI, data, model, task, or trainer behavior changes;
- no unsupported dataset-count, algorithm-count, benchmark-performance, or release claims;
- no hash/checksum/digest/receipt/ledger additions.

## Validation

- documentation validation;
- maintained configuration validation;
- generated documentation consistency;
- repository layout and submodule policy checks.
