### PR TITLE
docs(readme): publish the first baseline-valid reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ device, objective, or estimator than the user intended.
 | Configuration defaults silently change the experiment | Explicit configuration resolution and fail-fast validation |
 | Data, model, task, and trainer logic are entangled | Four factories with narrow, reviewable responsibilities |
 | Evaluation depends on uncontrolled random sampling | Deterministic validation and test behavior on maintained paths |
-| A source file is mistaken for a supported capability | Generated support tables distinguish discovery, execution, and maintained evidence |
+| A source file is mistaken for a supported capability | Generated support tables distinguish discovery, execution, and scientific evidence |
 | Replacing one component requires editing the runtime | Component selection remains configuration-first |
 
 Two practical design rules follow:
@@ -85,6 +85,7 @@ PHMFactory is intended to provide:
 - explicit data, model, task, and trainer boundaries;
 - actionable failures rather than silent fallback;
 - maintained smoke configurations and generated support documentation;
+- one scientifically closed real-data reference with an explicit claim boundary;
 - a common runtime for CLI and optional Streamlit usage.
 
 PHMFactory does not claim that every implementation in the repository is mutually
@@ -140,8 +141,10 @@ A successful run writes below:
 results/demo/dummy_dg_smoke/
 ```
 
-and prints the location of the run record. For expected output and failure diagnosis, see
-[Quickstart](docs/quickstart.md).
+The terminal prints the compatibility run-record path when that optional diagnostic is
+available. A `run_manifest=unavailable` warning does not invalidate completed fitting,
+best-checkpoint restoration, evaluation, or finite metrics. For expected output and
+failure diagnosis, see [Quickstart](docs/quickstart.md).
 
 ### What the offline demo proves
 
@@ -187,6 +190,7 @@ normally extend their own factory rather than add special cases to `main.py`.
 | **Deterministic evaluation boundaries** | Maintained validation and test paths do not depend on uncontrolled patch or augmentation randomness. |
 | **Offline first-run path** | `doctor`, `preflight`, and `demo` work without downloading an external dataset. |
 | **Modular replacement** | Data, model, task, and trainer choices remain explicit and independently reviewable. |
+| **Configuration-specific evidence** | Generated support authority separates bounded smokes from an exact `baseline_valid` protocol. |
 | **One runtime, optional interfaces** | The CLI is authoritative; Streamlit adapts the same command rather than creating a second training system. |
 
 ## Choose your path
@@ -196,6 +200,7 @@ normally extend their own factory rather than add special cases to `main.py`.
 | Understand the first run and its outputs | [Quickstart](docs/quickstart.md) |
 | Install on CPU, GPU, Linux, macOS, or Windows | [Installation](docs/installation.md) |
 | Run an existing maintained experiment | [Configuration guide](configs/README.md) |
+| Prepare and run the first real-data reference | [MFPT baseline](configs/baselines/01_mfpt/README.md) |
 | Connect local PHM data | [Data layout](data/README.md) and [custom dataset guide](docs/custom_dataset.md) |
 | Select or add a model | [Model Factory](src/model_factory/README.md) |
 | Select or add a task | [Task Factory](src/task_factory/README.md) |
@@ -224,8 +229,9 @@ trainer:      # device, epochs, precision, logging, checkpoint behavior
   ...
 ```
 
-Start from the nearest maintained file under `configs/demo/`. Put research variants under
-`configs/experiments/`, and pass machine-specific paths explicitly:
+Start from the nearest maintained file under `configs/demo/` or `configs/baselines/`.
+Put research variants under `configs/experiments/`, and pass machine-specific paths
+explicitly:
 
 ```bash
 phmfactory preflight \
@@ -274,31 +280,42 @@ phmfactory data --help
 
 ## Support boundary
 
-PHMFactory distinguishes three levels:
+PHMFactory distinguishes four terms:
 
 ```text
-discoverable  = an implementation or registry entry exists
-runnable      = a reviewed execution path exists
-supported     = a maintained configuration has current smoke evidence
+discoverable       = an implementation or registry entry exists
+runnable           = a reviewed execution path exists
+execution-verified = the exact maintained command has current execution evidence
+baseline-valid     = the exact complete experiment passed its declared scientific protocol
 ```
 
-The required relation is:
+The software relationship is:
 
 ```text
