### PR TITLE
fix(trainer): preserve builder exceptions

### DIFF
--- a/src/trainer_factory/trainer_factory.py
+++ b/src/trainer_factory/trainer_factory.py
@@ -73,26 +73,15 @@ def trainer_factory(
     args_data: Namespace,
     path: str,
 ) -> pl.Trainer:
-    """Instantiate one trainer or raise at the trainer factory boundary."""
+    """Instantiate one trainer while preserving builder failures."""
 
-    name, trainer_function = _resolve_trainer_function(args_trainer)
-    try:
-        return trainer_function(
-            args_e=args_environment,
-            args_t=args_trainer,
-            args_d=args_data,
-            path=path,
-        )
-    except Exception as exc:
-        function_name = getattr(
-            trainer_function,
-            "__name__",
-            type(trainer_function).__name__,
-        )
-        raise RuntimeError(
-            f"Cannot construct trainer {name!r} with {function_name}: {exc}. "
-            "Check trainer settings, device availability, and output path."
-        ) from exc
+    _, trainer_function = _resolve_trainer_function(args_trainer)
+    return trainer_function(
+        args_e=args_environment,
+        args_t=args_trainer,
+        args_d=args_data,
+        path=path,
+    )
 
 
 __all__ = [

--- a/test/test_classification_runtime.py
+++ b/test/test_classification_runtime.py
@@ -420,10 +420,11 @@ def test_trainer_import_failure_preserves_requested_module_and_cause(
     assert isinstance(captured.value.__cause__, ModuleNotFoundError)
 
 
-def test_trainer_construction_failure_is_raised_with_original_cause(
+def test_trainer_construction_failure_preserves_original_exception(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     def broken_trainer(**kwargs):
+        del kwargs
         raise OSError("output path is read-only")
 
     monkeypatch.setattr(
@@ -432,15 +433,10 @@ def test_trainer_construction_failure_is_raised_with_original_cause(
         lambda key: broken_trainer,
     )
 
-    with pytest.raises(
-        RuntimeError,
-        match="Cannot construct trainer 'Default_trainer'.*output path is read-only",
-    ) as captured:
+    with pytest.raises(OSError, match="output path is read-only"):
         trainer_factory_module.trainer_factory(
             args_environment=SimpleNamespace(),
             args_trainer=SimpleNamespace(name="Default_trainer"),
             args_data=SimpleNamespace(),
             path="results/run",
         )
-
-    assert isinstance(captured.value.__cause__, OSError)


### PR DESCRIPTION
## Objective

Preserve the original trainer-builder exception type and traceback on the maintained Trainer Factory path.

## Failure invariant

```text
resolved trainer builder cannot create the requested Trainer
→ the exact builder error escapes Trainer Factory
→ no generic RuntimeError replaces it
```

Trainer builders own device availability, callback, logger, checkpoint, output-path, and Lightning-construction semantics. Their native `OSError`, `ValueError`, `TypeError`, or framework error is more precise than a factory-level wrapper.

## Changes

- remove the broad `try/except Exception` around the resolved trainer builder;
- document the builder-error behavior in `trainer_factory(...)`;
- update the existing Trainer Factory contract test to make the native `OSError` authoritative.

## Boundaries

- trainer lookup, registry behavior, historical module paths, import diagnostics, builder arguments, device resolution, callbacks, loggers, checkpoints, and Lightning behavior are unchanged;
- trainer import errors remain outside this PR;
- no fallback trainer, exception hierarchy, wrapper, manager, schema, registry expansion, hash, checksum, digest, receipt, ledger, evidence, or attestation.

## Acceptance

- a trainer-defined builder exception escapes `trainer_factory(...)` unchanged;
- valid maintained trainers construct exactly as before;
- missing trainer modules and missing historical `trainer` symbols retain current fail-fast behavior;
- core offline smoke, Model/Task/Trainer authority tests, UXFD, docs/config checks, layout, and submodule policy remain green.
