### PR TITLE
fix(runtime): keep diagnostic records outside run success

### DIFF
--- a/docs/developer_runtime_control_plane.md
+++ b/docs/developer_runtime_control_plane.md
@@ -1,7 +1,14 @@
 # Runtime control plane
 
-PHMFactory separates user intent, execution, and run records so one command cannot be
-silently reinterpreted by a downstream Pipeline.
+PHMFactory separates configuration authority, scientific execution, and diagnostic run
+records. The central invariant is:
+
+```text
+requested experiment = executed experiment
+```
+
+A Pipeline failure must propagate from its source. A diagnostic-file failure must not
+rewrite a completed scientific run as failed.
 
 ## Maintained public path
 
@@ -12,16 +19,17 @@ preset or YAML
   -> phmfactory.config.analyze_config
   -> ConfigAnalysis
   -> CompiledRunSpec
-  -> RunAttestation (pending)
+  -> ExecutionEnvelope
+  -> optional pending diagnostic manifest
   -> Pipeline maturity gate
   -> canonical Pipeline module or narrow adapter
   -> protected src runtime
-  -> Pipeline-specific evidence registration
-  -> RunAttestation (succeeded or failed)
+  -> optional evidence indexing
+  -> optional terminal diagnostic manifest
 ```
 
-The public path has one configuration authority. Validators, inspectors, preflight, the
-CLI, support generation, Pipeline 06, and the optional Streamlit workspace all consume the
+Configuration composition has one authority. Validators, inspectors, preflight, the CLI,
+support generation, Pipeline adapters, and the optional Streamlit workspace consume the
 same effective mapping.
 
 ## `ConfigAnalysis`: one configuration truth
@@ -53,43 +61,25 @@ base_configs
 No public component automatically searches for `configs/local/local.yaml`. Hidden files
 would make the same visible command execute different experiments on different machines.
 
-The effective hash includes only the canonical effective mapping. It deliberately excludes
-preset spelling, source path, installation path, and provenance metadata. Consequently:
+The effective configuration hash remains a diagnostic identity for config-parity checks.
+It is not a security claim and does not determine whether training, checkpoint selection,
+evaluation, or metrics succeeded.
 
-```text
---config smoke
+## `CompiledRunSpec`: configuration-to-runtime boundary
+
+`CompiledRunSpec` contains a deep-copied runtime mapping. Runtime adapters call:
+
+```python
+compiled_run_spec.runtime_config()
 ```
 
-and:
+They must not re-read source YAML, discover a local file, or reapply CLI overrides. The
+existing spec hash is retained for compatibility and config-parity tooling; it is not a
+run-success gate.
 
-```text
---config configs/demo/00_smoke/dummy_dg.yaml
-```
+## Scientific execution authority
 
