### PR TITLE
fix(task): make loss and metrics match declared semantics

### DIFF
--- a/.github/workflows/core-quality-gates.yml
+++ b/.github/workflows/core-quality-gates.yml
@@ -224,16 +224,19 @@ jobs:
       - name: Record smoke environment
         run: python -m pip freeze > offline-smoke-environment.txt
 
-      - name: Run shared runtime, data, device, and Pipeline 02 contract tests
+      - name: Run shared runtime, data, task, device, and Pipeline 02 contract tests
         shell: bash
         run: |
           set -o pipefail
           python -m py_compile \
             phmfactory/runtime/execution.py \
+            phmfactory/task_semantics.py \
             src/data_factory/explicit_data_factory.py \
             src/data_factory/dataset_task/Default_dataset.py \
             src/model_factory/ISFM/system_utils.py \
             src/model_factory/ISFM/task_head/H_01_Linear_cla.py \
+            src/task_factory/Components/loss.py \
+            src/task_factory/Components/metrics.py \
             src/task_factory/Default_task.py \
             src/task_factory/task/pretrain/hse_contrastive.py \
             src/trainer_factory/Default_trainer.py \
@@ -250,6 +253,7 @@ jobs:
             test/test_pipeline02_runtime.py \
             test/test_runtime_execution.py \
             test/test_split_scientific_truth.py \
+            test/test_task_estimator_truth.py \
             test/test_transform_truth.py
           python -m pytest \
             test/test_classification_runtime.py \
@@ -260,6 +264,7 @@ jobs:
             test/test_pipeline02_runtime.py \
             test/test_runtime_execution.py \
             test/test_split_scientific_truth.py \
+            test/test_task_estimator_truth.py \
             test/test_transform_truth.py \
             -vv --tb=long 2>&1 | tee runtime-contracts-pytest.log
 

--- a/phmfactory/task_semantics.py
+++ b/phmfactory/task_semantics.py
@@ -1,0 +1,127 @@
+"""Pure task-semantic validation shared by config and runtime boundaries.
+
+This module deliberately has no Torch or Lightning import.  It only decides whether a
+configured loss and metric set describe one coherent mathematical problem.  Tensor
+shape, dtype, and value checks remain next to the loss and metric implementations that
+consume them.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+
+CLASSIFICATION_INDEX_LOSSES = frozenset({"CE", "NLL"})
+BINARY_CLASSIFICATION_LOSSES = frozenset({"BCE"})
+REGRESSION_LOSSES = frozenset({"MSE", "MAE"})
+
+CLASSIFICATION_METRICS = frozenset(
+    {"acc", "f1", "precision", "recall", "auroc"}
+)
+REGRESSION_METRICS = frozenset({"mse", "mae", "r2", "mape"})
+KNOWN_METRICS = CLASSIFICATION_METRICS | REGRESSION_METRICS
+
+
+def normalize_loss_name(loss_name: object) -> str:
+    """Return one non-empty uppercase loss identifier."""
+
+    if not isinstance(loss_name, str) or not loss_name.strip():
+        raise TypeError("task.loss must be a non-empty string")
+    return loss_name.strip().upper()
+
+
+def normalize_metric_names(metric_names: object) -> tuple[str, ...]:
+    """Return explicit, unique, known metric identifiers in configured order."""
+
+    if isinstance(metric_names, (str, bytes)) or not isinstance(
+        metric_names, Sequence
+    ):
+        raise TypeError("task.metrics must be a non-empty sequence of metric names")
+
+    normalized: list[str] = []
+    for index, raw_name in enumerate(metric_names):
+        if not isinstance(raw_name, str) or not raw_name.strip():
+            raise TypeError(
+                f"task.metrics[{index}] must be a non-empty string, got {raw_name!r}"
+            )
+        normalized.append(raw_name.strip().lower())
+
+    if not normalized:
+        raise ValueError("task.metrics must contain at least one metric")
+    if len(set(normalized)) != len(normalized):
+        duplicates = sorted(
+            name for name in set(normalized) if normalized.count(name) > 1
+        )
+        raise ValueError(f"task.metrics contains duplicate metric(s): {duplicates}")
+
+    unknown = sorted(set(normalized) - KNOWN_METRICS)
+    if unknown:
+        available = ", ".join(sorted(KNOWN_METRICS))
+        raise ValueError(
+            f"Unknown task metric(s): {unknown}. Available metrics: {available}. "
+            "PHMFactory does not silently skip requested metrics."
+        )
+    return tuple(normalized)
+
+
+def loss_family(loss_name: object) -> str:
+    """Return the declared prediction/target family for one loss."""
+
+    normalized = normalize_loss_name(loss_name)
+    if normalized in CLASSIFICATION_INDEX_LOSSES:
+        return "multiclass"
+    if normalized in BINARY_CLASSIFICATION_LOSSES:
+        return "binary"
+    if normalized in REGRESSION_LOSSES:
+        return "regression"
+    return "custom"
+
+
+def validate_loss_metric_contract(
+    loss_name: object,
+    metric_names: object,
+) -> tuple[str, ...]:
+    """Reject configurations that mix incompatible estimands.
+
+    Classification and regression metrics cannot share one generic output tensor because
+    they require different target dtypes and prediction representations.  Known losses
+    additionally constrain the metric family.  Custom losses may use either one family,
+    but never both in the same task.
+    """
+
+    family = loss_family(loss_name)
+    normalized = normalize_metric_names(metric_names)
+    requested = set(normalized)
+    has_classification = bool(requested & CLASSIFICATION_METRICS)
+    has_regression = bool(requested & REGRESSION_METRICS)
+
+    if has_classification and has_regression:
+        raise ValueError(
+            "task.metrics cannot mix classification and regression estimators in one "
+            f"generic task: metrics={list(normalized)}"
+        )
+    if family in {"multiclass", "binary"} and has_regression:
+        raise ValueError(
+            f"task.loss={normalize_loss_name(loss_name)} requires classification "
+            f"metrics, got {list(normalized)}"
+        )
+    if family == "regression" and has_classification:
+        raise ValueError(
+            f"task.loss={normalize_loss_name(loss_name)} requires regression metrics, "
+            f"got {list(normalized)}"
+        )
+    return normalized
+
+
+__all__ = [
+    "BINARY_CLASSIFICATION_LOSSES",
+    "CLASSIFICATION_INDEX_LOSSES",
+    "CLASSIFICATION_METRICS",
+    "KNOWN_METRICS",
+    "REGRESSION_LOSSES",
+    "REGRESSION_METRICS",
+    "loss_family",
+    "normalize_loss_name",
+    "normalize_metric_names",
+    "validate_loss_metric_contract",
+]

--- a/src/task_factory/Components/loss.py
+++ b/src/task_factory/Components/loss.py
@@ -1,25 +1,35 @@
 """Common loss utilities used across PHM-Vibench tasks."""
 
+from __future__ import annotations
+
+from typing import Any
+
 import torch
 import torch.nn as nn
-from .metric_loss import MatchingLoss
-from .prediction_loss import *
-from .contrastive_losses import (
-    InfoNCELoss, TripletLoss, SupConLoss, PrototypicalLoss,
-    BarlowTwinsLoss, VICRegLoss
+
+from phmfactory.task_semantics import (
+    BINARY_CLASSIFICATION_LOSSES,
+    CLASSIFICATION_INDEX_LOSSES,
+    REGRESSION_LOSSES,
+    normalize_loss_name,
 )
 
-def get_loss_fn(loss_name: str) -> nn.Module:
-    """Return a loss module according to ``loss_name``.
+from .contrastive_losses import (
+    BarlowTwinsLoss,
+    InfoNCELoss,
+    PrototypicalLoss,
+    SupConLoss,
+    TripletLoss,
+    VICRegLoss,
+)
+from .metric_loss import MatchingLoss
+from .prediction_loss import *  # noqa: F403 - historical prediction losses
 
