### PR TITLE
release(version): promote source identity to 0.3.0rc1

### DIFF
--- a/phmfactory/__init__.py
+++ b/phmfactory/__init__.py
@@ -9,4 +9,4 @@ from __future__ import annotations
 
 __all__ = ["__version__"]
 
-__version__ = "0.3.0.dev0"
+__version__ = "0.3.0rc1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "phmfactory"
-version = "0.3.0.dev0"
+version = "0.3.0rc1"
 description = "Configuration-first PHM research and evaluation framework"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/test/test_phmfactory_entrypoints.py
+++ b/test/test_phmfactory_entrypoints.py
@@ -48,8 +48,8 @@ def _analysis(
     )
 
 
-def test_public_version_is_v030_development_release() -> None:
-    assert __version__ == "0.3.0.dev0"
+def test_public_version_is_v030_rc1() -> None:
+    assert __version__ == "0.3.0rc1"
 
 
 def test_parser_preserves_legacy_config_path_alias() -> None:


### PR DESCRIPTION
## Objective

Promote the authoritative PHMFactory source identity from `0.3.0.dev0` to `0.3.0rc1` after the scientific RC1 readiness contract was merged and reduced the expected blocker set to `VERSION_NOT_RC1` only.

## Changes

```text
pyproject.toml
0.3.0.dev0 -> 0.3.0rc1

phmfactory/__init__.py
0.3.0.dev0 -> 0.3.0rc1

test/test_phmfactory_entrypoints.py
public version contract -> 0.3.0rc1
```

The test update preserves an exact version assertion; it does not weaken or remove the package contract.

## Required result

The same readiness checker used on `dev` changes from:

```text
BLOCKED: 1 blocker
VERSION_NOT_RC1
```

to:

```text
PHMFactory v0.3.0-rc1 readiness PASS: 0 blockers
```

## Boundaries

- no tag;
- no GitHub Release;
- no wheel or source-distribution upload;
- no package-index publication;
- no `dev -> main` promotion;
- no repository rename;
- no Data, Model, Task, Trainer, Pipeline, reader, split, objective, checkpoint, metric, or estimator changes;
- no hash/checksum/digest/receipt/ledger/attestation/evidence additions.

## Verified result

All seven workflows passed on the final head:

- release readiness: zero blockers;
- public package: focused API tests, wheel/sdist build, wheel inspection, clean installation, public CLI/module/doctor/demo/preflight/dispatch checks;
- core quality gates, including offline Dummy smoke;
- CWRU bundle contract;
- dependency ownership;
- repository layout;
- submodule policy.

The public-package gate initially exposed the old exact `0.3.0.dev0` test. The fix updated that assertion to the exact RC1 identity and the complete workflow then passed.

User-facing status documentation will be synchronized in a separate bounded documentation PR. That PR will also retrigger the public MFPT three-seed workflow on the merged RC1 source version.