-share `effective_config_sha256` when their final mappings are equal.
-
-## `CompiledRunSpec`: runtime and invocation identity
-
-`CompiledRunSpec` contains a deep-copied runtime mapping and two hashes:
-
-```text
-effective_config_sha256
-  identifies the scientific configuration semantics
-
-sha256 / run_spec_sha256
-  identifies this invocation, including requested source and explicit overrides
-```
-
-Runtime adapters call `compiled_run_spec.runtime_config()` to obtain a mutable copy. They
-must not re-read the source YAML or reapply CLI overrides.
-
-The absolute resolved config path remains available for diagnostics but is excluded from
-both identities. An installed preset therefore behaves consistently across checkout and
-wheel locations.
-
-## Execution boundary
-
-`ExecutionEnvelope` records the finite states:
+`ExecutionEnvelope` records:
 
 ```text
 pending -> running -> succeeded
@@ -98,39 +88,46 @@ pending -> running -> succeeded
 
 A Pipeline module must expose `pipeline(args)` and return an explicit result. Returning
 `None`, omitting the callable, or executing one envelope twice is a contract error.
-Exceptions keep their traceback while the envelope records failure stage, type, and
-message.
+Exceptions preserve their original traceback while the envelope records failure stage,
+type, and message.
 
-The public process prints the completion message only after execution, evidence
-registration, and final manifest writing succeed. A printed warning followed by `return
-None` cannot become a successful command.
+For maintained classification paths, success is governed by the scientific lifecycle:
 
-## Mandatory run manifest
+```text
+fit completed
++ best checkpoint exists and loads
++ evaluation completed
++ returned metrics are non-empty and finite
+```
 
-Before Pipeline import, PHMFactory creates:
+The public completion message is printed only after the Pipeline returns successfully.
+No evidence adapter, artifact index, digest, receipt, ledger index, or diagnostic manifest
+may convert that result into a failed run.
+
+## Diagnostic run manifest during v0.3 migration
+
+The historical writer may create:
 
 ```text
 <environment.output_dir>/.phmfactory/runs/<run-id>/run_manifest.json
 ```
 
-The pending file is atomically replaced with the terminal state. The manifest includes:
+It is now optional diagnostic output rather than an execution authority:
 
-```text
-run ID and status
-run_spec_sha256
-effective_config_sha256
-canonical Pipeline and imported module
-requested source, resolved path, and overrides
-code revision when available
-Python/platform summary
-execution timestamps
-structured failure information
-indexed artifacts and evidence sections
-```
+- preparation failure emits a warning and execution continues;
+- Pipeline-specific evidence-indexing failure emits a warning and execution continues;
+- terminal write failure emits a warning and preserves the Pipeline result;
+- a Pipeline exception remains authoritative and is never replaced by a manifest-write
+  exception.
 
-Writes use a same-directory temporary file, flush, `fsync`, and `os.replace`. Failure to
-create the pending manifest prevents Pipeline import. Failure to write the final success
-state prevents a success claim.
+When available, the compatibility manifest can still contain config identities, indexed
+artifacts, and evidence sections. Those fields are not proof of scientific correctness.
+The maintained results remain the actual checkpoints, test metrics, split information,
+and aggregate run summary produced by the scientific path.
+
+A later bounded cleanup may replace this compatibility file with a smaller `run_status`
+record. That change must not introduce a second runtime or make status-file writing a
+success condition.
 
 ## Shared classification runtime
 
@@ -143,11 +140,12 @@ consume compiled config
 -> fit
 -> restore best checkpoint
 -> test and write metrics
+-> aggregate repeated seeds
 -> close data and logging resources in finally
 ```
 
-Pipeline 01 is a thin default adapter. Pipeline 05 adds only explainability hooks. Hooks
-must not duplicate config loading, factory construction, training, testing, or cleanup.
+Pipeline 01 is the default adapter. Pipeline 05 adds explainability hooks. Hooks must not
+duplicate config loading, factory construction, training, testing, or cleanup.
 
 Pipeline 02 chooses exactly one mode before execution:
 
@@ -159,9 +157,9 @@ explicit legacy_dual_yaml       -> compatibility adapter + orchestrator
 
 An exception never changes the selected algorithm.
 
-## Pipeline 06 compiled-config adapter
+## Pipeline 06 boundary
 
-The train/sample/eval science remains in:
+The train/sample/eval implementation remains in:
 
 ```text
 src.Pipeline_06_Generative_Modeling
@@ -173,67 +171,58 @@ The public descriptor imports the narrow adapter:
 phmfactory.runtime.pipeline06_adapter
 ```
 
-Its only responsibilities are:
-
-1. require the compiled Pipeline to be `Pipeline_06_Generative_Modeling`;
-2. convert `compiled_run_spec.runtime_config()` to the namespace shape expected by the
-   protected implementation;
-3. dispatch the already selected `train`, `sample`, or `eval` stage;
-4. preserve stage-ledger failure handling.
-
-It does not re-read YAML, apply overrides a second time, discover local files, or alter
-the generative algorithm. Direct imports of the historical `src` function keep an
-explicit compatibility loader, but that path is not the maintained CLI authority.
+The adapter consumes the compiled configuration and dispatches the already selected
+stage. Pipeline 06 may define internal scientific or stage-completion requirements.
+However, after the Pipeline explicitly returns success, failure of the optional CLI
+evidence index to find or register a stage ledger no longer changes the invocation to
+failed.
 
 ## Streamlit boundary
 
-The optional UI edits values and calls the public inspector. It does not merge base
-configs in Python UI code, discover a local YAML, import a Pipeline, or construct a
-Trainer.
+The optional UI edits values and calls the public config/runtime entrypoint. It does not
+merge base configs independently, discover local YAML, construct a Trainer, or create a
+second success definition.
 
