### PR TITLE
docs(release): publish the validated 0.3.0rc1 source status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,11 @@
 # Changelog
 
-## v0.3.0 - Release Candidate Preparation
+## v0.3.0-rc1 - Source Candidate
 
-PHMFactory v0.3 is preparing its first release candidate from the current
-`PHMbench/PHM-Vibench` repository. This entry records the release delta; it does not claim
-that an RC1 or final tag has already been published.
+PHMFactory has promoted its source identity to `0.3.0rc1` in the current
+`PHMbench/PHM-Vibench` repository. This records the validated source candidate; it does
+not claim that an RC1 tag, GitHub Release, wheel upload, source-distribution upload, or
+package-index publication has occurred.
 
 - User-facing overview: [`RELEASE_NOTES_v0.3.0.md`](RELEASE_NOTES_v0.3.0.md)
 - Upgrade procedure: [`MIGRATION_v0.2_to_v0.3.md`](MIGRATION_v0.2_to_v0.3.md)
@@ -37,6 +38,7 @@ that an RC1 or final tag has already been published.
 
 - Public identity converges on `PHMFactory` / `phmfactory` while the current repository
   remains `PHMbench/PHM-Vibench`.
+- Source version authorities and their exact public test now agree on `0.3.0rc1`.
 - `main.py` remains a supported thin dispatcher over the public package.
 - Data, Model, Task, and Trainer Factory responsibilities are kept narrow; Pipeline code
   orchestrates rather than repairs their inputs.
@@ -94,22 +96,23 @@ performance claim.
 - Compatibility does not authorize reader, split, task, device, loss, metric, or
   checkpoint substitution.
 
-### RC1 status
+### RC1 validation status
 
-The current source version remains `0.3.0.dev0`. After the scientific-readiness authority
-is merged, the expected checker result is exactly:
+The promoted source identity passed:
 
 ```text
-1 x VERSION_NOT_RC1
+release readiness: PASS, 0 blockers
+wheel/sdist build and wheel inspection: PASS
+clean installed public entrypoints: PASS
+offline Dummy smoke: PASS
+core quality gates: PASS
+CWRU bundle contract: PASS
+dependency, layout, and submodule policy: PASS
 ```
 
-A bounded promotion PR changes both version authorities to `0.3.0rc1`. The promotion must
-then pass release readiness with zero blockers, package build and clean installation,
-offline Dummy smoke, the public MFPT three-seed workflow, core quality gates, repository
-layout, and submodule policy.
-
-No RC1 tag, final tag, GitHub Release, wheel upload, source-distribution upload, or
-package-index publication is authorized merely by changing the source version.
+The status-synchronization PR reruns the public MFPT three-seed workflow against the RC1
+source version. No RC1 tag, final tag, GitHub Release, wheel upload, source-distribution
+upload, or package-index publication is authorized by the source-version change.
 
 ## v0.2.0 Release Candidate - 2026-07-11
 

--- a/KNOWN_LIMITATIONS.md
+++ b/KNOWN_LIMITATIONS.md
@@ -1,14 +1,16 @@
-# Known Limitations for the PHMFactory v0.3 Pre-release
+# Known Limitations for the PHMFactory v0.3.0-rc1 Source Candidate
 
-This page describes the current maintained source state. It does not imply that an RC1 or
-final tag, GitHub Release, or package-index publication has occurred.
+This page describes the current maintained source candidate. It does not imply that an
+RC1 or final tag, GitHub Release, wheel upload, source-distribution upload, or
+package-index publication has occurred.
 
 ## Repository and installation state
 
 - The project and Python package are named PHMFactory; the current GitHub repository is
   `PHMbench/PHM-Vibench`.
-- The source version is `0.3.0.dev0` until the bounded RC1 version-promotion PR.
-- The maintained pre-release installation path is an editable checkout installation:
+- The source-version authorities are both `0.3.0rc1`.
+- The source candidate passes the machine-checked RC1 release gate with zero blockers.
+- The maintained source installation path is an editable checkout installation:
   `python -m pip install -e .`.
 - A package-index release is not claimed. Do not document `pip install phmfactory` as
   generally available until a real publication has been completed and verified.
