### PR TITLE
fix(model): require explicit checkpoint strictness

### DIFF
--- a/src/model_factory/README.md
+++ b/src/model_factory/README.md
@@ -71,7 +71,38 @@ model_module = importlib.import_module(
 model = model_module.Model(args_model, metadata)
 ```
 
-If `weights_path` is provided, the factory will load that checkpoint into the model.
+If `weights_path` is provided, the factory loads that checkpoint into the model.
+Construction and checkpoint exceptions retain their original type and traceback.
+
+### 2.3 Checkpoint strictness
+
+Checkpoint loading is strict by default:
+
+```yaml
+model:
+  weights_path: "/path/to/checkpoint.ckpt"
+  weights_strict: true
+```
+
+Use `weights_strict: false` only for an intentional transfer-learning run. Non-strict
+loading still requires at least one parameter with the same name and shape; zero matches
+fail instead of continuing with random initialization.
+
+`weights_strict` must be a YAML boolean:
+
+```yaml
+weights_strict: true   # valid
+weights_strict: false  # valid
+```
+
+Do not quote it:
+
+```yaml
+weights_strict: "false"  # invalid string, fails before checkpoint loading
+```
+
+PHMFactory does not interpret strings, integers, or other truthy/falsy values as a
+checkpoint policy.
 
 ## 3. Recommended demo configuration (current)
 

--- a/src/model_factory/model_factory.py
+++ b/src/model_factory/model_factory.py
@@ -57,7 +57,12 @@ def model_factory(args_model: Any, metadata: Any):
 
     weights_path = getattr(args_model, "weights_path", None)
     if weights_path:
-        strict = bool(getattr(args_model, "weights_strict", True))
+        strict = getattr(args_model, "weights_strict", True)
+        if not isinstance(strict, bool):
+            raise TypeError(
+                "model.weights_strict must be a boolean; use true for exact "
+                "checkpoint loading or false for an explicitly compatible subset"
+            )
         load_ckpt(model, weights_path, strict=strict)
 
     return model

--- a/test/test_device_authority.py
+++ b/test/test_device_authority.py
@@ -264,3 +264,74 @@ def test_model_factory_preserves_checkpoint_exception_type(
         match="checkpoint tensor layout is invalid",
     ):
         module.model_factory(args_model, metadata=None)
+
+
+@pytest.mark.parametrize("strict", [True, False])
+def test_model_factory_passes_explicit_checkpoint_strictness(
+    monkeypatch: pytest.MonkeyPatch,
+    strict: bool,
+) -> None:
+    module = _model_factory_module()
+    observed: list[bool] = []
+
+    class ValidModel:
+        def __init__(self, args_model, metadata):
+            del args_model, metadata
+
+    monkeypatch.setattr(
+        module.importlib,
+        "import_module",
+        lambda path: Namespace(Model=ValidModel),
+    )
+    monkeypatch.setattr(
+        module,
+        "load_ckpt",
+        lambda model, path, *, strict: observed.append(strict),
+    )
+    args_model = Namespace(
+        type="Valid",
+        name="Model",
+        num_classes=2,
+        weights_path="requested.ckpt",
+        weights_strict=strict,
+    )
+
+    module.model_factory(args_model, metadata=None)
+
+    assert observed == [strict]
+
+
+def test_model_factory_rejects_non_boolean_checkpoint_strictness(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = _model_factory_module()
+
+    class ValidModel:
+        def __init__(self, args_model, metadata):
+            del args_model, metadata
+
+    monkeypatch.setattr(
+        module.importlib,
+        "import_module",
+        lambda path: Namespace(Model=ValidModel),
+    )
+    monkeypatch.setattr(
+        module,
+        "load_ckpt",
+        lambda *args, **kwargs: pytest.fail(
+            "checkpoint loading must not start for invalid weights_strict"
+        ),
+    )
+    args_model = Namespace(
+        type="Valid",
+        name="Model",
+        num_classes=2,
+        weights_path="requested.ckpt",
+        weights_strict="false",
+    )
+
+    with pytest.raises(
+        TypeError,
+        match="model.weights_strict must be a boolean",
+    ):
+        module.model_factory(args_model, metadata=None)


### PR DESCRIPTION
## Objective

Prevent truthiness coercion from changing the requested checkpoint-loading policy.

## Scientific invariant

```text
model.weights_strict=true  → exact state-dict loading
model.weights_strict=false → explicit compatible-subset loading
any other value            → fail before checkpoint loading
```

The previous `bool(value)` conversion made values such as the string `"false"` evaluate to `True`, so the executed loading policy could differ from the visible configuration.

## Changes

- read `model.weights_strict` without coercion;
- require it to be a real boolean whenever `weights_path` is configured;
- pass explicit `True` and `False` unchanged to `load_ckpt(...)`;
- add regression tests proving both valid modes and rejection before checkpoint I/O for non-boolean values;
- document strict default, explicit transfer-learning mode, zero-match failure, and correct YAML syntax.

## Boundaries

- no change to model construction, checkpoint path resolution, strict state-dict behavior, compatible-parameter matching, zero-match failure, or successful weights;
- no automatic parsing of strings, integers, environment values, or truthy/falsy objects;
- no fallback to random initialization and no implicit partial loading;
- no new schema, manager, wrapper, registry, hash, checksum, digest, receipt, ledger, evidence, or attestation.

## Acceptance

- omitted `weights_strict` remains strict by default;
- explicit booleans reach `load_ckpt(...)` unchanged;
- `weights_strict: "false"` raises `TypeError` before loading starts;
- existing strict/non-strict checkpoint contracts, offline smoke, UXFD, docs/config checks, layout, and submodule policy remain green.
