### PR TITLE
fix(task): enforce explicit task, metric, label, and regularization semantics

### DIFF
--- a/configs/base/task/README.md
+++ b/configs/base/task/README.md
@@ -1,53 +1,128 @@
 # `configs/base/task/`
 
-## 1) What This Block Controls
+## What this block controls
 
-`task` controls the learning objective and data splitting logic:
-- `task.type` + `task.name` selects a concrete task implementation in `task_factory`
-- optimizer/loss/metrics live here (unless a task hardcodes behavior)
+The `task` block owns the learning problem presented to the model:
 
-## 2) Minimal Example (YAML Snippet)
+- `task.type` + `task.name` selects one Task Factory implementation;
+- `task.loss` selects the main objective;
+- `task.metrics` selects the complete metric lifecycle;
+- optimizer, scheduler, and optional regularization settings live here;
+- task-specific split fields select the requested source and target population.
+
+Task Factory does not control the device and does not repair Data or Model Factory inputs.
+
+## Minimal classification example
 
 ```yaml
 task:
   type: "DG"
   name: "classification"
-  lr: 0.001
+  loss: "CE"
   metrics: ["acc"]
+  optimizer: "adam"
+  lr: 0.001
 ```
 
-## 3) Key Fields
+`task.name` is also the default model-head task identity for the maintained
+classification path. A specialized task such as `hse_contrastive` declares its model
+head explicitly inside that task implementation. Missing batch metadata must not inject
+an unrelated `classification` task or override the configured Task Factory semantics.
 
-| Field | Type | Notes |
-|---|---:|---|
-| `task.type` | enum | One of `DG/CDDG/FS/GFS/pretrain/Default_task`. |
-| `task.name` | str | Task name under the given type. |
-| `task.target_system_id` | list[int] | System selection using metadata `Dataset_id`. |
-| `task.source_domain_id` | list[int] | DG domain split ids (depends on metadata). |
-| `task.target_domain_id` | list[int] | DG target domain split ids. |
+## Core fields
 
-## 4) Typical Overrides
+| Field | Type | Meaning |
+| --- | ---: | --- |
+| `task.type` | enum | Registered task family such as `DG`, `CDDG`, `FS`, `GFS`, `pretrain`, or `Default_task`. |
+| `task.name` | str | Concrete Task Factory implementation and maintained model-task identity where applicable. |
+| `task.loss` | str | Main objective consumed during backward. Unknown losses must fail. |
+| `task.metrics` | list[str] | Complete requested metric set. Unknown metrics fail instead of being skipped. |
+| `task.target_system_id` | list[int] | Selected metadata `Dataset_id` values. |
+| `task.source_domain_id` | list[int] | Explicit DG source domains when the protocol uses them. |
+| `task.target_domain_id` | list[int] | Explicit DG target domains when the protocol uses them. |
+
+## Label ontology
+
+Classification labels are a mathematical contract, not a display convention. For each
+independent dataset/system ontology, labels must be exactly:
+
+```text
+{0, 1, ..., K-1}
+```
+
+Examples that fail:
+
+```text
+{1, 2}    # does not start at zero
+{0, 2}    # contains a gap
+{-1, 0}   # contains a negative label
+```
+
+PHMFactory does not silently filter or re-encode labels. Correct the metadata or provide
+an explicit data-conversion step outside the experiment runtime.
+
+## Batch identity
+
+One maintained classification batch must resolve to one metadata `Name` and one
+`Dataset_id`. A mixed-dataset batch is rejected before model forward or metric update,
+because selecting the first sample's head or metric state would change the experiment.
+Use a dataset-homogeneous sampler when multiple systems participate in one run.
+
+## Metrics
+
+Maintained common identifiers are:
+
+```text
+classification: acc, f1, precision, recall, auroc
+regression:     mse, mae, r2, mape
+```
+
+A requested metric is never converted into a warning-and-skip path. If a metric is
+unknown or its label ontology is invalid, Task Factory construction fails with the
+available identifiers and the offending metadata group.
+
+## Regularization
+
+The recommended explicit form is:
+
+```yaml
+task:
+  regularization:
+    l1: 0.0001
+    l2: 0.0005
+```
+
+Supported methods are `l1` and `l2`. Weights must be finite and non-negative. The term is
+computed over the complete trainable parameter list; inspecting the parameter device
+must not consume and omit the first parameter. Unknown methods fail instead of being
+silently ignored.
+
+The historical explicit form remains readable for old configurations:
+
+```yaml
+task:
+  regularization:
+    flag: true
+    method:
+      l1: 0.0001
+```
+
+Contradictory settings such as `flag: false` with a non-empty `method` fail.
+
+## Typical overrides
 
 ```bash
-python main.py --config <yaml> --override task.lr=0.0005
-python main.py --config <yaml> --override task.target_system_id=[1]
+phmfactory preflight --config <yaml> --override task.lr=0.0005
+phmfactory preflight --config <yaml> --override task.target_system_id=[1]
 ```
 
-## 5) Coupling Notes
+## How to extend
 
-- Task implementations are indexed by `src/task_factory/task_registry.csv`.
-- `task.target_system_id` values must exist in your metadata `Dataset_id` column.
+1. Add one task module under `src/task_factory/task/<TYPE>/`.
+2. Register or expose the task through the existing Task Factory convention.
+3. Add or update the row in `src/task_factory/task_registry.csv`.
+4. Define the objective, metric lifecycle, required batch fields, and failure conditions.
+5. Add a focused test and one compatible maintained or experimental configuration.
 
-## 6) How to Extend
-
-1) Add a new task module under `src/task_factory/task/<TYPE>/`.
-2) Add an entry to `src/task_factory/task_registry.csv`.
-
-## 7) Common Pitfalls
-
-1) Confusing metadata `Dataset_id` with folder order (use inspect + metadata table).
-2) Using domain ids that do not exist in metadata.
-3) Setting `task.type` to a value without a matching registry entry.
-4) Mixing FS/GFS semantics (ensure the right task.type is used).
-5) Forgetting to update task_registry.csv when adding a new task.
-
+Do not add a second task registry, task manager, fallback dispatcher, or Pipeline-specific
+task repair layer.

--- a/src/model_factory/model_factory.py
+++ b/src/model_factory/model_factory.py
@@ -24,16 +24,23 @@ def model_factory(args_model: Any, metadata: Any):
     loaded, model construction fails instead of continuing with random or partial
     initialization.
     """
-    # Validate any declared classification ontology even when num_classes was
-    # supplied manually. A configured output width must not hide labels such as
-    # {1, 2} or {0, 2} that change the mathematical classification problem.
-    validate_metadata_label_ontology(
-        metadata,
-        group_field="Dataset_id",
-        require_labels=False,
-    )
+    # Validate every label ontology that is actually supplied, even when
+    # num_classes was configured manually. Some isolated model/checkpoint uses
+    # intentionally provide no metadata and an explicit output width; in that
+    # case there is no ontology to validate or silently reinterpret.
+    if metadata is not None:
+        validate_metadata_label_ontology(
+            metadata,
+            group_field="Dataset_id",
+            require_labels=False,
+        )
 
     if not getattr(args_model, "num_classes", None):
+        if metadata is None:
+            raise ValueError(
+                "model.num_classes is required when model construction receives "
+                "no metadata"
+            )
         inferred = get_num_classes(metadata)
         if isinstance(inferred, dict):
             args_model.num_classes = (

--- a/src/model_factory/model_factory.py
+++ b/src/model_factory/model_factory.py
@@ -8,6 +8,7 @@ from typing import Any, Mapping
 
 import torch
 
+from ..utils.label_ontology import validate_metadata_label_ontology
 from ..utils.utils import get_num_classes
 
 
@@ -23,6 +24,15 @@ def model_factory(args_model: Any, metadata: Any):
     loaded, model construction fails instead of continuing with random or partial
     initialization.
     """
+    # Validate any declared classification ontology even when num_classes was
+    # supplied manually. A configured output width must not hide labels such as
+    # {1, 2} or {0, 2} that change the mathematical classification problem.
+    validate_metadata_label_ontology(
+        metadata,
+        group_field="Dataset_id",
+        require_labels=False,
+    )
+
     if not getattr(args_model, "num_classes", None):
         inferred = get_num_classes(metadata)
         if isinstance(inferred, dict):

--- a/src/task_factory/Components/metrics.py
+++ b/src/task_factory/Components/metrics.py
@@ -1,75 +1,112 @@
 """Utilities for building common evaluation metrics."""
 
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import Any
+
 import torch.nn as nn
 import torchmetrics
-from typing import List, Any
+
+from ...utils.label_ontology import (
+    metadata_rows,
+    validate_metadata_label_ontology,
+)
 
 
-def get_metrics(metric_names: List[str], metadata: Any) -> nn.ModuleDict:
-    """Create metrics according to ``metric_names`` for each dataset.
+_CLASSIFICATION_METRICS = {
+    "acc": torchmetrics.Accuracy,
+    "f1": torchmetrics.F1Score,
+    "precision": torchmetrics.Precision,
+    "recall": torchmetrics.Recall,
+    "auroc": torchmetrics.AUROC,
+}
 
-    Parameters
-    ----------
-    metric_names : list of str
-        Metric identifiers such as ``acc`` or ``f1``.
-    metadata : Any
-        Dataset metadata used to infer the number of classes.
-    """
-    metric_classes = {
-        # Classification metrics
-        "acc": torchmetrics.Accuracy,
-        "f1": torchmetrics.F1Score,
-        "precision": torchmetrics.Precision,
-        "recall": torchmetrics.Recall,
-        "auroc": torchmetrics.AUROC,
-        # Regression metrics
-        "mse": torchmetrics.MeanSquaredError,
-        "mae": torchmetrics.MeanAbsoluteError,
-        "r2": torchmetrics.R2Score,
-        "mape": torchmetrics.MeanAbsolutePercentageError,
-    }
+_REGRESSION_METRICS = {
+    "mse": torchmetrics.MeanSquaredError,
+    "mae": torchmetrics.MeanAbsoluteError,
+    "r2": torchmetrics.R2Score,
+    "mape": torchmetrics.MeanAbsolutePercentageError,
+}
+
+_METRIC_CLASSES = {**_CLASSIFICATION_METRICS, **_REGRESSION_METRICS}
+
+
+def _classification_metric(metric_name: str, num_classes: int):
+    if num_classes < 2:
+        raise ValueError(
+            "classification metrics require at least two classes, "
+            f"but the validated ontology has K={num_classes}"
+        )
+    metric_class = _CLASSIFICATION_METRICS[metric_name]
+    if num_classes == 2:
+        return metric_class(task="binary")
+    return metric_class(task="multiclass", num_classes=num_classes)
+
+
+def get_metrics(metric_names: Sequence[str], metadata: Any) -> nn.ModuleDict:
+    """Build every requested metric or fail at the Task Factory boundary."""
+
+    if isinstance(metric_names, (str, bytes)) or not isinstance(
+        metric_names, Sequence
+    ):
+        raise TypeError("task.metrics must be a non-empty sequence of metric names")
+    normalized_names = [str(name).strip().lower() for name in metric_names]
+    if not normalized_names or any(not name for name in normalized_names):
+        raise ValueError("task.metrics must contain at least one non-empty metric name")
+
+    unknown = sorted(set(normalized_names) - set(_METRIC_CLASSES))
+    if unknown:
+        available = ", ".join(sorted(_METRIC_CLASSES))
+        raise ValueError(
+            f"Unknown task metric(s): {unknown}. Available metrics: {available}. "
+            "PHMFactory does not silently skip requested metrics."
+        )
+
+    rows = metadata_rows(metadata)
+    dataset_names: list[Any] = []
+    for index, row in enumerate(rows):
+        if "Name" not in row:
+            raise KeyError(f"metadata row {index} is missing required field 'Name'")
+        if row["Name"] not in dataset_names:
+            dataset_names.append(row["Name"])
+
+    classification_requested = any(
+        name in _CLASSIFICATION_METRICS for name in normalized_names
+    )
+    class_counts = (
+        validate_metadata_label_ontology(
+            metadata,
+            group_field="Name",
+            require_labels=True,
+        )
+        if classification_requested
+        else {}
+    )
 
     metrics = nn.ModuleDict()
