### PR TITLE
fix(model): preserve constructor exceptions

### DIFF
--- a/src/model_factory/model_factory.py
+++ b/src/model_factory/model_factory.py
@@ -20,9 +20,10 @@ def resolve_model_module(args_model: Any) -> str:
 def model_factory(args_model: Any, metadata: Any):
     """Instantiate a model by name and load an explicitly configured checkpoint.
 
-    A configured checkpoint is part of the requested experiment. If it cannot be
-    loaded, model construction fails instead of continuing with random or partial
-    initialization.
+    Model import and construction failures retain their original exception type and
+    traceback. A configured checkpoint is part of the requested experiment. If it
+    cannot be loaded, model construction fails instead of continuing with random or
+    partial initialization.
     """
     # Validate every label ontology that is actually supplied, even when
     # num_classes was configured manually. Some isolated model/checkpoint uses
@@ -52,13 +53,7 @@ def model_factory(args_model: Any, metadata: Any):
     module_path = resolve_model_module(args_model)
     model_module = importlib.import_module(module_path)
     model_cls = model_module.Model
-
-    try:
-        model = model_cls(args_model, metadata)
-    except Exception as exc:
-        raise RuntimeError(
-            f"Failed to create model '{args_model.type}.{args_model.name}': {exc}"
-        ) from exc
+    model = model_cls(args_model, metadata)
 
     weights_path = getattr(args_model, "weights_path", None)
     if weights_path:

--- a/test/test_device_authority.py
+++ b/test/test_device_authority.py
@@ -16,6 +16,10 @@ def _default_trainer_module():
     return importlib.import_module("src.trainer_factory.Default_trainer")
 
 
+def _model_factory_module():
+    return importlib.import_module("src.model_factory.model_factory")
+
+
 class TrackingNetwork(nn.Module):
     def __init__(self) -> None:
         super().__init__()
@@ -191,3 +195,35 @@ def test_default_trainer_passes_resolved_cpu_request_to_lightning(
     assert result["devices"] == 1
     assert result["strategy"] == "auto"
     assert observed["accelerator"] == "cpu"
+
+
+def test_model_factory_preserves_constructor_exception_type(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = _model_factory_module()
+
+    class ModelConstructorFailure(ValueError):
+        pass
+
+    class BrokenModel:
+        def __init__(self, args_model, metadata):
+            del args_model, metadata
+            raise ModelConstructorFailure("invalid model dimensions")
+
+    monkeypatch.setattr(
+        module.importlib,
+        "import_module",
+        lambda path: Namespace(Model=BrokenModel),
+    )
+    args_model = Namespace(
+        type="Broken",
+        name="Model",
+        num_classes=2,
+        weights_path=None,
+    )
+
+    with pytest.raises(
+        ModelConstructorFailure,
+        match="invalid model dimensions",
+    ):
+        module.model_factory(args_model, metadata=None)


### PR DESCRIPTION
## Objective

Preserve the original model-constructor exception type and traceback on the maintained Model Factory path.

## Failure invariant

```text
Model(args_model, metadata) fails
→ the same exception escapes Model Factory
→ no generic construction wrapper replaces it
```

A model-specific `ValueError`, `TypeError`, shape error, or dependency error is the most precise explanation of why the requested model could not be constructed.

## Changes

- remove the broad `try/except Exception` around `model_cls(args_model, metadata)`;
- state the original-error contract in the Model Factory docstring;
- add a focused regression test to the existing core factory/device authority gate, using a custom `ValueError` subclass to prove exact type preservation.

## Boundaries

- no change to model selection, import path, label ontology, `num_classes` inference, parameters, forward behavior, device ownership, or metadata semantics;
- no change to checkpoint strict/non-strict loading in this PR;
- no new exception hierarchy, wrapper, manager, registry, schema, fallback, hash, checksum, digest, receipt, ledger, evidence, or attestation.

## Acceptance

- a model-defined exception escapes `model_factory(...)` unchanged;
- missing model modules and missing `Model` symbols retain their native import/attribute failures;
- valid maintained models construct exactly as before;
- offline smoke, Model/Task/Trainer authority tests, MFPT baseline, public package, release readiness, repository layout, and submodule policy remain green.