-The UI receives the same `effective_config_sha256` as CLI preflight. The displayed
-reproduction command is the command passed to the public runtime. Edited Advanced YAML is
-a standalone effective config and contains no invisible local layer.
+## Compatibility evidence API
 
-## Evidence convergence
+`RunAttestation` and `phmfactory.runtime.evidence` remain importable during migration for
+legacy tests and direct research tooling. They are not called as mandatory authorities by
+the public scientific result.
 
-`RunAttestation` is the only invocation-level run identity. Metrics, checkpoints,
-explainability files, stage ledgers, synthetic manifests, and evaluation reports remain
-separate artifacts indexed through:
+New maintained code should not add:
 
-```python
-run_attestation.register_artifact(role=..., path=..., sha256=..., metadata=...)
-run_attestation.set_evidence(section, value)
-run_attestation.append_evidence(section, value)
+```text
+hash chains
+receipts
+ledgers as global success gates
+artifact-integrity auditing
+new evidence registries
 ```
 
-A Pipeline-specific file extends the run; it does not create another top-level run
-identity. Missing required evidence changes the invocation to failed even when model code
-completed.
+Tests should instead protect data population, split disjointness, model/task identity,
+objective participation, checkpoint restoration, estimator definition, and finite metrics.
 
 ## Pipeline maturity
 
 `phmfactory.pipelines.PIPELINE_DESCRIPTORS` separates discoverability, opt-in execution,
-and release support. Pipeline 03 and Pipeline 04 require:
+and maintained support. Pipeline 03 and Pipeline 04 require explicit opt-in. The flag
+acknowledges maturity; it does not promote scientific support.
 
-```bash
-phmfactory --config <yaml> --allow-experimental
-```
+Exact execution and protocol claims are configuration-specific and listed in:
 
-The flag acknowledges maturity; it does not promote support. Pipeline 01 and the
-maintained single-stage Pipeline 02 path remain the release-supported surface. Pipeline
-05, Pipeline 06, and Pipeline_ID remain outside the maintained combination table unless
-current evidence promotes an exact configuration.
+- `SUPPORTED_COMPONENTS.md`
+- `SUPPORTED_COMBINATIONS.md`
+- `configs/config_registry.csv`
 
 ## Invariants for future changes
 
 1. Public configuration composition has one implementation.
 2. Machine-local YAML is an explicit input.
-3. Run, preflight, inspect, validate, UI, and Pipeline 06 share the effective hash.
-4. Overrides are applied exactly once.
-5. Runtime code receives a copy and cannot mutate the compiled contract.
-6. Errors propagate from their source; no exception activates another algorithm.
-7. `None` is not a successful Pipeline result.
-8. Resources close through `finally` boundaries.
-9. Every public run creates one mandatory terminal manifest.
-10. Discoverable, runnable, supported, and benchmark-valid remain distinct claims.
+3. Overrides are applied exactly once.
+4. Runtime code receives a copy and cannot mutate the compiled contract.
+5. Errors propagate from their source; no exception activates another algorithm.
+6. `None` is not a successful Pipeline result.
+7. Resources close through `finally` boundaries.
+8. Pipeline success is determined by scientific execution, not diagnostic finalization.
+9. Diagnostic write failure never replaces the original Pipeline exception.
+10. Discoverable, runnable, execution-verified, and baseline-valid remain distinct claims.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -13,7 +13,7 @@ By the end of this page you will have:
 1. checked the Python environment;
 2. checked one exact effective configuration without training;
 3. completed one offline train/test run;
-4. located metrics and the run record;
+4. located metrics, checkpoints, and the optional diagnostic run record;
 5. understood how to supply local paths explicitly.
 
 ## 1. Install the source checkout
@@ -91,11 +91,13 @@ maturity=supported
 output_dir=.../results/demo/dummy_dg_smoke
 ```
 
-The two hashes have different purposes:
+These identities support configuration-parity diagnosis:
 
-- `effective_config_sha256` identifies the final resolved experiment semantics;
-- `run_spec_sha256` preserves this invocation, including requested source and explicit
-  overrides.
+- `effective_config_sha256` identifies the final resolved configuration mapping;
+- `run_spec_sha256` identifies the explicit invocation source and overrides.
+
+They are not security proofs and do not determine whether training or evaluation
+succeeded.
 
 Preflight does not:
 