-
-    unique_ids = set()
-    max_labels = {}
-    for item_id, item_data in metadata.items():
-        if "Name" in item_data:
-            data_id = item_data["Name"]
-            unique_ids.add(data_id)
-            if "Label" in item_data:
-                current_label = item_data["Label"]
-                if data_id not in max_labels or current_label > max_labels[data_id]:
-                    max_labels[data_id] = current_label
-
-    for data_name, n_class in max_labels.items():
-        if n_class is None:
-            raise ValueError(f"数据集 '{data_name}' 的配置缺少 'n_classes'")
-
-        task_type = "multiclass" if n_class >= 2 else "binary" # fix
+    for raw_data_name in dataset_names:
+        data_name = str(raw_data_name)
         data_metrics = nn.ModuleDict()
-        for stage in ["train", "val", "test"]:
-            for metric_name in metric_names:
-                key = metric_name.lower()
-                if key in metric_classes:
-                    # Classification metrics need task and num_classes
-                    if key in ["acc", "f1", "precision", "recall", "auroc"]:
-                        data_metrics[f"{stage}_{key}"] = metric_classes[key](
-                            task=task_type,
-                            num_classes=int(n_class) + 1,
-                        )
-                    # Regression metrics don't need these parameters
-                    else:
-                        data_metrics[f"{stage}_{key}"] = metric_classes[key]()
+        for stage in ("train", "val", "test"):
+            for metric_name in normalized_names:
+                key = f"{stage}_{metric_name}"
+                if metric_name in _CLASSIFICATION_METRICS:
+                    data_metrics[key] = _classification_metric(
+                        metric_name,
+                        class_counts[raw_data_name],
+                    )
                 else:
-                    print(f"警告: 不支持的指标类型 '{metric_name}'，已跳过。")
+                    data_metrics[key] = _REGRESSION_METRICS[metric_name]()
         metrics[data_name] = data_metrics
 
     return metrics
 
 
 if __name__ == "__main__":
-    # Minimal demonstration
-    dummy_meta = {1: {"Name": "ds", "Label": 2}}
-    m = get_metrics(["acc", "f1"], dummy_meta)
-    print("Built metrics:", list(m["ds"].keys()))
+    dummy_meta = {
+        1: {"Name": "ds", "Dataset_id": 1, "Label": 0},
+        2: {"Name": "ds", "Dataset_id": 1, "Label": 1},
+    }
+    built = get_metrics(["acc", "f1"], dummy_meta)
+    print("Built metrics:", list(built["ds"].keys()))

--- a/src/task_factory/Components/regularization.py
+++ b/src/task_factory/Components/regularization.py
@@ -1,71 +1,139 @@
+"""Regularization terms used by Task Factory objectives."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping
+from math import isfinite
+from numbers import Real
+from typing import Any
+
 import torch
-from typing import Dict, Any, Iterable
 
-def calculate_regularization(reg_config: Dict[str, Any], params: Iterable[torch.nn.Parameter]) -> Dict[str, torch.Tensor]:
-    """
-    计算正则化损失。
 
-    Args:
-        reg_config: 正则化配置字典，例如 {'flag': True, 'method': {'l1': 0.01, 'l2': 0.005}}
-        params: 需要计算正则化的模型参数迭代器。
+_SUPPORTED_METHODS = frozenset({"l1", "l2"})
 