-    Parameters
-    ----------
-    loss_name: str
-        Key identifying the loss type. Supported values include standard losses
-        (``CE``, ``MSE``, ``MAE``, ``BCE``, ``NLL``) and SOTA contrastive losses
-        (``INFONCE``, ``TRIPLET``, ``SUPCON``, ``PROTOTYPICAL``, ``BARLOWTWINS``, ``VICREG``).
-    """
-    # loss_name = args.loss
+
+def get_loss_fn(loss_name: str) -> nn.Module:
+    """Return the explicitly configured loss implementation."""
+
+    key = normalize_loss_name(loss_name)
     loss_mapping = {
         "CE": nn.CrossEntropyLoss(),
         "MSE": nn.MSELoss(),
@@ -27,8 +37,7 @@ def get_loss_fn(loss_name: str) -> nn.Module:
         "BCE": nn.BCEWithLogitsLoss(),
         "NLL": nn.NLLLoss(),
         "MATCHING": MatchingLoss,
-        "SIGNAL_MASK_LOSS": Signal_mask_Loss,  # TODO Time Series Prediction
-        # SOTA Contrastive Learning Losses
+        "SIGNAL_MASK_LOSS": Signal_mask_Loss,  # noqa: F405
         "INFONCE": InfoNCELoss(),
         "TRIPLET": TripletLoss(),
         "SUPCON": SupConLoss(),
@@ -36,85 +45,242 @@ def get_loss_fn(loss_name: str) -> nn.Module:
         "BARLOWTWINS": BarlowTwinsLoss(),
         "VICREG": VICRegLoss(),
     }
-
-    key = loss_name.upper()
     if key not in loss_mapping:
+        available = ", ".join(sorted(loss_mapping))
         raise ValueError(
-            f"不支持的损失函数类型: {loss_name}，可选类型: {list(loss_mapping.keys())}"
+            f"Unsupported task loss {loss_name!r}. Available losses: {available}."
         )
-    if key == "MATCHING":
-        return MatchingLoss  # Return class for special initialization
-    if key == "SIGNAL_MASK_LOSS":
-        return Signal_mask_Loss  # Return class for special initialization
-
     return loss_mapping[key]
 
 
-if __name__ == "__main__":
-    print("🔥 Testing PHM-Vibench Loss Functions")
-    
-    # Test standard losses
-    print("\n1. Standard Losses:")
-    pred = torch.randn(4, 5)
-    target = torch.randint(0, 5, (4,))
-    
-    for loss_name in ["CE", "MSE", "MAE", "BCE", "NLL"]:
-        try:
-            loss_fn = get_loss_fn(loss_name)
-            if loss_name in ["MSE", "MAE"]:
-                test_target = torch.randn(4, 5)  # Continuous target
-            elif loss_name == "BCE":
-                test_pred = torch.randn(4, 5)  # Logits for BCE
-                test_target = torch.randint(0, 2, (4, 5)).float()  # Binary target
-                loss_val = loss_fn(test_pred, test_target)
-            elif loss_name == "NLL":
-                test_pred = torch.log_softmax(pred, dim=1)  # Log probabilities for NLL
-                loss_val = loss_fn(test_pred, target)
-            else:
-                test_target = target
-                loss_val = loss_fn(pred, test_target)
-            
-            if loss_name not in ["BCE", "NLL"]:
-                if loss_name in ["MSE", "MAE"]:
-                    loss_val = loss_fn(pred, test_target)
-                else:
-                    loss_val = loss_fn(pred, test_target)
-            
-            print(f"   ✓ {loss_name}: {loss_val:.4f}")
-        except Exception as e:
-            print(f"   ✗ {loss_name} failed: {e}")
-    
-    # Test contrastive losses
-    print("\n2. SOTA Contrastive Losses:")
-    batch_size = 8
-    feature_dim = 64
-    num_classes = 3
-    
-    features = torch.randn(batch_size, feature_dim)
-    labels = torch.randint(0, num_classes, (batch_size,))
-    features2 = torch.randn(batch_size, feature_dim)
-    
-    contrastive_losses = {
-        "INFONCE": lambda: get_loss_fn("INFONCE")(temperature=0.07),
-        "TRIPLET": lambda: get_loss_fn("TRIPLET")(margin=0.3), 
-        "SUPCON": lambda: get_loss_fn("SUPCON")(temperature=0.07),
-        "PROTOTYPICAL": lambda: get_loss_fn("PROTOTYPICAL")(distance_fn='euclidean'),
-        "BARLOWTWINS": lambda: get_loss_fn("BARLOWTWINS")(lambda_param=5e-3),
-        "VICREG": lambda: get_loss_fn("VICREG")(lambda_inv=25.0, mu_var=25.0, nu_cov=1.0),
-    }
-    
-    for loss_name, loss_creator in contrastive_losses.items():
-        try:
-            loss_fn = loss_creator()
-            
-            if loss_name in ["INFONCE", "TRIPLET", "SUPCON", "PROTOTYPICAL"]:
-                loss_val = loss_fn(features, labels)
-            else:  # BARLOWTWINS, VICREG (require two views)
-                loss_val = loss_fn(features, features2)
-            
-            print(f"   ✓ {loss_name}: {loss_val:.4f}")
-        except Exception as e:
-            print(f"   ✗ {loss_name} failed: {e}")
-    
-    print("\n✅ All loss functions tested successfully!")
-    print(f"Total available losses: {len(get_loss_fn.__defaults__ or []) + 11}")  # Approximate count
+def _require_tensor(value: Any, *, context: str) -> torch.Tensor:
+    if not torch.is_tensor(value):
+        raise TypeError(f"{context} must be a torch.Tensor, got {type(value).__name__}")
+    return value
+
+
+def _require_real_finite_predictions(
+    predictions: Any,
+    *,
+    context: str,
+) -> torch.Tensor:
+    tensor = _require_tensor(predictions, context=context)
+    if not torch.is_floating_point(tensor) or torch.is_complex(tensor):
+        raise TypeError(
+            f"{context} must contain real floating-point values, got {tensor.dtype}"
+        )
+    if tensor.numel() == 0:
+        raise ValueError(f"{context} must be non-empty")
+    if not torch.isfinite(tensor).all():
+        raise FloatingPointError(f"{context} contains NaN or Inf")
+    return tensor
+
+
+def _require_real_finite_target(target: Any, *, context: str) -> torch.Tensor:
+    tensor = _require_tensor(target, context=context)
+    if tensor.dtype == torch.bool or torch.is_complex(tensor):
+        raise TypeError(f"{context} must contain real numeric values, got {tensor.dtype}")
+    if tensor.numel() == 0:
+        raise ValueError(f"{context} must be non-empty")
+    if not torch.isfinite(tensor).all():
+        raise FloatingPointError(f"{context} contains NaN or Inf")
+    return tensor
+
+
+def _scalar_target_vector(target: torch.Tensor, *, batch_size: int, context: str) -> torch.Tensor:
+    if target.ndim == 0 and batch_size == 1:
+        target = target.reshape(1)
+    elif target.ndim == 2 and target.shape[1] == 1:
+        target = target[:, 0]
+    if target.ndim != 1:
+        raise ValueError(
+            f"{context} must have shape [B] or [B,1], got {tuple(target.shape)}"
+        )
+    if target.shape[0] != batch_size:
+        raise ValueError(
+            f"{context} batch size mismatch: predictions={batch_size}, "
+            f"target={target.shape[0]}"
+        )
+    return target
+
+
+def _prepare_multiclass_inputs(
+    predictions: Any,
+    target: Any,
+    *,
+    loss_name: str,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    logits = _require_real_finite_predictions(
+        predictions,
+        context=f"task.loss={loss_name} predictions",
+    )
+    if logits.ndim != 2 or logits.shape[1] < 2:
+        raise ValueError(
+            f"task.loss={loss_name} predictions must have shape [B,C] with C>=2, "
+            f"got {tuple(logits.shape)}"
+        )
+
+    labels = _require_real_finite_target(
+        target,
+        context=f"task.loss={loss_name} target",
+    )
+    labels = _scalar_target_vector(
+        labels,
+        batch_size=logits.shape[0],
+        context=f"task.loss={loss_name} target",
+    )
+    if torch.is_floating_point(labels) and not torch.equal(labels, labels.round()):
+        raise ValueError(
+            f"task.loss={loss_name} target must contain integer class indices"
+        )
+    labels = labels.to(device=logits.device, dtype=torch.long)
+    minimum = int(labels.min().item())
+    maximum = int(labels.max().item())
+    if minimum < 0 or maximum >= logits.shape[1]:
+        raise ValueError(
+            f"task.loss={loss_name} target is outside the logits class range: "
+            f"observed=[{minimum}, {maximum}], expected=[0, {logits.shape[1] - 1}]"
+        )
+    return logits, labels
+
+
+def _prepare_binary_inputs(
+    predictions: Any,
+    target: Any,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    logits = _require_real_finite_predictions(
+        predictions,
+        context="task.loss=BCE predictions",
+    )
+    labels = _require_real_finite_target(
+        target,
+        context="task.loss=BCE target",
+    )
+
+    if logits.ndim == 0:
+        logits = logits.reshape(1)
+    elif logits.ndim == 2 and logits.shape[1] == 1:
+        logits = logits[:, 0]
+    if labels.ndim == 0:
+        labels = labels.reshape(1)
+    elif labels.ndim == 2 and labels.shape[1] == 1:
+        labels = labels[:, 0]
+
+    if logits.ndim != 1 or labels.ndim != 1 or logits.shape != labels.shape:
+        raise ValueError(
+            "task.loss=BCE requires one logit and one target per sample with matching "
+            f"shape [B] or [B,1], got predictions={tuple(logits.shape)}, "
+            f"target={tuple(labels.shape)}"
+        )
+    if (labels < 0).any() or (labels > 1).any():
+        raise ValueError("task.loss=BCE target values must lie in [0, 1]")
+    return logits, labels.to(device=logits.device, dtype=logits.dtype)
+
+
+def _prepare_regression_inputs(
+    predictions: Any,
+    target: Any,
+    *,
+    loss_name: str,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    estimates = _require_real_finite_predictions(
+        predictions,
+        context=f"task.loss={loss_name} predictions",
+    )
+    values = _require_real_finite_target(
+        target,
+        context=f"task.loss={loss_name} target",
+    )
+
+    if estimates.ndim == 0:
+        estimates = estimates.reshape(1)
+    if values.ndim == 0:
+        values = values.reshape(1)
+    if estimates.ndim == 2 and estimates.shape[1] == 1 and values.ndim == 1:
+        estimates = estimates[:, 0]
+    elif values.ndim == 2 and values.shape[1] == 1 and estimates.ndim == 1:
+        values = values[:, 0]
+
+    if estimates.shape != values.shape:
+        raise ValueError(
+            f"task.loss={loss_name} requires matching prediction and target shapes, "
+            f"got predictions={tuple(estimates.shape)}, target={tuple(values.shape)}"
+        )
+    return estimates, values.to(device=estimates.device, dtype=estimates.dtype)
+
+
+def prepare_loss_inputs(
+    loss_name: str,
+    predictions: Any,
+    target: Any,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Validate and prepare the exact tensors consumed by one declared loss.
+
+    Integer conversion occurs only for class-index losses.  Regression and binary
+    targets retain their numeric values, and PHMFactory never reshapes a general tensor
+    to force compatibility.
+    """
+
+    normalized = normalize_loss_name(loss_name)
+    if normalized in CLASSIFICATION_INDEX_LOSSES:
+        return _prepare_multiclass_inputs(
+            predictions,
+            target,
+            loss_name=normalized,
+        )
+    if normalized in BINARY_CLASSIFICATION_LOSSES:
+        return _prepare_binary_inputs(predictions, target)
+    if normalized in REGRESSION_LOSSES:
+        return _prepare_regression_inputs(
+            predictions,
+            target,
+            loss_name=normalized,
+        )
+
+    checked_predictions = _require_real_finite_predictions(
+        predictions,
+        context=f"task.loss={normalized} predictions",
+    )
+    checked_target = _require_real_finite_target(
+        target,
+        context=f"task.loss={normalized} target",
+    )
+    return checked_predictions, checked_target
+
+
+def compute_task_loss(
+    loss_fn: Any,
+    loss_name: str,
+    predictions: Any,
+    target: Any,
+) -> torch.Tensor:
+    """Compute one finite scalar objective from its declared tensor contract."""
+
+    prepared_predictions, prepared_target = prepare_loss_inputs(
+        loss_name,
+        predictions,
+        target,
+    )
+    result = loss_fn(prepared_predictions, prepared_target)
+    if not torch.is_tensor(result):
+        raise TypeError(
+            f"task.loss={normalize_loss_name(loss_name)} must return a torch.Tensor, "
+            f"got {type(result).__name__}"
+        )
+    if result.ndim != 0:
+        raise ValueError(
+            f"task.loss={normalize_loss_name(loss_name)} must return one scalar, "
+            f"got shape {tuple(result.shape)}"
+        )
+    if not torch.isfinite(result):
+        raise FloatingPointError(
+            f"task.loss={normalize_loss_name(loss_name)} returned NaN or Inf"
+        )
+    return result
+
+
+__all__ = [
+    "compute_task_loss",
+    "get_loss_fn",
+    "prepare_loss_inputs",
+]

