### PR TITLE
fix(data): make normal runs strictly local and format-explicit

### DIFF
--- a/src/data_factory/data_utils.py
+++ b/src/data_factory/data_utils.py
@@ -1,239 +1,207 @@
+from __future__ import annotations
+
 import os
-import pandas as pd
-from typing import Union, Optional
+from pathlib import Path
 import subprocess
-import sys
+from typing import Optional
+
+import pandas as pd
 
 
-def download_data(data_file: Optional[str] = "metadata.xlsx",
-                       save_path: Optional[str] = './data/',
-                       source: str = 'auto') -> bool:
+def download_data(
+    data_file: Optional[str] = "metadata.xlsx",
+    save_path: Optional[str] = "./data/",
+    source: str = "auto",
+) -> bool:
+    """Explicitly download one data file from a configured remote provider.
+
+    This helper is retained for explicit provider workflows. The maintained
+    ``ExplicitDataFactory`` never calls it during a normal local run.
     """
-    下载元数据文件，支持 ModelScope 和 Hugging Face 两种源
-    Args:
-        data_file: 数据文件名，默认为 "metadata_6_1.xlsx"
-        save_path: 保存路径，默认为当前目录
-        source: 下载源，'modelscope', 'huggingface' 或 'auto'
-        
-    Returns:
-        bool: 下载是否成功
-    """
 
-    # 创建保存目录
     os.makedirs(save_path, exist_ok=True)
-    check_exists = os.path.exists(os.path.join(save_path, data_file))
-    if check_exists:
-        print(f"[INFO] 检查缓存文件: 数据文件已存在: {os.path.join(save_path, data_file)} ")
+    target = os.path.join(save_path, data_file)
+    if os.path.exists(target):
+        print(f"[INFO] 数据文件已存在: {target}")
         return True
-    
-    success = False
 
-    if source == 'auto' or source == 'modelscope':
-        print(f"[INFO] 检查缓存文件, 尝试从 ModelScope 下载 {data_file}...")
+    success = False
+    if source in {"auto", "modelscope"}:
+        print(f"[INFO] 尝试从 ModelScope 下载 {data_file}...")
         try:
-            # 使用 modelscope 下载
-            cmd = f"modelscope download --dataset PHMbench/PHM-Vibench {data_file} --local_dir {save_path}"
-            result = subprocess.run(cmd, shell=True, capture_output=True, text=True, timeout=300)
+            command = (
+                "modelscope download --dataset PHMbench/PHM-Vibench "
+                f"{data_file} --local_dir {save_path}"
+            )
+            result = subprocess.run(
+                command,
+                shell=True,
+                capture_output=True,
+                text=True,
+                timeout=300,
+            )
             if result.returncode == 0:
                 print(f"[SUCCESS] 从 ModelScope 成功下载 {data_file}")
                 success = True
             else:
                 print(f"[WARNING] ModelScope 下载失败: {result.stderr}")
+        except (subprocess.TimeoutExpired, FileNotFoundError) as exc:
+            print(f"[WARNING] ModelScope 下载失败: {exc}")
 
-        except (subprocess.TimeoutExpired, FileNotFoundError, Exception) as e:
-            print(f"[WARNING] ModelScope 下载失败: {e}")
-    
-    # 如果 ModelScope 失败，尝试 Hugging Face
-    if not success and (source == 'auto' or source == 'huggingface'):
+    if not success and source in {"auto", "huggingface"}:
         print(f"[INFO] 尝试从 Hugging Face 下载 {data_file}...")
         try:
-            
-            # 使用 huggingface_hub 下载
             from huggingface_hub import hf_hub_download
-            
-            downloaded_file = hf_hub_download(
+
+            hf_hub_download(
                 repo_id="PHMbench/PHM-Vibench",
                 filename=data_file,
                 repo_type="dataset",
                 local_dir=save_path,
-                local_dir_use_symlinks=False
+                local_dir_use_symlinks=False,
             )
             print(f"[SUCCESS] 从 Hugging Face 成功下载 {data_file}")
             success = True
-            
         except ImportError:
-            print("[WARNING] huggingface_hub 未安装，请运行: pip install huggingface_hub")
-        except Exception as e:
-            print(f"[WARNING] Hugging Face 下载失败: {e}")
-    
+            print("[WARNING] huggingface_hub 未安装")
+        except Exception as exc:
+            print(f"[WARNING] Hugging Face 下载失败: {exc}")
+
     if not success:
-        print(f"[ERROR] 所有下载源都失败，无法下载 {data_file}")
-        print("[INFO] 请手动下载元数据文件或检查网络连接")
-    
+        print(f"[ERROR] 无法下载 {data_file}")
     return success
 
-if __name__ == "__main__":
-    # 测试下载功能
-    download_data(data_file=" 'RM_006_THU.h5'", save_path="./data/", source='auto')
-    print("测试完成")
+
+def _metadata_encoding(value: object | None) -> str:
+    if value is None:
+        return "utf-8-sig"
+    if not isinstance(value, str) or not value.strip():
+        raise TypeError(
+            "data.metadata_encoding must be a non-empty encoding name when provided"
+        )
+    return value.strip()
 
 
+def read_metadata_table(
+    file_path: str | os.PathLike[str],
+    *,
+    encoding: object | None = None,
+) -> pd.DataFrame:
+    """Read one declared local metadata file with extension-defined semantics.
+
+    ``.csv`` means comma-separated text and ``.tsv`` means tab-separated text.
+    Both default to UTF-8 with optional BOM. Excel files use pandas' Excel
+    reader. The function never guesses a separator, drops undecodable bytes, or
+    tries a second encoding after a parse failure.
+    """
+
+    path = Path(file_path)
+    if not path.is_file():
+        raise FileNotFoundError(
+            f"Metadata file not found: {path}. Set data.data_dir and "
+            "data.metadata_file to an existing local file. Normal runs do not "
+            "download replacement metadata."
+        )
+
+    suffix = path.suffix.lower()
+    if suffix in {".xlsx", ".xls"}:
+        if encoding is not None:
+            raise ValueError(
+                "data.metadata_encoding applies only to .csv and .tsv metadata"
+            )
+        return pd.read_excel(path)
+
+    if suffix == ".csv":
+        separator = ","
+    elif suffix == ".tsv":
+        separator = "\t"
+    else:
+        raise ValueError(
+            f"Unsupported metadata format {suffix!r} for {path}. "
+            "Use .csv, .tsv, .xlsx, or .xls."
+        )
+
+    return pd.read_csv(
+        path,
+        sep=separator,
+        encoding=_metadata_encoding(encoding),
+    )
 
 
-def smart_read_csv(file_path, auto_detect=True):
-    """智能读取CSV/Excel文件，自动尝试不同的分隔符和编码"""
-    # 检查文件扩展名
-    file_ext = os.path.splitext(file_path)[1].lower()
-    
-    # 如果是Excel文件，直接使用pandas读取
-    if file_ext in ['.xlsx', '.xls']:
-        try:
-            return pd.read_excel(file_path)
-        except Exception as e:
-            print(f"读取Excel文件失败: {e}")
-            raise Exception(f"无法读取Excel文件 {file_path}: {e}")
-    
-    # CSV读取逻辑
-    if auto_detect:
-        # 先尝试检测文件前几行来判断可能的分隔符
-        try:
-            with open(file_path, 'rb') as f:
-                sample = f.read(4096)  # 读取前4KB判断格式
-                
-            # 尝试用UTF-8解码
-            sample_text = sample.decode('utf-8', errors='ignore')
-            
-            # 根据文件内容推测分隔符
-            comma_count = sample_text.count(',')
-            tab_count = sample_text.count('\t')
-            
-            # 根据分隔符频率选择解析策略
-            if comma_count > tab_count:
-                # 更可能是逗号分隔的文件
-                try:
-                    return pd.read_csv(file_path)
-                except UnicodeDecodeError:
-                    return pd.read_csv(file_path, encoding='gbk')
-            else:
-                # 更可能是制表符分隔的文件
-                try:
-                    return pd.read_csv(file_path, sep='\t')
-                except UnicodeDecodeError:
-                    return pd.read_csv(file_path, sep='\t', encoding='gbk', low_memory=False)
-                
-        except Exception as e:
-            print(f"自动检测格式失败: {e}，尝试默认方法")
-        
-        # 如果检测失败，按照优先级尝试不同组合
-        encodings = ['utf-8', 'gbk', 'latin1']
-        separators = [',', '\t']
-        
-        for encoding in encodings:
-            for sep in separators:
-                try:
-                    return pd.read_csv(file_path, encoding=encoding, sep=sep)
-                except Exception as e:
-                    continue
-                    
-        # 最后的后备方案，使用最宽松的参数
-        try:
-            return pd.read_csv(file_path, encoding='latin1', sep=None, engine='python')
-        except Exception as e:
-            raise Exception(f"无法读取文件 {file_path}，尝试了所有常见格式: {e}")
+def smart_read_csv(
+    file_path: str | os.PathLike[str],
+    auto_detect: bool = True,
+    *,
+    encoding: object | None = None,
+) -> pd.DataFrame:
+    """Compatibility alias for strict extension-defined metadata parsing.
+
+    ``auto_detect`` is retained for existing callers but no longer enables
+    encoding or delimiter guessing.
+    """
+
+    if not isinstance(auto_detect, bool):
+        raise TypeError("auto_detect must be a boolean")
+    return read_metadata_table(file_path, encoding=encoding)
 
 
 class MetadataAccessor:
-    """提供类似字典的接口访问DataFrame数据的类"""
-    
-    def __init__(self, dataframe, key_column='Id'):
-        """初始化元数据访问器
-        
-        Args:
-            dataframe: pandas DataFrame包含元数据
-            key_column: 用作键的列名，默认为'Id'
-        """
-        self.df = dataframe
+    """Provide dictionary-like access to a metadata DataFrame."""
+
+    def __init__(self, dataframe: pd.DataFrame, key_column: str = "Id"):
+        if not isinstance(dataframe, pd.DataFrame):
+            raise TypeError(
+                f"metadata must be a pandas.DataFrame, got {type(dataframe).__name__}"
+            )
+        if dataframe.empty:
+            raise ValueError("metadata contains no rows")
+        if key_column not in dataframe.columns:
+            raise ValueError(
+                f"metadata is missing required column {key_column!r}; "
+                f"observed columns: {list(dataframe.columns)}"
+            )
+        if dataframe[key_column].isna().any():
+            raise ValueError(f"metadata column {key_column!r} contains missing values")
+        duplicated = dataframe.loc[
+            dataframe[key_column].duplicated(keep=False), key_column
+        ].tolist()
+        if duplicated:
+            raise ValueError(
+                f"metadata column {key_column!r} must be unique; duplicate values: "
+                f"{duplicated}"
+            )
+
+        self.df = dataframe.copy()
         self.key_column = key_column
-        # 为了加速查询，将索引设置为key_column
         self.df.set_index(key_column, inplace=True, drop=False)
-    
+
     def __getitem__(self, key):
-        """通过键获取元数据行，返回一个字典
-        
-        Args:
-            key: 要查找的键值
-            
-        Returns:
-            dict: 包含该行所有数据的字典
-        """
         try:
             return self.df.loc[key].to_dict()
-        except KeyError:
-            raise KeyError(f"找不到ID为{key}的记录")
-    
+        except KeyError as exc:
+            raise KeyError(f"找不到ID为{key}的记录") from exc
+
     def __contains__(self, key):
-        """检查键是否存在
-        
-        Args:
-            key: 要检查的键值
-            
-        Returns:
-            bool: 键是否存在
-        """
         return key in self.df.index
-    
+
     def keys(self):
-        """获取所有键的列表
-        
-        Returns:
-            列表: 所有键的列表
-        """
         return list(self.df[self.key_column])
-    
+
     def items(self):
-        """获取(key, value)对的列表，类似字典的items方法
-        
-        Returns:
-            列表: (key, value)元组的列表
-        """
         for key in self.keys():
-            yield (key, self[key])
-    
+            yield key, self[key]
+
     def values(self):
-        """获取所有值的列表
-        
-        Returns:
-            列表: 所有行数据字典的列表
-        """
         return [row.to_dict() for _, row in self.df.iterrows()]
-    
+
     def get(self, key, default=None):
-        """获取键对应的值，如果不存在返回默认值
-        
-        Args:
-            key: 要查找的键
-            default: 键不存在时返回的默认值
-            
-        Returns:
-            字典或默认值
-        """
         try:
             return self[key]
         except KeyError:
             return default
-    
-    def __len__(self):
-        """返回元数据条目数量"""
-        return len(self.df)
-    
-    def query(self, query_str):
-        """使用pandas的query功能直接查询数据
-        
-        Args:
-            query_str: pandas query语法的查询字符串
-            
-        Returns:
-            查询结果DataFrame
-        """
-        return self.df.query(query_str)
 
+    def __len__(self):
+        return len(self.df)
+
+    def query(self, query_str):
+        return self.df.query(query_str)

--- a/src/data_factory/explicit_data_factory.py
+++ b/src/data_factory/explicit_data_factory.py
@@ -15,6 +15,7 @@ from tqdm import tqdm
 
 from .contracts import format_loader_summary, require_nonempty_dataloaders
 from .data_factory import _cache_directory, data_factory
+from .data_utils import MetadataAccessor, read_metadata_table
 from .dataset_task.Dataset_cluster import IdIncludedDataset
 from .dataset_task.adapters import resolve_dataset_adapter
 from .splitting import resolve_data_splits
@@ -213,7 +214,8 @@ class ExplicitDataFactory(data_factory):
 
     Reader behavior, ID selection, windowing, samplers and DataLoaders remain in
     their existing modules. This class owns user-visible boundaries for explicit
-    adapters, complete caches, non-empty loaders, and observable split facts.
+    local metadata, explicit adapters, complete caches, non-empty loaders, and
+    observable split facts.
     """
 
     def __init__(self, args_data, args_task):
