### PR TITLE
fix(data): fail when packaged Dummy signals are missing or malformed

### DIFF
--- a/configs/demo/00_smoke/README.md
+++ b/configs/demo/00_smoke/README.md
@@ -1,30 +1,53 @@
 # Demo: Dummy DG Smoke (`demo_00_smoke_dummy_dg`)
 
-Purpose: one-command end-to-end run using repo-shipped dummy metadata + raw CSV.
+Purpose: one-command end-to-end run using repository-shipped dummy metadata and raw CSV files.
 
-## Minimal Run
+## Minimal run
 
 ```bash
 python main.py --config configs/demo/00_smoke/dummy_dg.yaml
 ```
 
-## Expected Outputs
-
-- Output base dir: `results/demo/dummy_dg_smoke/`
-- A subfolder `{experiment_name}/iter_0/` with Lightning logs/checkpoints.
-
-## Recommended Overrides
+The installed command is equivalent:
 
 ```bash
-python main.py --config configs/demo/00_smoke/dummy_dg.yaml --override trainer.num_epochs=1
+phmfactory --config configs/demo/00_smoke/dummy_dg.yaml
 ```
 
-## Common Pitfalls
+## Expected outputs
 
-1) Running from a different working directory (paths are repo-relative).
-2) Deleting `data/metadata_dummy.csv`.
-3) Using a very large `data.batch_size` (the smoke dataset is tiny; keep it small, e.g. `4`).
-4) Increasing `data.window_size` beyond the dummy signal length (when using real dummy CSVs).
+- Output base directory: `results/demo/dummy_dg_smoke/`
+- A subfolder `{experiment_name}/iter_0/` with Lightning logs and checkpoints
+- Finite test metrics and an aggregate run summary
 
-Note:
-- If `data/raw/Dummy_Data/*.csv` is missing, `Dummy_Data` will generate synthetic signals so the smoke demo still runs.
+## Recommended override
+
+```bash
+python main.py \
+  --config configs/demo/00_smoke/dummy_dg.yaml \
+  --override trainer.num_epochs=1
+```
+
+## Input contract
+
+The smoke run consumes the packaged files:
+
+```text
+data/metadata_dummy.csv
+data/raw/Dummy_Data/dummy1.csv
+data/raw/Dummy_Data/dummy2.csv
+```
+
+Each signal CSV must contain numeric `ch1` and `ch2` columns in that order. Missing,
+empty, malformed, or non-finite files fail at the reader boundary. PHMFactory does not
+generate substitute signals, guess columns, pad channels, or silently repair the fixture.
+
+## Common failures
+
+1. Running from a different working directory while using repository-relative paths.
+2. Deleting `data/metadata_dummy.csv` or either packaged signal CSV.
+3. Using a very large `data.batch_size` for the small smoke dataset.
+4. Increasing `data.window_size` beyond the available signal length.
+
+This command is an execution smoke. It proves the maintained data → model → task →
+trainer path can run; it does not establish a real-data benchmark or algorithm claim.

--- a/src/data_factory/reader/Dummy_Data.py
+++ b/src/data_factory/reader/Dummy_Data.py
@@ -1,92 +1,74 @@
-import pandas as pd
-import numpy as np
+"""Strict reader for the repository-shipped Dummy_Data CSV fixtures."""
+
+from __future__ import annotations
+
 from pathlib import Path
+from typing import Any
 
-def _make_synthetic(args_data=None, seed: int = 0) -> np.ndarray:
-    window_size = int(getattr(args_data, "window_size", 128)) if args_data is not None else 128
-    num_window = int(getattr(args_data, "num_window", 8)) if args_data is not None else 8
-    stride = int(getattr(args_data, "stride", 16)) if args_data is not None else 16
-
-    min_len = window_size + max(0, num_window - 1) * stride
-    length = max(min_len, 2048)
-
-    rng = np.random.default_rng(seed)
-    t = np.linspace(0, 10, length, dtype=np.float32)
-    s1 = np.sin(2 * np.pi * 5.0 * t) + 0.1 * rng.standard_normal(length, dtype=np.float32)
-    s2 = np.sin(2 * np.pi * 13.0 * t + 0.3) + 0.1 * rng.standard_normal(length, dtype=np.float32)
-    return np.stack([s1, s2], axis=1)
+import numpy as np
+import pandas as pd
 
 
-def read(file_path, *args):
+_SIGNAL_COLUMNS = ("ch1", "ch2")
+
+
+def read(file_path: str | Path, args_data: Any = None) -> np.ndarray:
+    """Read one Dummy_Data CSV as a ``[length, 2]`` float32 signal.
+
+    The offline demo is valid only when it consumes the CSV files shipped with the
+    repository or wheel. Missing or malformed inputs fail at the reader boundary;
+    this reader never generates substitute signals, pads channels, or guesses columns.
     """
