### PR TITLE
fix(data): validate reader returns before caching

### DIFF
--- a/src/data_factory/explicit_data_factory.py
+++ b/src/data_factory/explicit_data_factory.py
@@ -171,6 +171,43 @@ def _format_split_summary(summary: dict[str, Any]) -> str:
     )
 
 
+def _validate_reader_output(
+    data: Any,
+    *,
+    file_id: Any,
+    file_path: Path,
+) -> np.ndarray:
+    """Validate one successful reader return before publishing derived data."""
+
+    if not isinstance(data, np.ndarray):
+        raise TypeError(
+            f"Reader for ID {file_id} ({file_path}) must return numpy.ndarray; "
+            f"got {type(data).__name__}."
+        )
+    if data.ndim not in {1, 2, 3}:
+        raise ValueError(
+            f"Reader for ID {file_id} ({file_path}) returned shape {data.shape}; "
+            "supported reader ranks are 1, 2, or 3."
+        )
+    if data.size == 0 or any(int(size) <= 0 for size in data.shape):
+        raise ValueError(
+            f"Reader for ID {file_id} ({file_path}) returned empty shape "
+            f"{data.shape}."
+        )
+    if not np.issubdtype(data.dtype, np.number) or np.iscomplexobj(data):
+        raise TypeError(
+            f"Reader for ID {file_id} ({file_path}) must return real numeric "
+            f"samples; got dtype {data.dtype}."
+        )
+    if not np.isfinite(data).all():
+        raise FloatingPointError(
+            f"Reader for ID {file_id} ({file_path}) returned NaN or Inf."
+        )
+    if data.ndim == 2:
+        return np.expand_dims(data, axis=-1)
+    return data
+
+
 class ExplicitDataFactory(data_factory):
     """Build data through explicit adapters and publish only usable data stacks.
 
@@ -208,9 +245,12 @@ class ExplicitDataFactory(data_factory):
             f"src.data_factory.reader.{dataset_name}"
         )
         data = reader.read(str(file_path), args_data)
-        if data.ndim == 2:
-            data = np.expand_dims(data, axis=-1)
-        return file_id, data, None
+        validated = _validate_reader_output(
+            data,
+            file_id=file_id,
+            file_path=file_path,
+        )
+        return file_id, validated, None
 
     def _init_data(self, args_data, use_cache=None, max_workers=32):
         """Read current raw inputs unless cache reuse is explicitly enabled.

--- a/src/data_factory/reader/README.md
+++ b/src/data_factory/reader/README.md
@@ -1,36 +1,13 @@
 # Data Factory Readers
 
-Dataset reader modules convert one metadata-addressed raw file into a NumPy
-signal array. This page documents the behavior implemented by the current data
-factory; it is not a redesign of the reader runtime.
+Dataset reader modules convert one metadata-addressed raw file into a signal array. The
+maintained public Data Factory treats the reader result as scientific input: a reader
+failure remains a failure, and an invalid successful return is rejected before any HDF5
+cache is published.
 
-## Current runtime contract
+## Runtime resolution
 
-The maintained data factory reads each metadata row's `Name` field and imports:
-
-```text
-src.data_factory.reader.<Name>
-```
-
-The imported module must expose a callable compatible with:
-
-```python
-def read(file_path, args_data):
-    """Return one sample as a NumPy array."""
-```
-
-Several historical readers accept `*args` rather than naming `args_data`, but
-the current factory calls every reader with both `file_path` and `args_data`.
-A new reader should therefore accept those two arguments explicitly unless a
-reviewed compatibility reason requires a broader signature.
-
-Reader modules are resolved by module name. They are **not** currently
-registered as `BaseReader` subclasses, and `reader/__init__.py` is not a reader
-registry.
-
-## Metadata and raw-file resolution
-
-The factory requires each selected metadata row to provide at least:
+For each selected metadata row, the public Data Factory requires:
 
 ```text
 Id
@@ -38,87 +15,141 @@ Name
 File
 ```
 
-It constructs the raw path as:
+It resolves:
 
 ```text
+raw file:
 <data.data_dir>/raw/<Name>/<File>
+
+reader module:
+src.data_factory.reader.<Name>
 ```
 
