### PR TITLE
fix(release): define v0.3.0-rc1 readiness by scientific contracts

### DIFF
--- a/.github/workflows/phmfactory-release-readiness.yml
+++ b/.github/workflows/phmfactory-release-readiness.yml
@@ -10,9 +10,15 @@ on:
       - "CITATION.cff"
       - "CHANGELOG.md"
       - "RELEASE_NOTES_v0.3.0.md"
+      - "KNOWN_LIMITATIONS.md"
+      - "configs/config_registry.csv"
+      - "configs/baselines/01_mfpt/**"
+      - "scripts/prepare_mfpt_baseline.py"
+      - "src/data_factory/reader/RM_007_MFPT.py"
       - "phmfactory/data_sources/manifests/cwru-demo-v1.yaml"
       - ".gitmodules"
       - ".github/phmfactory-v0.3-submodules.allowlist.yml"
+      - ".github/workflows/mfpt-baseline.yml"
       - "docs/PHMFACTORY_V0_3_RELEASE_READINESS.md"
       - "docs/PHM_DATA_FACTORY_BACKEND_V0_3.md"
       - "docs/releases/v0.3.0-backend-deferral.yaml"
@@ -21,6 +27,7 @@ on:
       - "docs/index.md"
       - "tools/repo/check_release_readiness.py"
       - "tools/repo/check_submodule_policy.py"
+      - "test/test_mfpt_baseline.py"
       - "test/test_release_readiness.py"
       - "test/test_submodule_policy.py"
       - ".github/workflows/phmfactory-release-readiness.yml"
@@ -34,7 +41,7 @@ permissions:
 
 jobs:
   readiness-audit:
-    name: Audit v0.3 release blockers
+    name: Audit v0.3.0-rc1 readiness
     runs-on: ubuntu-latest
     timeout-minutes: 5
 
@@ -61,7 +68,7 @@ jobs:
           test/test_release_readiness.py
           test/test_submodule_policy.py
 
-      - name: Run release and submodule negative tests
+      - name: Run release and submodule tests
         run: >-
           python -m pytest -vv
           test/test_release_readiness.py
@@ -70,45 +77,48 @@ jobs:
       - name: Enforce deny-by-default submodule policy
         run: python tools/repo/check_submodule_policy.py --mode release
 
-      - name: Record current blockers
+      - name: Record current RC1 blockers
         run: python tools/repo/check_release_readiness.py --mode audit | tee release-readiness.txt
 
-      - name: Require only the intentionally deferred pre-release blockers
+      - name: Require scientific RC1 readiness or the single version-promotion blocker
         shell: bash
         run: |
           set -euo pipefail
-          if python tools/repo/check_release_readiness.py --mode release; then
-            echo "Release mode unexpectedly passed before CWRU, rename, and final version preparation." >&2
-            exit 1
-          fi
 
-          grep -q 'PHMFactory v0.3 release readiness BLOCKED: 6 blocker(s)' release-readiness.txt
-          test "$(grep -c 'CWRU_REVISION_FLOATING' release-readiness.txt)" = 2
-          test "$(grep -c 'CWRU_HASH_MISSING' release-readiness.txt)" = 2
-          test "$(grep -c 'REPOSITORY_RENAME_PENDING' release-readiness.txt)" = 1
-          test "$(grep -c 'VERSION_NOT_FINAL' release-readiness.txt)" = 1
-
-          for resolved in \
-            PHM_DATA_FACTORY_BACKEND_PENDING \
-            BACKEND_DEFERRAL_INVALID \
-            LEGACY_SUBMODULES_REMAIN \
-            README_BRAND_PENDING \
-            CITATION_BRAND_PENDING \
-            CITATION_REPOSITORY_PENDING \
-            CHANGELOG_V030_MISSING \
-            RELEASE_NOTES_V030_MISSING \
-            V020_PROVENANCE_UNRESOLVED \
-            UNKNOWN_SUBMODULES_PRESENT
+          for obsolete in \
+            CWRU_HASH_MISSING \
+            CWRU_HASH_KEY_CONFLICT \
+            CWRU_REVISION_FLOATING \
+            REPOSITORY_RENAME_PENDING
           do
-            if grep -q "${resolved}" release-readiness.txt; then
-              echo "Resolved or unexpected blocker returned: ${resolved}" >&2
+            if grep -q "${obsolete}" release-readiness.txt; then
+              echo "Obsolete non-scientific blocker returned: ${obsolete}" >&2
               exit 1
             fi
           done
 
+          unexpected="$(grep '^- ' release-readiness.txt | grep -v 'VERSION_NOT_RC1' || true)"
+          if [ -n "${unexpected}" ]; then
+            echo "Unexpected RC1 blocker(s):" >&2
+            printf '%s\n' "${unexpected}" >&2
+            exit 1
+          fi
+
+          if grep -q 'VERSION_NOT_RC1' release-readiness.txt; then
+            grep -q 'PHMFactory v0.3.0-rc1 readiness BLOCKED: 1 blocker(s)' release-readiness.txt
+            test "$(grep -c 'VERSION_NOT_RC1' release-readiness.txt)" = 1
+            if python tools/repo/check_release_readiness.py --mode release; then
+              echo "Release mode unexpectedly passed before the RC1 version promotion." >&2
+              exit 1
+            fi
+          else
+            grep -q 'PHMFactory v0.3.0-rc1 readiness PASS: 0 blockers' release-readiness.txt
+            python tools/repo/check_release_readiness.py --mode release
+          fi
+
       - name: Upload readiness report
         uses: actions/upload-artifact@v4
         with:
-          name: phmfactory-v030-release-readiness
+          name: phmfactory-v030rc1-release-readiness
           path: release-readiness.txt
           if-no-files-found: error

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,56 +1,86 @@
 # Changelog
 
-## v0.3.0 - Unreleased
+## v0.3.0 - Release Candidate Preparation
 
-PHM-Vibench is being renamed to **PHMFactory**. This entry records the release delta only.
+PHMFactory v0.3 is preparing its first release candidate from the current
+`PHMbench/PHM-Vibench` repository. This entry records the release delta; it does not claim
+that an RC1 or final tag has already been published.
 
 - User-facing overview: [`RELEASE_NOTES_v0.3.0.md`](RELEASE_NOTES_v0.3.0.md)
 - Upgrade procedure: [`MIGRATION_v0.2_to_v0.3.md`](MIGRATION_v0.2_to_v0.3.md)
-- Current blockers: [`docs/PHMFACTORY_V0_3_RELEASE_READINESS.md`](docs/PHMFACTORY_V0_3_RELEASE_READINESS.md)
+- Current RC1 gate: [`docs/PHMFACTORY_V0_3_RELEASE_READINESS.md`](docs/PHMFACTORY_V0_3_RELEASE_READINESS.md)
 
 ### Added
 
-- Public `phmfactory` distribution and Python package.
-- Equivalent entrypoints: `python main.py`, `python -m phmfactory`, and `phmfactory`.
-- Public configuration resolver under `phmfactory.config`.
-- Canonical Pipeline registry and descriptive Pipeline 01–06 identifiers.
-- Provider-neutral CWRU bundle download, validation, comparison, and quickstart interfaces.
-- Subsystem-owned optional requirements and dependency-ownership checks.
-- Runtime/reader fingerprints, repository-boundary guards, release-readiness checks,
-  submodule policy, and paper-migration tracking.
+- Public `phmfactory` distribution, Python package, and installed command.
+- Equivalent entrypoints through `python main.py`, `python -m phmfactory`, and
+  `phmfactory`.
+- One public configuration authority shared by inspect, preflight, CLI execution, and
+  maintained Pipeline adapters.
+- Canonical Pipeline names and explicit maturity boundaries.
+- Strict experiment contracts for data population, task selection, device ownership,
+  objective construction, metrics, checkpoints, and evaluation.
+- Deterministic maintained HSE validation/test behavior and shape fail-fast checks.
+- Strict Dummy and MFPT readers with no substitute-signal fallback.
+- A 2 x 2 Data Factory x Model Factory replacement acceptance path.
+- The first real-data `baseline_valid` configuration:
+  `configs/baselines/01_mfpt/mfpt_global_average_linear.yaml`.
+- Public MFPT preparation command, focused reader/protocol tests, and a real three-seed
+  GitHub Actions workflow.
+- Generated support tables that separate execution evidence from protocol validity.
 - Explicit v0.2.0 release-candidate provenance anchored to
   `a331769d4005018bc833534ecf4efeb5e8a5a78d`.
-- Machine-readable `phm-data-factory` v0.3.0 exclusion and v0.3.1 deferral contract.
+- Machine-readable exclusion of optional `phm-data-factory` from v0.3 and deferral to
+  v0.3.1.
 
 ### Changed
 