@@ -144,10 +146,15 @@ A successful run should:
 
 - initialize Dummy data from repository files;
 - construct the maintained model, task, and trainer;
-- train and test without downloading an external dataset;
-- print `run_manifest=<path>`;
+- fit, restore the best checkpoint, and test without downloading an external dataset;
+- print `run_manifest=<path>` when the compatibility diagnostic record is available, or
+  `run_manifest=unavailable` when only that optional write failed;
 - print the completion message;
 - exit with status code `0`.
+
+The scientific result is governed by fit, checkpoint restoration, evaluation, and finite
+metrics. A warning about the optional diagnostic manifest or evidence index does not
+invalidate a completed Pipeline.
 
 ## 5. Find the results
 
@@ -164,20 +171,21 @@ Get-ChildItem results/demo/dummy_dg_smoke -Recurse -File |
   Select-Object -ExpandProperty FullName
 ```
 
-The output normally contains:
+Required scientific outputs normally include:
 
 - per-iteration test metrics such as `test_result_0.csv`;
 - aggregate metrics such as `all_results.csv`;
-- checkpoints and logger outputs;
-- one `run_manifest.json` under `.phmfactory/runs/<run-id>/`.
+- `run_summary.json` for repeated-run estimators;
+- the best checkpoint and logger outputs.
 
-The manifest records both config hashes, selected Pipeline, overrides, status,
-timestamps, code revision when available, and indexed artifacts. You do not need to
-understand its internal schema to complete this quickstart.
+When diagnostic recording is available, one compatibility `run_manifest.json` also
+appears under `.phmfactory/runs/<run-id>/`. It may index config identities and artifacts,
+but it is not the authority for scientific success. A failed manifest write produces a
+warning rather than changing a completed experiment to failed.
 
 ## 6. Verify compatible entrypoints
 
-These commands should report the same effective config hash and process status:
+These commands should report the same effective config identity and process status:
 
 ```bash
 phmfactory preflight --config smoke
@@ -199,8 +207,11 @@ print(report["effective_config_sha256"])
 
 ## 7. Run a maintained config with local data
 