@@ -224,6 +226,21 @@ class ExplicitDataFactory(data_factory):
             args_data,
         )
         print(f"[SUCCESS] 数据加载器可用: {format_loader_summary(counts)}")
+
+    def _init_metadata(self, args_data):
+        """Read exactly the local metadata file declared by the user."""
+
+        metadata_path = Path(args_data.data_dir) / str(args_data.metadata_file)
+        metadata_frame = read_metadata_table(
+            metadata_path,
+            encoding=getattr(args_data, "metadata_encoding", None),
+        )
+        metadata = MetadataAccessor(metadata_frame, key_column="Id")
+        print(
+            f"[SUCCESS] 成功加载本地元数据: {metadata_path} "
+            f"({len(metadata)} 条记录)"
+        )
+        return metadata
 
     def _read_single_data(self, file_id, meta, args_data):
         """Read one declared raw file without replacing reader exceptions."""

--- a/test/test_data_cache_contract.py
+++ b/test/test_data_cache_contract.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+import importlib
 from pathlib import Path
+import sys
 from types import SimpleNamespace
 
 import h5py
@@ -16,6 +18,9 @@ from src.data_factory.contracts import (
 from src.data_factory.data_factory import data_factory as BaseDataFactory
 from src.data_factory.reader.CSV_Signal import read as read_csv_signal
 from src.data_factory.reader.Dummy_Data import read as read_dummy_signal
+
+
+data_factory_module = importlib.import_module("src.data_factory.data_factory")
 
 
 def _factory(metadata):
@@ -323,7 +328,15 @@ def test_compatible_csv_dataset_uses_existing_data_and_task_contracts(
         factory.data.close()
 
 
-def _write_dummy_csv(path: Path) -> None:
+def _write_dummy_csv(path: Path, offset: float = 0.0, samples: int = 16) -> None:
+    rows = ["index,ch1,ch2"]
+    for index in range(samples):
+        rows.append(f"{index},{offset + index},{offset + 2 * index}")
+    path.write_text("\n".join(rows) + "\n", encoding="utf-8")
+
+
+def test_dummy_reader_consumes_exact_declared_columns(tmp_path: Path) -> None:
+    path = tmp_path / "dummy.csv"
     path.write_text(
         "index,ch1,ch2\n"
         "0,0.0,1.0\n"
@@ -331,11 +344,6 @@ def _write_dummy_csv(path: Path) -> None:
         "2,1.0,0.0\n",
         encoding="utf-8",
     )
-
-
-def test_dummy_reader_consumes_exact_declared_columns(tmp_path: Path) -> None:
-    path = tmp_path / "dummy.csv"
-    _write_dummy_csv(path)
 
     signal = read_dummy_signal(path)
 
@@ -695,3 +703,161 @@ def test_valid_reader_ranks_preserve_existing_cache_representation(
     assert observed.shape == expected_shape
     assert observed.dtype == reader_value.dtype
     assert raw_path.is_file()
+
+
+def test_missing_metadata_has_zero_remote_calls(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    remote_calls: list[tuple[tuple, dict]] = []
+
+    def forbidden_remote(*args, **kwargs):
+        remote_calls.append((args, kwargs))
+        raise AssertionError("normal local runs must not call download_data")
+
+    monkeypatch.setattr(data_factory_module, "download_data", forbidden_remote)
+    factory = ExplicitDataFactory.__new__(ExplicitDataFactory)
+
+    with pytest.raises(
+        FileNotFoundError,
+        match="Normal runs do not download replacement metadata",
+    ):
+        factory._init_metadata(
+            SimpleNamespace(
+                data_dir=str(tmp_path),
+                metadata_file="missing.csv",
+            )
+        )
+
+    assert remote_calls == []
+    assert not list(tmp_path.glob("*.h5"))
+
+
+def test_malformed_utf8_metadata_fails_before_cache_publication(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "metadata.csv"
+    path.write_bytes(
+        b"Id,Name,File,Dataset_id,Domain_id,Label,Sample_Rate\n"
+        b"1,Dummy_Data,dummy.csv,0,0,0,1000\xff\n"
+    )
+    factory = ExplicitDataFactory.__new__(ExplicitDataFactory)
+
+    with pytest.raises(UnicodeDecodeError):
+        factory._init_metadata(_args(tmp_path))
+
+    assert not list(tmp_path.glob("*.h5"))
+
+
+def test_tab_separated_content_named_csv_fails_schema_validation(
+    tmp_path: Path,
+) -> None:
+    (tmp_path / "metadata.csv").write_text(
+        "Id\tName\tFile\tDataset_id\tDomain_id\tLabel\tSample_Rate\n"
+        "1\tDummy_Data\tdummy.csv\t0\t0\t0\t1000\n",
+        encoding="utf-8",
+    )
+    factory = ExplicitDataFactory.__new__(ExplicitDataFactory)
+
+    with pytest.raises(ValueError, match="missing required column 'Id'"):
+        factory._init_metadata(_args(tmp_path))
+
+    assert not list(tmp_path.glob("*.h5"))
+
+
+def test_explicit_tsv_metadata_is_supported(tmp_path: Path) -> None:
+    (tmp_path / "metadata.tsv").write_text(
+        "Id\tName\tFile\tDataset_id\tDomain_id\tLabel\tSample_Rate\n"
+        "1\tDummy_Data\tdummy.csv\t0\t0\t0\t1000\n",
+        encoding="utf-8",
+    )
+    factory = ExplicitDataFactory.__new__(ExplicitDataFactory)
+
+    metadata = factory._init_metadata(
+        SimpleNamespace(
+            data_dir=str(tmp_path),
+            metadata_file="metadata.tsv",
+        )
+    )
+
+    assert metadata[1]["Name"] == "Dummy_Data"
+
+
+def _write_tiny_local_dummy_fixture(root: Path) -> None:
+    raw_dir = root / "raw" / "Dummy_Data"
+    raw_dir.mkdir(parents=True)
+    rows = [
+        (1, "source_c0.csv", 0, 0),
+        (2, "source_c1.csv", 0, 1),
+        (3, "target_c0.csv", 1, 0),
+        (4, "target_c1.csv", 1, 1),
+    ]
+    for file_id, file_name, domain_id, label in rows:
+        _write_dummy_csv(
+            raw_dir / file_name,
+            offset=float(file_id * 100),
+            samples=64,
+        )
+    (root / "metadata.csv").write_text(
+        "Id,Name,File,Dataset_id,Domain_id,Label,Sample_Rate\n"
+        "1,Dummy_Data,source_c0.csv,0,0,0,1000\n"
+        "2,Dummy_Data,source_c1.csv,0,0,1,1000\n"
+        "3,Dummy_Data,target_c0.csv,0,1,0,1000\n"
+        "4,Dummy_Data,target_c1.csv,0,1,1,1000\n",
+        encoding="utf-8",
+    )
+
+
+def test_tiny_local_dummy_builds_loaders_without_provider_imports(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _write_tiny_local_dummy_fixture(tmp_path)
+    remote_calls: list[tuple[tuple, dict]] = []
+
+    def forbidden_remote(*args, **kwargs):
+        remote_calls.append((args, kwargs))
+        raise AssertionError("normal local runs must not call download_data")
+
+    monkeypatch.setattr(data_factory_module, "download_data", forbidden_remote)
+    before_modules = set(sys.modules)
+    args_data = SimpleNamespace(
+        factory_name="default",
+        data_dir=str(tmp_path),
+        metadata_file="metadata.csv",
+        batch_size=2,
+        num_workers=0,
+        train_ratio=0.5,
+        val_ratio=0.25,
+        test_ratio=0.25,
+        unused_ratio=0.0,
+        normalization="none",
+        window_size=8,
+        window_sampling_strategy="evenly_spaced",
+        num_window=4,
+        window_sampling_seed=0,
+        dtype="float32",
+        pin_memory=False,
+    )
+    args_task = SimpleNamespace(
+        type="DG",
+        name="classification",
+        target_system_id=[0],
+        source_domain_id=[0],
+        target_domain_id=[1],
+    )
+
+    factory = build_data(args_data, args_task)
+    try:
+        assert len(factory.train_loader) > 0
+        assert len(factory.val_loader) > 0
+        assert len(factory.test_loader) > 0
+        batch = next(iter(factory.train_loader))
+        assert batch["x"].shape[-2:] == (8, 2)
+    finally:
+        factory.data.close()
+
+    imported = set(sys.modules) - before_modules
+    assert remote_calls == []
+    assert "huggingface_hub" not in imported
+    assert not any(name == "modelscope" or name.startswith("modelscope.") for name in imported)


### PR DESCRIPTION
## Objective

Close the two release-level data-boundary findings from the 100-reviewer audit without introducing a new backend, schema framework, downloader, hash, receipt, ledger, or attestation layer.

## User invariant

```text
requested local metadata source + declared file extension
=
metadata consumed by the maintained run
```

## Changes

- make `ExplicitDataFactory` read exactly `data.data_dir / data.metadata_file`;
- fail with an actionable `FileNotFoundError` when local metadata is absent;
- remove normal-run calls to `download_data(..., source="auto")` from the maintained path;
- parse `.csv` as comma-separated UTF-8/UTF-8-SIG, `.tsv` as tab-separated UTF-8/UTF-8-SIG, and Excel through the Excel reader;
- allow a non-default text encoding only through explicit `data.metadata_encoding`;
- remove byte dropping, Latin-1 fallback, delimiter guessing, and retry parsing from the maintained metadata path;
- validate non-empty metadata, required unique `Id`, and preserve parser exceptions;
- keep explicit remote download helper outside the normal Data Factory path;
- extend the existing offline Data Factory contract tests with missing-file, malformed UTF-8, wrong-extension delimiter, explicit TSV, and tiny local Dummy cases.

## Offline-only validation

All new tests use either the repository-shipped Dummy path or `tmp_path` fixtures with local CSV files. They assert:

```text
remote provider calls = 0
new huggingface_hub imports = 0
new modelscope imports = 0
parse failure publishes no HDF5 cache
valid tiny local Dummy loaders remain non-empty
```

No Hugging Face, ModelScope, dataset, or model download is used.

## Boundaries

- no Model, Task, Trainer, Pipeline, checkpoint, metric, estimator, or IoTDB changes;
- no automatic download command added;
- no fallback encoding, delimiter, data source, reader, or backend;
- no FactoryManager, BackendManager, new registry, second schema, hash, checksum, digest, receipt, ledger, evidence, or attestation.

## Acceptance

- existing `test/test_data_cache_contract.py` passes with the new strict-local cases;
- `phmfactory demo` remains fully offline;
- core quality gates, public package, repository layout, and submodule policy remain green;
- any real-data workflow touched by the public Data Factory continues to use its declared local metadata and explicit preparation step.