-- Public identity converges on `PHMFactory` / `phmfactory`; the target repository is
-  `PHMbench/phmfactory`.
-- Six Pipeline files are renamed directly; no old-filename wrapper modules are added.
-- Maintained configs and documentation use canonical Pipeline names; legacy YAML values
-  remain explicit aliases with deprecation warnings.
-- Root `main.py` remains a supported thin dispatcher over the public package.
-- `apps/streamlit/app.py` becomes the only maintained web entrypoint.
-- Root `requirements.txt` remains the core authority; Streamlit, ModelScope, plotting,
-  and test dependencies live with their owning subsystems.
-- CWRU requires `metadata.xlsx` and `RM_001_CWRU.h5`; `corpus.xlsx` is optional for the
-  fault-diagnosis quickstart.
-- The mature `src.*` runtime remains in place behind the public façade.
-- Optional `phm-data-factory` integration is deferred to v0.3.1; v0.3.0 contains no
-  backend gitlink, runtime import, support claim, or live-IoTDB claim.
+- Public identity converges on `PHMFactory` / `phmfactory` while the current repository
+  remains `PHMbench/PHM-Vibench`.
+- `main.py` remains a supported thin dispatcher over the public package.
+- Data, Model, Task, and Trainer Factory responsibilities are kept narrow; Pipeline code
+  orchestrates rather than repairs their inputs.
+- Pipeline 02 propagates evaluation errors, rejects empty or non-finite metrics, and closes
+  resources through explicit lifecycle boundaries.
+- Trainer configuration is the sole device authority; Task and Model code do not silently
+  move the network or change an unavailable device request.
+- Unknown tasks, metrics, regularizers, invalid labels, impossible domain selections, and
+  missing sampler metadata now fail at their source.
+- Maintained classification runs restore the best checkpoint before testing.
+- Compatibility run manifests and Pipeline evidence indexes remain optional diagnostics;
+  their write/index failures cannot override the scientific Pipeline result.
+- CWRU release readiness is defined by provider declaration, metadata schema, unique IDs,
+  Id-to-signal coverage, `(L, C)` shape, and length/channel consistency. Per-file digests
+  and cross-provider byte identity are not scientific or RC1 gates.
+- `apps/streamlit/app.py` remains the maintained browser interface and delegates execution
+  to the same public CLI.
+
+### First real baseline result
+
+The transparent MFPT reference executes three explicit seeds:
+
+| Seed | Test accuracy | Test F1 | Test loss |
+| ---: | ---: | ---: | ---: |
+| 17 | 0.500000 | 0.500000 | 1.058720 |
+| 18 | 0.333333 | 0.333333 | 1.161241 |
+| 19 | 0.166667 | 0.166667 | 1.326827 |
+| **Mean +/- sample SD** | **0.333333 +/- 0.166667** | **0.333333 +/- 0.166667** | **1.182263 +/- 0.135284** |
+
+The low result is retained as the honest output of a deliberately weak temporal-mean
+linear model. It establishes a closed real-data execution and estimator contract, not a
+performance claim.
 
 ### Removed or migrated
 
 - Legacy `app/` and root `streamlit_app.py`.
-- Root/hidden Agent workspaces, `.archive/`, and `dev/`, after verified preservation.
+- Root/hidden Agent workspaces, `.archive/`, and historical development workspaces after
+  reviewed preservation.
 - Tracked `results/` and `metrics_reports/` placeholders.
-- Personal `data/Rotor_simulation` and `paper/LQ_vibench_fix` gitlinks after complete
-  fixed-commit preservation.
-- P01–P09 paper/research gitlinks after destination-level fixed-SHA preservation,
-  accepted Foundation partitioning, and machine-verifiable migration tracking.
+- Personal, paper, and research gitlinks after content-level preservation or migration.
 - `.gitmodules` after the final migrated gitlink was removed.
 - Case-colliding lowercase authority files.
-- Historical `docs/past/` and `docs/v0.1.0/` trees after provenance preservation.
+- Silent scientific fallbacks on the maintained user path.
+- Hash-based CWRU release blockers and the future repository rename as an RC1 blocker.
 
 ### Compatibility
 
@@ -61,23 +91,25 @@ PHM-Vibench is being renamed to **PHMFactory**. This entry records the release d
 - No `phm_factory` or `phm_vibench` namespace is introduced.
 - Direct Python imports of old Pipeline filenames must be updated; legacy YAML Pipeline
   values continue through explicit aliases.
-- Reader signatures, parsing, channel order, shape/dtype semantics, data splitting,
-  metrics, checkpoints, seeds, and Pipeline algorithms are not intentionally changed.
+- Compatibility does not authorize reader, split, task, device, loss, metric, or
+  checkpoint substitution.
 
-### Release status
+### RC1 status
 
-The paper/submodule migration and optional-backend decisions are complete. v0.3.0 remains
-unpublishable only while these machine-checked conditions remain:
+The current source version remains `0.3.0.dev0`. After the scientific-readiness authority
+is merged, the expected checker result is exactly:
 
 ```text
-2 x CWRU_HASH_MISSING
-2 x CWRU_REVISION_FLOATING
-1 x REPOSITORY_RENAME_PENDING
-1 x VERSION_NOT_FINAL
+1 x VERSION_NOT_RC1
 ```
 
-The package remains `0.3.0.dev0`; no final tag or release is authorized. The version is
-changed to `0.3.0` only in the final promotion after CWRU and repository identity are ready.
+A bounded promotion PR changes both version authorities to `0.3.0rc1`. The promotion must
+then pass release readiness with zero blockers, package build and clean installation,
+offline Dummy smoke, the public MFPT three-seed workflow, core quality gates, repository
+layout, and submodule policy.
+
+No RC1 tag, final tag, GitHub Release, wheel upload, source-distribution upload, or
+package-index publication is authorized merely by changing the source version.
 
 ## v0.2.0 Release Candidate - 2026-07-11
 
@@ -110,5 +142,4 @@ changed to `0.3.0` only in the final promotion after CWRU and repository identit
 
 - v0.2.0 support is limited to the maintained demo combinations listed in
   `SUPPORTED_COMBINATIONS.md`.
-- The evidence is functional smoke and contract evidence, not a performance
-  benchmark.
+- The evidence is functional smoke and contract evidence, not a performance benchmark.

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -7,8 +7,8 @@ title: PHMFactory
 type: software
 authors:
   - name: PHMFactory contributors
-repository-code: https://github.com/PHMbench/phmfactory
-url: https://github.com/PHMbench/phmfactory
+repository-code: https://github.com/PHMbench/PHM-Vibench
+url: https://github.com/PHMbench/PHM-Vibench
 license: Apache-2.0
 keywords:
   - prognostics and health management

--- a/KNOWN_LIMITATIONS.md
+++ b/KNOWN_LIMITATIONS.md
@@ -1,42 +1,82 @@
 # Known Limitations for the PHMFactory v0.3 Pre-release
 
-This page describes the current maintained source state. It does not imply that the final
-`v0.3.0` tag, repository rename, or package publication has occurred.
+This page describes the current maintained source state. It does not imply that an RC1 or
+final tag, GitHub Release, or package-index publication has occurred.
 
 ## Repository and installation state
 
-- The project and Python package are named PHMFactory, but the current GitHub repository
-  remains `PHMbench/PHM-Vibench`.
-- The source version is `0.3.0.dev0`.
+- The project and Python package are named PHMFactory; the current GitHub repository is
+  `PHMbench/PHM-Vibench`.
+- The source version is `0.3.0.dev0` until the bounded RC1 version-promotion PR.
 - The maintained pre-release installation path is an editable checkout installation:
   `python -m pip install -e .`.
-- A final package-index release is not claimed. Do not document `pip install phmfactory`
-  as generally available until a real release is published and verified.
+- A package-index release is not claimed. Do not document `pip install phmfactory` as
+  generally available until a real publication has been completed and verified.
+- A possible future repository rename is a product-governance decision, not a current
+  scientific or RC1 blocker.
 
 ## Supported surface
 
-- Release support is limited to the exact configurations listed in
-  `SUPPORTED_COMBINATIONS.md`, not every discovered model/task/data combination.
+- Release support is limited to exact configurations listed by the generated support
+  authority, not every discovered model/task/data combination.
 - A registry row, importable module, source file, or experimental opt-in is discovery
   information; it is not by itself a support claim.
 - `Pipeline_01_Fault_Diagnosis` is the primary maintained classification path.
-- `Pipeline_02_Pretraining_Few_Shot` is supported only for the current bounded maintained
-  path; multi-stage workflows require their own evidence.
+- `Pipeline_02_Pretraining_Few_Shot` is supported only for its bounded maintained path;
+  multi-stage workflows require separate validation.
 - Pipeline 03 and Pipeline 04 remain experimental and require explicit acknowledgement.
 - Pipeline 05, Pipeline 06, and Pipeline_ID have compatibility or experimental contracts
-  but are not automatically part of the release-supported combination table.
+  but are not automatically part of the maintained combination table.
+- `execution_status=sanity_ok` means an exact command has current bounded execution
+  evidence. It does not imply scientific protocol validity.
+- `protocol_status=baseline_valid` applies only to the complete reviewed experiment
+  combination that earned it.
+
+## Real-data baseline status
+
+PHMFactory now has one real-data `baseline_valid` reference:
+
+```text
+configs/baselines/01_mfpt/mfpt_global_average_linear.yaml
+```
+
+It uses the public MFPT provider train/test population, a file-grouped training/validation
+split, held-out provider test files, a transparent temporal-mean linear classifier, best
+checkpoint restoration, and explicit seeds 17, 18, and 19.
+
+Its observed mean test accuracy and F1 are both `0.333333`, with sample standard deviation
+`0.166667`. This is a deliberately weak diagnostic model. The result demonstrates protocol
+closure and estimator execution; it does not demonstrate a strong representation, useful
+industrial accuracy, or state-of-the-art performance.
+
+The small source population also means the repeated-run estimator has high uncertainty.
+Any algorithmic claim requires stronger models, additional datasets or conditions, and a
+reviewed comparison protocol.
 
 ## Data availability
 