-    Reads data from a CSV file specified by file_path.
 
-    Args:
-        args_data: Data configuration arguments (currently unused).
-        file_path (str): Path to the CSV data file (e.g., Vbench/data/Dummy_Dataset/dummy1.csv).
+    del args_data
+    path = Path(file_path)
+    if not path.is_file():
+        raise FileNotFoundError(
+            f"Dummy_Data signal file not found: {path}. The offline demo requires "
+            "the repository-shipped data/raw/Dummy_Data/*.csv files and does not "
+            "synthesize fallback signals. Reinstall the package or restore the "
+            "missing fixture."
+        )
 
-    Returns:
-        numpyarray: dimention as lenth \times channel
-    """
     try:
-        args_data = args[0] if args else None
-        file_path = str(file_path)
-        if not Path(file_path).exists():
-            # Repo-shipped smoke/demo mode: generate deterministic synthetic data.
-            seed = abs(hash(file_path)) % (2**32)
-            data = _make_synthetic(args_data=args_data, seed=int(seed))
-            print(f"[Dummy_Data] raw file missing; generated synthetic data for: {file_path}")
-            return data
+        frame = pd.read_csv(path)
+    except pd.errors.EmptyDataError as exc:
+        raise ValueError(f"Dummy_Data signal file is empty: {path}") from exc
+    except (OSError, UnicodeError, pd.errors.ParserError) as exc:
+        raise ValueError(f"Unable to parse Dummy_Data CSV file {path}: {exc}") from exc
 
-        # Read the CSV file into a pandas DataFrame
-        df = pd.read_csv(file_path)
-        # Depending on downstream requirements, you might want to convert
-        # the DataFrame to a NumPy array, e.g., return df.values
-        # For now, returning the DataFrame is flexible.
-        print(f"Successfully read data from: {file_path}")
-        # 💯这里加对应数据的各种读取
-        # Extract columns 2-5 (indices 1-4 in zero-based indexing)
-        df = df.iloc[:, 1:3]
-        print(f"Selected columns 2-5 from the dataset.")
+    missing = [column for column in _SIGNAL_COLUMNS if column not in frame.columns]
+    if missing:
+        raise ValueError(
+            f"Dummy_Data signal file {path} is missing required column(s) {missing}. "
+            f"Expected channel order {list(_SIGNAL_COLUMNS)}; available columns are "
+            f"{list(frame.columns)}."
+        )
 
-        return df.values.astype(np.float32)
-    
-    
-    except FileNotFoundError:
-        args_data = args[0] if args else None
-        seed = abs(hash(str(file_path))) % (2**32)
-        data = _make_synthetic(args_data=args_data, seed=int(seed))
-        print(f"[Dummy_Data] file not found; generated synthetic data for: {file_path}")
-        return data
-    except pd.errors.EmptyDataError:
-        print(f"Error: The file at {file_path} is empty.")
-        return None
-    except Exception as e:
-        print(f"An error occurred while reading {file_path}: {e}")
-        return None
-    
-    # 加入更多的异常处理
-    # 例如：处理文件格式错误、数据解析错误等
+    selected = frame.loc[:, list(_SIGNAL_COLUMNS)]
+    try:
+        numeric = selected.apply(pd.to_numeric, errors="raise")
+    except (TypeError, ValueError) as exc:
+        raise ValueError(
+            f"Dummy_Data columns {list(_SIGNAL_COLUMNS)} must contain only numeric "
+            f"signal values: {path}."
+        ) from exc
 
-def get_dataset(args_data, file_path):
-    """
-    Reads data from a CSV file specified by file_path.
+    signal = numeric.to_numpy(dtype=np.float32, copy=True)
+    if signal.ndim != 2 or signal.shape[0] == 0 or signal.shape[1] != len(_SIGNAL_COLUMNS):
+        raise ValueError(
+            f"Dummy_Data signal file {path} produced invalid shape {signal.shape}; "
+            f"expected [length, {len(_SIGNAL_COLUMNS)}] with at least one row."
+        )
+    if not np.isfinite(signal).all():
+        raise FloatingPointError(
+            f"Dummy_Data signal file {path} contains NaN or Inf in "
+            f"{list(_SIGNAL_COLUMNS)}."
+        )
+    return signal
 
-    Args:
-        args_data: Data configuration arguments (currently unused).
-        file_path (str): Path to the CSV data file (e.g., Vbench/data/Dummy_Dataset/dummy1.csv).
 