-supported ⊆ runnable ⊆ discoverable
+execution-verified ⊆ runnable ⊆ discoverable
 ```
 
-A file, registry row, or successful import is not a support claim. Current maintained
-surfaces are generated from repository configuration and runtime descriptors:
+`baseline-valid` is a separate property of one complete configuration. It is not inferred
+from component importability, Pipeline maturity, or another configuration's successful
+run.
+
+Current authority is generated from repository configuration and runtime descriptors:
 
 - [Supported components](SUPPORTED_COMPONENTS.md)
 - [Supported combinations](SUPPORTED_COMBINATIONS.md)
 - [Configuration registry](configs/config_registry.csv)
 - [Configuration Atlas](docs/CONFIG_ATLAS.md)
 
-`sanity_ok` means bounded functional evidence exists. It does not mean benchmark-valid
-performance, state-of-the-art results, unrestricted dataset redistribution, or arbitrary
-Cartesian-product compatibility.
+`execution_status=sanity_ok` means that the exact registered command has current evidence.
+`protocol_status=smoke_only` forbids benchmark or algorithm-validity claims.
+`protocol_status=baseline_valid` applies only to the exact data population, split, model,
+task, checkpoint-selection, seed, and estimator combination that passed review.
+
+The current `baseline_valid` reference is
+[MFPT + GlobalAverageLinear](configs/baselines/01_mfpt/README.md). Its deliberately weak
+model produced low accuracy, which is retained as an honest result. The promotion proves
+protocol closure, not strong performance, state-of-the-art results, unrestricted dataset
+redistribution, or arbitrary Cartesian-product compatibility.
 
 ## Optional Streamlit workspace
 
@@ -331,7 +348,7 @@ phmfactory command / python -m phmfactory / main.py
 Primary paths:
 
 - `phmfactory/` — public package, commands, configuration resolver, Pipeline descriptors, and run control;
-- `configs/` — reusable blocks, maintained demos, research experiments, and registry;
+- `configs/` — reusable blocks, maintained demos, baselines, research experiments, and registry;
 - `src/data_factory/` — metadata, readers, datasets, samplers, and data assembly;
 - `src/model_factory/` — model families and model construction;
 - `src/task_factory/` — tasks, objectives, metrics, and task construction;
@@ -360,10 +377,11 @@ See [docs/testing.md](docs/testing.md) for focused gates and test terminology.
 
 PHMFactory remains an alpha `0.3.0.dev0` source release:
 
-- only the Dummy demo is fully offline and repository-shipped;
-- most real-data configurations require local metadata and raw signals;
-- no real-data configuration has yet been promoted as the first scientifically closed `baseline_valid` reference;
-- CWRU provider, reader, and final acceptance conditions are still being finalized;
+- the Dummy demo is the only fully offline, repository-shipped first-run path;
+- one exact real-data reference is now `baseline_valid`: MFPT + `GlobalAverageLinear`;
+- that reference establishes protocol and estimator closure, not strong diagnostic accuracy;
+- most other real-data configurations still require local metadata and raw signals and remain `smoke_only` unless explicitly listed otherwise;
+- broader SEU, PU, and final CWRU acceptance are not yet complete;
 - the GitHub repository has not been renamed;
 - no final `v0.3.0` tag or package publication is claimed;
 - experimental Pipelines and unlisted model/task combinations are not release-supported.

--- a/README_CN.md
+++ b/README_CN.md
@@ -59,7 +59,7 @@ PHMFactory 面向工业信号故障诊断及相关 PHM 实验，提供模块化�
 | 默认值在不知情时改变实验 | 显式解析配置，并在不满足条件时立即失败 |
 | 数据、模型、任务和训练器彼此耦合 | 四个 Factory 分工清晰，责任可以独立审查 |
 | 评价结果受无约束随机采样影响 | 维护路径中的验证与测试采用确定性边界 |
-| 源码文件存在就被误认为“已支持” | 自动生成支持表，区分可发现、可运行和维护证据 |
+| 源码文件存在就被误认为“已支持” | 自动生成支持表，区分可发现、可运行、执行证据与科学证据 |
 | 替换一个组件需要修改运行时 | 组件选择保持配置优先 |
 
 由此形成两条直接的设计规则：
@@ -83,6 +83,7 @@ PHMFactory 主要提供：
 - 清晰的数据、模型、任务与训练器边界；
 - 可执行的错误提示，而不是静默兜底；
 - 维护中的冒烟配置和自动生成的支持文档；
+- 一个具有明确声明边界、科学闭合的真实数据参考实验；
 - CLI 与可选 Streamlit 共用的同一运行时。
 
 PHMFactory 不宣称仓库中的所有实现都可以任意组合，也不因源码存在、import 成功或一次
@@ -137,7 +138,9 @@ demo
 results/demo/dummy_dg_smoke/
 ```
 