-- Only the Dummy smoke demo is fully offline and shipped with the repository.
-- Most non-Dummy demos require local metadata and raw files supplied through explicit
-  configuration or CLI overrides.
+- Only the Dummy smoke data are shipped with the repository and fully offline.
+- The MFPT baseline preparation command downloads public files at execution time; network
+  access and the external provider must be available.
+- Most other non-Dummy configurations require local metadata and raw files supplied
+  through explicit configuration or CLI overrides.
 - Dataset source, license, citation, and redistribution rights remain the responsibility
   of each dataset contribution and user environment.
-- The CWRU public bundle interface exists, but final provider revisions and required-file
-  SHA-256 values are not yet frozen. It is therefore not a finalized release artifact.
-- A successful software smoke does not prove external data availability, data quality, or
-  permission to redistribute the source data.
+- A successful software or baseline run does not authorize redistribution of external
+  raw data.
+
+## CWRU scope
+
+- The CWRU public bundle interface remains a compatibility path, not the current
+  `baseline_valid` reference.
+- Its executable validator checks provider declaration, metadata fields, unique selected
+  IDs, Id-to-signal coverage, `(L, C)` shape, sample length, channel count, and optional
+  corpus foreign keys.
+- CWRU remains suitable for later local acceptance of reader and data semantics.
+- Per-file hashes and cross-provider byte identity may be used as optional diagnostics,
+  but they are not scientific-validity or RC1 release gates.
+- CWRU availability must not block unrelated Data, Model, Task, Trainer, Pipeline, or MFPT
+  development.
 
 ## Platform and dependency coverage
 
@@ -47,43 +87,56 @@ This page describes the current maintained source state. It does not imply that 
 - Optional model families may require research dependencies beyond the first-run path.
   An unconditional optional import should be reported as a dependency-boundary bug.
 - `phmfactory doctor` verifies real imports in the active environment; it cannot guarantee
-  every optional research model or external system integration.
+  every optional research model or external-system integration.
 
 ## Configuration compatibility
 
 - Public process entrypoints resolve maintained configs and explicit CLI overrides through
-  the public resolver.
+  one public resolver.
 - Historical direct Pipeline imports retain compatibility behavior and should not be
   treated as a second public configuration contract.
 - Machine-specific paths should be passed explicitly or kept in an untracked local
   experiment file. A public run must not silently change because a hidden local file is
   discovered.
-- The current repository still contains historical configs under `configs/v0.0.9/`.
-  Their presence does not make them part of the v0.3 quickstart or supported surface.
+- The repository still contains historical configs under `configs/v0.0.9/`. Their
+  presence does not make them part of the v0.3 quickstart or supported surface.
 
-## Runtime and evidence boundaries
+## Runtime and result-record boundaries
 
-- `sanity_ok` is bounded functional evidence, not benchmark-performance evidence.
-- The offline Dummy demo verifies configuration, factory construction, training, testing,
-  and result writing. Its metrics are not a scientific baseline.
-- Fair comparison requires the same effective config, code revision, environment, data,
-  split, seed, protocol, metric set, and aggregation rule.
-- The run manifest records the invocation and indexed artifacts, but not every historical
-  Pipeline has equally complete data, protocol, seed, and environment detail.
-- Failure to write the required run record makes a public invocation unsuccessful; richer
-  optional reports may still have Pipeline-specific limitations.
+The authoritative scientific outcome is the Pipeline lifecycle. For the maintained
+classification path:
+
+```text
+fit
+-> best checkpoint restore
+-> evaluation
+-> non-empty finite metrics
+```
+
+- Pipeline, maturity, import, task, data, objective, checkpoint, and evaluation failures
+  remain fatal and preserve their original diagnostic.
+- A Pipeline returning `None` is not successful.
+- Compatibility run manifests and evidence indexes are optional diagnostics.
+- Failure to prepare, enrich, or finalize an optional record emits a warning and does not
+  replace a completed Pipeline result.
+- Historical Pipelines do not all index outputs with equal detail; users should treat the
+  actual result files and explicit experiment protocol as authoritative.
+- Fair comparison still requires the same code, data population, split, seed, model,
+  objective, metric set, and aggregation rule.
 
 ## Factory compatibility risks
 
 - Model, task, and trainer factories still include historical compatibility paths. New
   work should fail at the source error rather than printing and returning `None`.
 - Checkpoint compatibility must not be inferred from partial `strict=False` loading.
-  Missing, unexpected, and shape-mismatched parameters require explicit policy and user
-  acknowledgement.
+  Missing, unexpected, and shape-mismatched parameters require an explicit method-specific
+  decision.
 - Dataset-adapter fallback to `Default_dataset` is historical behavior and must be reviewed
   carefully when adding a new task name.
 - Sampler compatibility must be derived from current runtime behavior and focused tests;
   stale tables or comments are not release evidence.
+- The current `baseline_valid` reference proves one narrow Data x Model path. It does not
+  prove arbitrary Cartesian-product compatibility across all factories.
 
 ## Streamlit scope
 
@@ -94,15 +147,20 @@ This page describes the current maintained source state. It does not imply that 
   limits documented in `apps/streamlit/README.md`.
 - The CLI remains the source of execution semantics when UI and documentation disagree.
 
-## Release blockers intentionally retained
+## RC1 and final release boundary
 
-The following items are not resolved by ordinary usability refactors:
+Before the RC1 version-promotion PR, the only expected machine-checked blocker is:
 
-- immutable CWRU provider revisions;
-- byte-identical required CWRU file hashes;
-- final GitHub repository rename;
-- version promotion from `0.3.0.dev0` to `0.3.0`;
-- final tag, GitHub Release, and package publication.
+```text
+VERSION_NOT_RC1
+```
+
+The promotion changes both version authorities from `0.3.0.dev0` to `0.3.0rc1` and must
+then pass all RC1 checks. This does not automatically create or publish an RC1 artifact.
+
+A final `v0.3.0` remains a later decision after RC1 review. Final tagging and publication
+require separate authorization and verification that the exact approved commit built the
+published artifacts.
 
 The current authority is
 [`docs/PHMFACTORY_V0_3_RELEASE_READINESS.md`](docs/PHMFACTORY_V0_3_RELEASE_READINESS.md).

--- a/RELEASE_NOTES_v0.3.0.md
+++ b/RELEASE_NOTES_v0.3.0.md
@@ -1,31 +1,42 @@
 # PHMFactory v0.3.0 Release Notes
 
-> Status: **pre-release draft**  
-> Repository rename, final version, immutable CWRU pins, tag, and publication are not complete.
+> Status: **release-candidate preparation**  
+> The source version is still `0.3.0.dev0`. No RC1 tag, final tag, GitHub Release,
+> wheel publication, or package-index publication is claimed by this document.
 
 ## Overview
 
-PHM-Vibench becomes **PHMFactory** in v0.3.0. The release establishes a public package,
-CLI, configuration surface, reproducible CWRU bundle contract, and stricter repository
-boundaries while preserving the mature runtime under `src.*`.
+PHMFactory v0.3 establishes a configuration-first public package and a scientifically
+reviewable execution path for industrial PHM experiments. The current repository remains
+`PHMbench/PHM-Vibench`; the project and Python distribution are named `PHMFactory` and
+`phmfactory`.
 
-This document is the user-facing release summary. For step-by-step upgrade instructions,
-use [`MIGRATION_v0.2_to_v0.3.md`](MIGRATION_v0.2_to_v0.3.md). For the exact release gate,
-use [`docs/PHMFACTORY_V0_3_RELEASE_READINESS.md`](docs/PHMFACTORY_V0_3_RELEASE_READINESS.md).
+The governing invariant is:
+
+```text
+requested experiment = executed experiment
+```
+
+The release candidate is built around explicit data, split, model, objective, checkpoint,
+evaluation, and estimator semantics. It does not use artifact hashes, receipts, ledgers,
+or compatibility run records as substitutes for scientific correctness.
+
+For upgrade steps, see [`MIGRATION_v0.2_to_v0.3.md`](MIGRATION_v0.2_to_v0.3.md). The exact
+RC1 gate is [`docs/PHMFACTORY_V0_3_RELEASE_READINESS.md`](docs/PHMFACTORY_V0_3_RELEASE_READINESS.md).
 
 ## Public identity and entrypoints
 
-| Surface | v0.3 value |
+| Surface | v0.3 RC1 value |
 | --- | --- |
 | Project | `PHMFactory` |
-| Target repository | `PHMbench/phmfactory` |
+| Current repository | `PHMbench/PHM-Vibench` |
 | Distribution | `phmfactory` |
 | Import namespace | `phmfactory` |
 | Console command | `phmfactory` |
 | Root entrypoint | `python main.py` |
 | Module entrypoint | `python -m phmfactory` |
 
