### PR TITLE
fix(task): preserve constructor exceptions

### DIFF
--- a/src/task_factory/task_factory.py
+++ b/src/task_factory/task_factory.py
@@ -77,26 +77,18 @@ def task_factory(
     args_environment: Namespace,
     metadata: Any,
 ) -> pl.LightningModule:
-    """Instantiate one task or raise at the task factory boundary."""
+    """Instantiate one task while preserving constructor failures."""
 
-    key = f"{args_task.type}.{args_task.name}"
     task_class = _resolve_task_class(args_task)
-    try:
-        return task_class(
-            network=network,
-            args_data=args_data,
-            args_model=args_model,
-            args_task=args_task,
-            args_trainer=args_trainer,
-            args_environment=args_environment,
-            metadata=metadata,
-        )
-    except Exception as exc:
-        class_name = getattr(task_class, "__name__", type(task_class).__name__)
-        raise RuntimeError(
-            f"Cannot construct task {key!r} with {class_name}: {exc}. Check "
-            "the task configuration and constructor arguments."
-        ) from exc
+    return task_class(
+        network=network,
+        args_data=args_data,
+        args_model=args_model,
+        args_task=args_task,
+        args_trainer=args_trainer,
+        args_environment=args_environment,
+        metadata=metadata,
+    )
 
 
 __all__ = [

--- a/test/test_classification_runtime.py
+++ b/test/test_classification_runtime.py
@@ -363,11 +363,12 @@ def test_task_module_requires_registration_or_task_symbol(
         )
 
 
-def test_task_construction_failure_is_raised_with_original_cause(
+def test_task_construction_failure_preserves_original_exception(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     class BrokenTask:
         def __init__(self, **kwargs):
+            del kwargs
             raise ValueError("invalid task dimensions")
 
     monkeypatch.setattr(
@@ -376,10 +377,7 @@ def test_task_construction_failure_is_raised_with_original_cause(
         lambda key: BrokenTask,
     )
 
-    with pytest.raises(
-        RuntimeError,
-        match="Cannot construct task 'DG.classification'.*invalid task dimensions",
-    ) as captured:
+    with pytest.raises(ValueError, match="invalid task dimensions"):
         task_factory_module.task_factory(
             args_task=SimpleNamespace(type="DG", name="classification"),
             network=object(),
@@ -389,8 +387,6 @@ def test_task_construction_failure_is_raised_with_original_cause(
             args_environment=SimpleNamespace(),
             metadata={},
         )
-
-    assert isinstance(captured.value.__cause__, ValueError)
 
 
 def test_trainer_import_failure_preserves_requested_module_and_cause(

--- a/test/test_device_authority.py
+++ b/test/test_device_authority.py
@@ -20,6 +20,10 @@ def _model_factory_module():
     return importlib.import_module("src.model_factory.model_factory")
 
 
+def _task_factory_module():
+    return importlib.import_module("src.task_factory.task_factory")
+
+
 class TrackingNetwork(nn.Module):
     def __init__(self) -> None:
         super().__init__()
@@ -335,3 +339,37 @@ def test_model_factory_rejects_non_boolean_checkpoint_strictness(
         match="model.weights_strict must be a boolean",
     ):
         module.model_factory(args_model, metadata=None)
+
+
+def test_task_factory_preserves_constructor_exception_type(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = _task_factory_module()
+
+    class TaskConstructorFailure(ValueError):
+        pass
+
+    class BrokenTask:
+        def __init__(self, **kwargs):
+            del kwargs
+            raise TaskConstructorFailure("invalid task objective")
+
+    monkeypatch.setattr(
+        module,
+        "_resolve_task_class",
+        lambda args_task: BrokenTask,
+    )
+
+    with pytest.raises(
+        TaskConstructorFailure,
+        match="invalid task objective",
+    ):
+        module.task_factory(
+            args_task=Namespace(type="DG", name="classification"),
+            network=nn.Identity(),
+            args_data=Namespace(),
+            args_model=Namespace(),
+            args_trainer=Namespace(),
+            args_environment=Namespace(),
+            metadata={},
+        )

--- a/test/test_device_authority.py
+++ b/test/test_device_authority.py
@@ -20,10 +20,6 @@ def _model_factory_module():
     return importlib.import_module("src.model_factory.model_factory")
 
 
-def _task_factory_module():
-    return importlib.import_module("src.task_factory.task_factory")
-
-
 class TrackingNetwork(nn.Module):
     def __init__(self) -> None:
         super().__init__()
@@ -339,37 +335,3 @@ def test_model_factory_rejects_non_boolean_checkpoint_strictness(
         match="model.weights_strict must be a boolean",
     ):
         module.model_factory(args_model, metadata=None)
-
-
-def test_task_factory_preserves_constructor_exception_type(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    module = _task_factory_module()
-
-    class TaskConstructorFailure(ValueError):
-        pass
-
-    class BrokenTask:
-        def __init__(self, **kwargs):
-            del kwargs
-            raise TaskConstructorFailure("invalid task objective")
-
-    monkeypatch.setattr(
-        module,
-        "_resolve_task_class",
-        lambda args_task: BrokenTask,
-    )
-
-    with pytest.raises(
-        TaskConstructorFailure,
-        match="invalid task objective",
-    ):
-        module.task_factory(
-            args_task=Namespace(type="DG", name="classification"),
-            network=nn.Identity(),
-            args_data=Namespace(),
-            args_model=Namespace(),
-            args_trainer=Namespace(),
-            args_environment=Namespace(),
-            metadata={},
-        )


### PR DESCRIPTION
## Objective

Preserve the original task-constructor exception type and traceback on the maintained Task Factory path.

## Failure invariant

```text
resolved task class cannot be constructed
→ the exact task error escapes Task Factory
→ no generic RuntimeError replaces it
```

Task implementations own objective, metric, label, and task-specific configuration semantics. Their native `ValueError`, `TypeError`, numerical error, or dependency failure is more precise than a factory-level wrapper.

## Changes

- remove the broad `try/except Exception` around the resolved task class constructor;
- document the constructor-error behavior in the public factory function;
- add a focused regression test using a custom `ValueError` subclass.

## Boundaries

- task lookup, registry behavior, historical module paths, import diagnostics, constructor arguments, network, metadata, objective, metrics, optimizer, and device ownership are unchanged;
- task import errors remain outside this PR;
- no fallback task, default objective, exception hierarchy, wrapper, manager, schema, registry expansion, hash, checksum, digest, receipt, ledger, evidence, or attestation.

## Acceptance

- a task-defined constructor exception escapes `task_factory(...)` unchanged;
- valid maintained tasks construct exactly as before;
- missing task modules and missing historical `task` symbols retain current fail-fast behavior;
- core offline smoke, Task/Model/Trainer authority tests, UXFD, docs/config checks, layout, and submodule policy remain green.