-Example:
+The imported module must expose a callable compatible with:
+
+```python
+def read(file_path, args_data) -> np.ndarray:
+    ...
+```
+
+Historical readers may accept `*args`, but the factory always supplies both the resolved
+raw path and the current `data` configuration.
+
+## Failure contract
+
+The maintained public path does not replace reader exceptions:
 
 ```text
-metadata Name: RM_001_CWRU
-metadata File: 98.mat
-resolved path: <data_dir>/raw/RM_001_CWRU/98.mat
-reader module: src.data_factory.reader.RM_001_CWRU
+missing declared raw file
+→ FileNotFoundError with Id and resolved path
+
+reader raises ValueError / FloatingPointError / domain-specific error
+→ the same exception type and traceback escape Data Factory
+
+any reader failure
+→ no new dataset cache is published
 ```
 
-Other metadata fields such as labels, domains, sampling rate, sample length,
-channel count, and task flags are consumed by metadata selection and task
-adapters rather than being returned in a reader dictionary.
+Readers should raise at the point where source format, required fields, channel order,
+units, or numeric assumptions are violated. They must not return `None`, an empty signal,
+or a substitute signal to keep the experiment running.
 
-## Signal return value
+## Successful return contract
 
-A reader returns a NumPy signal array, normally with shape:
+A successful reader must return a `numpy.ndarray` satisfying:
+
+```text
+rank ∈ {1, 2, 3}
+all dimensions > 0
+real numeric dtype
+all values finite
+```
+
+New maintained readers should normally return:
 
 ```text
 (L, C)
 ```
 
-where `L` is signal length and `C` is channel count. The current data factory
-expands a two-dimensional reader result before writing its runtime cache, so
-reader implementations must not add an extra singleton dimension merely to
-anticipate that factory behavior.
+where `L` is signal length and `C` is channel count. Rank-1 and rank-3 arrays remain
+accepted for existing reader compatibility, but a new reader should use them only when
+its documented source semantics require that representation.
+
+The Data Factory does not:
+
+- convert Python lists or arbitrary objects into arrays;
+- coerce string/object samples to numbers;
+- discard NaN or Inf;
+- take real parts of complex signals;
+- pad, repeat, copy, or guess channels;
+- squeeze an unexpected rank into a supported one.
+
+The historical cache representation is preserved:
+
+```text
+reader rank 1 → cached unchanged
+reader rank 2 → singleton axis appended before caching
+reader rank 3 → cached unchanged
+```
+
+The Dataset layer later validates the signal again before windowing. Early reader-output
+validation exists to prevent invalid derived data from being published, not to replace
+Dataset-level window and preprocessing checks.
+
+## Reader documentation
 
 Document for every maintained reader:
 
-- accepted source format and required source keys or columns;
+- accepted source format and required source fields or columns;
 - returned shape and channel ordering;
 - dtype and physical units when known;
 - truncation, alignment, resampling, normalization, or byte-order handling;
-- missing-channel and malformed-input behavior.
+- malformed-input and missing-channel behavior.
 
-Do not change an existing reader's channel order, shape, dtype handling, or
-numeric preprocessing in a repository-cleanup PR.
+Do not change an existing reader's channel order, shape, dtype handling, or numerical
+preprocessing in a cleanup PR. Such changes require a focused scientific bugfix with
+before/after tests.
 
-## Cache flow
+## Derived cache flow
 
-The current factory uses two cache levels:
+The public path uses two derived HDF5 levels:
 
 ```text
 raw/<Name>/<File>
         ↓ reader.read(...)
-<Name>.h5, keyed by Id
+<cache_dir or data_dir>/<Name>.h5, keyed by Id
         ↓ consolidation
-cache.h5, keyed by Id
+<cache_dir or data_dir>/cache.h5, keyed by Id
 ```
 
-If an `Id` already exists in `<Name>.h5`, the raw reader can be skipped. The
-final `cache.h5` contains the IDs selected for the run and is exposed through
-`H5DataDict`.
-
-Reader code must not assume that every training run will execute the raw-file
-conversion path; a compatible prebuilt `<Name>.h5` cache may be used instead.
-
-## Existing readers and support status
-
-Files under this directory include dataset-specific readers such as
-`RM_001_CWRU.py`, `RM_002_XJTU.py`, and `RM_003_FEMTO.py`, plus the offline
-`Dummy_Data.py` reader. File presence alone does not establish maintained or
-benchmark-supported status. Support claims must be backed by the maintained
-configuration registry, focused tests, a runnable demo where applicable, and
-explicit limitations.
-
-`Dummy_Data` can generate deterministic synthetic signals when raw files are
-absent. It remains the fully offline smoke path used by:
+Cache reuse is explicit:
 
 ```text
-configs/demo/00_smoke/dummy_dg.yaml
+data.use_cache omitted or false
+→ execute the current readers and rebuild selected data
+
+data.use_cache true
+→ reuse complete existing HDF5 entries by selected Id
 ```
 