-The three command forms share one parser and dispatcher:
+The three command forms share the same resolver and dispatcher:
 
 ```bash
 python main.py --config configs/demo/00_smoke/dummy_dg.yaml
@@ -38,16 +49,123 @@ phmfactory --config configs/demo/00_smoke/dummy_dg.yaml
 
 ## Main changes
 
-### Public package and configuration
+### One configuration truth
 
-- Added the root `phmfactory` package and installed CLI.
-- Added `phmfactory.config` for maintained preset/path resolution, ordered
-  `base_configs`, typed dotted overrides, Pipeline canonicalization, and cycle errors.
-- Kept root `main.py` as a thin compatibility dispatcher.
+- Added the public `phmfactory` package and installed CLI.
+- Added a shared configuration resolver with ordered `base_configs`, typed dotted
+  overrides, Pipeline canonicalization, explicit local-config input, and cycle detection.
+- Kept `main.py` as a thin compatibility dispatcher.
+- Public preflight, config inspection, CLI execution, and maintained Pipeline adapters
+  consume the same effective configuration.
+- Configuration or runtime errors fail at their source; they do not activate another
+  Pipeline, task, device, loss, or data path.
+
+### Factory responsibility boundaries
+
+The maintained architecture freezes the following responsibilities:
+
+```text
+Data Factory    -> reader, metadata, selected IDs, datasets, samplers, loaders
+Model Factory   -> model identity and construction
+Task Factory    -> task identity, objective, and metric lifecycle
+Trainer Factory -> device, checkpoint, callbacks, fit/test lifecycle
+Pipeline        -> orchestration and user-visible result path
+```
+
+The current acceptance suite includes a 2 x 2 Data Factory x Model Factory test using
+Dummy/CSV inputs and transparent/ISFM model paths. Replacing one component does not require
+modifying the other factories or the Pipeline.
+
+### First real `baseline_valid` reference
+
+The repository now contains one exact real-data reference:
+
+```text
+config:
+configs/baselines/01_mfpt/mfpt_global_average_linear.yaml
+
+data:
+public MFPT provider train/test population
+
+model:
+GlobalAverageLinear
+
+seeds:
+17, 18, 19
+
+protocol status:
+baseline_valid
+```
+
+The protocol uses 14 provider training files, a file-grouped and label-stratified 10/4
+training/validation split, and six provider test files that never participate in fitting,
+early stopping, or checkpoint selection. Every seed restores its best checkpoint and
+returns finite test metrics.
+
+Observed test accuracy and F1 are both:
+
+```text
+0.333333 +/- 0.166667 sample standard deviation
+```
+
+This weak result is retained intentionally. It proves a closed real-data execution and
+estimator contract; it does not claim a strong representation or state-of-the-art fault
+diagnosis.
+
+### Strict reader and evaluation semantics
+
+Maintained paths now reject, rather than repair, conditions such as:
+
+- missing or malformed configuration fields;
+- invalid labels or unavailable target domains;
+- unsupported task, metric, or regularization names;
+- implicit Task-side device movement;
+- stochastic validation/test HSE patch selection;
+- patch sizes larger than the available signal or channel dimensions;
+- empty or non-finite evaluation results;
+- missing or partially compatible best checkpoints;
+- reader failures that would otherwise produce substitute signals.
+
+### Compatibility run records are non-authoritative
+
+A public run may still write a compatibility `run_manifest.json` and index existing
+outputs. These are optional diagnostics. Failure to prepare, enrich, or finalize such a
+record emits a warning and cannot convert a completed scientific Pipeline into failure.
+
+The authoritative outcome is the Pipeline lifecycle itself. For the maintained
+classification path:
+
+```text
+fit
+-> best checkpoint restore
+-> evaluation
+-> non-empty finite metrics
+```
+
+Pipeline, import, maturity, and contract exceptions continue to propagate unchanged.
+
+### CWRU compatibility bundle
+
+The v0.3 compatibility bundle remains:
+
+```text
+metadata.xlsx      required
+RM_001_CWRU.h5     required
+corpus.xlsx        optional
+```
+
+The executable validator checks provider declaration, required metadata fields, unique
+selected IDs, Id-to-signal coverage, `(L, C)` signal shape, sample-length agreement,
+channel-count agreement, and optional corpus foreign keys.
+
+CWRU is not the current `baseline_valid` reference and does not block unrelated RC1 work.
+Per-file digests and cross-provider byte identity are optional diagnostics, not scientific
+or release gates. CWRU remains available for later local acceptance based on reader and
+data semantics.
 
 ### Pipeline names
 
-The six established Pipeline modules are renamed directly:
+The six established Pipeline modules use canonical names:
 
 | Previous | Canonical v0.3 name |
 | --- | --- |
@@ -59,144 +177,77 @@ The six established Pipeline modules are renamed directly:
 | `Pipeline_06_generative` | `Pipeline_06_Generative_Modeling` |
 
 Legacy YAML values remain explicit aliases with warnings. Direct Python imports of old
-module filenames must be updated. The rename does not intentionally change Pipeline
-function bodies, data splits, metrics, checkpoints, seeds, or reader behavior.
+module filenames must be updated.
 
-### CWRU bundle
-
-The v0.3 bundle contract is:
-
-```text
-metadata.xlsx      required
-RM_001_CWRU.h5     required
-corpus.xlsx        optional
-```
-
-Available operations include selective Hugging Face/ModelScope download, local
-validation, cross-directory hash comparison, and a non-interactive quickstart. The
-online path is not release-ready until both providers use immutable revisions and the
-required files have matching SHA-256 values.
-
-### Dependencies and UI
+### Dependencies, UI, and repository boundary
 
 - Root `requirements.txt` remains the core dependency authority.
 - Streamlit, ModelScope, plotting, and test requirements are owned by their subsystems.
-- `apps/streamlit/app.py` is the only maintained web entrypoint.
-- The old `app/` prototype and root `streamlit_app.py` were archived and removed.
-
-### Repository boundary and paper migration
-
-The public repository no longer carries root/hidden Agent workspaces, `.archive/`,
-`dev/`, tracked result placeholders, or legacy personal/paper gitlinks. P01–P09 content
-was resolved through fixed-SHA destination evidence; the Foundation tree was partitioned
-into accepted P08/P09 imports and provenance/reference classes. All legacy mode-160000
-entries and the now-empty `.gitmodules` file are removed.
-
-### Optional backend decision
-
-`phm-data-factory` is deferred to v0.3.1. It is not part of the v0.3.0 runtime, package,
-submodule tree, supported component set, or release blocker.
-
-The v0.3.0 contract requires:
-
-```text
-backend gitlink absent
-runtime import absent
-silent fallback forbidden
-core runtime independent
-backend integration/support/live-IoTDB claims false
-```
-
-The machine-readable authority is
-`docs/releases/v0.3.0-backend-deferral.yaml`. A future v0.3.1 integration still requires
-an organization-owned public repository, compatible license, immutable reviewed commit,
-bounded adapter PR, and proof that core paths pass without backend initialization.
+- `apps/streamlit/app.py` is the maintained browser entrypoint and delegates to the public
+  CLI rather than implementing a second training system.
+- Legacy root/hidden Agent workspaces, tracked result placeholders, personal/paper
+  gitlinks, and `.gitmodules` have been removed after preservation or migration.
+- `phm-data-factory` remains deferred to v0.3.1 and is absent from the RC1 runtime and
+  support claims.
 
 ## Preserved compatibility boundary
 
-v0.3 intentionally preserves:
+v0.3 intentionally preserves the mature implementations under:
 
 ```text
-src/data_factory/reader/
-src/data_factory/dataset_task/
-src/data_factory/samplers/
-src/data_factory/H5DataDict.py
-src/data_factory/data_factory.py
+src/data_factory/
 src/model_factory/
 src/task_factory/
 src/trainer_factory/
 ```
 
-Reader signatures, parsing, channel order, `(L, C)` signal semantics, dtype behavior,
-normalization, task/trainer logic, and Pipeline algorithms are not mechanically rewritten.
-New integrations should prefer `phmfactory.*`; `src.*` remains the packaged compatibility
-engine for this release.
-
-## v0.2 migration baseline
-
-The migration baseline is the recorded v0.2.0 release candidate:
-
-```text
-project:         PHM-Vibench
-status:          release_candidate
-formal release:  false
-baseline commit: a331769d4005018bc833534ecf4efeb5e8a5a78d
-tag present:     false
-```
-
-No retroactive final v0.2.0 tag is created. The machine-readable authority is
-`docs/releases/v0.2.0-rc-provenance.yaml`.
+New integrations should prefer `phmfactory.*`, while the protected `src.*` runtime remains
+the compatibility engine for this release candidate. Compatibility does not authorize
+silent fallback or scientific-semantic repair.
 
 ## Validation coverage
 
-The canonical integration exercises:
+The RC1 validation surface includes:
 
-- documentation, maintained config, generated Atlas, and whitespace checks;
-- offline Dummy smoke, Pipeline 06 shell/CFM, and UXFD focused contracts;
-- public package tests, wheel/sdist build, wheel inspection, and clean installation;
-- dependency ownership and subsystem requirement boundaries;
-- offline CWRU validation and manifest packaging;
-- Streamlit tests on Ubuntu and Windows;
-- portable/case-insensitive path and Agent-boundary guards;
-- submodule policy, paper migration policy, and release-readiness auditing.
+- documentation, maintained configs, generated Atlas, and support-authority checks;
+- offline Dummy install/preflight/train/test smoke;
+- strict MFPT reader and preparation tests;
+- a real public MFPT three-seed workflow;
+- Pipeline 02 evaluation, trainer-only device, HSE determinism, objective, label, metric,
+  split, and sampler contracts;
+- Pipeline 06 shell/CFM and UXFD focused contracts;
+- public wheel/sdist build, wheel inspection, and clean installation;
+- repository layout and deny-by-default submodule policy.
 
-Functional and smoke evidence validates software paths; it is not a performance benchmark
-or a universal compatibility claim.
+Functional evidence validates exact software paths. Only the reviewed MFPT configuration
+is currently promoted to `baseline_valid`.
 
-## Remaining release blockers
+## RC1 readiness status
 
-The strict release gate now expects exactly:
-
-```text
-2 x CWRU_HASH_MISSING
-2 x CWRU_REVISION_FLOATING
-1 x REPOSITORY_RENAME_PENDING
-1 x VERSION_NOT_FINAL
-```
-
-Resolved conditions that must not return include:
+Before the bounded version-promotion PR, the expected release-readiness finding is:
 
 ```text
