### PR TITLE
docs(release): mark RC1 source validation complete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,14 +105,14 @@ release readiness: PASS, 0 blockers
 wheel/sdist build and wheel inspection: PASS
 clean installed public entrypoints: PASS
 offline Dummy smoke: PASS
+public MFPT three-seed baseline: PASS
 core quality gates: PASS
 CWRU bundle contract: PASS
 dependency, layout, and submodule policy: PASS
 ```
 
-The status-synchronization PR reruns the public MFPT three-seed workflow against the RC1
-source version. No RC1 tag, final tag, GitHub Release, wheel upload, source-distribution
-upload, or package-index publication is authorized by the source-version change.
+No RC1 tag, final tag, GitHub Release, wheel upload, source-distribution upload, or
+package-index publication is authorized by the source-version change.
 
 ## v0.2.0 Release Candidate - 2026-07-11
 

--- a/KNOWN_LIMITATIONS.md
+++ b/KNOWN_LIMITATIONS.md
@@ -157,12 +157,10 @@ The promoted source identity has passed:
 release readiness: PASS, 0 blockers
 wheel/sdist build and clean installation: PASS
 offline Dummy smoke: PASS
+public MFPT three-seed baseline: PASS
 core quality gates: PASS
 CWRU, dependency, layout, and submodule contracts: PASS
 ```
-
-The status-synchronization PR reruns the public MFPT three-seed workflow against the
-merged `0.3.0rc1` source version.
 
 The candidate identity does not automatically create or publish an RC1 artifact. A final
 `v0.3.0` remains a later decision after RC1 review. Tagging and publication require

--- a/RELEASE_NOTES_v0.3.0.md
+++ b/RELEASE_NOTES_v0.3.0.md
@@ -218,15 +218,16 @@ The promoted `0.3.0rc1` source identity has passed:
 - public CLI, module, doctor, demo, preflight, and compiled-config dispatch checks;
 - documentation, maintained configs, generated Atlas, and support-authority checks;
 - offline Dummy install/preflight/train/test smoke;
+- public MFPT three-seed data preparation, preflight, best-checkpoint evaluation, and
+  scientific closure;
 - Pipeline 02 evaluation, trainer-only device, HSE determinism, objective, label, metric,
   split, and sampler contracts;
 - Pipeline 06 shell/CFM and UXFD focused contracts;
 - CWRU compatibility-bundle semantics;
 - dependency ownership, repository layout, and deny-by-default submodule policy.
 
-The status-synchronization PR reruns the public MFPT three-seed workflow against the
-merged RC1 source identity. Functional evidence validates exact software paths. Only the
-reviewed MFPT configuration is currently promoted to `baseline_valid`.
+Functional evidence validates exact software paths. Only the reviewed MFPT configuration
+is currently promoted to `baseline_valid`.
 
 ## RC1 readiness status
 

--- a/docs/PHMFACTORY_V0_3_RELEASE_READINESS.md
+++ b/docs/PHMFACTORY_V0_3_RELEASE_READINESS.md
@@ -8,7 +8,7 @@ publication already exists.
 ## Current status
 
 ```text
-status: RC1_SOURCE_PROMOTED
+status: RC1_SOURCE_VALIDATED
 release target: v0.3.0-rc1
 current repository: PHMbench/PHM-Vibench
 package version: 0.3.0rc1
@@ -154,7 +154,9 @@ The following areas are complete and must not return as RC1 blockers:
 - formal deferral of optional `phm-data-factory` integration to v0.3.1;
 - synchronized package metadata and public `__version__` at `0.3.0rc1`;
 - wheel/sdist construction, wheel inspection, clean installation, public entrypoints, and
-  offline Dummy smoke on the RC1 source identity.
+  offline Dummy smoke on the RC1 source identity;
+- public MFPT three-seed preparation, preflight, best-checkpoint evaluation, and scientific
+  closure on the promoted RC1 source identity.
 
 The backend decision authority remains:
 
@@ -186,20 +188,18 @@ pyproject.toml:          0.3.0rc1
 phmfactory.__version__:  0.3.0rc1
 ```
 
-The version-promotion PR passed:
+The promoted source identity passed:
 
 ```text
 release readiness: PASS, 0 blockers
 public package build and clean installation: PASS
 offline Dummy smoke: PASS
+public MFPT three-seed baseline: PASS
 core quality gates: PASS
 CWRU bundle contract: PASS
 dependency ownership: PASS
 repository layout and submodule policy: PASS
 ```
-
-The user-facing status synchronization PR must additionally rerun the public MFPT
-three-seed workflow on the merged RC1 source identity.
 
 Version promotion does not itself create a tag, GitHub Release, or package-index
 publication.
@@ -213,7 +213,7 @@ publication.
 4. 0.3.0.dev0 -> 0.3.0rc1 in both authorities                   DONE
 5. release/public-package/core/repository gates rerun            DONE
 6. release-readiness PASS with zero blockers                     DONE
-7. user-facing status + MFPT revalidation on RC1 source          IN PROGRESS
+7. user-facing status + MFPT revalidation on RC1 source          DONE
 8. tag or publish only under separate explicit authorization     NOT AUTHORIZED
 ```
 


### PR DESCRIPTION
## Objective

Remove the last transient “in progress / reruns” wording from the release authority after PR #190 completed the full `0.3.0rc1` validation surface.

## Changes

- mark the RC1 source state as `RC1_SOURCE_VALIDATED`;
- mark user-facing status synchronization and MFPT revalidation as `DONE`;
- record the public MFPT three-seed baseline as `PASS` in release readiness, release notes, changelog, and known limitations;
- retain the explicit boundary that no tag, GitHub Release, artifact upload, package-index publication, or `dev -> main` promotion is authorized.

## Scope

```text
docs/PHMFACTORY_V0_3_RELEASE_READINESS.md
RELEASE_NOTES_v0.3.0.md
CHANGELOG.md
KNOWN_LIMITATIONS.md
```

Four documentation files only. The net change removes stale future tense; it does not alter source version, runtime behavior, configuration, support authority, or scientific protocol.

## Verified factual basis

PR #190 completed all six workflows on the `0.3.0rc1` source identity:

```text
release readiness: PASS, 0 blockers
wheel/sdist build and clean installation: PASS
offline Dummy smoke: PASS
public MFPT three-seed preparation/preflight/evaluation/closure: PASS
core quality gates: PASS
repository layout and submodule policy: PASS
```

## Boundaries

- no code or version changes;
- no new CI, factory, manager, adapter, registry, schema, hash, digest, receipt, ledger, attestation, or evidence layer;
- no tag or publication;
- no final `v0.3.0` claim.

## Acceptance

- documentation and maintained-config validation remain green;
- generated Atlas/support authority remains unchanged;
- release readiness remains zero blockers;
- public-package, core, layout, and submodule gates remain green.