-终端会打印运行记录的位置。预期输出和故障排查见[快速开始](docs/quickstart.md)。
+当兼容运行记录可用时，终端会打印其路径。`run_manifest=unavailable` 警告不否定已经完成
+的训练、最佳 checkpoint 恢复、评价和有限指标。预期输出与故障排查见
+[快速开始](docs/quickstart.md)。
 
 ### 离线示例能够证明什么
 
@@ -182,6 +185,7 @@ fit → best checkpoint → evaluation → finite metrics
 | **确定性评价边界** | 维护中的验证与测试不依赖无约束的 patch 或增强随机性。 |
 | **离线首次运行** | `doctor`、`preflight` 和 `demo` 不需要下载外部数据。 |
 | **模块化替换** | 数据、模型、任务和训练器的选择显式且可以独立审查。 |
+| **配置级证据** | 自动生成的支持 authority 区分受控冒烟与精确 `baseline_valid` 协议。 |
 | **单一运行时** | CLI 是权威入口；Streamlit 只是同一命令的界面适配。 |
 
 ## 按任务选择文档
@@ -191,6 +195,7 @@ fit → best checkpoint → evaluation → finite metrics
 | 理解第一次运行及其输出 | [快速开始](docs/quickstart.md) |
 | 在 CPU、GPU、Linux、macOS 或 Windows 上安装 | [安装指南](docs/installation.md) |
 | 运行已有的维护实验 | [配置系统](configs/README.md) |
+| 准备并运行首个真实数据参考实验 | [MFPT 基线](configs/baselines/01_mfpt/README.md) |
 | 接入本地 PHM 数据 | [数据目录](data/README.md)和[自定义数据集](docs/custom_dataset.md) |
 | 选择或新增模型 | [模型工厂](src/model_factory/README_CN.md) |
 | 选择或新增任务 | [任务工厂](src/task_factory/README.md) |
@@ -219,7 +224,7 @@ trainer:      # 设备、epoch、精度、日志和 checkpoint 行为
   ...
 ```
 
-本地实验从 `configs/demo/` 中最接近的维护配置开始，研究变体放入
+本地实验从 `configs/demo/` 或 `configs/baselines/` 中最接近的维护配置开始，研究变体放入
 `configs/experiments/`，本机路径通过显式 override 传入：
 
 ```bash
@@ -268,30 +273,40 @@ phmfactory data --help
 
 ## 支持边界
 
-PHMFactory 明确区分三个层级：
+PHMFactory 明确区分四个术语：
 
 ```text
-discoverable  = 源码或注册表条目存在
-runnable      = 已建立经过审查的执行路径
-supported     = 维护配置具有当前功能冒烟证据
+discoverable       = 源码或注册表条目存在
+runnable           = 已建立经过审查的执行路径
+execution-verified = 精确维护命令具有当前执行证据
+baseline-valid     = 精确完整实验通过其声明的科学协议
 ```
 
-必须满足：
+软件层面的包含关系为：
 
 ```text
-supported ⊆ runnable ⊆ discoverable
+execution-verified ⊆ runnable ⊆ discoverable
 ```
 
-源码文件、注册表行或 import 成功都不是支持声明。当前维护范围由仓库配置和运行时描述
-自动生成：
+`baseline-valid` 是一个完整配置的独立属性，不能由组件可导入、Pipeline 成熟度或另一个配置
+运行成功推导出来。
+
+当前 authority 由仓库配置和运行时描述自动生成：
 
 - [支持组件](SUPPORTED_COMPONENTS.md)
 - [支持组合](SUPPORTED_COMBINATIONS.md)
 - [配置注册表](configs/config_registry.csv)
 - [配置图谱](docs/CONFIG_ATLAS.md)
 