-PHM_DATA_FACTORY_BACKEND_PENDING
-LEGACY_SUBMODULES_REMAIN
-UNKNOWN_SUBMODULES_PRESENT
+1 x VERSION_NOT_RC1
 ```
 
-Until the remaining conditions are cleared:
+The next PR changes:
 
-- the version remains `0.3.0.dev0`;
-- the repository remains `PHMbench/PHM-Vibench`;
-- no `v0.3.0` tag, GitHub Release, wheel, or sdist publication is authorized;
-- no CWRU online parity claim may be made.
-
-The final version switch to `0.3.0` belongs in the last promotion step after CWRU and
-repository identity are ready; it is not performed early merely to suppress the version gate.
-
-Audit commands:
-
-```bash
-python tools/repo/check_release_readiness.py --mode audit
-python tools/repo/check_release_readiness.py --mode release
+```text
+0.3.0.dev0 -> 0.3.0rc1
 ```
 
-The second command must remain non-zero until all final release blockers are resolved.
+in `pyproject.toml` and `phmfactory/__init__.py` together. After that change, the RC1
+readiness checker must report zero blockers.
+
+The following are explicitly not RC1 blockers:
+
+```text
+CWRU per-file hashes
+cross-provider byte identity
+future repository rename
+optional manifest/evidence finalization
+```
+
+No tag or publication follows automatically from a successful version-promotion PR.
+Creating an RC1 tag, GitHub Release, wheel upload, or package-index publication requires
+separate explicit authorization.

--- a/docs/PHMFACTORY_V0_3_RELEASE_READINESS.md
+++ b/docs/PHMFACTORY_V0_3_RELEASE_READINESS.md
@@ -1,151 +1,241 @@
-# PHMFactory v0.3 Release Readiness
+# PHMFactory v0.3.0-rc1 Release Readiness
 
-This document is the blocking contract for the final PHMFactory v0.3.0 release. It records the current tree, not an assertion that publication is already authorized.
+This document is the blocking contract for the first PHMFactory v0.3 release candidate.
+It describes the current repository state and the conditions for promoting the source
+version to `0.3.0rc1`; it does not claim that a tag or package publication already exists.
 
 ## Current status
 
 ```text
-status: BLOCKED
-release target: v0.3.0
+status: READY_FOR_RC1_VERSION_PROMOTION
+release target: v0.3.0-rc1
 current repository: PHMbench/PHM-Vibench
-target repository: PHMbench/phmfactory
 package version: 0.3.0.dev0
+current baseline_valid references: 1
 ```
+
+The expected finding set before the version-promotion PR is exactly:
+
+```text
+1 x VERSION_NOT_RC1
+```
+
+After `pyproject.toml` and `phmfactory.__version__` are changed together to
+`0.3.0rc1`, release mode must report zero blockers.
 
 Audit commands:
 
 ```bash
-python tools/repo/check_submodule_policy.py --mode policy
 python tools/repo/check_submodule_policy.py --mode release
 python tools/repo/check_release_readiness.py --mode audit
 python tools/repo/check_release_readiness.py --mode release
 ```
 
-The submodule release policy must now pass. The overall release command remains non-zero while any final release finding exists.
+## First-principles readiness contract
+
+A release candidate is scientifically ready only when its maintained user path executes a
+defined experiment rather than merely importing successfully:
+
+$$
+C_{\mathrm{RC1}}
+=
+C_{\mathrm{config}}
+\land
+C_{\mathrm{runtime}}
+\land
+C_{\mathrm{baseline}}
+\land
+C_{\mathrm{package}}
+\land
+C_{\mathrm{docs}}
+\land
+C_{\mathrm{repository}}.
+$$
+
+The factors mean:
+
+- `C_config`: one resolved configuration is used from preflight through Pipeline execution;
+- `C_runtime`: failures propagate from their source and no alternate algorithm is selected;
+- `C_baseline`: at least one exact real-data configuration has a closed data, split,
+  checkpoint, evaluation, metric, and repeated-run estimator contract;
+- `C_package`: wheel/source build and clean installed entrypoints work;
+- `C_docs`: user-facing claims match the generated support authority;
+- `C_repository`: repository and optional-submodule boundaries remain explicit.
+
+A file hash, receipt, ledger, or artifact index is not one of these scientific conditions.
+
+## Machine-checked scientific reference
+
+The RC1 authority requires exactly one reviewed registry row:
+
+```text
+id: baseline_01_mfpt_global_average_linear
+config: configs/baselines/01_mfpt/mfpt_global_average_linear.yaml
+pipeline: Pipeline_01_Fault_Diagnosis
+execution status: sanity_ok
+protocol status: baseline_valid
+```
+
+The reference uses the public MFPT provider split, file-grouped and label-stratified
+training/validation groups, a held-out provider test population, the transparent
+`GlobalAverageLinear` model, best-checkpoint restoration, and explicit seeds 17, 18, and
+19. Its low accuracy is retained as the honest result of a deliberately weak transparent
+model. `baseline_valid` denotes protocol closure, not model superiority.
+
+The checker also requires the reviewed preparation command, strict MFPT reader, focused
+contract test, and real-data workflow to remain present. The workflow itself performs the
+real download and end-to-end scientific validation; the release checker does not replace
+that experiment with metadata bookkeeping.
+
+## CWRU compatibility boundary
+
+CWRU remains a compatibility bundle and a later local acceptance target. It is not the
+current `baseline_valid` reference and it does not block unrelated RC1 progress.
+
+The CWRU bundle contract is:
+
+$$
+C_{\mathrm{CWRU}}
+=
+C_{\mathrm{provider}}
+\land
+C_{\mathrm{schema}}
+\land
+C_{\mathrm{ID}}
+\land
+C_{\mathrm{shape}}
+\land
+C_{\mathrm{metadata}}.
+$$
+
+The executable validator checks:
+
+```text
+explicit provider and revision declaration
+required metadata.xlsx and RM_001_CWRU.h5 mappings
+required Dataset_id / Label / Domain_id fields
+non-empty selector and Id field
+unique selected Id values
+selected Id -> HDF5 signal coverage
+signal shape (L, C)
+metadata sample-length agreement
+metadata channel-count agreement
+optional corpus foreign-key validity
+```
+
+RC1 does **not** require:
+
+```text
+per-file SHA-256 pins
+cross-provider byte identity
+hash-chain or receipt construction
+artifact-integrity attestation
+```
+
+Those mechanisms may remain available as optional diagnostics for users who need them,
+but they do not establish reader semantics, label correctness, split validity, or
+benchmark validity.
 
 ## Resolved release areas
 
-The following areas are complete and must not return as blockers:
+The following areas are complete and must not return as RC1 blockers:
 
-- PHMFactory README and citation branding;
 - public `phmfactory` package, CLI, configuration resolver, and canonical Pipeline names;
-- explicit v0.2.0 release-candidate provenance anchored to `a331769d4005018bc833534ecf4efeb5e8a5a78d`;
-- P01–P09 content-level migration evidence;
-- Foundation 257-path partition with zero unassigned paths;
-- removal of every legacy mode-160000 paper, personal, and research gitlink;
-- removal of `.gitmodules` after the last gitlink was deleted;
-- deny-by-default submodule policy with zero submodule release blockers;
+- one configuration authority shared by inspect, preflight, CLI, and maintained runtime;
+- fail-fast data population, task, device, objective, metric, and checkpoint semantics on
+  maintained paths;
+- deterministic maintained evaluation boundaries;
+- strict Dummy and MFPT readers;
+- 2 x 2 Data Factory x Model Factory replacement acceptance;
+- one real MFPT `baseline_valid` reference;
+- optional compatibility run records that cannot override Pipeline success or failure;
+- P01-P09 migration, zero legacy gitlinks, and deny-by-default submodule policy;
 - formal deferral of optional `phm-data-factory` integration to v0.3.1.
 
-The backend decision authority is:
+The backend decision authority remains:
 
 ```text
 docs/releases/v0.3.0-backend-deferral.yaml
 ```
 
-A valid deferral means the backend is absent, optional, not imported by the v0.3.0 runtime, not claimed as supported, and not release-blocking.
+A valid deferral means the backend is absent, optional, not imported by the RC1 runtime,
+not claimed as supported, and not release-blocking.
 
-## Remaining machine-checked blockers
+## Repository identity
 