@@ -34,7 +36,7 @@ final tag, GitHub Release, or package-index publication has occurred.
 
 ## Real-data baseline status
 
-PHMFactory now has one real-data `baseline_valid` reference:
+PHMFactory has one real-data `baseline_valid` reference:
 
 ```text
 configs/baselines/01_mfpt/mfpt_global_average_linear.yaml
@@ -149,17 +151,22 @@ fit
 
 ## RC1 and final release boundary
 
-Before the RC1 version-promotion PR, the only expected machine-checked blocker is:
+The promoted source identity has passed:
 
 ```text
-VERSION_NOT_RC1
+release readiness: PASS, 0 blockers
+wheel/sdist build and clean installation: PASS
+offline Dummy smoke: PASS
+core quality gates: PASS
+CWRU, dependency, layout, and submodule contracts: PASS
 ```
 
-The promotion changes both version authorities from `0.3.0.dev0` to `0.3.0rc1` and must
-then pass all RC1 checks. This does not automatically create or publish an RC1 artifact.
+The status-synchronization PR reruns the public MFPT three-seed workflow against the
+merged `0.3.0rc1` source version.
 
-A final `v0.3.0` remains a later decision after RC1 review. Final tagging and publication
-require separate authorization and verification that the exact approved commit built the
+The candidate identity does not automatically create or publish an RC1 artifact. A final
+`v0.3.0` remains a later decision after RC1 review. Tagging and publication require
+separate authorization and verification that the exact approved commit built the
 published artifacts.
 
 The current authority is

--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@
   <p><em>One configuration from data selection to evaluation, without hidden scientific fallbacks.</em></p>
 
   <p>
-    <img src="https://img.shields.io/badge/status-alpha-orange" alt="Status: alpha"/>
-    <img src="https://img.shields.io/badge/version-0.3.0.dev0-blue" alt="Version 0.3.0.dev0"/>
+    <img src="https://img.shields.io/badge/status-RC1-blue" alt="Status: RC1 source candidate"/>
+    <img src="https://img.shields.io/badge/version-0.3.0rc1-blue" alt="Version 0.3.0rc1"/>
     <img src="https://img.shields.io/badge/Python-%3E%3D3.10-3776AB" alt="Python 3.10 or newer"/>
     <a href="https://github.com/PHMbench/PHM-Vibench/actions/workflows/core-quality-gates.yml"><img src="https://github.com/PHMbench/PHM-Vibench/actions/workflows/core-quality-gates.yml/badge.svg" alt="Core quality gates"/></a>
     <img src="https://img.shields.io/badge/license-Apache%202.0-green" alt="Apache 2.0 license"/>
@@ -31,10 +31,11 @@
 
 ---
 
-> **Repository identity.** The project and Python package are named
-> **PHMFactory**. During the v0.3 pre-release, the GitHub repository remains
-> [`PHMbench/PHM-Vibench`](https://github.com/PHMbench/PHM-Vibench). Use this
-> repository URL until a future rename is explicitly announced.
+> **Repository and release identity.** The project and Python package are named
+> **PHMFactory**. The current source version is **`0.3.0rc1`**, and the GitHub repository
+> remains [`PHMbench/PHM-Vibench`](https://github.com/PHMbench/PHM-Vibench). The source
+> candidate passes the RC1 readiness gate, but no RC1 tag, GitHub Release, wheel upload,
+> source-distribution upload, or package-index publication is claimed.
 
 PHMFactory is a modular research framework for fault diagnosis and related PHM
 experiments on industrial signals. A single resolved configuration connects the data,
@@ -373,17 +374,19 @@ See [docs/testing.md](docs/testing.md) for focused gates and test terminology.
 
 </details>
 
-## Current pre-release limits
+## Current RC1 source-candidate limits
 
-PHMFactory remains an alpha `0.3.0.dev0` source release:
+PHMFactory is currently a validated `0.3.0rc1` source candidate:
 
-- the Dummy demo is the only fully offline, repository-shipped first-run path;
-- one exact real-data reference is now `baseline_valid`: MFPT + `GlobalAverageLinear`;
+- release readiness reports zero blockers for the current source identity;
+- wheel/sdist construction, wheel inspection, clean installation, public entrypoints, and the offline Dummy smoke have passed;
+- the Dummy demo remains the only fully offline, repository-shipped first-run path;
+- one exact real-data reference is `baseline_valid`: MFPT + `GlobalAverageLinear`;
 - that reference establishes protocol and estimator closure, not strong diagnostic accuracy;
 - most other real-data configurations still require local metadata and raw signals and remain `smoke_only` unless explicitly listed otherwise;
 - broader SEU, PU, and final CWRU acceptance are not yet complete;
-- the GitHub repository has not been renamed;
-- no final `v0.3.0` tag or package publication is claimed;
+- the current repository remains `PHMbench/PHM-Vibench`;
+- no RC1 tag, final `v0.3.0` tag, GitHub Release, or package publication is claimed;
 - experimental Pipelines and unlisted model/task combinations are not release-supported.
 
 Read [Known limitations](KNOWN_LIMITATIONS.md) and the

--- a/README_CN.md
+++ b/README_CN.md
@@ -12,8 +12,8 @@
   <p><em>用一份配置贯通数据、模型、任务、训练与评价，不用隐式兜底改变实验。</em></p>
 
   <p>
-    <img src="https://img.shields.io/badge/状态-alpha-orange" alt="状态：alpha"/>
-    <img src="https://img.shields.io/badge/版本-0.3.0.dev0-blue" alt="版本 0.3.0.dev0"/>
+    <img src="https://img.shields.io/badge/状态-RC1-blue" alt="状态：RC1 源码候选"/>
+    <img src="https://img.shields.io/badge/版本-0.3.0rc1-blue" alt="版本 0.3.0rc1"/>
     <img src="https://img.shields.io/badge/Python-%3E%3D3.10-3776AB" alt="Python 3.10 或更高版本"/>
     <a href="https://github.com/PHMbench/PHM-Vibench/actions/workflows/core-quality-gates.yml"><img src="https://github.com/PHMbench/PHM-Vibench/actions/workflows/core-quality-gates.yml/badge.svg" alt="核心质量门禁"/></a>
     <img src="https://img.shields.io/badge/许可-Apache%202.0-green" alt="Apache 2.0 许可"/>
@@ -31,10 +31,11 @@
 
 ---
 
-> **当前仓库身份。** 项目名称和 Python 包名已经统一为 **PHMFactory**。在 v0.3
-> 预发布阶段，GitHub 仓库仍为
-> [`PHMbench/PHM-Vibench`](https://github.com/PHMbench/PHM-Vibench)。在后续改名被明确
-> 公布之前，请始终使用这里给出的真实仓库地址。
+> **仓库与发布身份。** 项目名称和 Python 包名已经统一为 **PHMFactory**。当前源码版本为
+> **`0.3.0rc1`**，GitHub 仓库仍为
+> [`PHMbench/PHM-Vibench`](https://github.com/PHMbench/PHM-Vibench)。该源码候选已通过
+> RC1 readiness gate，但当前不宣称已有 RC1 tag、GitHub Release、wheel 上传、源码包上传
+> 或包索引发布。
 
 PHMFactory 面向工业信号故障诊断及相关 PHM 实验，提供模块化、配置驱动的研究运行
 框架。一份解析完成的配置直接连接数据、模型、任务目标、训练器、checkpoint、评价与
@@ -363,17 +364,19 @@ python -m pytest test/ -q
 
 </details>
 
-## 当前预发布边界
+## 当前 RC1 源码候选边界
 
-PHMFactory 仍是 alpha 阶段的 `0.3.0.dev0` 源码版本：
+PHMFactory 当前是经过验证的 `0.3.0rc1` 源码候选：
 
+- 当前源码身份的 release readiness 为零 blocker；
+- wheel/sdist 构建、wheel 检查、干净安装、公共入口和离线 Dummy smoke 已通过；
 - Dummy demo 仍是唯一完全离线、随仓库提供的首次运行路径；
 - 当前已有一个精确真实数据参考达到 `baseline_valid`：MFPT + `GlobalAverageLinear`；
 - 该参考证明协议与估计量闭合，不表示故障诊断准确率较高；
 - 大部分其他真实数据配置仍需要本地 metadata 和原始信号，除非明确列出，否则仍为 `smoke_only`；
 - 更广泛的 SEU、PU 与最终 CWRU acceptance 尚未完成；
-- GitHub 仓库尚未改名；
-- 当前不宣称已有最终 `v0.3.0` tag 或正式包发布；
+- 当前仓库仍为 `PHMbench/PHM-Vibench`；
+- 当前不宣称已有 RC1 tag、最终 `v0.3.0` tag、GitHub Release 或正式包发布；
 - experimental Pipeline 和未列出的模型/任务组合不属于发布支持范围。
 
 进行发布或 benchmark 声明前，请阅读[已知限制](KNOWN_LIMITATIONS.md)和

--- a/RELEASE_NOTES_v0.3.0.md
+++ b/RELEASE_NOTES_v0.3.0.md
@@ -1,8 +1,9 @@
 # PHMFactory v0.3.0 Release Notes
 
-> Status: **release-candidate preparation**  
-> The source version is still `0.3.0.dev0`. No RC1 tag, final tag, GitHub Release,
-> wheel publication, or package-index publication is claimed by this document.
+> Status: **`0.3.0rc1` source candidate**  
+> The source identity has been promoted and passes the machine-checked RC1 gate. No RC1
+> tag, final tag, GitHub Release, wheel publication, source-distribution publication, or
+> package-index publication is claimed by this document.
 
 ## Overview
 
@@ -29,12 +30,15 @@ RC1 gate is [`docs/PHMFACTORY_V0_3_RELEASE_READINESS.md`](docs/PHMFACTORY_V0_3_R
 | Surface | v0.3 RC1 value |
 | --- | --- |
 | Project | `PHMFactory` |
+| Source version | `0.3.0rc1` |
 | Current repository | `PHMbench/PHM-Vibench` |
 | Distribution | `phmfactory` |
 | Import namespace | `phmfactory` |
 | Console command | `phmfactory` |
 | Root entrypoint | `python main.py` |
 | Module entrypoint | `python -m phmfactory` |
+| RC1 tag | not created |
+| Published artifacts | none |
 
 The three command forms share the same resolver and dispatcher:
 
@@ -78,7 +82,7 @@ modifying the other factories or the Pipeline.
 
 ### First real `baseline_valid` reference
 
-The repository now contains one exact real-data reference:
+The repository contains one exact real-data reference:
 
 ```text
 config:
