### PR TITLE
fix(model): preserve checkpoint exceptions

### DIFF
--- a/src/model_factory/model_factory.py
+++ b/src/model_factory/model_factory.py
@@ -20,10 +20,10 @@ def resolve_model_module(args_model: Any) -> str:
 def model_factory(args_model: Any, metadata: Any):
     """Instantiate a model by name and load an explicitly configured checkpoint.
 
-    Model import and construction failures retain their original exception type and
-    traceback. A configured checkpoint is part of the requested experiment. If it
-    cannot be loaded, model construction fails instead of continuing with random or
-    partial initialization.
+    Model import, construction, and checkpoint failures retain their original
+    exception type and traceback. A configured checkpoint is part of the requested
+    experiment. If it cannot be loaded, model construction fails instead of continuing
+    with random or partial initialization.
     """
     # Validate every label ontology that is actually supplied, even when
     # num_classes was configured manually. Some isolated model/checkpoint uses
@@ -58,20 +58,7 @@ def model_factory(args_model: Any, metadata: Any):
     weights_path = getattr(args_model, "weights_path", None)
     if weights_path:
         strict = bool(getattr(args_model, "weights_strict", True))
-        try:
-            load_ckpt(model, weights_path, strict=strict)
-        except FileNotFoundError:
-            raise
-        except Exception as exc:
-            suggestion = (
-                "Check that the checkpoint belongs to this model. "
-                "For intentional transfer learning with a compatible subset of "
-                "parameters, set model.weights_strict=false."
-            )
-            raise RuntimeError(
-                f"Failed to load checkpoint '{weights_path}' for model "
-                f"'{args_model.type}.{args_model.name}': {exc}. {suggestion}"
-            ) from exc
+        load_ckpt(model, weights_path, strict=strict)
 
     return model
 

--- a/test/test_device_authority.py
+++ b/test/test_device_authority.py
@@ -227,3 +227,40 @@ def test_model_factory_preserves_constructor_exception_type(
         match="invalid model dimensions",
     ):
         module.model_factory(args_model, metadata=None)
+
+
+def test_model_factory_preserves_checkpoint_exception_type(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = _model_factory_module()
+
+    class CheckpointLoadFailure(OSError):
+        pass
+
+    class ValidModel:
+        def __init__(self, args_model, metadata):
+            del args_model, metadata
+
+    def fail_checkpoint(model, path, *, strict):
+        del model, path, strict
+        raise CheckpointLoadFailure("checkpoint tensor layout is invalid")
+
+    monkeypatch.setattr(
+        module.importlib,
+        "import_module",
+        lambda path: Namespace(Model=ValidModel),
+    )
+    monkeypatch.setattr(module, "load_ckpt", fail_checkpoint)
+    args_model = Namespace(
+        type="Valid",
+        name="Model",
+        num_classes=2,
+        weights_path="requested.ckpt",
+        weights_strict=True,
+    )
+
+    with pytest.raises(
+        CheckpointLoadFailure,
+        match="checkpoint tensor layout is invalid",
+    ):
+        module.model_factory(args_model, metadata=None)


### PR DESCRIPTION
## Objective

Preserve the original checkpoint-loading exception type and traceback on the maintained Model Factory path.

## Failure invariant

```text
configured checkpoint cannot be loaded
→ the exact load failure escapes Model Factory
→ no generic wrapper replaces it
→ the model is not returned as a successful construction
```

`load_ckpt(...)` already provides path-specific errors for missing files, invalid checkpoint mappings, zero compatible parameters, and explicit strict/non-strict loading. Wrapping all remaining failures as a new `RuntimeError` hides useful exception types from PyTorch, filesystem, and model-specific loading code.

## Changes

- call `load_ckpt(...)` directly from `model_factory(...)`;
- update the factory docstring to include checkpoint failures in the original-error contract;
- add a focused regression test using a custom `OSError` subclass to prove exact exception preservation.

## Boundaries

- strict loading remains the default;
- `weights_strict=false` still requires at least one same-name, same-shape parameter;
- missing checkpoint files, state-dict extraction, key matching, parameter shapes, and successful loading are unchanged;
- no fallback to random initialization, no partial loading unless explicitly requested, and no change to model construction or device ownership;
- no new exception hierarchy, wrapper, manager, registry, schema, hash, checksum, digest, receipt, ledger, evidence, or attestation.

## Acceptance

- a checkpoint loader exception escapes `model_factory(...)` unchanged;
- `FileNotFoundError`, invalid mapping errors, strict state-dict failures, and zero-match failures remain fail-fast;
- valid checkpoints load exactly as before;
- core offline smoke, Model/Task/Trainer authority tests, UXFD, layout, and submodule policy remain green.