-    Returns:
-        一个字典，包含每种正则化损失和总正则化损失 ('total')。
-        如果不启用正则化或没有有效的正则化方法，则返回 {'total': tensor(0.0)}。
-    """
-    reg_losses = {}
-    total_reg_loss = torch.tensor(0.0, device=next(iter(params)).device if params else 'cpu', dtype=torch.float32) # 获取设备信息
 
-    if not reg_config or not reg_config.get('regularization', False):
-        reg_losses['total'] = total_reg_loss
-        return reg_losses
+def _as_mapping(value: Any, *, context: str) -> dict[str, Any]:
+    if isinstance(value, Mapping):
+        return dict(value)
+    if hasattr(value, "__dict__"):
+        return dict(vars(value))
+    raise TypeError(f"{context} must be a mapping, got {type(value).__name__}")
 
-    method_dict = reg_config.get('regularization', {})
-    trainable_params = [p for p in params if p.requires_grad]
 
-    if not trainable_params: # 如果没有可训练参数
-        reg_losses['total'] = total_reg_loss
-        return reg_losses
+def _resolve_methods(reg_config: Any) -> dict[str, Any]:
+    """Resolve the two historical explicit configuration shapes without guessing."""
 
-    for reg_type, weight in method_dict.items():
+    if reg_config is None:
+        return {}
+    outer = _as_mapping(reg_config, context="task.regularization")
+    if not outer:
+        return {}
+
+    if "flag" in outer or "method" in outer:
+        flag = outer.get("flag", False)
+        if not isinstance(flag, bool):
+            raise TypeError("task.regularization.flag must be boolean")
+        methods = _as_mapping(
+            outer.get("method", {}),
+            context="task.regularization.method",
+        )
+        if not flag:
+            if methods:
+                raise ValueError(
+                    "task.regularization.flag=false conflicts with non-empty method"
+                )
+            return {}
+        if not methods:
+            raise ValueError(
+                "task.regularization.flag=true requires at least one method"
+            )
+        return methods
+
+    if "regularization" in outer:
+        raw_methods = outer["regularization"]
+        if raw_methods in (None, False):
+            return {}
+        if raw_methods is True:
+            raise ValueError(
+                "task.regularization.regularization=true requires a method mapping"
+            )
+        methods = _as_mapping(
+            raw_methods,
+            context="task.regularization.regularization",
+        )
+        if not methods:
+            return {}
+        return methods
+
+    # A direct mapping such as {"l1": 1e-4} is explicit and unambiguous.
+    return outer
+
+
+def calculate_regularization(
+    reg_config: Any,
+    params: Iterable[torch.nn.Parameter],
+) -> dict[str, torch.Tensor]:
+    """Calculate the declared regularization over every trainable parameter."""
+
+    methods = _resolve_methods(reg_config)
+    trainable_params = [parameter for parameter in params if parameter.requires_grad]
+
+    if not methods:
+        if trainable_params:
+            return {"total": trainable_params[0].new_zeros(())}
+        return {"total": torch.tensor(0.0, dtype=torch.float32)}
+
+    normalized_methods = {str(name).strip().lower(): weight for name, weight in methods.items()}
+    unknown = sorted(set(normalized_methods) - _SUPPORTED_METHODS)
+    if unknown:
+        raise ValueError(
+            f"Unknown regularization method(s): {unknown}. Available methods: "
+            f"{', '.join(sorted(_SUPPORTED_METHODS))}. PHMFactory does not "
+            "silently skip requested objective terms."
+        )
+
+    weights: dict[str, float] = {}
+    for method, raw_weight in normalized_methods.items():
+        if isinstance(raw_weight, bool) or not isinstance(raw_weight, Real):
+            raise TypeError(
+                f"regularization weight for {method!r} must be numeric, "
+                f"got {raw_weight!r}"
+            )
+        weight = float(raw_weight)
+        if not isfinite(weight) or weight < 0:
+            raise ValueError(
+                f"regularization weight for {method!r} must be finite and "
+                f"non-negative, got {raw_weight!r}"
+            )
+        weights[method] = weight
+
+    if not trainable_params:
+        raise RuntimeError(
+            "regularization is enabled but the task has no trainable parameters"
+        )
+
+    total = trainable_params[0].new_zeros(())
+    losses: dict[str, torch.Tensor] = {}
+    for method, weight in weights.items():
         if weight == 0:
             continue
-
-        current_reg_loss = torch.tensor(0.0, device=total_reg_loss.device, dtype=torch.float32)
-        reg_type_lower = reg_type.lower()
-
-        if reg_type_lower == 'l1':
-            for p in trainable_params:
-                current_reg_loss += torch.norm(p, 1)
-        elif reg_type_lower == 'l2':
-             for p in trainable_params:
-                current_reg_loss += torch.norm(p, 2).pow(2) # L2 正则化通常是范数的平方
+        current = trainable_params[0].new_zeros(())
+        if method == "l1":
+            for parameter in trainable_params:
+                current = current + parameter.abs().sum()
         else:
-            print(f"警告: 不支持的正则化类型: {reg_type}，已跳过。")
-            continue
+            for parameter in trainable_params:
+                current = current + parameter.square().sum()
 
-        weighted_loss = weight * current_reg_loss
-        reg_losses[reg_type_lower] = weighted_loss
-        total_reg_loss += weighted_loss
+        weighted = current * weight
+        losses[method] = weighted
+        total = total + weighted
 
-    reg_losses['total'] = total_reg_loss
-    return reg_losses
+    losses["total"] = total
+    return losses
+
+
 if __name__ == "__main__":
-    # 测试 calculate_regularization 函数
-    from torch import nn
-
-    # 创建一个简单的模型
-    model = nn.Linear(10, 2)
-    params = model.parameters()
-
-    # 定义正则化配置
-    reg_config = {
-        'regularization': {
-            'l1': 0.01,
-            'l2': 0.005
-        }
-    }
-
-    # 计算正则化损失
-    reg_losses = calculate_regularization(reg_config, params)
-    print("正则化损失:", reg_losses)
+    model = torch.nn.Linear(10, 2)
+    print(calculate_regularization({"l1": 0.01, "l2": 0.005}, model.parameters()))

--- a/src/task_factory/Default_task.py
+++ b/src/task_factory/Default_task.py
@@ -1,59 +1,57 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, Dict, Tuple
+
+import pytorch_lightning as pl
 import torch
 import torch.nn as nn
-import pytorch_lightning as pl
-import numpy as np
-from src.task_factory import register_task
-from typing import Dict, List, Optional, Any, Tuple
 
-# 导入解耦后的组件
+from src.task_factory import register_task
+
+from .Components.gradient_constraints import FisherGradientConstraint
 from .Components.loss import get_loss_fn
 from .Components.metrics import get_metrics
 from .Components.regularization import calculate_regularization
-from .Components.gradient_constraints import FisherGradientConstraint
 
 
 @register_task("Default_task", "Default_task")
 class Default_task(pl.LightningModule):
-    """
-    通用 PyTorch Lightning 任务模块 (已重构)
-
-    Features:
-    - 通过组件配置损失函数和评估指标
-    - 通过组件配置正则化方法
-    - 灵活的优化器和调度器配置
-    - 期望 batch 格式为 ((x, y), data_name)
-    """
+    """General Lightning task with explicit objective and metric semantics."""
 
     def __init__(
         self,
         network: nn.Module,
-        args_data: Any,  # Data args (Namespace)
-        args_model: Any,  # Model args (Namespace)
-        args_task: Any,  # Training args (Namespace)
-        args_trainer: Any,  # Trainer args (Namespace)
-        args_environment: Any,  # Environment args (Namespace)
-        metadata: Any # Metadata object/dict
+        args_data: Any,
+        args_model: Any,
+        args_task: Any,
+        args_trainer: Any,
+        args_environment: Any,
+        metadata: Any,
     ):
-        """
-        初始化训练模块
-
-        :param network: 待训练的主干网络
-        :param args_t: 训练参数配置对象 (Namespace)
-        :param args_m: 模型参数配置对象 (Namespace)
-        :param args_d: 数据参数配置对象 (Namespace)
-        :param metadata: 数据元信息
-        """
         super().__init__()
 
-        # Device placement belongs exclusively to the Lightning Trainer.  Task
-        # construction must preserve the model exactly as returned by Model Factory.
+        # Device placement belongs exclusively to Trainer Factory. Task
+        # construction preserves the model returned by Model Factory.
         self.network = network
         self.args_task = args_task
         self.args_model = args_model
         self.args_data = args_data
-        self.metadata = metadata # 存储 metadata
+        self.metadata = metadata
         self.args_trainer = args_trainer
         self.args_environment = args_environment
+
+        configured_task_id = getattr(
+            args_task,
+            "model_task_id",
+            getattr(args_task, "name", None),
+        )
+        if not isinstance(configured_task_id, str) or not configured_task_id.strip():
+            raise ValueError(
+                "task.model_task_id or task.name must explicitly identify the "
+                "model task head"
+            )
+        self.model_task_id = configured_task_id.strip()
 
         gradient_constraint = getattr(self.args_task, "gradient_constraint", None)
         self.gradient_constraint = None
@@ -72,28 +70,59 @@ class Default_task(pl.LightningModule):
                 raise ValueError("FIC gradient_constraint currently requires task.loss=CE")
             self.gradient_constraint = FisherGradientConstraint(epsilon=float(epsilon))
 
-        # 使用组件配置损失和指标
         self.loss_fn = get_loss_fn(self.args_task.loss)
-        # 假设 get_metrics 需要数据配置来确定任务类型和类别数
         self.metrics = get_metrics(self.args_task.metrics, self.metadata)
 
-        # 保存超参数 (确保 Namespace 可以转换为字典)
-        hparams_dict = {**vars(self.args_task),
-                            **vars(self.args_model),
-                            **vars(self.args_data),
-                            **vars(self.args_trainer),
-                            **vars(self.args_environment),
-                            # metadata 可能包含复杂对象，选择性保存或忽略
-                            # 'metadata': metadata
-                            }
-        self.save_hyperparameters(hparams_dict, ignore=['network', 'metadata'])
+        hparams_dict = {
+            **vars(self.args_task),
+            **vars(self.args_model),
+            **vars(self.args_data),
+            **vars(self.args_trainer),
+            **vars(self.args_environment),
+        }
+        self.save_hyperparameters(hparams_dict, ignore=["network", "metadata"])
 
+    def _resolve_model_task_id(self, batch: Mapping[str, Any]) -> str:
+        """Return the configured task head and reject batch-level overrides."""
+
+        if "task_id" not in batch:
+            return self.model_task_id
+
+        raw_task_id = batch["task_id"]
+        if isinstance(raw_task_id, str):
+            observed = [raw_task_id]
+        elif isinstance(raw_task_id, (list, tuple)):
+            observed = list(raw_task_id)
+        else:
+            raise TypeError(
+                "batch['task_id'] must be a string or a sequence of strings, "
+                f"got {type(raw_task_id).__name__}"
+            )
+
+        if not observed or any(not isinstance(value, str) for value in observed):
+            raise TypeError("batch['task_id'] must contain non-empty string values")
+        unique = {value.strip() for value in observed if value.strip()}
+        if len(unique) != 1:
+            raise ValueError(
+                f"one batch cannot mix model task IDs, observed={sorted(unique)}"
+            )
+        observed_task_id = next(iter(unique))
+        if observed_task_id != self.model_task_id:
+            raise ValueError(
+                "batch task identity conflicts with the configured Task Factory "
+                f"semantics: configured={self.model_task_id!r}, "
+                f"observed={observed_task_id!r}"
+            )
+        return self.model_task_id
 
     def forward(self, batch):
-        """模型前向传播"""
-        x = batch['x']
-        file_id = batch['file_id']
-        task_id = batch['task_id'] if 'task_id' in batch else None
+        """Forward one batch through the explicitly configured model task head."""
+
+        if not isinstance(batch, Mapping):
+            raise TypeError(f"task batch must be a mapping, got {type(batch).__name__}")
+        x = batch["x"]
+        file_id = batch["file_id"]
+        task_id = self._resolve_model_task_id(batch)
         if getattr(self.network, "requires_physical_metadata", False):
             canonical_fields = (
                 "sample_rate_hz",
@@ -111,262 +140,261 @@ class Default_task(pl.LightningModule):
             )
         return self.network(x, file_id, task_id)
 
-    # def _forward_pass(self, batch) -> torch.Tensor:
-    #     """执行前向传播"""
-    #     return self(batch)
-
     def _compute_loss(self, y_hat: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
-        """计算任务损失"""
-        # 确保 y 是 long 类型用于分类损失        
         return self.loss_fn(y_hat, y.long() if y.dtype != torch.long else y)
 
-    def _compute_metrics(self, y_hat: torch.Tensor, y: torch.Tensor, data_name: str, stage: str) -> Dict[str, torch.Tensor]:
-        """计算并更新评估指标"""
-        metric_values = {}
-        # print(f"计算 {stage} 阶段的指标: {data_name}")
-        if data_name in self.metrics:
-            for metric_key, metric_fn in self.metrics[data_name].items():
-                if metric_key.startswith(stage):
-                    # metric_fn 是 torchmetrics 对象，调用会更新内部状态并返回值
-                    value = metric_fn(y_hat, y)
-                    # 记录当前 step 的值 (注意：torchmetrics 通常在 epoch 结束时计算最终值)
-                    # 为了日志记录，我们可能需要记录瞬时值或累计值
-                    # 这里记录瞬时值，log_dict 会在 epoch 结束时聚合
-                    metric_values[f"{metric_key}_{data_name}"] = value
-        else:
-            # 仅在第一次遇到未知 data_name 时打印警告，避免刷屏
-            if not hasattr(self, '_warned_missing_metrics') or data_name not in self._warned_missing_metrics:
-                 print(f"警告: 在 metrics 中未找到数据名称 '{data_name}' 的指标配置。")
-                 if not hasattr(self, '_warned_missing_metrics'):
-                     self._warned_missing_metrics = set()
-                 self._warned_missing_metrics.add(data_name)
+    def _compute_metrics(
+        self,
+        y_hat: torch.Tensor,
+        y: torch.Tensor,
+        data_name: str,
+        stage: str,
+    ) -> Dict[str, torch.Tensor]:
+        if data_name not in self.metrics:
+            available = sorted(self.metrics.keys())
+            raise KeyError(
+                f"No metric lifecycle exists for dataset Name={data_name!r}; "
+                f"available={available}. The batch cannot be evaluated with a "
+                "different dataset's metrics."
+            )
 
+        metric_values = {}
+        for metric_key, metric_fn in self.metrics[data_name].items():
+            if metric_key.startswith(stage):
+                metric_values[f"{metric_key}_{data_name}"] = metric_fn(y_hat, y)
         return metric_values
 
     def _compute_regularization(self) -> Dict[str, torch.Tensor]:
-        """计算正则化损失"""
         return calculate_regularization(
-            getattr(self.args_task, 'regularization', {}),
-            self.parameters() # 只对当前 LightningModule 的参数计算正则化
+            getattr(self.args_task, "regularization", {}),
+            self.parameters(),
         )
 
-    def _shared_step(self, batch: Tuple,
-                     stage: str,
-                     task_id = False) -> Dict[str, torch.Tensor]:
-        """
-        通用处理步骤 (已重构)
-        期望 batch 格式: ((x, y), data_name)
-        """
-        batch.setdefault('task_id', 'classification')
-
-        batch_size = int(batch['x'].shape[0])
-        raw_file_ids = batch['file_id']
+    @staticmethod
+    def _file_id_values(raw_file_ids: Any) -> list[Any]:
         if isinstance(raw_file_ids, torch.Tensor):
-            file_ids = [value.item() for value in raw_file_ids.view(-1)]
-        elif isinstance(raw_file_ids, (list, tuple)):
-            file_ids = list(raw_file_ids)
-        else:
-            file_ids = [raw_file_ids]
+            return [value.item() for value in raw_file_ids.view(-1)]
+        if isinstance(raw_file_ids, (list, tuple)):
+            return list(raw_file_ids)
+        return [raw_file_ids]
 
+    def _resolve_batch_identity(
+        self,
+        batch: Mapping[str, Any],
+        batch_size: int,
+    ) -> tuple[str, Any, list[Any]]:
+        """Require one metadata dataset identity for the complete batch."""
+
+        file_ids = self._file_id_values(batch["file_id"])
         if len(file_ids) not in (1, batch_size):
             raise ValueError(
                 "batch['file_id'] must contain one ID or one ID per sample: "
                 f"received {len(file_ids)} IDs for batch_size={batch_size}."
             )
 
-        first_file_id = file_ids[0]
-        try:
-            data_name = self.metadata[first_file_id]['Name']
-        except (KeyError, IndexError, TypeError) as exc:
-            raise KeyError(
-                f"Unable to resolve metadata Name for file_id={first_file_id!r}."
-            ) from exc
-        if getattr(self.network, "requires_physical_metadata", False):
-            names = []
-            for current_file_id in file_ids:
-                try:
-                    names.append(self.metadata[current_file_id]['Name'])
-                except (KeyError, IndexError, TypeError) as exc:
-                    raise KeyError(
-                        "Unable to resolve metadata Name for "
-                        f"file_id={current_file_id!r}."
-                    ) from exc
-            if any(name != data_name for name in names):
-                raise ValueError(
-                    "decisive P04 batches cannot mix dataset Names because metric "
-                    "and physical metadata authority would be ambiguous"
-                )
+        names: list[Any] = []
+        dataset_ids: list[Any] = []
+        for current_file_id in file_ids:
+            try:
+                row = self.metadata[current_file_id]
+                names.append(row["Name"])
+                dataset_ids.append(row["Dataset_id"])
+            except (KeyError, IndexError, TypeError) as exc:
+                raise KeyError(
+                    "Unable to resolve metadata Name and Dataset_id for "
+                    f"file_id={current_file_id!r}."
+                ) from exc
 
-        # 1. 前向传播。保留原始逐样本 file_id，不得用首个文件覆盖整批。
+        unique_names = {str(name) for name in names}
+        unique_dataset_ids = {str(dataset_id) for dataset_id in dataset_ids}
+        if len(unique_names) != 1 or len(unique_dataset_ids) != 1:
+            raise ValueError(
+                "one batch cannot mix dataset identities because model heads and "
+                "metric states would be ambiguous: "
+                f"Names={sorted(unique_names)}, "
+                f"Dataset_ids={sorted(unique_dataset_ids)}. Use a "
+                "dataset-homogeneous sampler."
+            )
+        return str(names[0]), dataset_ids[0], file_ids
+
+    def _shared_step(
+        self,
+        batch: Tuple,
+        stage: str,
+        task_id=False,
+    ) -> Dict[str, torch.Tensor]:
+        del task_id
+        if not isinstance(batch, Mapping):
+            raise TypeError(f"task batch must be a mapping, got {type(batch).__name__}")
+
+        batch_size = int(batch["x"].shape[0])
+        data_name, _, _ = Default_task._resolve_batch_identity(
+            self,
+            batch,
+            batch_size,
+        )
+
+        # Preserve the original per-sample file IDs. The task does not rewrite
+        # the batch or inject an implicit classification task.
         y_hat = self.forward(batch)
 
-        # 2. 计算任务损失
-        y = batch['y']
+        y = batch["y"]
         loss = self._compute_loss(y_hat, y)
         y_argmax = torch.argmax(y_hat, dim=1) if y_hat.ndim > 1 else y_hat
 
-        # 3. 计算和记录指标
-        step_metrics = {f"{stage}_loss": loss}
-        step_metrics[f"{stage}_{data_name}_loss"] = loss # 记录特定数据集的损失
-        metric_values = self._compute_metrics(y_argmax, y, data_name, stage)
-        step_metrics.update(metric_values)
+        step_metrics = {
+            f"{stage}_loss": loss,
+            f"{stage}_{data_name}_loss": loss,
+        }
+        step_metrics.update(
+            self._compute_metrics(y_argmax, y, data_name, stage)
+        )
 
-        # 4. 计算正则化损失
         reg_dict = self._compute_regularization()
         for reg_type, reg_loss_val in reg_dict.items():
-            if reg_type != 'total':
+            if reg_type != "total":
                 step_metrics[f"{stage}_{reg_type}_reg_loss"] = reg_loss_val
 
-        # 5. Consume optional model-defined auxiliary losses exactly once.
-        # Models without this explicit hook retain the existing behavior.
         model_auxiliary = {}
-        consume_auxiliary = getattr(self.network, 'consume_auxiliary_losses', None)
+        consume_auxiliary = getattr(self.network, "consume_auxiliary_losses", None)
         if callable(consume_auxiliary):
             model_auxiliary = consume_auxiliary()
             if not isinstance(model_auxiliary, dict):
                 raise TypeError("network.consume_auxiliary_losses() must return a dict")
             for name, value in model_auxiliary.items():
                 if not isinstance(value, torch.Tensor) or value.ndim != 0:
-                    raise ValueError(f"model auxiliary loss {name!r} must be a scalar tensor")
+                    raise ValueError(
+                        f"model auxiliary loss {name!r} must be a scalar tensor"
+                    )
                 if not torch.isfinite(value):
                     raise ValueError(f"model auxiliary loss {name!r} is not finite")
                 step_metrics[f"{stage}_{name}_loss"] = value
 
-        # 6. 计算总损失
         auxiliary_total = sum(
-            model_auxiliary.values(), torch.tensor(0.0, device=loss.device)
+            model_auxiliary.values(),
+            torch.tensor(0.0, device=loss.device),
         )
         total_loss = (
             loss
-            + reg_dict.get('total', torch.tensor(0.0, device=loss.device))
+            + reg_dict.get("total", torch.tensor(0.0, device=loss.device))
             + auxiliary_total
         )
         step_metrics[f"{stage}_total_loss"] = total_loss
-
-        # 添加 batch size 用于日志记录
-        # step_metrics[f"{stage}_batch_size"] = torch.tensor(x.shape[0], dtype=torch.float, device=loss.device)
-
         return step_metrics
 
     def training_step(self, batch: dict, *args, **kwargs) -> torch.Tensor:
-        """训练步骤"""
         metrics = self._shared_step(batch, "train")
-        # 使用 _log_metrics 记录 (确保 batch_size 传递正确)
-      
         self._log_metrics(metrics, "train")
-        # 返回用于反向传播的总损失
         return metrics["train_total_loss"]
 
     def validation_step(self, batch: dict, *args, **kwargs) -> None:
-        """验证步骤"""
         metrics = self._shared_step(batch, "val")
-      
         self._log_metrics(metrics, "val")
-        # validation_step 通常不返回损失
 
     def test_step(self, batch: dict, *args, **kwargs) -> None:
-        """测试步骤"""
         metrics = self._shared_step(batch, "test")
-        
         self._log_metrics(metrics, "test")
-        # test_step 通常不返回损失
 
     def _log_metrics(self, metrics: Dict[str, torch.Tensor], stage: str) -> None:
-        """统一日志记录"""
-        log_dict = {}
-        prog_bar_metrics = {}
-        for k, v in metrics.items():
-            # 过滤掉非当前阶段或 batch_size 的指标
-            if k.startswith(stage) and "batch_size" not in k:
-                log_dict[k] = v
-                # 选择要在进度条上显示的指标
-                if any(prog_key in k for prog_key in ['loss', 'acc', 'f1']): # 简化进度条显示
-                    # 只显示不带数据集名称的总指标或第一个数据集的指标
-                    if f"{stage}_loss" == k or f"{stage}_acc_" in k or f"{stage}_f1_" in k:
-                         prog_bar_metrics[k.replace(f"_{stage}", "")] = v # 简化显示名称
-
-
+        log_dict = {
+            key: value
+            for key, value in metrics.items()
+            if key.startswith(stage) and "batch_size" not in key
+        }
         self.log_dict(
             log_dict,
-            on_step= (stage == "train"), # 训练时可以记录 step 级别的 loss
+            on_step=stage == "train",
             on_epoch=True,
-            prog_bar=False, # 单独控制进度条
+            prog_bar=False,
             logger=True,
             sync_dist=True,
         )
-        # 单独记录需要在进度条显示的指标 (只在 epoch 结束时显示聚合值)
-        # self.log_dict(
-        #     prog_bar_metrics,
-        #     on_step=False,
-        #     on_epoch=True,
-        #     prog_bar=True,
-        #     logger=False, # 避免重复记录
-        #     sync_dist=True,
-        # )
 
     def configure_optimizers(self):
-        """配置优化器和学习率调度器 (保持不变或根据需要调整)"""
         optimizer_name = self.args_task.optimizer.lower()
         lr = self.args_task.lr
-        weight_decay = getattr(self.args_task, 'weight_decay', 0.0) # 提供默认值
+        weight_decay = getattr(self.args_task, "weight_decay", 0.0)
 
-        # 选择优化器
-        if optimizer_name == 'adam':
-            optimizer = torch.optim.Adam(self.parameters(), lr=lr, weight_decay=weight_decay)
-        elif optimizer_name == 'adamw':
-            optimizer = torch.optim.AdamW(self.parameters(), lr=lr, weight_decay=weight_decay)
-        elif optimizer_name == 'sgd':
-            momentum = getattr(self.args_task, 'momentum', 0.9) # SGD momentum
-            optimizer = torch.optim.SGD(self.parameters(), lr=lr, weight_decay=weight_decay, momentum=momentum)
+        if optimizer_name == "adam":
+            optimizer = torch.optim.Adam(
+                self.parameters(), lr=lr, weight_decay=weight_decay
+            )
+        elif optimizer_name == "adamw":
+            optimizer = torch.optim.AdamW(
+                self.parameters(), lr=lr, weight_decay=weight_decay
+            )
+        elif optimizer_name == "sgd":
+            momentum = getattr(self.args_task, "momentum", 0.9)
+            optimizer = torch.optim.SGD(
+                self.parameters(),
+                lr=lr,
+                weight_decay=weight_decay,
+                momentum=momentum,
+            )
         else:
             raise ValueError(f"不支持的优化器: {optimizer_name}")
 
-        # 配置学习率调度器 (如果指定)
-        scheduler_config = getattr(self.args_task, 'scheduler', None)
-        if not scheduler_config or not isinstance(scheduler_config, dict) or not scheduler_config.get('name'):
-            return optimizer # 只返回优化器
+        scheduler_config = getattr(self.args_task, "scheduler", None)
+        if (
+            not scheduler_config
+            or not isinstance(scheduler_config, dict)
+            or not scheduler_config.get("name")
+        ):
+            return optimizer
 
-        scheduler_name = scheduler_config['name'].lower()
-        scheduler_options = scheduler_config.get('options', {}) # 获取调度器特定参数
+        scheduler_name = scheduler_config["name"].lower()
+        scheduler_options = scheduler_config.get("options", {})
 
-        if scheduler_name == 'reduceonplateau':
-            # 确保 monitor 指标存在
-            monitor_metric = getattr(self.args_task, 'monitor', 'val_total_loss')
-            # 可以在这里添加检查，确保 monitor_metric 会被记录
-            # if monitor_metric not in self.metrics... (但这比较复杂，因为指标是动态生成的)
-            patience = scheduler_options.get('patience', getattr(self.args_task, 'patience', 10) // 2 if hasattr(self.args_task, 'patience') else 5)
-            factor = scheduler_options.get('factor', 0.1)
-            mode = scheduler_options.get('mode', 'min')
+        if scheduler_name == "reduceonplateau":
+            monitor_metric = getattr(self.args_task, "monitor", "val_total_loss")
+            patience = scheduler_options.get(
+                "patience",
+                getattr(self.args_task, "patience", 10) // 2
+                if hasattr(self.args_task, "patience")
+                else 5,
+            )
+            factor = scheduler_options.get("factor", 0.1)
+            mode = scheduler_options.get("mode", "min")
             scheduler = torch.optim.lr_scheduler.ReduceLROnPlateau(
-                optimizer, mode=mode, factor=factor, patience=patience
+                optimizer,
+                mode=mode,
+                factor=factor,
+                patience=patience,
             )
             return {
-                'optimizer': optimizer,
-                'lr_scheduler': {
-                    'scheduler': scheduler,
-                    'monitor': monitor_metric, # 指定监控的指标
-                    'interval': 'epoch', # 通常在 epoch 结束时调整
-                    'frequency': 1
-                }
+                "optimizer": optimizer,
+                "lr_scheduler": {
+                    "scheduler": scheduler,
+                    "monitor": monitor_metric,
+                    "interval": "epoch",
+                    "frequency": 1,
+                },
             }
-        elif scheduler_name == 'cosine':
-            # 尝试从 trainer 获取 max_epochs，否则从 args_task 获取
-            max_epochs = getattr(self.trainer, 'max_epochs', None) or getattr(self.args_task, 'max_epochs', 100)
-            t_max = scheduler_options.get('T_max', max_epochs)
-            eta_min = scheduler_options.get('eta_min', 0)
-            scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(optimizer, T_max=t_max, eta_min=eta_min)
-        elif scheduler_name == 'step':
-            step_size = scheduler_options.get('step_size', 10)
-            gamma = scheduler_options.get('gamma', 0.1)
-            scheduler = torch.optim.lr_scheduler.StepLR(optimizer, step_size=step_size, gamma=gamma)
+        if scheduler_name == "cosine":
+            max_epochs = getattr(self.trainer, "max_epochs", None) or getattr(
+                self.args_task,
+                "max_epochs",
+                100,
+            )
+            scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(
+                optimizer,
+                T_max=scheduler_options.get("T_max", max_epochs),
+                eta_min=scheduler_options.get("eta_min", 0),
+            )
+        elif scheduler_name == "step":
+            scheduler = torch.optim.lr_scheduler.StepLR(
+                optimizer,
+                step_size=scheduler_options.get("step_size", 10),
+                gamma=scheduler_options.get("gamma", 0.1),
+            )
         else:
             raise ValueError(f"不支持的调度器: {scheduler_name}")
 
-        # 对于非 ReduceLROnPlateau 的调度器，返回列表形式
-        return [optimizer], [{'scheduler': scheduler, 'interval': 'epoch', 'frequency': 1}]
+        return [optimizer], [
+            {"scheduler": scheduler, "interval": "epoch", "frequency": 1}
+        ]
 
     def on_before_optimizer_step(self, optimizer) -> None:
-        """Apply an optional post-backward gradient constraint before the update."""
         del optimizer
         if self.gradient_constraint is None:
             return

--- a/src/task_factory/task/pretrain/hse_contrastive.py
+++ b/src/task_factory/task/pretrain/hse_contrastive.py
@@ -47,6 +47,9 @@ class task(Default_task):
         self.args_data = args_data
         self.args_environment = args_environment
         self.metadata = metadata
+        # hse_contrastive explicitly trains the classification head. This task
+        # identity belongs to the task implementation, not to a missing batch key.
+        self.model_task_id = "classification"
 
         self.contrast_weight = self._validated_weight(
             getattr(args_task, "contrast_weight", 1.0),
@@ -86,17 +89,25 @@ class task(Default_task):
     def _validated_weight(value: Any, name: str) -> float:
         weight = float(value)
         if not math.isfinite(weight) or weight < 0:
-            raise ValueError(f"task.{name} must be a finite non-negative number, got {value!r}.")
+            raise ValueError(
+                f"task.{name} must be a finite non-negative number, got {value!r}."
+            )
         return weight
 
     @staticmethod
     def _require_valid_loss(loss: torch.Tensor, name: str, stage: str) -> None:
         if not torch.is_tensor(loss):
-            raise TypeError(f"{name} must return a torch.Tensor, got {type(loss).__name__}.")
+            raise TypeError(
+                f"{name} must return a torch.Tensor, got {type(loss).__name__}."
+            )
         if loss.numel() != 1:
-            raise ValueError(f"{name} must return one scalar loss, got shape {tuple(loss.shape)}.")
+            raise ValueError(
+                f"{name} must return one scalar loss, got shape {tuple(loss.shape)}."
+            )
         if not torch.isfinite(loss).all():
-            raise FloatingPointError(f"{name} produced a non-finite loss during {stage}.")
+            raise FloatingPointError(
+                f"{name} produced a non-finite loss during {stage}."
+            )
         if stage == "train" and not loss.requires_grad:
             raise RuntimeError(
                 f"{name} is enabled but its training loss does not require gradients."
@@ -125,7 +136,7 @@ class task(Default_task):
         x: torch.Tensor = batch_dict["x"]
         y: torch.Tensor = batch_dict["y"]
         file_id: Any = batch_dict.get("file_id")
-        task_id: str = batch_dict.get("task_id", "classification")
+        task_id = self._resolve_model_task_id(batch_dict)
 
         system_ids: List[int] = []
         if self.classification_weight > 0:
@@ -146,7 +157,11 @@ class task(Default_task):
                 y,
                 system_ids=system_ids,
             )
-            self._require_valid_loss(classification_loss, "classification objective", stage)
+            self._require_valid_loss(
+                classification_loss,
+                "classification objective",
+                stage,
+            )
 
         contrastive_loss = x.new_zeros(())
         if self.contrast_weight > 0:
@@ -156,7 +171,11 @@ class task(Default_task):
                 stage=stage,
                 batch_idx=batch_idx,
             )
-            self._require_valid_loss(contrastive_loss, "contrastive objective", stage)
+            self._require_valid_loss(
+                contrastive_loss,
+                "contrastive objective",
+                stage,
+            )
 
         total_loss = (
             self.classification_weight * classification_loss
@@ -184,7 +203,9 @@ class task(Default_task):
     def _infer_system_ids(self, file_id: Any) -> List[int]:
         """Resolve the unique Dataset IDs for a classification batch."""
         if file_id is None:
-            raise ValueError("hse_contrastive classification requires batch['file_id'].")
+            raise ValueError(
+                "hse_contrastive classification requires batch['file_id']."
+            )
         if self.metadata is None:
             raise ValueError("hse_contrastive classification requires metadata.")
 
@@ -213,12 +234,9 @@ class task(Default_task):
 
     def _prepare_batch(self, batch: Any) -> Dict[str, Any]:
         if isinstance(batch, dict):
-            prepared = dict(batch)
-        else:
-            (x, y), data_name = batch
-            prepared = {"x": x, "y": y, "file_id": data_name}
-        prepared.setdefault("task_id", "classification")
-        return prepared
+            return dict(batch)
+        (x, y), data_name = batch
+        return {"x": x, "y": y, "file_id": data_name}
 
     def _forward_backbone(
         self,
@@ -239,7 +257,9 @@ class task(Default_task):
             )
         logits, features = output[0], output[1]
         if not torch.is_tensor(logits) or not torch.is_tensor(features):
-            raise TypeError("hse_contrastive model outputs must both be torch.Tensor values.")
+            raise TypeError(
+                "hse_contrastive model outputs must both be torch.Tensor values."
+            )
         return logits, self._flatten_features(features)
 
     @staticmethod
@@ -260,13 +280,17 @@ class task(Default_task):
         system_ids: Optional[List[int]] = None,
     ) -> Tuple[torch.Tensor, torch.Tensor]:
         if not torch.is_tensor(logits) or not torch.is_tensor(y):
-            raise TypeError("classification logits and labels must be torch.Tensor values.")
+            raise TypeError(
+                "classification logits and labels must be torch.Tensor values."
+            )
         if logits.ndim != 2:
             raise ValueError(
                 f"classification logits must have shape [B, C], got {tuple(logits.shape)}."
             )
         if y.ndim != 1:
-            raise ValueError(f"classification labels must have shape [B], got {tuple(y.shape)}.")
+            raise ValueError(
+                f"classification labels must have shape [B], got {tuple(y.shape)}."
+            )
         if logits.device != y.device:
             y = y.to(logits.device)
         if logits.shape[0] != y.shape[0]:
@@ -275,9 +299,13 @@ class task(Default_task):
                 f"logits={logits.shape[0]}, labels={y.shape[0]}."
             )
         if not torch.isfinite(logits).all():
-            raise FloatingPointError("classification logits contain NaN or Inf values.")
+            raise FloatingPointError(
+                "classification logits contain NaN or Inf values."
+            )
         if not torch.isfinite(y).all():
-            raise FloatingPointError("classification labels contain NaN or Inf values.")
+            raise FloatingPointError(
+                "classification labels contain NaN or Inf values."
+            )
 
         y = y.long()
         num_classes = logits.shape[1]
@@ -311,7 +339,9 @@ class task(Default_task):
                 "The contrastive objective is enabled but no strategy was initialized."
             )
         if not torch.is_tensor(features) or not torch.is_tensor(y):
-            raise TypeError("contrastive features and labels must be torch.Tensor values.")
+            raise TypeError(
+                "contrastive features and labels must be torch.Tensor values."
+            )
 
         features = self._flatten_features(features)
         target_device = features.device
@@ -323,9 +353,13 @@ class task(Default_task):
                 f"features={features.shape[0]}, labels={y.shape[0]}."
             )
         if not torch.isfinite(features).all():
-            raise FloatingPointError("contrastive features contain NaN or Inf values.")
+            raise FloatingPointError(
+                "contrastive features contain NaN or Inf values."
+            )
         if not torch.isfinite(y).all():
-            raise FloatingPointError("contrastive labels contain NaN or Inf values.")
+            raise FloatingPointError(
+                "contrastive labels contain NaN or Inf values."
+            )
 
         labels_ext: Optional[torch.Tensor] = None
         if getattr(self.strategy_manager, "requires_labels", False):
@@ -336,7 +370,8 @@ class task(Default_task):
             y = y.long()
             if int(y.min().item()) < 0:
                 raise ValueError(
-                    f"contrastive labels must be non-negative, got minimum {int(y.min().item())}."
+                    "contrastive labels must be non-negative, got minimum "
+                    f"{int(y.min().item())}."
                 )
             labels_ext = torch.cat([y, y], dim=0)
 
@@ -357,7 +392,8 @@ class task(Default_task):
         )
         if not isinstance(result, Mapping) or "loss" not in result:
             raise TypeError(
-                "The contrastive strategy must return a mapping containing a 'loss' tensor."
+                "The contrastive strategy must return a mapping containing a "
+                "'loss' tensor."
             )
         return result["loss"]
 
@@ -376,7 +412,8 @@ class task(Default_task):
             )
         if isinstance(batch_idx, bool) or int(batch_idx) != batch_idx or batch_idx < 0:
             raise ValueError(
-                f"HSE evaluation batch_idx must be a non-negative integer, got {batch_idx!r}"
+                "HSE evaluation batch_idx must be a non-negative integer, "
+                f"got {batch_idx!r}"
             )
 
         base_seed = int(getattr(self.args_environment, "seed", 0))
@@ -396,7 +433,9 @@ class task(Default_task):
         stage: str = "train",
         batch_idx: int = 0,
     ) -> torch.Tensor:
-        aug_type = str(getattr(self.args_task, "augmentation_type", "noise")).lower()
+        aug_type = str(
+            getattr(self.args_task, "augmentation_type", "noise")
+        ).lower()
         allowed = {"none", "noise", "scaling", "dropout", "mixed"}
         if aug_type not in allowed:
             raise ValueError(
@@ -404,15 +443,27 @@ class task(Default_task):
                 f"Available values: {', '.join(sorted(allowed))}."
             )
 
-        noise_std = float(getattr(self.args_task, "augmentation_noise_std", 0.1))
-        dropout_p = float(getattr(self.args_task, "augmentation_dropout_p", 0.1))
-        scale_std = float(getattr(self.args_task, "augmentation_scale_std", 0.1))
+        noise_std = float(
+            getattr(self.args_task, "augmentation_noise_std", 0.1)
+        )
+        dropout_p = float(
+            getattr(self.args_task, "augmentation_dropout_p", 0.1)
+        )
+        scale_std = float(
+            getattr(self.args_task, "augmentation_scale_std", 0.1)
+        )
         if not math.isfinite(noise_std) or noise_std < 0:
-            raise ValueError("task.augmentation_noise_std must be finite and non-negative.")
+            raise ValueError(
+                "task.augmentation_noise_std must be finite and non-negative."
+            )
         if not math.isfinite(scale_std) or scale_std < 0:
-            raise ValueError("task.augmentation_scale_std must be finite and non-negative.")
+            raise ValueError(
+                "task.augmentation_scale_std must be finite and non-negative."
+            )
         if not math.isfinite(dropout_p) or not 0 <= dropout_p < 1:
-            raise ValueError("task.augmentation_dropout_p must satisfy 0 <= p < 1.")
+            raise ValueError(
+                "task.augmentation_dropout_p must satisfy 0 <= p < 1."
+            )
 
         generator = self._augmentation_generator(
             features,

--- a/src/utils/label_ontology.py
+++ b/src/utils/label_ontology.py
@@ -1,0 +1,151 @@
+"""Classification label-ontology validation shared by runtime boundaries."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from math import isfinite
+from numbers import Integral, Real
+from typing import Any, Iterable
+
+
+def metadata_rows(metadata: Any) -> list[dict[str, Any]]:
+    """Return metadata as a non-empty list of plain row mappings."""
+
+    source = getattr(metadata, "df", metadata)
+    if isinstance(source, Mapping):
+        raw_rows = list(source.values())
+    elif hasattr(source, "to_dict"):
+        try:
+            raw_rows = source.to_dict(orient="records")
+        except TypeError:
+            raw_rows = source.to_dict("records")
+    else:
+        raise TypeError(
+            "metadata must be a mapping, a pandas-like table, or expose a .df table"
+        )
+
+    if not raw_rows:
+        raise ValueError("metadata must contain at least one row")
+
+    rows: list[dict[str, Any]] = []
+    for index, row in enumerate(raw_rows):
+        if not isinstance(row, Mapping) and hasattr(row, "to_dict"):
+            row = row.to_dict()
+        if not isinstance(row, Mapping):
+            raise TypeError(
+                f"metadata row {index} must be a mapping, got {type(row).__name__}"
+            )
+        rows.append(dict(row))
+    return rows
+
+
+def _normalize_label(value: Any, *, context: str) -> int:
+    if hasattr(value, "item") and not isinstance(value, (str, bytes)):
+        try:
+            value = value.item()
+        except (TypeError, ValueError):
+            pass
+
+    if isinstance(value, bool):
+        raise ValueError(f"{context} labels must be integers, not boolean values")
+    if isinstance(value, Integral):
+        label = int(value)
+    elif isinstance(value, Real):
+        numeric = float(value)
+        if not isfinite(numeric) or not numeric.is_integer():
+            raise ValueError(
+                f"{context} labels must be finite integers, got {value!r}"
+            )
+        label = int(numeric)
+    else:
+        raise ValueError(
+            f"{context} labels must be numeric integers, got {value!r}"
+        )
+
+    if label < 0:
+        raise ValueError(f"{context} labels must be non-negative, got {label}")
+    return label
+
+
+def validate_zero_based_contiguous_labels(
+    labels: Iterable[Any],
+    *,
+    context: str,
+) -> int:
+    """Validate ``{0, 1, ..., K-1}`` and return ``K``."""
+
+    normalized = [_normalize_label(value, context=context) for value in labels]
+    if not normalized:
+        raise ValueError(f"{context} has no labels")
+
+    observed = sorted(set(normalized))
+    expected = list(range(observed[-1] + 1))
+    if observed != expected:
+        missing = sorted(set(expected) - set(observed))
+        raise ValueError(
+            f"{context} labels must be zero-based and contiguous: "
+            f"expected={expected}, observed={observed}, missing={missing}. "
+            "PHMFactory does not silently re-encode labels."
+        )
+    return len(expected)
+
+
+def validate_metadata_label_ontology(
+    metadata: Any,
+    *,
+    group_field: str,
+    require_labels: bool,
+) -> dict[Any, int]:
+    """Validate label ontologies independently for each metadata group."""
+
+    grouped_labels: dict[Any, list[Any]] = {}
+    missing_label_groups: set[Any] = set()
+
+    for index, row in enumerate(metadata_rows(metadata)):
+        if group_field not in row:
+            raise KeyError(
+                f"metadata row {index} is missing required field {group_field!r}"
+            )
+        group = row[group_field]
+        try:
+            hash(group)
+        except TypeError as exc:
+            raise TypeError(
+                f"metadata field {group_field!r} must be scalar and hashable, "
+                f"got {group!r}"
+            ) from exc
+
+        if "Label" not in row:
+            missing_label_groups.add(group)
+            grouped_labels.setdefault(group, [])
+            continue
+        grouped_labels.setdefault(group, []).append(row["Label"])
+
+    results: dict[Any, int] = {}
+    for group, labels in grouped_labels.items():
+        if labels and group in missing_label_groups:
+            raise ValueError(
+                f"metadata group {group_field}={group!r} mixes rows with and "
+                "without Label values"
+            )
+        if not labels:
+            if require_labels:
+                raise ValueError(
+                    f"metadata group {group_field}={group!r} has no Label values"
+                )
+            continue
+        results[group] = validate_zero_based_contiguous_labels(
+            labels,
+            context=f"metadata group {group_field}={group!r}",
+        )
+
+    if require_labels and not results:
+        raise ValueError("metadata contains no classification label ontology")
+    return results
+
+
+__all__ = [
+    "metadata_rows",
+    "validate_metadata_label_ontology",
+    "validate_zero_based_contiguous_labels",
+]