@@ -207,37 +211,37 @@ silent fallback or scientific-semantic repair.
 
 ## Validation coverage
 
-The RC1 validation surface includes:
+The promoted `0.3.0rc1` source identity has passed:
 
+- release readiness with zero blockers;
+- public wheel/sdist build, wheel inspection, and clean installation;
+- public CLI, module, doctor, demo, preflight, and compiled-config dispatch checks;
 - documentation, maintained configs, generated Atlas, and support-authority checks;
 - offline Dummy install/preflight/train/test smoke;
-- strict MFPT reader and preparation tests;
-- a real public MFPT three-seed workflow;
 - Pipeline 02 evaluation, trainer-only device, HSE determinism, objective, label, metric,
   split, and sampler contracts;
 - Pipeline 06 shell/CFM and UXFD focused contracts;
-- public wheel/sdist build, wheel inspection, and clean installation;
-- repository layout and deny-by-default submodule policy.
+- CWRU compatibility-bundle semantics;
+- dependency ownership, repository layout, and deny-by-default submodule policy.
 
-Functional evidence validates exact software paths. Only the reviewed MFPT configuration
-is currently promoted to `baseline_valid`.
+The status-synchronization PR reruns the public MFPT three-seed workflow against the
+merged RC1 source identity. Functional evidence validates exact software paths. Only the
+reviewed MFPT configuration is currently promoted to `baseline_valid`.
 
 ## RC1 readiness status
 