-`sanity_ok` 只表示已有边界明确的功能冒烟，不表示 benchmark-valid、SOTA、允许任意重分发
-外部数据，或任意组件笛卡尔积都能组合。
+`execution_status=sanity_ok` 表示精确注册命令已有当前执行证据；
+`protocol_status=smoke_only` 禁止据此提出 benchmark 或算法有效性结论；
+`protocol_status=baseline_valid` 仅适用于经过审查的精确数据总体、划分、模型、任务、
+checkpoint 选择、随机种子与估计量组合。
+
+当前唯一 `baseline_valid` 参考是
+[MFPT + GlobalAverageLinear](configs/baselines/01_mfpt/README.md)。该模型被刻意设计得透明且
+较弱，其较低准确率被如实保留。该晋级证明的是协议闭合，不表示性能强、达到 SOTA、
+允许无限制重分发外部数据，或支持任意组件笛卡尔积组合。
 
 ## 可选 Streamlit 工作区
 
@@ -323,7 +338,7 @@ phmfactory 命令 / python -m phmfactory / main.py
 主要目录：
 
 - `phmfactory/`：公开包、命令、配置解析、Pipeline descriptor 和运行控制；
-- `configs/`：复用块、维护 demo、研究实验和配置注册表；
+- `configs/`：复用块、维护 demo、真实基线、研究实验和配置注册表；
 - `src/data_factory/`：metadata、reader、dataset、sampler 和数据装配；
 - `src/model_factory/`：模型家族和模型构造；
 - `src/task_factory/`：任务、目标函数、指标和任务构造；
@@ -352,10 +367,11 @@ python -m pytest test/ -q
 
 PHMFactory 仍是 alpha 阶段的 `0.3.0.dev0` 源码版本：
 
-- 只有 Dummy demo 完全离线并随仓库提供；
-- 大部分真实数据配置需要本地 metadata 和原始信号；
-- 尚无真实数据配置被提升为首个科学闭合的 `baseline_valid` 参考实验；
-- CWRU provider、reader 和最终 acceptance 条件仍在收敛；
+- Dummy demo 仍是唯一完全离线、随仓库提供的首次运行路径；
+- 当前已有一个精确真实数据参考达到 `baseline_valid`：MFPT + `GlobalAverageLinear`；
+- 该参考证明协议与估计量闭合，不表示故障诊断准确率较高；
+- 大部分其他真实数据配置仍需要本地 metadata 和原始信号，除非明确列出，否则仍为 `smoke_only`；
+- 更广泛的 SEU、PU 与最终 CWRU acceptance 尚未完成；
 - GitHub 仓库尚未改名；
 - 当前不宣称已有最终 `v0.3.0` tag 或正式包发布；
 - experimental Pipeline 和未列出的模型/任务组合不属于发布支持范围。


### PR DESCRIPTION
## Objective

Align the English and Chinese project homepages with the current validated repository state after the MFPT baseline and runtime-governance convergence.

## Changes

- link the first real-data reference directly from the user navigation table;
- replace the old three-level support wording with the generated authority terms: discoverable, runnable, execution-verified, and baseline-valid;
- state that `baseline_valid` is configuration-specific and cannot be inferred from component importability or another successful run;
- identify MFPT + `GlobalAverageLinear` as the sole current `baseline_valid` reference;
- retain its low observed accuracy as an explicit limitation rather than a performance claim;
- remove the stale statement that no real-data baseline exists;
- clarify that compatibility run records are optional diagnostics and do not determine scientific success;
- keep the English and Chinese homepages structurally aligned.

## Boundaries

- documentation only;
- no runtime, configuration, data, model, task, trainer, Pipeline, test, or CI behavior changes;
- no new benchmark, SOTA, dataset-redistribution, or universal-compatibility claim;
- no hash/checksum/digest/receipt/ledger/attestation additions.

## Validation

- documentation validation;
- maintained configuration and generated-support consistency;
- public package and release-readiness checks;
- repository layout and submodule policy.