--- a/src/task_factory/Components/metrics.py
+++ b/src/task_factory/Components/metrics.py
@@ -1,20 +1,31 @@
-"""Utilities for building common evaluation metrics."""
+"""Utilities for building and updating maintained evaluation metrics."""
 
 from __future__ import annotations
 
 from collections.abc import Sequence
 from typing import Any
 
+import torch
 import torch.nn as nn
 import torchmetrics
 
-from ...utils.label_ontology import (
+from phmfactory.task_semantics import (
+    CLASSIFICATION_METRICS,
+    REGRESSION_METRICS,
+    loss_family,
+    normalize_loss_name,
+    normalize_metric_names,
+    validate_loss_metric_contract,
+)
+from src.utils.label_ontology import (
     metadata_rows,
     validate_metadata_label_ontology,
 )
 
+from .loss import prepare_loss_inputs
 
-_CLASSIFICATION_METRICS = {
+
+_CLASSIFICATION_METRIC_CLASSES = {
     "acc": torchmetrics.Accuracy,
     "f1": torchmetrics.F1Score,
     "precision": torchmetrics.Precision,
@@ -22,46 +33,115 @@ _CLASSIFICATION_METRICS = {
     "auroc": torchmetrics.AUROC,
 }
 
-_REGRESSION_METRICS = {
+_REGRESSION_METRIC_CLASSES = {
     "mse": torchmetrics.MeanSquaredError,
     "mae": torchmetrics.MeanAbsoluteError,
     "r2": torchmetrics.R2Score,
     "mape": torchmetrics.MeanAbsolutePercentageError,
 }
 
-_METRIC_CLASSES = {**_CLASSIFICATION_METRICS, **_REGRESSION_METRICS}
 
+def _classification_metric(
+    metric_name: str,
+    num_classes: int,
+    *,
+    loss_name: str | None,
+):
+    """Build a binary or multiclass metric that matches the declared output."""
 
-def _classification_metric(metric_name: str, num_classes: int):
     if num_classes < 2:
         raise ValueError(
             "classification metrics require at least two classes, "
             f"but the validated ontology has K={num_classes}"
         )
-    metric_class = _CLASSIFICATION_METRICS[metric_name]
-    if num_classes == 2:
-        return metric_class(task="binary")
-    return metric_class(task="multiclass", num_classes=num_classes)
+
+    family = loss_family(loss_name) if loss_name is not None else "legacy"
+    if family == "binary":
+        if num_classes != 2:
+            raise ValueError(
+                "task.loss=BCE requires a two-class metadata ontology for the "
+                f"maintained binary metric contract, got K={num_classes}"
+            )
+        return _CLASSIFICATION_METRIC_CLASSES[metric_name](task="binary")
+
+    # CE/NLL models expose one logit per class, including the K=2 case.  Those
+    # outputs therefore use multiclass metrics rather than silently discarding one
+    # of the two logits through a binary threshold interface.
+    use_multiclass = family == "multiclass" or num_classes > 2
+    if not use_multiclass:
+        return _CLASSIFICATION_METRIC_CLASSES[metric_name](task="binary")
+
+    kwargs: dict[str, Any] = {
+        "task": "multiclass",
+        "num_classes": num_classes,
+    }
+    if metric_name in {"f1", "precision", "recall", "auroc"}:
+        kwargs["average"] = "macro"
+    return _CLASSIFICATION_METRIC_CLASSES[metric_name](**kwargs)
 
 
-def get_metrics(metric_names: Sequence[str], metadata: Any) -> nn.ModuleDict:
-    """Build every requested metric or fail at the Task Factory boundary."""
+def prepare_metric_inputs(
+    metric_name: str,
+    predictions: Any,
+    target: Any,
+    *,
+    loss_name: str,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Return the prediction representation required by one estimator.
 
-    if isinstance(metric_names, (str, bytes)) or not isinstance(
-        metric_names, Sequence
-    ):
-        raise TypeError("task.metrics must be a non-empty sequence of metric names")
-    normalized_names = [str(name).strip().lower() for name in metric_names]
-    if not normalized_names or any(not name for name in normalized_names):
-        raise ValueError("task.metrics must contain at least one non-empty metric name")
+    Classification metrics receive logits or binary scores directly.  AUROC therefore
+    never receives class indices produced by ``argmax``.  Regression metrics receive the
+    continuous prediction and target tensors used by regression losses.
+    """
 
-    unknown = sorted(set(normalized_names) - set(_METRIC_CLASSES))
-    if unknown:
-        available = ", ".join(sorted(_METRIC_CLASSES))
+    normalized_metric = normalize_metric_names([metric_name])[0]
+    normalized_loss = normalize_loss_name(loss_name)
+    family = loss_family(normalized_loss)
+
+    if normalized_metric in REGRESSION_METRICS:
+        if family in {"multiclass", "binary"}:
+            raise ValueError(
+                f"metric {normalized_metric!r} is incompatible with "
+                f"task.loss={normalized_loss}"
+            )
+        return prepare_loss_inputs("MSE", predictions, target)
+
+    if normalized_metric not in CLASSIFICATION_METRICS:
+        raise ValueError(f"Unknown task metric {metric_name!r}")
+    if family == "regression":
         raise ValueError(
-            f"Unknown task metric(s): {unknown}. Available metrics: {available}. "
-            "PHMFactory does not silently skip requested metrics."
+            f"metric {normalized_metric!r} is incompatible with "
+            f"task.loss={normalized_loss}"
         )
+    if family in {"multiclass", "binary"}:
+        return prepare_loss_inputs(normalized_loss, predictions, target)
+
+    # A custom loss may still expose one explicit classification representation.
+    # Infer only from an unambiguous output shape; do not squeeze or threshold a
+    # general tensor to force compatibility.
+    if torch.is_tensor(predictions) and predictions.ndim == 2 and predictions.shape[1] >= 2:
+        return prepare_loss_inputs("CE", predictions, target)
+    return prepare_loss_inputs("BCE", predictions, target)
+
+
+def get_metrics(
+    metric_names: Sequence[str],
+    metadata: Any,
+    *,
+    loss_name: str | None = None,
+) -> nn.ModuleDict:
+    """Build every requested metric or fail at the Task Factory boundary.
+
+    ``loss_name`` is optional for low-level construction compatibility.  Maintained Task
+    construction always supplies it, which rejects classification/regression mixtures
+    before training begins and selects the metric interface matching the model output.
+    """
+
+    normalized_names = (
+        validate_loss_metric_contract(loss_name, metric_names)
+        if loss_name is not None
+        else normalize_metric_names(metric_names)
+    )
 
     rows = metadata_rows(metadata)
     dataset_names: list[Any] = []
@@ -72,7 +152,7 @@ def get_metrics(metric_names: Sequence[str], metadata: Any) -> nn.ModuleDict:
             dataset_names.append(row["Name"])
 
     classification_requested = any(
-        name in _CLASSIFICATION_METRICS for name in normalized_names
+        name in CLASSIFICATION_METRICS for name in normalized_names
     )
     class_counts = (
         validate_metadata_label_ontology(
@@ -91,22 +171,17 @@ def get_metrics(metric_names: Sequence[str], metadata: Any) -> nn.ModuleDict:
         for stage in ("train", "val", "test"):
             for metric_name in normalized_names:
                 key = f"{stage}_{metric_name}"
-                if metric_name in _CLASSIFICATION_METRICS:
+                if metric_name in CLASSIFICATION_METRICS:
                     data_metrics[key] = _classification_metric(
                         metric_name,
                         class_counts[raw_data_name],
+                        loss_name=loss_name,
                     )
                 else:
-                    data_metrics[key] = _REGRESSION_METRICS[metric_name]()
+                    data_metrics[key] = _REGRESSION_METRIC_CLASSES[metric_name]()
         metrics[data_name] = data_metrics
 
     return metrics
 
 
-if __name__ == "__main__":
-    dummy_meta = {
-        1: {"Name": "ds", "Dataset_id": 1, "Label": 0},
-        2: {"Name": "ds", "Dataset_id": 1, "Label": 1},
-    }
-    built = get_metrics(["acc", "f1"], dummy_meta)
-    print("Built metrics:", list(built["ds"].keys()))
+__all__ = ["get_metrics", "prepare_metric_inputs"]

--- a/src/task_factory/Default_task.py
+++ b/src/task_factory/Default_task.py
@@ -6,12 +6,17 @@ from typing import Any, Dict, Tuple
 import pytorch_lightning as pl
 import torch
 import torch.nn as nn
+from torchmetrics import Metric
 
+from phmfactory.task_semantics import (
+    normalize_loss_name,
+    validate_loss_metric_contract,
+)
 from src.task_factory import register_task
 
 from .Components.gradient_constraints import FisherGradientConstraint
-from .Components.loss import get_loss_fn
-from .Components.metrics import get_metrics
+from .Components.loss import compute_task_loss, get_loss_fn
+from .Components.metrics import get_metrics, prepare_metric_inputs
 from .Components.regularization import calculate_regularization
 
 
@@ -70,8 +75,17 @@ class Default_task(pl.LightningModule):
                 raise ValueError("FIC gradient_constraint currently requires task.loss=CE")
             self.gradient_constraint = FisherGradientConstraint(epsilon=float(epsilon))
 
-        self.loss_fn = get_loss_fn(self.args_task.loss)
-        self.metrics = get_metrics(self.args_task.metrics, self.metadata)
+        self.loss_name = normalize_loss_name(self.args_task.loss)
+        self.metric_names = validate_loss_metric_contract(
+            self.loss_name,
+            self.args_task.metrics,
+        )
+        self.loss_fn = get_loss_fn(self.loss_name)
+        self.metrics = get_metrics(
+            self.metric_names,
+            self.metadata,
+            loss_name=self.loss_name,
+        )
 
         hparams_dict = {
             **vars(self.args_task),
@@ -141,7 +155,12 @@ class Default_task(pl.LightningModule):
         return self.network(x, file_id, task_id)
 
     def _compute_loss(self, y_hat: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
-        return self.loss_fn(y_hat, y.long() if y.dtype != torch.long else y)
+        return compute_task_loss(
+            self.loss_fn,
+            self.loss_name,
+            y_hat,
+            y,
+        )
 
     def _compute_metrics(
         self,
@@ -149,7 +168,15 @@ class Default_task(pl.LightningModule):
         y: torch.Tensor,
         data_name: str,
         stage: str,
-    ) -> Dict[str, torch.Tensor]:
+    ) -> Dict[str, Metric]:
+        """Update every requested metric over the full stage population.
+
+        TorchMetrics objects remain registered in ``self.metrics``.  Each batch updates
+        their state with the estimator-specific prediction representation, while
+        Lightning computes and resets the logged objects at the epoch boundary.  This
+        avoids averaging batch F1/AUROC values into a different estimator.
+        """
+
         if data_name not in self.metrics:
             available = sorted(self.metrics.keys())
             raise KeyError(
@@ -158,10 +185,20 @@ class Default_task(pl.LightningModule):
                 "different dataset's metrics."
             )
 
-        metric_values = {}
+        metric_values: Dict[str, Metric] = {}
+        stage_prefix = f"{stage}_"
         for metric_key, metric_fn in self.metrics[data_name].items():
-            if metric_key.startswith(stage):
-                metric_values[f"{metric_key}_{data_name}"] = metric_fn(y_hat, y)
+            if not metric_key.startswith(stage_prefix):
+                continue
+            metric_name = metric_key[len(stage_prefix) :]
+            metric_predictions, metric_target = prepare_metric_inputs(
+                metric_name,
+                y_hat,
+                y,
+                loss_name=self.loss_name,
+            )
+            metric_fn.update(metric_predictions, metric_target)
+            metric_values[f"{metric_key}_{data_name}"] = metric_fn
         return metric_values
 
     def _compute_regularization(self) -> Dict[str, torch.Tensor]:
@@ -222,7 +259,7 @@ class Default_task(pl.LightningModule):
         batch: Tuple,
         stage: str,
         task_id=False,
-    ) -> Dict[str, torch.Tensor]:
+    ) -> Dict[str, Any]:
         del task_id
         if not isinstance(batch, Mapping):
             raise TypeError(f"task batch must be a mapping, got {type(batch).__name__}")
@@ -240,14 +277,13 @@ class Default_task(pl.LightningModule):
 
         y = batch["y"]
         loss = self._compute_loss(y_hat, y)
-        y_argmax = torch.argmax(y_hat, dim=1) if y_hat.ndim > 1 else y_hat
 
-        step_metrics = {
+        step_metrics: Dict[str, Any] = {
             f"{stage}_loss": loss,
             f"{stage}_{data_name}_loss": loss,
         }
         step_metrics.update(
-            self._compute_metrics(y_argmax, y, data_name, stage)
+            self._compute_metrics(y_hat, y, data_name, stage)
         )
 
         reg_dict = self._compute_regularization()
@@ -295,20 +331,36 @@ class Default_task(pl.LightningModule):
         metrics = self._shared_step(batch, "test")
         self._log_metrics(metrics, "test")
 
-    def _log_metrics(self, metrics: Dict[str, torch.Tensor], stage: str) -> None:
-        log_dict = {
-            key: value
-            for key, value in metrics.items()
-            if key.startswith(stage) and "batch_size" not in key
-        }
-        self.log_dict(
-            log_dict,
-            on_step=stage == "train",
-            on_epoch=True,
-            prog_bar=False,
-            logger=True,
-            sync_dist=True,
-        )
+    def _log_metrics(self, metrics: Mapping[str, Any], stage: str) -> None:
+        metric_objects: dict[str, Metric] = {}
+        scalar_values: dict[str, Any] = {}
+        for key, value in metrics.items():
+            if not key.startswith(stage) or "batch_size" in key:
+                continue
+            if isinstance(value, Metric):
+                metric_objects[key] = value
+            else:
+                scalar_values[key] = value
+
+        for key, metric in metric_objects.items():
+            self.log(
+                key,
+                metric,
+                on_step=False,
+                on_epoch=True,
+                prog_bar=False,
+                logger=True,
+                sync_dist=False,
+            )
+        if scalar_values:
+            self.log_dict(
+                scalar_values,
+                on_step=stage == "train",
+                on_epoch=True,
+                prog_bar=False,
+                logger=True,
+                sync_dist=True,
+            )
 
     def configure_optimizers(self):
         optimizer_name = self.args_task.optimizer.lower()

--- a/test/test_device_authority.py
+++ b/test/test_device_authority.py
@@ -45,7 +45,11 @@ def test_default_task_preserves_model_device_and_trainer_config(
 ) -> None:
     module = _default_task_module()
     monkeypatch.setattr(module, "get_loss_fn", lambda name: nn.CrossEntropyLoss())
-    monkeypatch.setattr(module, "get_metrics", lambda metrics, metadata: {})
+    monkeypatch.setattr(
+        module,
+        "get_metrics",
+        lambda metrics, metadata, **kwargs: {},
+    )
     monkeypatch.setattr(
         module.torch.cuda,
         "is_available",
@@ -63,7 +67,7 @@ def test_default_task_preserves_model_device_and_trainer_config(
         args_task=Namespace(
             name="classification",
             loss="CE",
-            metrics=[],
+            metrics=["acc"],
             optimizer="adam",
             lr=1e-3,
         ),

--- a/test/test_task_estimator_truth.py
+++ b/test/test_task_estimator_truth.py
@@ -1,0 +1,166 @@
+"""Focused counterexamples for Task Factory objective and estimator truth."""
+
+from __future__ import annotations
+
+import pytorch_lightning as pl
+import pytest
+import torch
+import torch.nn as nn
+import torchmetrics
+
+from phmfactory.task_semantics import validate_loss_metric_contract
+from src.task_factory.Components.loss import (
+    compute_task_loss,
+    prepare_loss_inputs,
+)
+from src.task_factory.Components.metrics import (
+    get_metrics,
+    prepare_metric_inputs,
+)
+from src.task_factory.Default_task import Default_task
+
+
+_BINARY_METADATA = {
+    1: {"Name": "demo", "Dataset_id": 0, "Label": 0},
+    2: {"Name": "demo", "Dataset_id": 0, "Label": 1},
+}
+
+
+def test_regression_loss_preserves_fractional_targets() -> None:
+    predictions = torch.tensor([1.75], requires_grad=True)
+    targets = torch.tensor([1.75])
+
+    loss = compute_task_loss(nn.MSELoss(), "MSE", predictions, targets)
+
+    assert torch.equal(loss, torch.tensor(0.0))
+    assert targets.dtype == torch.float32
+    loss.backward()
+    assert predictions.grad is not None
+
+
+def test_class_index_loss_converts_only_integer_valued_targets() -> None:
+    logits = torch.tensor(
+        [[3.0, -1.0], [-1.0, 3.0]],
+        requires_grad=True,
+    )
+    integer_valued_float = torch.tensor([0.0, 1.0])
+
+    loss = compute_task_loss(
+        nn.CrossEntropyLoss(),
+        "CE",
+        logits,
+        integer_valued_float,
+    )
+
+    assert loss.ndim == 0
+    assert torch.isfinite(loss)
+    with pytest.raises(ValueError, match="integer class indices"):
+        prepare_loss_inputs("CE", logits, torch.tensor([0.0, 0.5]))
+
+
+def test_auroc_receives_logits_instead_of_argmax_indices() -> None:
+    logits = torch.tensor(
+        [[2.0, -1.0], [-0.5, 1.5], [0.25, 0.75]],
+    )
+    targets = torch.tensor([0, 1, 1])
+
+    observed_predictions, observed_targets = prepare_metric_inputs(
+        "auroc",
+        logits,
+        targets,
+        loss_name="CE",
+    )
+
+    assert torch.equal(observed_predictions, logits)
+    assert observed_predictions.shape == (3, 2)
+    assert torch.equal(observed_targets, targets)
+
+
+def _macro_f1(logits: torch.Tensor, targets: torch.Tensor) -> torch.Tensor:
+    metric = torchmetrics.F1Score(
+        task="multiclass",
+        num_classes=2,
+        average="macro",
+    )
+    return metric(logits, targets)
+
+
+def test_f1_is_computed_over_the_complete_epoch_population() -> None:
+    task = Default_task.__new__(Default_task)
+    pl.LightningModule.__init__(task)
+    task.loss_name = "CE"
+    task.metrics = get_metrics(
+        ["f1"],
+        _BINARY_METADATA,
+        loss_name="CE",
+    )
+
+    first_logits = torch.tensor([[4.0, -1.0], [4.0, -1.0]])
+    first_targets = torch.tensor([0, 1])
+    second_logits = torch.tensor([[-1.0, 4.0], [-1.0, 4.0]])
+    second_targets = torch.tensor([1, 1])
+
+    first = task._compute_metrics(
+        first_logits,
+        first_targets,
+        "demo",
+        "test",
+    )
+    second = task._compute_metrics(
+        second_logits,
+        second_targets,
+        "demo",
+        "test",
+    )
+
+    assert first["test_f1_demo"] is second["test_f1_demo"]
+    observed = task.metrics["demo"]["test_f1"].compute()
+    expected = _macro_f1(
+        torch.cat([first_logits, second_logits], dim=0),
+        torch.cat([first_targets, second_targets], dim=0),
+    )
+    batch_mean = torch.stack(
+        [
+            _macro_f1(first_logits, first_targets),
+            _macro_f1(second_logits, second_targets),
+        ]
+    ).mean()
+
+    assert torch.allclose(observed, expected)
+    assert not torch.allclose(observed, batch_mean)
+
+
+def test_loss_and_metric_families_cannot_be_mixed() -> None:
+    with pytest.raises(ValueError, match="requires regression metrics"):
+        validate_loss_metric_contract("MSE", ["acc"])
+    with pytest.raises(ValueError, match="requires classification metrics"):
+        validate_loss_metric_contract("CE", ["mse"])
+    with pytest.raises(ValueError, match="cannot mix classification and regression"):
+        validate_loss_metric_contract("CUSTOM", ["f1", "mae"])
+
+
+def test_two_logit_ce_uses_multiclass_metrics_even_for_two_classes() -> None:
+    metrics = get_metrics(
+        ["acc", "auroc"],
+        _BINARY_METADATA,
+        loss_name="CE",
+    )
+    logits = torch.tensor(
+        [[3.0, -1.0], [-1.0, 3.0], [2.0, 0.0], [0.0, 2.0]],
+    )
+    targets = torch.tensor([0, 1, 0, 1])
+
+    metrics["demo"]["test_acc"].update(logits, targets)
+    metrics["demo"]["test_auroc"].update(logits, targets)
+
+    assert torch.isfinite(metrics["demo"]["test_acc"].compute())
+    assert torch.isfinite(metrics["demo"]["test_auroc"].compute())
+
+
+def test_bce_rejects_ambiguous_two_logit_outputs() -> None:
+    with pytest.raises(ValueError, match="one logit and one target per sample"):
+        prepare_loss_inputs(
+            "BCE",
+            torch.tensor([[2.0, -2.0], [-1.0, 1.0]]),
+            torch.tensor([0.0, 1.0]),
+        )


### PR DESCRIPTION
## Objective

Make the tensor semantics and estimator lifecycle executed by `Default_task` match the configured loss and metric names.

## Scientific invariant

```text
declared task.loss / task.metrics
=
executed target dtype + prediction representation + population estimator
```

## Problems closed

- regression targets are no longer converted to integer class indices;
- CE/NLL convert only validated integer-valued labels and reject fractional/out-of-range labels;
- BCE accepts one explicit binary logit per sample and rejects ambiguous two-logit shapes;
- AUROC and other classification metrics receive logits/scores rather than `argmax` class indices;
- regression metrics receive continuous predictions and targets;
- classification and regression metric families cannot be mixed in the generic task;
- CE/NLL with two classes use a two-logit multiclass metric interface;
- stateful TorchMetrics objects are updated batch by batch and computed/reset at the epoch boundary, so F1/AUROC are not replaced by the mean of batch-level values.

## Changes

- add one small Torch-free task-semantic validator shared by loss and metric boundaries;
- validate loss-specific tensor shape, dtype, finiteness, and target range before objective evaluation;
- preserve estimator-specific prediction representations;
- log registered TorchMetrics objects as epoch-level metric states;
- add counterexample tests proving fractional regression targets, raw-logit AUROC input, full-population macro F1, incompatible family rejection, and explicit BCE shape behavior;
- include the focused tests in the existing offline core gate.

## Boundaries

- no Data Factory, split, sampling, Trainer, checkpoint, MFPT protocol, or model changes;
- no new manager, registry, factory, schema, wrapper hierarchy, hash, checksum, digest, receipt, ledger, evidence, or attestation;
- no remote data/model download;
- no fallback, automatic label re-encoding, output threshold guessing, or general tensor reshaping.

## Acceptance

- `MSE([1.75], [1.75]) == 0` without target truncation;
- fractional CE labels fail before loss evaluation;
- AUROC receives `[B,C]` logits for CE/NLL;
- accumulated macro F1 equals independent full-population F1 and differs from mean batch F1 on the counterexample;
- existing offline Dummy fit → best-checkpoint restoration → test → finite metrics remains green;
- all existing focused Task, HSE, runtime, Data, device, and Pipeline 02 contracts remain green.