-Before the bounded version-promotion PR, the expected release-readiness finding is:
+The source version has been promoted:
 
 ```text
-1 x VERSION_NOT_RC1
+pyproject.toml:          0.3.0rc1
+phmfactory.__version__:  0.3.0rc1
 ```
 
-The next PR changes:
+The machine-checked release result is:
 
 ```text
-0.3.0.dev0 -> 0.3.0rc1
+PHMFactory v0.3.0-rc1 readiness PASS: 0 blockers
 ```
-
-in `pyproject.toml` and `phmfactory/__init__.py` together. After that change, the RC1
-readiness checker must report zero blockers.
 
 The following are explicitly not RC1 blockers:
 
@@ -248,6 +252,6 @@ future repository rename
 optional manifest/evidence finalization
 ```
 
-No tag or publication follows automatically from a successful version-promotion PR.
-Creating an RC1 tag, GitHub Release, wheel upload, or package-index publication requires
-separate explicit authorization.
+No tag or publication follows automatically from a successful source promotion. Creating
+an RC1 tag, GitHub Release, wheel upload, source-distribution upload, or package-index
+publication requires separate explicit authorization.

--- a/docs/PHMFACTORY_V0_3_RELEASE_READINESS.md
+++ b/docs/PHMFACTORY_V0_3_RELEASE_READINESS.md
@@ -1,27 +1,28 @@
 # PHMFactory v0.3.0-rc1 Release Readiness
 
 This document is the blocking contract for the first PHMFactory v0.3 release candidate.
-It describes the current repository state and the conditions for promoting the source
-version to `0.3.0rc1`; it does not claim that a tag or package publication already exists.
+The source identity has been promoted to `0.3.0rc1` on `dev`; this does not claim that an
+RC1 tag, GitHub Release, wheel upload, source-distribution upload, or package-index
+publication already exists.
 
 ## Current status
 
 ```text