-Historical or placeholder files are retained until a separate inventory proves
-their consumers and disposition; they must not be deleted merely because their
-names overlap with another reader.
+Set `data.use_cache: true` only when raw files, reader code, and reader-relevant
+configuration are intentionally unchanged. The factory does not infer semantic
+equivalence from matching Id keys and does not add cache hashes or provenance machinery.
+
+`data.cache_dir` changes only the location of derived HDF5 files. Metadata and raw files
+continue to resolve from `data.data_dir`.
+
+## Current maintained examples
+
+- `Dummy_Data.py` strictly reads the repository-shipped `ch1` and `ch2` columns. Missing
+  or malformed fixtures fail; no synthetic fallback is generated.
+- `CSV_Signal.py` requires explicit `data.csv_signal_columns` and rejects guessed,
+  non-numeric, empty, or non-finite columns.
+- `RM_007_MFPT.py` validates the public MFPT signal and physical metadata used by the
+  current real-data reference.
+
+File presence alone is not a support claim. Consult `SUPPORTED_COMBINATIONS.md` and the
+configuration registry for the exact execution-verified or baseline-valid combinations.
 
 ## Adding a reader
 
@@ -126,30 +157,19 @@ names overlap with another reader.
 2. Add `src/data_factory/reader/<Name>.py`.
 3. Implement `read(file_path, args_data) -> np.ndarray`.
 4. Place local raw files under `<data_dir>/raw/<Name>/<File>`.
-5. Add or validate metadata rows using the same `Name` and source `File`.
-6. Document source provenance, license, signal contract, and preprocessing.
-7. Add focused parsing, shape, dtype, channel-order, and malformed-input tests.
-8. Run the relevant config inspection and smoke gates before claiming support.
+5. Add metadata rows using the same `Name` and source `File`.
+6. Document source provenance, license, signal contract, channel order, and
+   preprocessing.
+7. Add focused parsing, output-contract, malformed-input, and channel-order tests.
+8. Run the relevant public config and Data Factory gates before making a support claim.
 
-Do not hard-code a personal data directory in the reader's maintained execution
-path. Local paths belong in `configs/local/local.yaml` or CLI overrides.
-
-See [the data-factory contribution guide](../contributing.md) for evidence,
-licensing, configuration, and test requirements.
-
-## PHMFactory v0.3 preservation boundary
-
-The v0.3 repository cleanup preserves reader module paths and runtime behavior.
-The protected contract is recorded in
-[`docs/PHMFACTORY_V0_3_READER_PRESERVATION.md`](../../../docs/PHMFACTORY_V0_3_READER_PRESERVATION.md).
-
-Changes to reader parsing or numerical behavior require a separate bugfix or
-feature PR with before/after evidence. Documentation cleanup does not authorize
-runtime refactoring.
+Do not hard-code a personal path or modify Model, Task, Trainer, Pipeline, or CLI code to
+add a compatible reader.
 
 ## Related documentation
 
-- [Data directory and external-data boundary](../../../data/README.md)
-- [Data factory overview](../README.md)
-- [Data factory contribution guide](../contributing.md)
-- [Configuration guide](../../../configs/README.md)
+- [Data base configuration](../../../configs/base/data/README.md)
+- [Data directory and external-source boundary](../../../data/README.md)
+- [Data Factory overview](../README.md)
+- [Data Factory contribution guide](../contributing.md)
+- [v0.3 reader preservation boundary](../../../docs/PHMFACTORY_V0_3_READER_PRESERVATION.md)

--- a/test/test_data_cache_contract.py
+++ b/test/test_data_cache_contract.py
@@ -591,3 +591,107 @@ def test_explicit_reader_raises_for_missing_declared_raw_file(tmp_path: Path) ->
 
     assert not (tmp_path / "CSV_Signal.h5").exists()
     assert not (tmp_path / ".CSV_Signal.h5.tmp").exists()