-The expected current finding set is exactly:
-
-```text
-2 x CWRU_REVISION_FLOATING
-2 x CWRU_HASH_MISSING
-1 x REPOSITORY_RENAME_PENDING
-1 x VERSION_NOT_FINAL
-```
-
-Total expected findings:
+The actual RC1 repository is:
 
 ```text
-6
+PHMbench/PHM-Vibench
 ```
 
-No other finding is authorized. In particular, these must remain absent:
+Documentation and citation metadata must use this real URL. A future rename to
+`PHMbench/phmfactory` is a product-governance decision, not a scientific-validity gate and
+not an RC1 blocker. A rename, when authorized, requires its own bounded migration PR.
+
+## Version promotion
+
+The current source version remains:
 
 ```text
-PHM_DATA_FACTORY_BACKEND_PENDING
-BACKEND_DEFERRAL_INVALID
-LEGACY_SUBMODULES_REMAIN
-UNKNOWN_SUBMODULES_PRESENT
-README_BRAND_PENDING
-CITATION_BRAND_PENDING
-CITATION_REPOSITORY_PENDING
-V020_PROVENANCE_UNRESOLVED
+0.3.0.dev0
 ```
 
-## Meaning of the remaining blockers
-
-### CWRU immutable publication
-
-Both Hugging Face and ModelScope currently use floating revisions, and the logical `metadata` and `signals` SHA-256 values are not pinned. This is intentionally deferred from the present change set.
-
-Release requires:
+The next bounded PR changes both version authorities to:
 
 ```text
-immutable provider revisions
-metadata SHA-256
-signals SHA-256
-byte-identical required files across providers
+0.3.0rc1
 ```
 
-### Repository identity
-
-GitHub still reports `PHMbench/PHM-Vibench`. The final release identity is `PHMbench/phmfactory`. The rename is intentionally deferred from the present change set.
-
-### Final version
-
-`pyproject.toml` and `phmfactory.__version__` must remain `0.3.0.dev0` until the CWRU and repository-identity gates are ready. The final promotion PR changes both to `0.3.0` exactly once, after the other release blockers are cleared.
-
-`VERSION_NOT_FINAL` is therefore a finalization gate, not a request to publish final metadata early.
-
-## Backend boundary
-
-`phm-data-factory` is deferred to v0.3.1 and must not be added to the v0.3.0 tree.
-
-For v0.3.0:
+Only these two values may be changed for version identity:
 
 ```text
-backend gitlink: absent
-runtime import: forbidden
-silent fallback: forbidden
-core dependency: false
-release blocker: false
-support claim: false
+pyproject.toml
+phmfactory/__init__.py
 ```
 
-A future v0.3.1 integration still requires an organization-owned public repository, compatible license, immutable reviewed commit, bounded adapter PR, explicit missing-backend failure, and proof that core paths pass without backend initialization.
-
-See [PHM_DATA_FACTORY_BACKEND_V0_3.md](PHM_DATA_FACTORY_BACKEND_V0_3.md).
-
-## Final release order
+The version-promotion PR must then obtain:
 
 ```text
-1. keep the merged migration and backend-deferral authorities unchanged
-2. publish and verify the dual-source immutable CWRU bundle
-3. update the CWRU manifest with immutable revisions and logical-key SHA-256 values
-4. rerun release-readiness and confirm only rename/version remain
-5. prepare the final promotion PR
-6. rename the GitHub repository to PHMbench/phmfactory
-7. change 0.3.0.dev0 to 0.3.0 in package metadata
-8. update changelog and release-note status from pre-release to final
-9. run full CI, wheel/sdist build, clean installation, CLI and smoke validation
-10. require release-readiness PASS with 0 blockers
-11. create tag v0.3.0 and publish the release
+release readiness: PASS, 0 blockers
+public package build and clean installation: PASS
+offline Dummy smoke: PASS
+MFPT real-data three-seed workflow: PASS
+core quality gates: PASS
+repository layout and submodule policy: PASS
 ```
 
-## Human review required before tagging
+Version promotion does not itself create a tag, GitHub Release, or package-index
+publication.
 
-The final tagged commit still requires confirmation that:
+## RC1 promotion order
 
-- branch protection and required checks are correct for the final repository identity;
-- Hugging Face and ModelScope expose the exact immutable bundle revisions;
-- required CWRU files are byte-identical across providers;
-- release notes accurately separate maintained software behavior from experimental or deferred components;
-- wheel and source distribution are built from the exact tagged commit;
-- clean installation, CLI entrypoints, offline Dummy smoke, Pipeline 06, UXFD, Streamlit, dependency ownership, repository layout, submodule policy, and CWRU validation all pass.
+```text
+1. merge this scientific-readiness authority
+2. confirm the audit reports only VERSION_NOT_RC1
+3. create a version-only RC1 promotion PR
+4. change 0.3.0.dev0 -> 0.3.0rc1 in both version authorities
+5. rerun all required checks
+6. require release-readiness PASS with zero blockers
+7. review the exact RC1 commit
+8. create an RC1 tag or publish artifacts only under separate explicit authorization
+```
+
+## Final v0.3.0 boundary
+
+The final `v0.3.0` release remains a later decision. Before a final tag, review:
+
+- whether RC1 user feedback requires code or documentation corrections;
+- whether the current repository name should remain or be changed;
+- whether wheels and source distributions are built from the exact approved commit;
+- whether supported combinations and known limitations remain accurate;
+- whether any additional real-data baseline is necessary for the final claim boundary.
+
+CWRU local acceptance may contribute to that review, but it must validate scientific data
+semantics rather than substitute byte identity for experiment correctness.
 
 ## Rollback
 
-Before tagging, revert the final promotion commit or retain `0.3.0.dev0`. After publication, do not move or recreate the tag; issue a corrective release instead.
+Before tagging, revert the version-promotion commit or retain `0.3.0.dev0`. After an RC1
+artifact is published, do not move or recreate the tag; issue a corrected release
+candidate instead.

--- a/phmfactory/data_sources/manifests/cwru-demo-v1.yaml
+++ b/phmfactory/data_sources/manifests/cwru-demo-v1.yaml
@@ -1,7 +1,7 @@
 schema_version: 1
 bundle_id: cwru-demo-v1
 dataset_name: CWRU
-release_pin_required: true
+release_pin_required: false
 
 files:
   metadata:
@@ -50,7 +50,8 @@ providers:
       signals: RM_001_CWRU.h5
       corpus: corpus.xlsx
 
-# These values remain empty until the identical versioned bundle has been
-# published to both providers. The v0.3.0 release gate must replace floating
-# revisions with immutable revisions and populate these hashes.
-expected_sha256: {}
+# For v0.3.0-rc1, this compatibility bundle is accepted through executable
+# scientific checks: required metadata fields, unique selected IDs, Id-to-signal
+# coverage, (L, C) signal shape, and metadata length/channel consistency.
+# Per-file digests and cross-provider byte identity are optional diagnostics,
+# not release or scientific-validity gates.

--- a/test/test_release_readiness.py
+++ b/test/test_release_readiness.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from copy import deepcopy
 from types import SimpleNamespace
 
 import pytest
@@ -7,16 +8,105 @@ import pytest
 from tools.repo import check_release_readiness as readiness
 
 
+VALID_CWRU_MANIFEST = {
+    "schema_version": 1,
+    "bundle_id": "cwru-demo-v1",
+    "dataset_name": "CWRU",
+    "files": {
+        "metadata": {"filename": "metadata.xlsx", "required": True},
+        "signals": {"filename": "RM_001_CWRU.h5", "required": True},
+        "corpus": {"filename": "corpus.xlsx", "required": False},
+    },
+    "metadata": {
+        "id_column": "Id",
+        "required_columns": ["Dataset_id", "Label", "Domain_id"],
+        "selector": {"column": "Name", "values": ["RM_001_CWRU"]},
+        "column_aliases": {
+            "sample_length": ["Sample_lenth", "Sample_length"],
+            "channel_count": ["Channel"],
+        },
+    },
+    "providers": {
+        "huggingface": {
+            "repo_id": "PHMbench/PHM-Vibench",
+            "revision": "main",
+            "files": {
+                "metadata": "metadata.xlsx",
+                "signals": "RM_001_CWRU.h5",
+            },
+        },
+        "modelscope": {
+            "repo_id": "PHMbench/PHM-Vibench",
+            "revision": "master",
+            "files": {
+                "metadata": "metadata.xlsx",
+                "signals": "RM_001_CWRU.h5",
+            },
+        },
+    },
+}
+
+
+def test_cwru_release_contract_is_scientific_not_hash_based() -> None:
+    payload = deepcopy(VALID_CWRU_MANIFEST)
+    payload["expected_sha256"] = {}
+
+    assert readiness._cwru_contract_errors(payload) == ()
+
+
 @pytest.mark.parametrize(
-    "revision",
-    ("main", "master", "release/v0.3", "refs/heads/main", "v0.3.0", ""),
+    ("mutator", "message"),
+    [
+        (lambda payload: payload["metadata"].update({"id_column": ""}), "id_column"),
+        (
+            lambda payload: payload["metadata"].update(
+                {"required_columns": ["Dataset_id", "Domain_id"]}
+            ),
+            "Label",
+        ),
+        (
+            lambda payload: payload["providers"]["huggingface"].update(
+                {"revision": ""}
+            ),
+            "revision",
+        ),
+        (
+            lambda payload: payload["providers"]["modelscope"]["files"].update(
+                {"signals": "wrong.h5"}
+            ),
+            "wrong.h5",
+        ),
+    ],
 )