-status: READY_FOR_RC1_VERSION_PROMOTION
+status: RC1_SOURCE_PROMOTED
 release target: v0.3.0-rc1
 current repository: PHMbench/PHM-Vibench
-package version: 0.3.0.dev0
+package version: 0.3.0rc1
+release-readiness blockers: 0
 current baseline_valid references: 1
+RC1 tag present: false
+published artifacts: false
 ```
 
-The expected finding set before the version-promotion PR is exactly:
+The machine-checked result for the promoted source identity is:
 
 ```text
-1 x VERSION_NOT_RC1
+PHMFactory v0.3.0-rc1 readiness PASS: 0 blockers
 ```
-
-After `pyproject.toml` and `phmfactory.__version__` are changed together to
-`0.3.0rc1`, release mode must report zero blockers.
 
 Audit commands:
 
@@ -150,7 +151,10 @@ The following areas are complete and must not return as RC1 blockers:
 - one real MFPT `baseline_valid` reference;
 - optional compatibility run records that cannot override Pipeline success or failure;
 - P01-P09 migration, zero legacy gitlinks, and deny-by-default submodule policy;
-- formal deferral of optional `phm-data-factory` integration to v0.3.1.
+- formal deferral of optional `phm-data-factory` integration to v0.3.1;
+- synchronized package metadata and public `__version__` at `0.3.0rc1`;
+- wheel/sdist construction, wheel inspection, clean installation, public entrypoints, and
+  offline Dummy smoke on the RC1 source identity.
 
 The backend decision authority remains:
 
@@ -175,50 +179,42 @@ not an RC1 blocker. A rename, when authorized, requires its own bounded migratio
 
 ## Version promotion
 
-The current source version remains:
+The two source-version authorities now agree:
 
 ```text
-0.3.0.dev0
+pyproject.toml:          0.3.0rc1
+phmfactory.__version__:  0.3.0rc1
 ```
 
-The next bounded PR changes both version authorities to:
-
-```text
-0.3.0rc1
-```
-
-Only these two values may be changed for version identity:
-
-```text
-pyproject.toml
-phmfactory/__init__.py
-```
-
-The version-promotion PR must then obtain:
+The version-promotion PR passed:
 
 ```text
 release readiness: PASS, 0 blockers
 public package build and clean installation: PASS
 offline Dummy smoke: PASS