--- a/test/test_device_authority.py
+++ b/test/test_device_authority.py
@@ -53,6 +53,7 @@ def test_default_task_preserves_model_device_and_trainer_config(
         args_data=Namespace(),
         args_model=Namespace(),
         args_task=Namespace(
+            name="classification",
             loss="CE",
             metrics=[],
             optimizer="adam",

--- a/test/test_per_sample_metadata.py
+++ b/test/test_per_sample_metadata.py
@@ -9,7 +9,10 @@ from src.model_factory import build_model, resolve_model_module
 from src.model_factory.ISFM.system_utils import normalize_fs, resolve_batch_metadata
 from src.model_factory.ISFM.task_head.H_01_Linear_cla import H_01_Linear_cla
 from src.task_factory import build_task
+from src.task_factory.Components.metrics import get_metrics
+from src.task_factory.Components.regularization import calculate_regularization
 from src.task_factory.Default_task import Default_task
+from src.utils.label_ontology import validate_zero_based_contiguous_labels
 
 
 _METADATA = {
@@ -45,8 +48,21 @@ _EXTENSION_METADATA = {
 }
 
 
+def _task_args(**overrides):
+    values = {
+        "name": "classification",
+        "loss": "CE",
+        "metrics": ["acc"],
+        "optimizer": "adam",
+        "lr": 1e-3,
+    }
+    values.update(overrides)
+    return SimpleNamespace(**values)
+
+
 class _TaskHarness:
     metadata = _METADATA
+    _file_id_values = staticmethod(Default_task._file_id_values)
 
     def __init__(self):
         self.network = SimpleNamespace()
@@ -90,6 +106,7 @@ def test_default_task_preserves_per_sample_file_ids_and_sampling_rates():
 
     metrics = Default_task._shared_step(task, batch, "train")
 
+    assert "task_id" not in batch
     assert torch.equal(batch["file_id"], torch.tensor([101, 102]))
     assert torch.equal(task.seen_file_ids, torch.tensor([101, 102]))
     assert torch.equal(task.seen_sample_rates, torch.tensor([12_000.0, 48_000.0]))
@@ -105,6 +122,22 @@ def test_default_task_rejects_partial_file_id_vectors():
     }
 
     with pytest.raises(ValueError, match="one ID or one ID per sample"):
+        Default_task._shared_step(task, batch, "train")
+
+
+def test_default_task_rejects_mixed_dataset_identity_before_forward():
+    task = _TaskHarness()
+    task.metadata = {
+        101: {"Name": "Dataset_A", "Dataset_id": 1},
+        102: {"Name": "Dataset_B", "Dataset_id": 2},
+    }
+    batch = {
+        "x": torch.zeros(2, 8, 1),
+        "y": torch.tensor([0, 1]),
+        "file_id": torch.tensor([101, 102]),
+    }
+
+    with pytest.raises(ValueError, match="cannot mix dataset identities"):
         Default_task._shared_step(task, batch, "train")
 
 
@@ -126,10 +159,7 @@ def test_normalize_fs_preserves_vectors_and_rejects_wrong_lengths():
 
 def test_linear_head_requires_one_system_per_batch():
     head = H_01_Linear_cla(
-        SimpleNamespace(
-            num_classes={1: 2, 2: 2},
-            output_dim=4,
-        )
+        SimpleNamespace(num_classes={1: 2, 2: 2}, output_dim=4)
     )
     features = torch.randn(2, 4)
 
@@ -179,6 +209,7 @@ def test_existing_factory_supports_config_only_model_replacement_and_backward():
     }
     loss = task._shared_step(batch, "train")["train_total_loss"]
 
+    assert "task_id" not in batch
     assert loss.shape == ()
     assert torch.isfinite(loss)
     assert loss.requires_grad
@@ -202,30 +233,39 @@ def test_baseline_model_rejects_incompatible_input_without_padding_or_fallback()
         model(torch.randn(2, 128, 1))
 
 
-def test_default_task_forwards_explicit_physical_vectors_to_decisive_model():
-    class Network:
+def test_default_task_uses_configured_task_identity_without_mutating_batch():
+    class Network(torch.nn.Module):
         requires_physical_metadata = True
 
         def __init__(self):
+            super().__init__()
             self.received = None
 
-        def __call__(self, x, file_id, task_id, *, physical_metadata=None):
+        def forward(self, x, file_id, task_id, *, physical_metadata=None):
             self.received = (x, file_id, task_id, physical_metadata)
             return x
 
     network = Network()
-    task = SimpleNamespace(network=network)
+    task = Default_task(
+        network=network,
+        args_data=SimpleNamespace(normalization="none"),
+        args_model=SimpleNamespace(type="test", name="physical"),
+        args_task=_task_args(),
+        args_trainer=SimpleNamespace(device="cpu", gpus=1),
+        args_environment=SimpleNamespace(project="task_identity"),
+        metadata=_EXTENSION_METADATA,
+    )
     batch = {
         "x": torch.zeros(2, 16, 1),
-        "file_id": torch.tensor([101, 102]),
-        "task_id": "classification",
-        "sample_rate_hz": torch.tensor([12_000.0, 48_000.0]),
-        "rotation_speed_rpm": torch.tensor([1_797.0, 1_772.0]),
+        "file_id": torch.tensor([1, 2]),
+        "sample_rate_hz": torch.tensor([1000.0, 2000.0]),
+        "rotation_speed_rpm": torch.tensor([1797.0, 1772.0]),
         "load_hp": torch.tensor([0.0, 1.0]),
     }
 
-    Default_task.forward(task, batch)
+    task.forward(batch)
 
+    assert "task_id" not in batch
     assert network.received is not None
     _, received_ids, received_task, physical = network.received
     assert torch.equal(received_ids, batch["file_id"])
@@ -236,8 +276,11 @@ def test_default_task_forwards_explicit_physical_vectors_to_decisive_model():
         "load_hp",
     }
 