-    Returns:
-        numpyarray: dimention as lenth \times channel
-    """
-    # 读取数据
-    data = read(args_data, file_path)
-    
-    # 处理数据
-    if data is not None:
-        # 这里可以添加数据预处理的代码
-        print(f"Data shape: {data.shape}")
-        return data
-    else:
-        print("No data to process.")
-        return None
+def get_dataset(args_data: Any, file_path: str | Path) -> np.ndarray:
+    """Compatibility helper using the same strict reader contract."""
+
+    return read(file_path, args_data)

--- a/test/test_data_cache_contract.py
+++ b/test/test_data_cache_contract.py
@@ -14,6 +14,7 @@ from src.data_factory.contracts import (
 )
 from src.data_factory.data_factory import data_factory as BaseDataFactory
 from src.data_factory.reader.CSV_Signal import read as read_csv_signal
+from src.data_factory.reader.Dummy_Data import read as read_dummy_signal
 
 
 def _factory(metadata):
@@ -319,3 +320,57 @@ def test_compatible_csv_dataset_uses_existing_data_and_task_contracts(
         assert factory.split_summary["file_overlap"]["train_test"] == []
     finally:
         factory.data.close()
+
+
+def _write_dummy_csv(path: Path) -> None:
+    path.write_text(
+        "index,ch1,ch2\n"
+        "0,0.0,1.0\n"
+        "1,0.5,0.5\n"
+        "2,1.0,0.0\n",
+        encoding="utf-8",
+    )
+
+
+def test_dummy_reader_consumes_exact_declared_columns(tmp_path: Path) -> None:
+    path = tmp_path / "dummy.csv"
+    _write_dummy_csv(path)
+
+    signal = read_dummy_signal(path)
+
+    assert signal.shape == (3, 2)
+    assert signal.dtype == np.float32
+    assert np.array_equal(
+        signal,
+        np.array(
+            [[0.0, 1.0], [0.5, 0.5], [1.0, 0.0]],
+            dtype=np.float32,
+        ),
+    )
+
+
+def test_dummy_reader_rejects_missing_file_without_synthetic_fallback(
+    tmp_path: Path,
+) -> None:
+    with pytest.raises(FileNotFoundError, match="does not synthesize fallback signals"):
+        read_dummy_signal(tmp_path / "missing.csv")
+
+
+def test_dummy_reader_rejects_malformed_or_nonfinite_channels(tmp_path: Path) -> None:
+    missing_column = tmp_path / "missing_column.csv"
+    missing_column.write_text("index,ch1\n0,1.0\n", encoding="utf-8")
+    with pytest.raises(ValueError, match="missing required column"):
+        read_dummy_signal(missing_column)
+
+    non_numeric = tmp_path / "non_numeric.csv"
+    non_numeric.write_text(
+        "index,ch1,ch2\n0,not-a-number,1.0\n",
+        encoding="utf-8",
+    )
+    with pytest.raises(ValueError, match="must contain only numeric"):
+        read_dummy_signal(non_numeric)
+
+    non_finite = tmp_path / "non_finite.csv"
+    non_finite.write_text("index,ch1,ch2\n0,NaN,1.0\n", encoding="utf-8")
+    with pytest.raises(FloatingPointError, match="contains NaN or Inf"):
+        read_dummy_signal(non_finite)


### PR DESCRIPTION
## Objective

Make the offline Dummy smoke consume exactly the repository-shipped CSV fixtures and fail at the reader boundary when those fixtures are missing or malformed.

## Runtime invariant

```text
Dummy smoke success
=> metadata_dummy.csv exists
&& dummy1.csv and dummy2.csv exist
&& ch1/ch2 are numeric and finite
```

The reader never synthesizes replacement signals, guesses columns, duplicates channels, or converts malformed input into a successful run.

## Changes

- remove deterministic synthetic-signal fallback from `Dummy_Data`;
- require the packaged `ch1`, `ch2` channel schema explicitly;
- reject missing, empty, non-numeric, malformed, and non-finite fixtures with actionable errors;
- protect the behavior in the existing data-contract test suite;
- update the smoke guide to state the exact packaged input and claim boundary.

## Boundaries

- no Data Factory architecture or split changes;
- no model, task, trainer, Pipeline, metric, or checkpoint changes;
- no new manager, registry, schema, hash, checksum, digest, receipt, ledger, or attestation;
- the successful packaged Dummy execution path is unchanged.

## Validation

- existing offline user-first smoke;
- data cache and reader contracts;
- documentation/config validation;
- repository layout and submodule policy.
