### PR TITLE
fix(data): preserve original reader failures

### DIFF
--- a/src/data_factory/explicit_data_factory.py
+++ b/src/data_factory/explicit_data_factory.py
@@ -3,12 +3,14 @@
 from __future__ import annotations
 
 import concurrent.futures
+import importlib
 import os
 from pathlib import Path
 import shutil
 from typing import Any
 
 import h5py
+import numpy as np
 from tqdm import tqdm
 
 from .contracts import format_loader_summary, require_nonempty_dataloaders
@@ -185,6 +187,30 @@ class ExplicitDataFactory(data_factory):
             args_data,
         )
         print(f"[SUCCESS] 数据加载器可用: {format_loader_summary(counts)}")
+
+    def _read_single_data(self, file_id, meta, args_data):
+        """Read one declared raw file without replacing reader exceptions."""
+
+        dataset_name = meta["Name"]
+        file_name = meta["File"]
+        file_path = (
+            Path(args_data.data_dir)
+            / "raw"
+            / str(dataset_name)
+            / str(file_name)
+        )
+        if not file_path.is_file():
+            raise FileNotFoundError(
+                f"Raw data file not found for ID {file_id}: {file_path}"
+            )
+
+        reader = importlib.import_module(
+            f"src.data_factory.reader.{dataset_name}"
+        )
+        data = reader.read(str(file_path), args_data)
+        if data.ndim == 2:
+            data = np.expand_dims(data, axis=-1)
+        return file_id, data, None
 
     def _init_data(self, args_data, use_cache=None, max_workers=32):
         """Read current raw inputs unless cache reuse is explicitly enabled.

--- a/test/test_data_cache_contract.py
+++ b/test/test_data_cache_contract.py
@@ -7,6 +7,7 @@ import h5py
 import numpy as np
 import pytest
 
+import src.data_factory.reader.CSV_Signal as csv_signal_reader
 from src.data_factory import ExplicitDataFactory, build_data
 from src.data_factory.contracts import (
     format_loader_summary,
@@ -527,3 +528,66 @@ def test_cache_dir_owns_all_derived_hdf5_files(
 
     with h5py.File(cache_root / "cache.h5", "r") as h5_file:
         assert set(h5_file.keys()) == {"1", "2"}
+
+
+class _ReaderFailure(ValueError):
+    pass
+
+
+def test_explicit_reader_preserves_original_exception_type(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    raw_dir = tmp_path / "raw" / "CSV_Signal"
+    raw_dir.mkdir(parents=True)
+    (raw_dir / "signal.csv").write_text(
+        "time,sensor_a\n0,1.0\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "metadata.csv").write_text(
+        "Id,Name,File\n1,CSV_Signal,signal.csv\n",
+        encoding="utf-8",
+    )
+    factory = _factory(
+        {1: {"Name": "CSV_Signal", "File": "signal.csv"}}
+    )
+
+    def fail_reader(path, args_data):
+        raise _ReaderFailure("reader contract exploded")
+
+    monkeypatch.setattr(csv_signal_reader, "read", fail_reader)
+
+    with pytest.raises(_ReaderFailure, match="reader contract exploded"):
+        factory._update_name_cache(
+            "CSV_Signal",
+            [1],
+            _args(tmp_path),
+            1,
+        )
+
+    assert not (tmp_path / "CSV_Signal.h5").exists()
+    assert not (tmp_path / ".CSV_Signal.h5.tmp").exists()
+
+
+def test_explicit_reader_raises_for_missing_declared_raw_file(tmp_path: Path) -> None:
+    (tmp_path / "metadata.csv").write_text(
+        "Id,Name,File\n1,CSV_Signal,missing.csv\n",
+        encoding="utf-8",
+    )
+    factory = _factory(
+        {1: {"Name": "CSV_Signal", "File": "missing.csv"}}
+    )
+
+    with pytest.raises(
+        FileNotFoundError,
+        match=r"Raw data file not found for ID 1: .*missing\.csv",
+    ):
+        factory._update_name_cache(
+            "CSV_Signal",
+            [1],
+            _args(tmp_path),
+            1,
+        )
+
+    assert not (tmp_path / "CSV_Signal.h5").exists()
+    assert not (tmp_path / ".CSV_Signal.h5.tmp").exists()


### PR DESCRIPTION
## Objective

Preserve the original raw-reader exception type and traceback on the maintained public Data Factory path.

## Failure invariant

```text
reader failure
→ the same exception escapes Data Factory
→ no dataset cache is published
```

A missing declared raw file is a direct `FileNotFoundError`. A reader's `ValueError`, `FloatingPointError`, or domain-specific exception must not be converted into a string tuple and then a generic `RuntimeError`.

## Changes

- override `ExplicitDataFactory._read_single_data` on the maintained public path;
- resolve exactly `data_dir/raw/<Name>/<File>` and fail immediately when it is absent;
- import the declared reader and call it without catching its exception;
- preserve the existing successful 2D-to-3D cache representation;
- add threaded cache-build tests proving original exception propagation and zero cache publication.

## Boundaries

- no change to successful reader outputs, metadata selection, split, windowing, normalization, cache reuse policy, model, task, trainer, checkpoint, or estimator semantics;
- no new exception hierarchy, wrapper, manager, registry, schema, logger, manifest, hash, receipt, ledger, evidence, or attestation;
- historical non-default Data Factory implementations remain outside this slice.

## Acceptance

- a reader-defined `ValueError` subclass exits `_update_name_cache` unchanged;
- a missing declared raw file raises `FileNotFoundError` containing the selected ID and path;
- neither failure creates or replaces `Name.h5`;
- existing Data Factory contracts, offline smoke, public MFPT three-seed baseline, public package, release-readiness, layout, and submodule gates remain green.