+
+
+def _reader_output_fixture(tmp_path: Path) -> tuple[ExplicitDataFactory, Path]:
+    raw_dir = tmp_path / "raw" / "CSV_Signal"
+    raw_dir.mkdir(parents=True)
+    raw_path = raw_dir / "signal.csv"
+    raw_path.write_text("placeholder\n", encoding="utf-8")
+    return (
+        _factory({1: {"Name": "CSV_Signal", "File": "signal.csv"}}),
+        raw_path,
+    )
+
+
+@pytest.mark.parametrize(
+    ("reader_value", "error_type", "message"),
+    [
+        (None, TypeError, "must return numpy.ndarray"),
+        ([1.0, 2.0], TypeError, "must return numpy.ndarray"),
+        (np.array(["bad"]), TypeError, "real numeric samples"),
+        (
+            np.array([[1.0 + 2.0j]], dtype=np.complex64),
+            TypeError,
+            "real numeric samples",
+        ),
+        (
+            np.empty((0, 1), dtype=np.float32),
+            ValueError,
+            "returned empty shape",
+        ),
+        (
+            np.ones((1, 1, 1, 1), dtype=np.float32),
+            ValueError,
+            "supported reader ranks",
+        ),
+        (
+            np.array([[np.nan]], dtype=np.float32),
+            FloatingPointError,
+            "returned NaN or Inf",
+        ),
+        (
+            np.array([[np.inf]], dtype=np.float32),
+            FloatingPointError,
+            "returned NaN or Inf",
+        ),
+    ],
+)
+def test_invalid_reader_outputs_fail_before_cache_publication(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    reader_value,
+    error_type: type[BaseException],
+    message: str,
+) -> None:
+    factory, _ = _reader_output_fixture(tmp_path)
+    monkeypatch.setattr(
+        csv_signal_reader,
+        "read",
+        lambda path, args_data: reader_value,
+    )
+
+    with pytest.raises(error_type, match=message):
+        factory._update_name_cache(
+            "CSV_Signal",
+            [1],
+            _args(tmp_path),
+            1,
+        )
+
+    assert not (tmp_path / "CSV_Signal.h5").exists()
+    assert not (tmp_path / ".CSV_Signal.h5.tmp").exists()
+
+
+@pytest.mark.parametrize(
+    ("reader_value", "expected_shape"),
+    [
+        (np.arange(4, dtype=np.float32), (4,)),
+        (np.ones((4, 2), dtype=np.float32), (4, 2, 1)),
+        (np.ones((4, 2, 1), dtype=np.float32), (4, 2, 1)),
+    ],
+)
+def test_valid_reader_ranks_preserve_existing_cache_representation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    reader_value: np.ndarray,
+    expected_shape: tuple[int, ...],
+) -> None:
+    factory, raw_path = _reader_output_fixture(tmp_path)
+    monkeypatch.setattr(
+        csv_signal_reader,
+        "read",
+        lambda path, args_data: reader_value,
+    )
+
+    file_id, observed, error = factory._read_single_data(
+        1,
+        {"Name": "CSV_Signal", "File": "signal.csv"},
+        _args(tmp_path),
+    )
+
+    assert file_id == 1
+    assert error is None
+    assert observed.shape == expected_shape
+    assert observed.dtype == reader_value.dtype
+    assert raw_path.is_file()


### PR DESCRIPTION
## Objective

Reject invalid successful reader returns before they can become derived HDF5 data on the maintained public Data Factory path.

## Scientific invariant

```text
successful reader return
= non-empty finite real numeric NumPy signal
with a supported rank
```

Reader exceptions remain unchanged. This PR addresses the separate case where a reader returns normally but returns `None`, a Python container, an unsupported rank, an empty array, non-numeric or complex samples, or NaN/Inf.

## Changes

- validate the public reader return immediately after `reader.read(...)`;
- require `numpy.ndarray`, rank 1/2/3, positive dimensions, real numeric dtype, and finite values;
- preserve existing valid cache representation: rank 1 unchanged, rank 2 gains the historical singleton axis, rank 3 unchanged;
- fail before creating or replacing `<Name>.h5` for every invalid return;
- add parameterized threaded cache-build tests covering invalid types, dtypes, ranks, empty arrays, NaN, and Inf;
- document the current reader, exception, output-shape, and explicit cache-reuse contracts without adding new infrastructure.

## Boundaries

- no conversion of arbitrary Python objects into arrays;
- no dtype coercion, real-part extraction, padding, repeat, channel copying, squeeze, or shape repair;
- no change to a valid reader's samples or existing rank transformation;
- no change to metadata selection, split, windowing, normalization, Model, Task, Trainer, checkpoint, or estimator semantics;
- no validator class, schema, manager, registry, wrapper, hash, checksum, digest, receipt, ledger, evidence, or attestation.

## Acceptance

- invalid successful returns fail at the reader/Data Factory boundary with ID and raw path;
- no invalid return publishes or replaces a dataset cache;
- reader-thrown exceptions continue to propagate unchanged;
- valid historical rank-1/2/3 arrays preserve their existing cached shapes;
- Data Factory contract tests, offline smoke, public MFPT three-seed baseline, public package, release readiness, layout, and submodule gates remain green.