-def test_mutable_revision_forms_are_not_immutable(revision: str) -> None:
-    assert not readiness._is_immutable_revision(revision)
+def test_cwru_release_contract_rejects_semantic_gaps(mutator, message: str) -> None:
+    payload = deepcopy(VALID_CWRU_MANIFEST)
+    mutator(payload)
+
+    assert message in "; ".join(readiness._cwru_contract_errors(payload))
 
 
-def test_full_commit_revision_is_immutable() -> None:
-    assert readiness._is_immutable_revision("a" * 40)
+def test_baseline_valid_reference_requires_the_exact_reviewed_row() -> None:
+    row = {
+        "id": readiness.BASELINE_REGISTRY_ID,
+        "category": "baseline",
+        "path": readiness.BASELINE_CONFIG_PATH,
+        "pipeline": "Pipeline_01_Fault_Diagnosis",
+        "status": "sanity_ok",
+        "protocol_status": "baseline_valid",
+    }
+
+    assert readiness._baseline_valid_error([row]) == ""
+
+    row["protocol_status"] = "smoke_only"
+    assert "baseline_valid" in readiness._baseline_valid_error([row])
+
+
+def test_registry_reader_requires_release_authority_columns(tmp_path) -> None:
+    registry = tmp_path / "registry.csv"
+    registry.write_text("id,path\nbaseline,x.yaml\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="missing columns"):
+        readiness._read_registry_rows(registry)
 
 
 def test_gitlinks_enumerates_raw_unconfigured_entries(

--- a/tools/repo/check_release_readiness.py
+++ b/tools/repo/check_release_readiness.py
@@ -1,32 +1,40 @@
 #!/usr/bin/env python3
-"""Audit PHMFactory v0.3 release readiness without mutating repository state."""
+"""Audit PHMFactory v0.3.0-rc1 readiness without mutating repository state."""
 
 from __future__ import annotations
 
 import argparse
 import configparser
-import os
+import csv
 import re
 import subprocess
 import sys
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Iterable
+from typing import Any, Iterable, Mapping
 
 import yaml
 
 
 ROOT = Path(__file__).resolve().parents[2]
-TARGET_VERSION = "0.3.0"
-TARGET_REPOSITORY = "PHMbench/phmfactory"
+TARGET_VERSION = "0.3.0rc1"
+TARGET_RELEASE_LABEL = "v0.3.0-rc1"
+TARGET_REPOSITORY = "PHMbench/PHM-Vibench"
 TARGET_BACKEND_PATH = "packages/phm-data-factory"
 TARGET_BACKEND_URL = "https://github.com/PHMbench/phm-data-factory.git"
-REQUIRED_BUNDLE_HASHES = ("metadata", "signals")
-FLOATING_REVISIONS = {"main", "master", "latest", "develop", "development", ""}
-SHA40 = re.compile(r"[0-9a-f]{40}")
 V020_PROVENANCE_PATH = "docs/releases/v0.2.0-rc-provenance.yaml"
 SUBMODULE_ALLOWLIST_PATH = ".github/phmfactory-v0.3-submodules.allowlist.yml"
 BACKEND_DEFERRAL_PATH = "docs/releases/v0.3.0-backend-deferral.yaml"
+BASELINE_REGISTRY_PATH = "configs/config_registry.csv"
+BASELINE_REGISTRY_ID = "baseline_01_mfpt_global_average_linear"
+BASELINE_CONFIG_PATH = "configs/baselines/01_mfpt/mfpt_global_average_linear.yaml"
+BASELINE_REQUIRED_PATHS = (
+    BASELINE_CONFIG_PATH,
+    "scripts/prepare_mfpt_baseline.py",
+    "src/data_factory/reader/RM_007_MFPT.py",
+    "test/test_mfpt_baseline.py",
+    ".github/workflows/mfpt-baseline.yml",
+)
 V020_BASELINE_COMMIT = "a331769d4005018bc833534ecf4efeb5e8a5a78d"
 V020_EXPECTED_PROVENANCE: dict[str, Any] = {
     "project_name": "PHM-Vibench",
@@ -38,6 +46,7 @@ V020_EXPECTED_PROVENANCE: dict[str, Any] = {
     "superseded_by": "v0.3.0",
 }
 DEFERRED_STATUS = "deferred_to_v0.3.1"
+SHA40 = re.compile(r"[0-9a-f]{40}")
 
 
 @dataclass(frozen=True)
@@ -92,10 +101,6 @@ def _gitlinks() -> dict[str, str]:
 
 def _gitlink(path: str) -> str:
     return _gitlinks().get(path, "")
-
-
-def _is_immutable_revision(value: str) -> bool:
-    return SHA40.fullmatch(value.casefold()) is not None
 
 
 def _configured_submodules() -> dict[str, dict[str, str]]:
@@ -289,6 +294,125 @@ def _submodule_findings() -> tuple[Finding, ...]:
     return tuple(findings)
 
 
+def _mapping(value: Any) -> Mapping[str, Any]:
+    return value if isinstance(value, Mapping) else {}
+
+
+def _nonempty(value: Any) -> bool:
+    return isinstance(value, str) and bool(value.strip())
+
+
+def _cwru_contract_errors(payload: Mapping[str, Any]) -> tuple[str, ...]:
+    """Return scientific CWRU manifest errors without treating file hashes as semantics."""
+
+    errors: list[str] = []
+    if payload.get("schema_version") != 1:
+        errors.append("schema_version must be 1")
+    if payload.get("bundle_id") != "cwru-demo-v1":
+        errors.append("bundle_id must be 'cwru-demo-v1'")
+    if payload.get("dataset_name") != "CWRU":
+        errors.append("dataset_name must be 'CWRU'")
+
+    files = _mapping(payload.get("files"))
+    declared_files: dict[str, str] = {}
+    for logical_name in ("metadata", "signals"):
+        entry = _mapping(files.get(logical_name))
+        filename = entry.get("filename")
+        if not _nonempty(filename):
+            errors.append(f"files.{logical_name}.filename must be non-empty")
+        else:
+            declared_files[logical_name] = str(filename).strip()
+        if entry.get("required") is not True:
+            errors.append(f"files.{logical_name}.required must be true")
+
+    metadata = _mapping(payload.get("metadata"))
+    if not _nonempty(metadata.get("id_column")):
+        errors.append("metadata.id_column must be non-empty")
+    required_columns = {
+        str(value).strip()
+        for value in metadata.get("required_columns") or ()
+        if _nonempty(value)
+    }
+    missing_columns = sorted({"Dataset_id", "Label", "Domain_id"} - required_columns)
+    if missing_columns:
+        errors.append(f"metadata.required_columns missing {missing_columns}")
+
+    selector = _mapping(metadata.get("selector"))
+    if not _nonempty(selector.get("column")):
+        errors.append("metadata.selector.column must be non-empty")
+    selector_values = [
+        str(value).strip()
+        for value in selector.get("values") or ()
+        if _nonempty(value)
+    ]
+    if not selector_values:
+        errors.append("metadata.selector.values must be non-empty")
+
+    aliases = _mapping(metadata.get("column_aliases"))
+    for logical_name in ("sample_length", "channel_count"):
+        values = [
+            str(value).strip()
+            for value in aliases.get(logical_name) or ()
+            if _nonempty(value)
+        ]
+        if not values:
+            errors.append(f"metadata.column_aliases.{logical_name} must be non-empty")
+
+    providers = _mapping(payload.get("providers"))
+    if not providers:
+        errors.append("providers must contain at least one provider")
+    for provider_name, raw_provider in sorted(providers.items()):
+        provider = _mapping(raw_provider)
+        if not _nonempty(provider.get("repo_id")):
+            errors.append(f"providers.{provider_name}.repo_id must be non-empty")
+        if not _nonempty(provider.get("revision")):
+            errors.append(f"providers.{provider_name}.revision must be explicit")
+        provider_files = _mapping(provider.get("files"))
+        for logical_name in ("metadata", "signals"):
+            expected = declared_files.get(logical_name)
+            actual = provider_files.get(logical_name)
+            if expected and actual != expected:
+                errors.append(
+                    f"providers.{provider_name}.files.{logical_name}={actual!r}, "
+                    f"expected {expected!r}"
+                )
+
+    return tuple(errors)
+
+
+def _read_registry_rows(path: Path) -> list[dict[str, str]]:
+    with path.open("r", encoding="utf-8", newline="") as handle:
+        reader = csv.DictReader(handle)
+        required = {"id", "category", "path", "pipeline", "status", "protocol_status"}
+        missing = required - set(reader.fieldnames or ())
+        if missing:
+            raise ValueError(f"{path} missing columns: {sorted(missing)}")
+        return [
+            {str(key): str(value or "").strip() for key, value in row.items()}
+            for row in reader
+        ]
+
+
+def _baseline_valid_error(rows: Iterable[Mapping[str, str]]) -> str:
+    matches = [row for row in rows if row.get("id") == BASELINE_REGISTRY_ID]
+    if len(matches) != 1:
+        return f"expected exactly one {BASELINE_REGISTRY_ID!r} row, found {len(matches)}"
+    row = matches[0]
+    expected = {
+        "category": "baseline",
+        "path": BASELINE_CONFIG_PATH,
+        "pipeline": "Pipeline_01_Fault_Diagnosis",
+        "status": "sanity_ok",
+        "protocol_status": "baseline_valid",
+    }
+    mismatches = [
+        f"{field}={row.get(field)!r}, expected {value!r}"
+        for field, value in expected.items()
+        if row.get(field) != value
+    ]
+    return "; ".join(mismatches)
+
+
 def collect_findings() -> tuple[Finding, ...]:
     findings: list[Finding] = []
 
@@ -297,7 +421,7 @@ def collect_findings() -> tuple[Finding, ...]:
     readme = _read("README.md")
     citation = _yaml_mapping("CITATION.cff")
     changelog = _read("CHANGELOG.md")
-    manifest = _yaml_mapping("phmfactory/data_sources/manifests/cwru-demo-v1.yaml")
+    cwru_manifest = _yaml_mapping("phmfactory/data_sources/manifests/cwru-demo-v1.yaml")
 
     project_version = _toml_version(pyproject)
     package_version = _python_version(package_init)
@@ -311,7 +435,7 @@ def collect_findings() -> tuple[Finding, ...]:
     if project_version != TARGET_VERSION:
         findings.append(
             Finding(
-                "VERSION_NOT_FINAL",
+                "VERSION_NOT_RC1",
                 f"expected {TARGET_VERSION!r}, found {project_version!r}",
             )
         )
@@ -338,41 +462,27 @@ def collect_findings() -> tuple[Finding, ...]:
             Finding("RELEASE_NOTES_V030_MISSING", "RELEASE_NOTES_v0.3.0.md absent")
         )
 
-    providers = manifest.get("providers") or {}
-    release_pin_required = manifest.get("release_pin_required") is True
-    for provider_name, provider in sorted(providers.items()):
-        revision = str((provider or {}).get("revision") or "")
-        if (
-            release_pin_required and not _is_immutable_revision(revision)
-        ) or revision.casefold() in FLOATING_REVISIONS:
-            findings.append(
-                Finding(
-                    "CWRU_REVISION_FLOATING",
-                    f"{provider_name} revision={revision!r}",
-                )
-            )
+    cwru_errors = _cwru_contract_errors(cwru_manifest)
+    if cwru_errors:
+        findings.append(Finding("CWRU_CONTRACT_INVALID", "; ".join(cwru_errors)))
 
-    expected_hashes = manifest.get("expected_sha256") or {}
-    filename_hash_keys = {
-        str((manifest.get("files") or {}).get(key, {}).get("filename") or "")
-        for key in REQUIRED_BUNDLE_HASHES
-    }
-    conflicting_filename_keys = sorted(
-        key for key in filename_hash_keys if key and expected_hashes.get(key)
-    )
-    if conflicting_filename_keys:
+    registry_path = ROOT / BASELINE_REGISTRY_PATH
+    if not registry_path.is_file():
+        findings.append(Finding("BASELINE_VALID_REFERENCE_INVALID", f"{registry_path} absent"))
+    else:
+        baseline_error = _baseline_valid_error(_read_registry_rows(registry_path))
+        if baseline_error:
+            findings.append(Finding("BASELINE_VALID_REFERENCE_INVALID", baseline_error))
+    missing_baseline_paths = [
+        path for path in BASELINE_REQUIRED_PATHS if not (ROOT / path).is_file()
+    ]
+    if missing_baseline_paths:
         findings.append(
             Finding(
-                "CWRU_HASH_KEY_CONFLICT",
-                f"filename hash keys are forbidden; use logical keys: {conflicting_filename_keys}",
+                "BASELINE_VALID_REFERENCE_INVALID",
+                "missing reviewed baseline path(s): " + ", ".join(missing_baseline_paths),
             )
         )
-    for key in REQUIRED_BUNDLE_HASHES:
-        value = str(expected_hashes.get(key) or "")
-        if not re.fullmatch(r"[0-9a-f]{64}", value):
-            findings.append(
-                Finding("CWRU_HASH_MISSING", f"expected_sha256.{key} is not pinned")
-            )
 
     findings.extend(_submodule_findings())
 
@@ -381,17 +491,13 @@ def collect_findings() -> tuple[Finding, ...]:
         provenance_error = _v020_provenance_error()
         if provenance_error:
             findings.append(Finding("V020_PROVENANCE_UNRESOLVED", provenance_error))
-    if any(tag in {"v0.3.0", "0.3.0"} for tag in tags):
-        findings.append(Finding("V030_TAG_ALREADY_EXISTS", "release tag exists before readiness pass"))
-
-    repository = os.environ.get("GITHUB_REPOSITORY", "")
-    if repository and repository != TARGET_REPOSITORY:
+    reserved_tags = {"v0.3.0rc1", "0.3.0rc1", "v0.3.0-rc1", "0.3.0-rc1"}
+    if any(tag in reserved_tags for tag in tags):
         findings.append(
-            Finding(
-                "REPOSITORY_RENAME_PENDING",
-                f"current={repository!r}, expected={TARGET_REPOSITORY!r}",
-            )
+            Finding("V030RC1_TAG_ALREADY_EXISTS", "release-candidate tag exists before readiness pass")
         )
+    if any(tag in {"v0.3.0", "0.3.0"} for tag in tags):
+        findings.append(Finding("V030_TAG_ALREADY_EXISTS", "final release tag already exists"))
 
     return tuple(sorted(findings, key=lambda item: (item.code, item.detail)))
 
@@ -399,9 +505,12 @@ def collect_findings() -> tuple[Finding, ...]:
 def _print_findings(findings: Iterable[Finding]) -> None:
     findings = tuple(findings)
     if not findings:
-        print("PHMFactory v0.3 release readiness PASS: 0 blockers")
+        print(f"PHMFactory {TARGET_RELEASE_LABEL} readiness PASS: 0 blockers")
         return
-    print(f"PHMFactory v0.3 release readiness BLOCKED: {len(findings)} blocker(s)")
+    print(
+        f"PHMFactory {TARGET_RELEASE_LABEL} readiness BLOCKED: "
+        f"{len(findings)} blocker(s)"
+    )
     for finding in findings:
         print(f"- {finding.code}: {finding.detail}")
 
@@ -417,6 +526,7 @@ def main() -> int:
         OSError,
         ValueError,
         configparser.Error,
+        csv.Error,
         yaml.YAMLError,
         subprocess.CalledProcessError,
     ) as exc:


### PR DESCRIPTION
## Objective

Replace the stale final-release gate with a bounded `v0.3.0-rc1` readiness contract whose blockers correspond to executable scientific and user-facing conditions.

## First-principles contract

```text
RC1 ready
=
configuration truth
∧ runtime truth
∧ one exact baseline_valid real-data protocol
∧ package/install truth
∧ documentation truth
∧ repository-boundary truth
```

File hashes, cross-provider byte identity, receipts, ledgers, evidence indexes, and a possible future repository rename are not used as proxies for reader semantics or experiment validity.

## Changes

- retarget release readiness from final `v0.3.0` to source candidate `v0.3.0rc1`;
- make the current repository `PHMbench/PHM-Vibench` the citation and RC1 repository authority;
- remove `CWRU_HASH_MISSING`, `CWRU_REVISION_FLOATING`, and `REPOSITORY_RENAME_PENDING` from the RC1 blocker model;
- validate the CWRU compatibility manifest through provider declaration, required metadata fields, selector/ID semantics, file mappings, and shape/channel aliases;
- require the exact reviewed MFPT `baseline_01_mfpt_global_average_linear` row to remain `sanity_ok + baseline_valid`;
- require its canonical config, strict reader, preparation command, focused test, and real-data workflow to remain present;
- update the workflow so the current tree must have exactly one blocker: `VERSION_NOT_RC1`;
- protect the new semantics with focused unit tests;
- synchronize release-readiness, release notes, changelog, known limitations, CWRU manifest commentary, and citation metadata.

## Expected current result

```text
PHMFactory v0.3.0-rc1 readiness BLOCKED: 1 blocker(s)
- VERSION_NOT_RC1: expected '0.3.0rc1', found '0.3.0.dev0'
```

A later version-only PR may change both version authorities to `0.3.0rc1`; the same checker must then return zero blockers.

## Boundaries

- no Data, Model, Task, Trainer, Pipeline, split, objective, checkpoint, or metric behavior changes;
- no new Factory, manager, adapter, registry, schema, evidence, ledger, receipt, or artifact-auditing layer;
- optional existing bundle hashes remain compatibility diagnostics, but do not determine RC1 readiness;
- CWRU remains a compatibility/final-local-acceptance path, not the current `baseline_valid` reference;
- no RC1 tag, GitHub Release, wheel upload, or package publication;
- no version bump in this PR.

## Validation performed before PR

- `python -m py_compile tools/repo/check_release_readiness.py`;
- 8 focused release-readiness tests passed in an isolated repository;
- reconstructed audit at `0.3.0.dev0` returned exactly `VERSION_NOT_RC1`;
- reconstructed release mode at `0.3.0rc1` returned `PASS: 0 blockers`.

## CI acceptance

- release-readiness workflow;
- focused release/submodule tests;
- documentation and configuration contracts;
- public package and clean installation;
- offline user-first smoke;
- real MFPT three-seed workflow;
- repository layout and submodule policy.