+    with pytest.raises(ValueError, match="conflicts with the configured"):
+        task.forward({**batch, "task_id": "prediction"})
 
-def test_default_task_delegates_cuda_validation_to_trainer(monkeypatch):  # type: ignore[no-untyped-def]
+
+def test_default_task_delegates_cuda_validation_to_trainer(monkeypatch):
     monkeypatch.setattr(
         torch.cuda,
         "is_available",
@@ -250,14 +293,59 @@ def test_default_task_delegates_cuda_validation_to_trainer(monkeypatch):  # type
         network=network,
         args_data=SimpleNamespace(normalization="none"),
         args_model=SimpleNamespace(type="test", name="cuda_required"),
-        args_task=SimpleNamespace(
-            loss="CE", metrics=["acc"], optimizer="adam", lr=1e-3
-        ),
+        args_task=_task_args(),
         args_trainer=args_trainer,
-        args_environment=SimpleNamespace(project="p04_cuda_fail_fast"),
-        metadata={0: {"Name": "Dummy", "Label": 0}},
+        args_environment=SimpleNamespace(project="cuda_fail_fast"),
+        metadata=_EXTENSION_METADATA,
     )
 
     assert task.network is network
     assert next(task.network.parameters()).device.type == "cpu"
     assert vars(args_trainer) == {"device": "cuda", "gpus": 1}