-Only the Dummy smoke is fully offline. Keep machine paths out of maintained YAML and pass
-them explicitly:
+The Dummy smoke is fully offline. The first real-data reference uses MFPT and has its own
+preparation guide under `configs/baselines/01_mfpt/README.md`. Other real-data configs
+require local metadata and raw signals.
+
+Keep machine paths out of maintained YAML and pass them explicitly:
 
 ```bash
 phmfactory preflight \
@@ -243,12 +254,13 @@ Read [data/README.md](../data/README.md) for layout and
 
 ## 8. Create a local experiment variant
 
-1. Copy the nearest file from `configs/demo/` to `configs/experiments/`.
+1. Copy the nearest file from `configs/demo/` or `configs/baselines/` to
+   `configs/experiments/`.
 2. Change only values required by the experiment.
 3. Keep machine paths in explicit overrides or an explicit `--local-config` file.
 4. Run `phmfactory preflight --config <your-yaml>` with the same extra inputs as the run.
 5. Run the smallest applicable test or one-epoch smoke.
-6. Record the commit, effective config hash, command, data source, seed, and environment.
+6. Record the commit, config, command, data source, split, seed, and environment.
 
 Do not add a local variant to `configs/config_registry.csv` unless it is being reviewed
 for promotion to the maintained surface.
@@ -260,6 +272,13 @@ for promotion to the maintained surface.
 Use the same config, `--local-config`, and overrides in both commands. If visible inputs
 are identical but hashes differ, report both commands, both hashes, installed package
 location, stdout, and stderr. That is a config-parity bug.
+
+### The run prints `run_manifest=unavailable`
+
+First verify that training, best-checkpoint restoration, test metrics, and shell exit code
+all succeeded. The message means the optional compatibility record could not be prepared
+or finalized. Preserve stderr for diagnosis, but do not rerun or change the scientific
+experiment solely to make that diagnostic file appear.
 
 ### A command prints useful output but the shell reports exit code `1`
 
@@ -302,6 +321,6 @@ requires the same code, data, split, seed, protocol, and environment. See
 
 ## Developer details
 
-Developers working on config compilation, execution, or evidence should read
+Developers working on config compilation, execution, or diagnostic records should read
 [Runtime control plane](developer_runtime_control_plane.md). First-time users do not need
 those internals to run an experiment.

--- a/phmfactory/cli.py
+++ b/phmfactory/cli.py
@@ -1,6 +1,6 @@
 """Public command routing and process entrypoints for PHMFactory.
 
-This module exposes a programmatic API and an operating-system process boundary.  Both
+This module exposes a programmatic API and an operating-system process boundary. Both
 consume the same :class:`phmfactory.config.ConfigAnalysis`; neither reparses YAML or
 searches for machine-local configuration after compilation.
 """
@@ -63,26 +63,58 @@ def _resolve_pipeline(args: argparse.Namespace, config_path: str) -> str:
     ).pipeline
 
 
-def _write_failed_attestation(
-    attestation: RunAttestation,
+def _record_warning(context: str, error: Exception) -> None:
+    """Report a non-authoritative run-record failure without hiding the run result."""
+
+    print(
+        f"[WARNING] {context} could not be recorded: "
+        f"{type(error).__name__}: {error}",
+        file=sys.stderr,
+    )
+
+
+def _prepare_optional_attestation(
+    compiled: CompiledRunSpec,
+    module_name: str,
     envelope: ExecutionEnvelope,
-    original_error: BaseException,
-) -> None:
-    """Persist terminal failure state without replacing the original exception."""
+) -> RunAttestation | None:
+    """Prepare the legacy diagnostic manifest without making it a run gate."""
 
     try:
+        return RunAttestation.prepare(compiled, module_name, envelope)
+    except Exception as error:
+        _record_warning("pending run manifest", error)
+        return None
+
+
+def _write_optional_attestation(
+    attestation: RunAttestation | None,
+    envelope: ExecutionEnvelope,
+    *,
+    context: str,
+) -> bool:
+    """Best-effort manifest update that never replaces the scientific outcome."""
+
+    if attestation is None:
+        return False
+    try:
         attestation.write(envelope)
-    except AttestationWriteError as write_error:
-        raise write_error from original_error
+    except AttestationWriteError as error:
+        _record_warning(context, error)
+        return False
+    return True
 
 
 def run(args: argparse.Namespace) -> Any:
-    """Analyze, record, authorize, execute, and index one Pipeline invocation.
+    """Analyze, authorize, execute, and return one Pipeline invocation.
 
-    Configuration composition occurs exactly once in :func:`analyze_config`.  Protected
+    Configuration composition occurs exactly once in :func:`analyze_config`. Protected
     runtime code receives a mutable copy through ``CompiledRunSpec.runtime_config()``.
-    The function returns the Pipeline's explicit Python result for programmatic callers;
-    process exit handling is owned by :func:`entrypoint`.
+
+    The Pipeline result and exception are authoritative. The historical run manifest and
+    Pipeline-specific evidence index are retained as optional diagnostics during the v0.3
+    migration; inability to prepare, enrich, or finalize them cannot convert a completed
+    fit/checkpoint/evaluation path into a failed scientific run.
     """
 
     requested = requested_config(args)
@@ -108,15 +140,12 @@ def run(args: argparse.Namespace) -> Any:
     envelope = ExecutionEnvelope(spec=compiled, pipeline_module=module_name)
     args.execution_envelope = envelope
 
-    try:
-        attestation = RunAttestation.prepare(compiled, module_name, envelope)
-    except BaseException as error:
-        envelope.record_failure(error, stage="attestation_prepare")
-        raise
-
+    attestation = _prepare_optional_attestation(compiled, module_name, envelope)
     args.run_attestation = attestation
-    args.run_id = attestation.run_id
-    args.run_manifest_path = str(attestation.manifest_path)
+    args.run_id = attestation.run_id if attestation is not None else None
+    args.run_manifest_path = (
+        str(attestation.manifest_path) if attestation is not None else None
+    )
 
     try:
         descriptor = require_pipeline_access(
@@ -126,7 +155,11 @@ def run(args: argparse.Namespace) -> Any:
         )
     except BaseException as error:
         envelope.record_failure(error, stage="maturity")
-        _write_failed_attestation(attestation, envelope, error)
+        _write_optional_attestation(
+            attestation,
+            envelope,
+            context="failed run manifest",
+        )
         raise
     args.pipeline_descriptor = descriptor
 
@@ -134,29 +167,38 @@ def run(args: argparse.Namespace) -> Any:
         pipeline_module = importlib.import_module(module_name)
     except BaseException as error:
         envelope.record_failure(error, stage="import")
-        _write_failed_attestation(attestation, envelope, error)
+        _write_optional_attestation(
+            attestation,
+            envelope,
+            context="failed run manifest",
+        )
         raise
 
     try:
         result = envelope.execute(pipeline_module, args)
-    except BaseException as error:
-        _write_failed_attestation(attestation, envelope, error)
+    except BaseException:
+        _write_optional_attestation(
+            attestation,
+            envelope,
+            context="failed run manifest",
+        )
         raise
 
-    try:
-        register_pipeline_result_evidence(attestation, compiled, result)
-    except BaseException as error:
-        envelope.record_failure(error, stage="evidence_finalize")
-        _write_failed_attestation(attestation, envelope, error)
-        raise
+    if attestation is not None:
+        try:
+            register_pipeline_result_evidence(attestation, compiled, result)
+        except Exception as error:
+            _record_warning("optional Pipeline evidence", error)
 
-    try:
-        attestation.write(envelope)
-    except AttestationWriteError as error:
-        envelope.record_failure(error, stage="attestation_finalize")
-        raise
-
-    print(f"run_manifest={attestation.manifest_path}")
+    manifest_written = _write_optional_attestation(
+        attestation,
+        envelope,
+        context="terminal run manifest",
+    )
+    if manifest_written and attestation is not None:
+        print(f"run_manifest={attestation.manifest_path}")
+    else:
+        print("run_manifest=unavailable")
     print("完成所有实验！")
     return result
 

--- a/test/test_runtime_attestation.py
+++ b/test/test_runtime_attestation.py
@@ -49,6 +49,17 @@ def _analysis(tmp_path: Path) -> ConfigAnalysis:
     )
 
 
+def _args() -> argparse.Namespace:
+    return argparse.Namespace(
+        config="smoke",
+        config_path=None,
+        local_config=None,
+        notes="",
+        override=None,
+        allow_experimental=False,
+    )
+
+
 def _load(path: Path) -> dict:
     return json.loads(path.read_text(encoding="utf-8"))
 
@@ -103,7 +114,7 @@ def test_failure_manifest_preserves_stage_and_error(tmp_path: Path) -> None:
     }
 
 
-def test_missing_output_dir_blocks_before_execution(tmp_path: Path) -> None:
+def test_missing_output_dir_is_an_attestation_error(tmp_path: Path) -> None:
     resolved = _resolved(tmp_path)
     resolved.data["environment"] = {}
     spec = CompiledRunSpec.compile(resolved)
@@ -134,7 +145,10 @@ def test_failed_atomic_replace_leaves_previous_manifest_valid(
     assert _load(attestation.manifest_path) == before
 
 
-def test_cli_writes_success_manifest(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_cli_writes_success_manifest_when_diagnostic_writer_is_available(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     analysis = _analysis(tmp_path)
     monkeypatch.setattr(cli, "analyze_config", lambda *args, **kwargs: analysis)
     monkeypatch.setattr(
@@ -142,13 +156,7 @@ def test_cli_writes_success_manifest(tmp_path: Path, monkeypatch: pytest.MonkeyP
         "import_module",
         lambda name: SimpleNamespace(pipeline=lambda args: ["ok"]),
     )
-    args = argparse.Namespace(
-        config="smoke",
-        config_path=None,
-        local_config=None,
-        notes="",
-        override=None,
-    )
+    args = _args()
 
     assert cli.run(args) == ["ok"]
     payload = _load(Path(args.run_manifest_path))
@@ -161,7 +169,7 @@ def test_cli_writes_success_manifest(tmp_path: Path, monkeypatch: pytest.MonkeyP
     assert args.execution_envelope.status is ExecutionStatus.SUCCEEDED
 
 
-def test_cli_writes_failed_manifest_and_reraises(
+def test_cli_writes_failed_manifest_and_reraises_original_pipeline_error(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -176,13 +184,7 @@ def test_cli_writes_failed_manifest_and_reraises(
         "import_module",
         lambda name: SimpleNamespace(pipeline=fail),
     )
-    args = argparse.Namespace(
-        config="smoke",
-        config_path=None,
-        local_config=None,
-        notes="",
-        override=None,
-    )
+    args = _args()
 
     with pytest.raises(ValueError, match="bad pipeline"):
         cli.run(args)
@@ -191,3 +193,108 @@ def test_cli_writes_failed_manifest_and_reraises(
     assert payload["status"] == "failed"
     assert payload["failure"]["stage"] == "pipeline"
     assert payload["failure"]["type"] == "ValueError"
+
+
+def test_cli_continues_when_pending_manifest_cannot_be_prepared(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    analysis = _analysis(tmp_path)
+    monkeypatch.setattr(cli, "analyze_config", lambda *args, **kwargs: analysis)
+    monkeypatch.setattr(
+        cli.RunAttestation,
+        "prepare",
+        lambda *args, **kwargs: (_ for _ in ()).throw(
+            AttestationWriteError("write denied")
+        ),
+    )
+    monkeypatch.setattr(
+        cli.importlib,
+        "import_module",
+        lambda name: SimpleNamespace(pipeline=lambda args: ["scientific-result"]),
+    )
+    args = _args()
+
+    assert cli.run(args) == ["scientific-result"]
+    captured = capsys.readouterr()
+    assert "pending run manifest could not be recorded" in captured.err
+    assert "run_manifest=unavailable" in captured.out
+    assert "完成所有实验" in captured.out
+    assert args.run_manifest_path is None
+    assert args.execution_envelope.status is ExecutionStatus.SUCCEEDED
+
+
+def test_cli_success_survives_terminal_manifest_write_failure(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    analysis = _analysis(tmp_path)
+    monkeypatch.setattr(cli, "analyze_config", lambda *args, **kwargs: analysis)
+
+    class BrokenAttestation:
+        run_id = "diagnostic-only"
+        manifest_path = tmp_path / "run_manifest.json"
+
+        @staticmethod
+        def write(envelope):
+            del envelope
+            raise AttestationWriteError("final replace denied")
+
+    monkeypatch.setattr(
+        cli.RunAttestation,
+        "prepare",
+        lambda *args, **kwargs: BrokenAttestation(),
+    )
+    monkeypatch.setattr(
+        cli.importlib,
+        "import_module",
+        lambda name: SimpleNamespace(pipeline=lambda args: ["scientific-result"]),
+    )
+    args = _args()
+
+    assert cli.run(args) == ["scientific-result"]
+    captured = capsys.readouterr()
+    assert "terminal run manifest could not be recorded" in captured.err
+    assert "run_manifest=unavailable" in captured.out
+    assert "完成所有实验" in captured.out
+    assert args.execution_envelope.status is ExecutionStatus.SUCCEEDED
+
+
+def test_manifest_write_failure_never_replaces_original_pipeline_exception(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    analysis = _analysis(tmp_path)
+    monkeypatch.setattr(cli, "analyze_config", lambda *args, **kwargs: analysis)
+
+    class BrokenAttestation:
+        run_id = "diagnostic-only"
+        manifest_path = tmp_path / "run_manifest.json"
+
+        @staticmethod
+        def write(envelope):
+            del envelope
+            raise AttestationWriteError("failed replace denied")
+
+    def fail(args):
+        raise ValueError("training failed first")
+
+    monkeypatch.setattr(
+        cli.RunAttestation,
+        "prepare",
+        lambda *args, **kwargs: BrokenAttestation(),
+    )
+    monkeypatch.setattr(
+        cli.importlib,
+        "import_module",
+        lambda name: SimpleNamespace(pipeline=fail),
+    )
+    args = _args()
+
+    with pytest.raises(ValueError, match="training failed first"):
+        cli.run(args)
+    assert "failed run manifest could not be recorded" in capsys.readouterr().err
+    assert args.execution_envelope.status is ExecutionStatus.FAILED

--- a/test/test_runtime_evidence.py
+++ b/test/test_runtime_evidence.py
@@ -13,6 +13,7 @@ from phmfactory.runtime import (
     AttestationError,
     CompiledRunSpec,
     ExecutionEnvelope,
+    ExecutionStatus,
     RunAttestation,
 )
 from phmfactory.runtime.evidence import register_pipeline_result_evidence
@@ -170,7 +171,9 @@ def test_pipeline06_result_indexes_existing_stage_artifacts(tmp_path: Path) -> N
     assert attestation.evidence["generative_stages"][0]["stage"] == "eval"
 
 
-def test_pipeline06_missing_ledger_invalidates_evidence(tmp_path: Path) -> None:
+def test_legacy_pipeline06_evidence_adapter_reports_missing_ledger(
+    tmp_path: Path,
+) -> None:
     spec, _, attestation = _attestation(tmp_path, "Pipeline_06_Generative_Modeling")
     with pytest.raises(AttestationError, match="stage ledger is missing"):
         register_pipeline_result_evidence(
@@ -180,21 +183,21 @@ def test_pipeline06_missing_ledger_invalidates_evidence(tmp_path: Path) -> None:
         )
 
 
-def test_cli_records_evidence_finalize_failure(
+def test_cli_does_not_fail_a_completed_pipeline_when_optional_evidence_is_missing(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
 ) -> None:
     pipeline = "Pipeline_06_Generative_Modeling"
     analysis = _analysis(tmp_path, pipeline)
     monkeypatch.setattr(cli, "analyze_config", lambda *args, **kwargs: analysis)
+    expected = [
+        {"stage": "train", "status": "completed", "run_dir": str(tmp_path)}
+    ]
     monkeypatch.setattr(
         cli.importlib,
         "import_module",
-        lambda name: SimpleNamespace(
-            pipeline=lambda args: [
-                {"stage": "train", "status": "completed", "run_dir": str(tmp_path)}
-            ]
-        ),
+        lambda name: SimpleNamespace(pipeline=lambda args: expected),
     )
     args = argparse.Namespace(
         config="generative",
@@ -205,9 +208,13 @@ def test_cli_records_evidence_finalize_failure(
         allow_experimental=False,
     )
 
-    with pytest.raises(AttestationError, match="stage ledger is missing"):
-        cli.run(args)
+    assert cli.run(args) == expected
 
     payload = json.loads(Path(args.run_manifest_path).read_text(encoding="utf-8"))
-    assert payload["status"] == "failed"
-    assert payload["failure"]["stage"] == "evidence_finalize"
+    assert payload["status"] == "succeeded"
+    assert payload["failure"] is None
+    assert args.execution_envelope.status is ExecutionStatus.SUCCEEDED
+    captured = capsys.readouterr()
+    assert "optional Pipeline evidence could not be recorded" in captured.err
+    assert "stage ledger is missing" in captured.err
+    assert "完成所有实验" in captured.out


### PR DESCRIPTION
## Objective

Remove optional run-record, evidence-index, and manifest-write failures from the scientific success definition of the public PHMFactory command.

## Runtime invariant

```text
Pipeline success
= explicit Pipeline result
= completed scientific lifecycle defined by that Pipeline
```

For the maintained classification path, this means fit, best-checkpoint restoration, evaluation, and finite returned metrics. It does not mean that a compatibility manifest, artifact index, or Pipeline-specific evidence adapter also finalized successfully.

## Changes

- prepare the historical `RunAttestation` as an optional diagnostic rather than a pre-execution gate;
- preserve maturity, import, contract, and Pipeline exceptions as authoritative failures;
- make evidence-index failures warnings instead of `evidence_finalize` run failures;
- make terminal manifest-write failures warnings instead of replacing a successful result;
- ensure manifest-write failure never replaces the original Pipeline exception;
- print `run_manifest=unavailable` when the optional diagnostic record cannot be produced;
- retain the legacy attestation/evidence API as a compatibility surface without promoting it as runtime authority;
- update focused tests and user/developer documentation.

## Boundaries

- no change to Data, Model, Task, or Trainer Factory semantics;
- no change to fit, checkpoint, evaluation, metric, split, or estimator logic;
- no new status manager, registry, adapter, schema, hash, digest, receipt, ledger, or evidence layer;
- no deletion of compatibility modules in this slice;
- Pipeline-internal scientific requirements remain authoritative; only the post-return CLI diagnostic index is demoted.

## Acceptance

- a Pipeline exception still exits non-zero with its original type and traceback;
- a Pipeline returning `None` still fails;
- failed maturity or import still fails;
- pending/final diagnostic write failure cannot block or invalidate a successful Pipeline result;
- missing Pipeline 06 evidence ledger after an explicit successful return emits a warning but does not fail the command;
- normal runs still write the compatibility manifest when available;
- existing offline smoke and public-package contracts remain green.