-MFPT real-data three-seed workflow: PASS
 core quality gates: PASS
+CWRU bundle contract: PASS
+dependency ownership: PASS
 repository layout and submodule policy: PASS
 ```
+
+The user-facing status synchronization PR must additionally rerun the public MFPT
+three-seed workflow on the merged RC1 source identity.
 
 Version promotion does not itself create a tag, GitHub Release, or package-index
 publication.
 
-## RC1 promotion order
+## RC1 promotion state
 
 ```text
-1. merge this scientific-readiness authority
-2. confirm the audit reports only VERSION_NOT_RC1
-3. create a version-only RC1 promotion PR
-4. change 0.3.0.dev0 -> 0.3.0rc1 in both version authorities
-5. rerun all required checks
-6. require release-readiness PASS with zero blockers
-7. review the exact RC1 commit
-8. create an RC1 tag or publish artifacts only under separate explicit authorization
+1. scientific-readiness authority merged                         DONE
+2. pre-promotion audit isolated VERSION_NOT_RC1                  DONE
+3. version-only RC1 promotion PR created                         DONE
+4. 0.3.0.dev0 -> 0.3.0rc1 in both authorities                   DONE
+5. release/public-package/core/repository gates rerun            DONE
+6. release-readiness PASS with zero blockers                     DONE
+7. user-facing status + MFPT revalidation on RC1 source          IN PROGRESS
+8. tag or publish only under separate explicit authorization     NOT AUTHORIZED
 ```
 
 ## Final v0.3.0 boundary
@@ -236,6 +232,6 @@ semantics rather than substitute byte identity for experiment correctness.
 
 ## Rollback
 
-Before tagging, revert the version-promotion commit or retain `0.3.0.dev0`. After an RC1
-artifact is published, do not move or recreate the tag; issue a corrected release
-candidate instead.
+Before tagging, a reviewed revert may return both version authorities to `0.3.0.dev0` if
+the candidate is invalidated. After an RC1 artifact is published, do not move or recreate
+the tag; issue a corrected release candidate instead.


### PR DESCRIPTION
## Objective

Synchronize the English and Chinese user entrypoints and release authorities with the merged `0.3.0rc1` source identity, while preserving the explicit boundary that no tag or artifact publication has occurred.

## Changes

- change README badges from alpha / `0.3.0.dev0` to RC1 source candidate / `0.3.0rc1`;
- state the current repository authority as `PHMbench/PHM-Vibench`;
- state that machine-checked release readiness has zero blockers;
- retain MFPT + `GlobalAverageLinear` as the sole current `baseline_valid` reference and retain its weak result honestly;
- state that compatibility manifests/evidence remain optional diagnostics;
- update release readiness, release notes, changelog, and known limitations from “promotion pending” to “source identity promoted”;
- preserve the distinction between source candidate, tag, GitHub Release, built artifact upload, and package-index publication.

## Current release state

```text
source version: 0.3.0rc1
release-readiness blockers: 0
baseline_valid references: 1
RC1 tag: absent
GitHub Release: absent
published wheel/sdist: absent
package-index publication: absent
```

## Boundaries

- documentation only;
- no source-version change;
- no tag, GitHub Release, wheel/sdist upload, or package publication;
- no `dev -> main` promotion;
- no repository rename;
- no Data, Model, Task, Trainer, Pipeline, reader, split, objective, checkpoint, metric, estimator, runtime, or support-authority behavior change;
- no hash/checksum/digest/receipt/ledger/attestation/evidence additions.

## Acceptance

- documentation validation passes;
- generated config/support authority remains unchanged;
- release readiness remains zero blockers;
- public package and clean-install checks remain green;
- offline Dummy smoke remains green;
- public MFPT real-data workflow completes all three seeds on the merged RC1 source identity;
- repository layout and submodule policy remain green.