+
+
+def test_metric_requests_and_label_ontology_fail_closed():
+    with pytest.raises(ValueError, match="Unknown task metric"):
+        get_metrics(["acc", "not_a_metric"], _EXTENSION_METADATA)
+
+    nonzero_labels = {
+        1: {"Name": "bad", "Dataset_id": 1, "Label": 1},
+        2: {"Name": "bad", "Dataset_id": 1, "Label": 2},
+    }
+    with pytest.raises(ValueError, match="zero-based and contiguous"):
+        get_metrics(["acc"], nonzero_labels)
+
+    gapped_labels = {
+        1: {"Name": "bad", "Dataset_id": 1, "Label": 0},
+        2: {"Name": "bad", "Dataset_id": 1, "Label": 2},
+    }
+    with pytest.raises(ValueError, match="zero-based and contiguous"):
+        build_model(
+            SimpleNamespace(
+                type="Baseline",
+                name="GlobalAverageLinear",
+                input_dim=1,
+                num_classes=3,
+            ),
+            metadata=gapped_labels,
+        )
+
+    assert validate_zero_based_contiguous_labels(
+        [0, 1, 1], context="test"
+    ) == 2
+
+
+def test_regularization_consumes_the_complete_parameter_set():
+    first = torch.nn.Parameter(torch.tensor([1.0]))
+    second = torch.nn.Parameter(torch.tensor([2.0]))
+
+    result = calculate_regularization(
+        {"l2": 1.0},
+        iter([first, second]),
+    )
+
+    assert torch.equal(result["l2"], torch.tensor(5.0))
+    assert torch.equal(result["total"], torch.tensor(5.0))
+
+    with pytest.raises(ValueError, match="Unknown regularization method"):
+        calculate_regularization({"elastic": 1.0}, iter([first, second]))

--- a/test/test_regression_metrics.py
+++ b/test/test_regression_metrics.py
@@ -1,259 +1,105 @@
-"""
-Unit tests for regression metrics extensions in the metrics system.
+"""Focused tests for classification and regression metric construction."""
 
-Tests the bug fixes implemented for extending the metrics system
-to support regression tasks (MSE, MAE, R2, MAPE) alongside 
-classification metrics.
-
-Author: PHM-Vibench Team  
-Date: 2025-09-08
-"""
-
-import sys
-import os
-sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
-
-import unittest
+import pytest
 import torch
-import torch.nn as nn
-from unittest.mock import patch
-
-from src.task_factory.Components.metrics import get_metrics
 import torchmetrics
 
-
-class TestRegressionMetrics(unittest.TestCase):
-    """Test cases for regression metrics extensions."""
-    
-    def setUp(self):
-        """Set up test fixtures."""
-        # Mock metadata for testing
-        self.metadata_classification = {
-            1: {'Name': 'dataset1', 'Label': 0},
-            2: {'Name': 'dataset1', 'Label': 1},
-            3: {'Name': 'dataset1', 'Label': 2},
-        }
-        
-        self.metadata_mixed = {
-            1: {'Name': 'dataset1', 'Label': 0},
-            2: {'Name': 'dataset1', 'Label': 1}, 
-            3: {'Name': 'dataset1', 'Label': 2},
-            4: {'Name': 'dataset2', 'Label': 0},  # Second dataset
-        }
-    
-    def test_classification_metrics_only(self):
-        """Test that classification metrics still work correctly."""
-        metric_names = ['acc', 'f1', 'precision', 'recall']
-        metrics = get_metrics(metric_names, self.metadata_classification)
-        
-        self.assertIn('dataset1', metrics)
-        dataset_metrics = metrics['dataset1']
-        
-        # Check all stages and metrics are present
-        expected_keys = []
-        for stage in ['train', 'val', 'test']:
-            for metric in metric_names:
-                expected_keys.append(f"{stage}_{metric}")
-        
-        for key in expected_keys:
-            self.assertIn(key, dataset_metrics)
-            
-        # Check that metrics are torchmetrics instances
-        self.assertTrue(hasattr(dataset_metrics['train_acc'], '__call__'))  # Callable metric
-        self.assertTrue(hasattr(dataset_metrics['train_f1'], '__call__'))
-        self.assertTrue(hasattr(dataset_metrics['train_precision'], '__call__'))
-        self.assertTrue(hasattr(dataset_metrics['train_recall'], '__call__'))
-    
-    def test_regression_metrics_only(self):
-        """Test that regression metrics work correctly."""
-        metric_names = ['mse', 'mae', 'r2', 'mape']
-        metrics = get_metrics(metric_names, self.metadata_classification)
-        
-        self.assertIn('dataset1', metrics)
-        dataset_metrics = metrics['dataset1']
-        
-        # Check all stages and metrics are present
-        expected_keys = []
-        for stage in ['train', 'val', 'test']:
-            for metric in metric_names:
-                expected_keys.append(f"{stage}_{metric}")
-        
-        for key in expected_keys:
-            self.assertIn(key, dataset_metrics)
-            
-        # Check that metrics are torchmetrics instances
-        self.assertIsInstance(dataset_metrics['train_mse'], torchmetrics.MeanSquaredError)
-        self.assertIsInstance(dataset_metrics['train_mae'], torchmetrics.MeanAbsoluteError)
-        self.assertIsInstance(dataset_metrics['train_r2'], torchmetrics.R2Score)
-        self.assertIsInstance(dataset_metrics['train_mape'], torchmetrics.MeanAbsolutePercentageError)
-    
-    def test_mixed_metrics(self):
-        """Test that classification and regression metrics work together."""
-        metric_names = ['acc', 'f1', 'mse', 'mae', 'r2']
-        metrics = get_metrics(metric_names, self.metadata_classification)
-        
-        self.assertIn('dataset1', metrics)
-        dataset_metrics = metrics['dataset1']
-        
-        # Check classification metrics are callable
-        self.assertTrue(hasattr(dataset_metrics['train_acc'], '__call__'))
-        self.assertTrue(hasattr(dataset_metrics['train_f1'], '__call__'))
-        
-        # Check regression metrics are callable
-        self.assertTrue(hasattr(dataset_metrics['train_mse'], '__call__'))
-        self.assertTrue(hasattr(dataset_metrics['train_mae'], '__call__'))
-        self.assertTrue(hasattr(dataset_metrics['train_r2'], '__call__'))
-    
-    def test_regression_metrics_no_parameters(self):
-        """Test that regression metrics don't require task/num_classes parameters."""
-        metric_names = ['mse', 'mae', 'r2', 'mape']
-        
-        # Should not raise any errors about missing parameters
-        try:
-            metrics = get_metrics(metric_names, self.metadata_classification)
-            # Test that we can instantiate the metrics
-            mse_metric = metrics['dataset1']['train_mse']
-            mae_metric = metrics['dataset1']['train_mae']
-            
-            # Test basic functionality
-            preds = torch.tensor([1.0, 2.0, 3.0])
-            targets = torch.tensor([1.1, 2.2, 2.9])
-            
-            mse_value = mse_metric(preds, targets)
-            mae_value = mae_metric(preds, targets)
-            
-            self.assertIsInstance(mse_value, torch.Tensor)
-            self.assertIsInstance(mae_value, torch.Tensor)
-            self.assertTrue(mse_value >= 0)
-            self.assertTrue(mae_value >= 0)
-            
-        except Exception as e:
-            self.fail(f"Regression metrics should not require parameters: {e}")
-    
-    def test_classification_metrics_with_parameters(self):
-        """Test that classification metrics still get required parameters."""
-        metric_names = ['acc', 'f1']
-        metrics = get_metrics(metric_names, self.metadata_classification)
-        
-        # Classification metrics should work with integer inputs
-        acc_metric = metrics['dataset1']['train_acc']
-        f1_metric = metrics['dataset1']['train_f1']
-        
-        # Test with multiclass predictions
-        preds = torch.tensor([0, 1, 2, 1])
-        targets = torch.tensor([0, 1, 2, 2])
-        
-        acc_value = acc_metric(preds, targets)
-        f1_value = f1_metric(preds, targets)
-        
-        self.assertIsInstance(acc_value, torch.Tensor)
-        self.assertIsInstance(f1_value, torch.Tensor)
-        self.assertTrue(0 <= acc_value <= 1)
-        self.assertTrue(0 <= f1_value <= 1)
-    
-    def test_auroc_metrics(self):
-        """Test AUROC metrics for binary classification."""
-        metric_names = ['auroc']
-        metrics = get_metrics(metric_names, self.metadata_classification)
-        
-        auroc_metric = metrics['dataset1']['train_auroc']
-        self.assertTrue(hasattr(auroc_metric, '__call__'))  # Callable metric
-        
-        # Test with multiclass probabilities (3 classes from metadata)  
-        # Shape: [batch_size, num_classes]
-        preds = torch.tensor([[0.7, 0.2, 0.1],
-                             [0.1, 0.8, 0.1], 
-                             [0.2, 0.1, 0.7],
-                             [0.6, 0.3, 0.1]])
-        targets = torch.tensor([0, 1, 2, 0])
-        
-        auroc_value = auroc_metric(preds, targets)
-        self.assertIsInstance(auroc_value, torch.Tensor)
-        self.assertTrue(0 <= auroc_value <= 1)
-    
-    def test_multiple_datasets(self):
-        """Test that metrics work correctly with multiple datasets."""
-        metric_names = ['acc', 'mse', 'mae']
-        metrics = get_metrics(metric_names, self.metadata_mixed)
-        
-        self.assertIn('dataset1', metrics)
-        self.assertIn('dataset2', metrics)
-        
-        # Both datasets should have the same metrics
-        for dataset_name in ['dataset1', 'dataset2']:
-            dataset_metrics = metrics[dataset_name]
-            for stage in ['train', 'val', 'test']:
-                for metric in metric_names:
-                    key = f"{stage}_{metric}"
-                    self.assertIn(key, dataset_metrics)
-                    
-        # Verify metrics are callable for both datasets
-        self.assertTrue(hasattr(metrics['dataset1']['train_acc'], '__call__'))
-        self.assertTrue(hasattr(metrics['dataset1']['train_mse'], '__call__'))
-        self.assertTrue(hasattr(metrics['dataset2']['train_acc'], '__call__'))
-        self.assertTrue(hasattr(metrics['dataset2']['train_mse'], '__call__'))
-    
-    def test_unsupported_metrics(self):
-        """Test handling of unsupported metric names."""
-        metric_names = ['acc', 'unsupported_metric', 'mse']
-        
-        with patch('builtins.print') as mock_print:
-            metrics = get_metrics(metric_names, self.metadata_classification)
-        
-        # Should print warning for unsupported metric
-        mock_print.assert_called()
-        args, _ = mock_print.call_args
-        self.assertIn('unsupported_metric', args[0])
-        
-        # Supported metrics should still work
-        self.assertIn('dataset1', metrics)
-        dataset_metrics = metrics['dataset1']
-        self.assertIn('train_acc', dataset_metrics)
-        self.assertIn('train_mse', dataset_metrics)
-        
-        # Unsupported metric should not be present
-        self.assertNotIn('train_unsupported_metric', dataset_metrics)
-    
-    def test_empty_metadata(self):
-        """Test behavior with empty metadata."""
-        empty_metadata = {}
-        metric_names = ['acc', 'mse']
-        
-        # Should not raise an error, but return empty metrics dict
-        metrics = get_metrics(metric_names, empty_metadata)
-        self.assertEqual(len(metrics), 0)
-    
-    def test_binary_vs_multiclass_handling(self):
-        """Test that binary vs multiclass classification is handled correctly."""
-        # Binary classification case (only 1 class max)
-        binary_metadata = {
-            1: {'Name': 'binary_dataset', 'Label': 0},
-            2: {'Name': 'binary_dataset', 'Label': 1},
-        }
-        
-        # Multiclass classification case (more than 2 classes)
-        multiclass_metadata = {
-            1: {'Name': 'multiclass_dataset', 'Label': 0},
-            2: {'Name': 'multiclass_dataset', 'Label': 1},
-            3: {'Name': 'multiclass_dataset', 'Label': 2},
-            4: {'Name': 'multiclass_dataset', 'Label': 3},
-        }
-        
-        metric_names = ['acc', 'f1']
-        
-        binary_metrics = get_metrics(metric_names, binary_metadata)
-        multiclass_metrics = get_metrics(metric_names, multiclass_metadata)
-        
-        # Both should work without errors
-        self.assertIn('binary_dataset', binary_metrics)
-        self.assertIn('multiclass_dataset', multiclass_metrics)
-        
-        # Both should have the same structure
-        for dataset_name, metrics_dict in [('binary_dataset', binary_metrics), 
-                                          ('multiclass_dataset', multiclass_metrics)]:
-            self.assertIn('train_acc', metrics_dict[dataset_name])
-            self.assertIn('train_f1', metrics_dict[dataset_name])
+from src.task_factory.Components.metrics import get_metrics
 
 
-if __name__ == '__main__':
-    unittest.main()
+_CLASSIFICATION_METADATA = {
+    1: {"Name": "dataset1", "Dataset_id": 1, "Label": 0},
+    2: {"Name": "dataset1", "Dataset_id": 1, "Label": 1},
+    3: {"Name": "dataset1", "Dataset_id": 1, "Label": 2},
+}
+
+_MIXED_METADATA = {
+    **_CLASSIFICATION_METADATA,
+    4: {"Name": "dataset2", "Dataset_id": 2, "Label": 0},
+    5: {"Name": "dataset2", "Dataset_id": 2, "Label": 1},
+}
+
+
+def test_classification_metrics_are_built_for_every_stage():
+    names = ["acc", "f1", "precision", "recall", "auroc"]
+    metrics = get_metrics(names, _CLASSIFICATION_METADATA)
+
+    for stage in ("train", "val", "test"):
+        for name in names:
+            assert f"{stage}_{name}" in metrics["dataset1"]
+
+    predictions = torch.tensor([0, 1, 2, 1])
+    targets = torch.tensor([0, 1, 2, 2])
+    value = metrics["dataset1"]["train_acc"](predictions, targets)
+    assert 0 <= value <= 1
+
+
+def test_regression_metrics_do_not_require_classification_parameters():
+    names = ["mse", "mae", "r2", "mape"]
+    metrics = get_metrics(names, _CLASSIFICATION_METADATA)
+
+    assert isinstance(
+        metrics["dataset1"]["train_mse"],
+        torchmetrics.MeanSquaredError,
+    )
+    assert isinstance(
+        metrics["dataset1"]["train_mae"],
+        torchmetrics.MeanAbsoluteError,
+    )
+    assert isinstance(metrics["dataset1"]["train_r2"], torchmetrics.R2Score)
+    assert isinstance(
+        metrics["dataset1"]["train_mape"],
+        torchmetrics.MeanAbsolutePercentageError,
+    )
+
+    predictions = torch.tensor([1.0, 2.0, 3.0])
+    targets = torch.tensor([1.1, 2.2, 2.9])
+    assert metrics["dataset1"]["train_mse"](predictions, targets) >= 0
+    assert metrics["dataset1"]["train_mae"](predictions, targets) >= 0
+
+
+def test_mixed_metric_families_and_multiple_datasets_are_explicit():
+    names = ["acc", "mse", "mae"]
+    metrics = get_metrics(names, _MIXED_METADATA)
+
+    assert set(metrics.keys()) == {"dataset1", "dataset2"}
+    for dataset_name in metrics:
+        for stage in ("train", "val", "test"):
+            for name in names:
+                assert f"{stage}_{name}" in metrics[dataset_name]
+
+
+def test_binary_and_multiclass_ontologies_select_matching_metric_modes():
+    binary_metadata = {
+        1: {"Name": "binary", "Dataset_id": 1, "Label": 0},
+        2: {"Name": "binary", "Dataset_id": 1, "Label": 1},
+    }
+    multiclass_metrics = get_metrics(["acc", "f1"], _CLASSIFICATION_METADATA)
+    binary_metrics = get_metrics(["acc", "f1"], binary_metadata)
+
+    assert "train_acc" in binary_metrics["binary"]
+    assert "train_acc" in multiclass_metrics["dataset1"]
+
+
+def test_unknown_metric_fails_instead_of_being_skipped():
+    with pytest.raises(ValueError, match="Unknown task metric"):
+        get_metrics(["acc", "unsupported_metric", "mse"], _CLASSIFICATION_METADATA)
+
+
+def test_empty_metadata_and_invalid_ontologies_fail_closed():
+    with pytest.raises(ValueError, match="at least one row"):
+        get_metrics(["acc"], {})
+
+    nonzero = {
+        1: {"Name": "bad", "Dataset_id": 1, "Label": 1},
+        2: {"Name": "bad", "Dataset_id": 1, "Label": 2},
+    }
+    with pytest.raises(ValueError, match="zero-based and contiguous"):
+        get_metrics(["acc"], nonzero)
+
+    gapped = {
+        1: {"Name": "bad", "Dataset_id": 1, "Label": 0},
+        2: {"Name": "bad", "Dataset_id": 1, "Label": 2},
+    }
+    with pytest.raises(ValueError, match="zero-based and contiguous"):
+        get_metrics(["acc"], gapped)


### PR DESCRIPTION
## Objective

Close the remaining Task/Metric/Label/Regularization P0 mismatches so that the declared learning problem equals the executed learning problem.

## Scientific/runtime invariants

```text
configured task identity == model task head used by the batch
one classification batch == one Name and one Dataset_id
classification labels == {0, 1, ..., K-1}
requested metric set == constructed metric set
regularization == declared term over every trainable parameter
```

## Changes

- remove `batch.setdefault("task_id", "classification")` from the maintained task path;
- derive the model task identity from explicit Task Factory semantics without mutating batches;
- reject batch-level task overrides and mixed dataset identities before forward/metric update;
- make `hse_contrastive` explicitly select the classification head rather than relying on a missing batch key;
- reject unknown metrics instead of warning and skipping them;
- validate zero-based contiguous label ontologies per `Dataset_id` and per metadata `Name`;
- validate declared label ontologies before model construction even when `model.num_classes` is supplied;
- materialize the complete trainable parameter list before device lookup and regularization;
- include the first trainable parameter in L1/L2 terms;
- reject unknown regularization methods and invalid weights;
- update focused tests and Task configuration documentation.

## Boundaries

- no Data Factory split/sampler changes;
- no Trainer Factory, device, checkpoint, or Pipeline changes;
- no metric aggregation or benchmark estimator redesign;
- no automatic label filtering or re-encoding;
- no hash/checksum/digest/receipt/ledger/attestation work;
- no new manager, registry, adapter, or schema layer.

## Validation

- maintained offline runtime and Dummy demo;
- per-sample metadata and task semantic tests;
- HSE objective tests;
- device authority tests;
- regression/classification metric tests where applicable;
- documentation/configuration validation;
- repository layout and submodule policy checks.
