### PR TITLE
fix(trainer): make checkpoint direction explicit

### DIFF
--- a/configs/base/trainer/README.md
+++ b/configs/base/trainer/README.md
@@ -6,7 +6,8 @@
 
 - device and accelerator selection;
 - epoch count;
-- callbacks such as checkpointing and early stopping.
+- checkpoint selection and early stopping;
+- training log cadence.
 
 The Trainer Factory is the only device-placement authority. Data, Model, and Task
 Factories must not move a model to CPU or CUDA during construction.
@@ -21,6 +22,8 @@ trainer:
   num_epochs: 10
   device: "cpu"
   gpus: 1
+  monitor: "val_loss"
+  monitor_mode: "min"
 ```
 
 Explicit CUDA:
@@ -31,9 +34,11 @@ trainer:
   num_epochs: 10
   device: "cuda"
   gpus: 1
+  monitor: "val_loss"
+  monitor_mode: "min"
 ```
 
-Explicit automatic selection:
+Explicit automatic device selection:
 
 ```yaml
 trainer:
@@ -41,6 +46,8 @@ trainer:
   num_epochs: 10
   device: "auto"
   gpus: 1
+  monitor: "val_loss"
+  monitor_mode: "min"
 ```
 
 ## 3) Device Contract
@@ -49,12 +56,47 @@ trainer:
 |---|---|
 | `cpu` | Passes `accelerator="cpu"` to Lightning. CUDA availability is irrelevant. |
 | `cuda` | Passes `accelerator="gpu"`; fails before Trainer construction when CUDA or the requested device count is unavailable. |
-| `auto` | Passes `accelerator="auto"` to Lightning. Automatic selection occurs only when the user explicitly writes `auto`. |
+| `auto` | Selects from the hardware observed by PHMFactory only because the user explicitly wrote `auto`. |
 
 There is no implicit `cuda -> cpu` fallback. A CUDA request that cannot be satisfied is
 an invalid run request and terminates with a corrective error.
 
-## 4) Key Fields
+## 4) Checkpoint Selection Contract
+
+`Default_trainer` requires an explicit pair:
+
+```yaml
+trainer:
+  monitor: "val_loss"
+  monitor_mode: "min"
+```
+
+or, for a metric that should be maximized:
+
+```yaml
+trainer:
+  monitor: "val_acc_Dummy_Data"
+  monitor_mode: "max"
+```
+
+The exact same `monitor` and `monitor_mode` drive:
+
+```text
+ModelCheckpoint
+EarlyStopping
+best-checkpoint restoration
+```
+
+PHMFactory does not infer direction from the metric name. This is intentional: names
+such as `score`, `error`, `utility`, or custom metrics do not define a reliable direction.
+Writing `monitor_mode: "min"` means minimize the selected metric even when its name
+contains `acc`; writing `max` means maximize it even when its name contains `loss`.
+The configuration is authoritative.
+
+Checkpoint filenames contain only epoch and step. They do not embed a hard-coded
+`val_loss` field when another metric is selected.
+
+## 5) Key Fields
 
 | Field | Type | Notes |
 |---|---:|---|
@@ -63,14 +105,26 @@ an invalid run request and terminates with a corrective error.
 | `trainer.device` | str | Required: `cpu`, `cuda`, or `auto`. |
 | `trainer.gpus` | positive int | Compatibility name for the Lightning device count. |
 | `trainer.devices` | positive int | Preferred device-count spelling when present; takes precedence over `gpus`. |
+| `trainer.monitor` | non-empty str | Logged validation scalar used to select the checkpoint. |
+| `trainer.monitor_mode` | `min` or `max` | Explicit optimization direction; never inferred. |
+| `trainer.early_stopping` | bool | When true, stopping uses the same monitor pair as checkpointing. |
+| `trainer.patience` | positive int | Early-stopping patience when enabled. |
 
-## 5) Typical Overrides
+## 6) Typical Overrides
 
 ```bash
 python main.py --config <yaml> --override trainer.num_epochs=1
 python main.py --config <yaml> \
   --override trainer.device=cpu \
   --override trainer.gpus=1
+```
+
+To select by validation accuracy:
+
+```bash
+python main.py --config <yaml> \
+  --override trainer.monitor=val_acc_Dummy_Data \
+  --override trainer.monitor_mode=max
 ```
 
 A GPU run must be requested explicitly:
@@ -81,25 +135,28 @@ python main.py --config <yaml> \
   --override trainer.gpus=1
 ```
 
-## 6) Coupling Notes
+## 7) Coupling Notes
 
 - Built by `src/trainer_factory/__init__.py:build_trainer`.
 - `Default_trainer` maps the explicit device request to the Lightning accelerator.
+- `Default_trainer` owns checkpoint and early-stopping selection semantics.
 - Task constructors preserve the model returned by Model Factory and do not inspect
   CUDA availability.
 
-## 7) How to Extend
+## 8) How to Extend
 
 1. Add a trainer implementation under `src/trainer_factory/`.
 2. Point configs at it through `trainer.name`.
-3. Keep hardware selection in the trainer implementation; do not add `.cuda()` calls to
-   Tasks or Models.
+3. Keep hardware and checkpoint selection in the trainer implementation.
+4. Do not add `.cuda()` calls or checkpoint selection to Tasks or Models.
 
-## 8) Common Failures
+## 9) Common Failures
 
 1. `trainer.device` is absent or not one of `cpu`, `cuda`, `auto`.
 2. `trainer.device=cuda` is requested on a host without CUDA.
 3. The requested CUDA device count exceeds `torch.cuda.device_count()`.
 4. `trainer.gpus` or `trainer.devices` is zero, boolean, non-integral, or negative.
-5. DDP is requested indirectly with more devices than the host provides.
-6. Early-stopping and checkpoint monitor names do not match logged metrics.
+5. `trainer.monitor` is absent, empty, or does not match a logged validation metric.
+6. `trainer.monitor_mode` is absent or is not exactly `min` or `max`.
+7. Early stopping and checkpoint selection are configured against a metric that the Task
+   never logs.

--- a/configs/base/trainer/default_single_gpu.yaml
+++ b/configs/base/trainer/default_single_gpu.yaml
@@ -1,6 +1,7 @@
 trainer:
   name: "Default_trainer"
   monitor: "val_loss"
+  monitor_mode: "min"
   num_epochs: 10
   gpus: 1
   device: "cuda"

--- a/src/trainer_factory/Default_trainer.py
+++ b/src/trainer_factory/Default_trainer.py
@@ -1,9 +1,11 @@
+from __future__ import annotations
+
 import os
+from typing import Any
 
 import pytorch_lightning as pl
 from pytorch_lightning.callbacks import EarlyStopping, ModelCheckpoint, ModelPruning
 from pytorch_lightning.loggers import CSVLogger, WandbLogger
-from torch.utils.tensorboard.writer import SummaryWriter
 
 try:
     from swanlab.integration.pytorch_lightning import SwanLabLogger
@@ -23,27 +25,50 @@ if "LOCAL_RANK" in os.environ:
     is_main_process = local_rank == 0
 
 
+_SELECTION_MODES = frozenset({"min", "max"})
+
+
+def resolve_selection_contract(args: Any) -> tuple[str, str]:
+    """Return the exact checkpoint metric and optimization direction.
+
+    PHMFactory never infers direction from a metric name.  The same explicit pair is
+    consumed by ModelCheckpoint and EarlyStopping so checkpoint restoration cannot use a
+    different estimator direction from stopping.
+    """
+
+    monitor = getattr(args, "monitor", None)
+    if not isinstance(monitor, str) or not monitor.strip():
+        raise ValueError(
+            "trainer.monitor is required and must name one logged validation metric"
+        )
+
+    raw_mode = getattr(args, "monitor_mode", None)
+    if not isinstance(raw_mode, str) or not raw_mode.strip():
+        raise ValueError(
+            "trainer.monitor_mode is required and must be 'min' or 'max'; "
+            "PHMFactory does not infer checkpoint direction from the metric name"
+        )
+    mode = raw_mode.strip().lower()
+    if mode not in _SELECTION_MODES:
+        raise ValueError(
+            f"unsupported trainer.monitor_mode {raw_mode!r}; expected min or max"
+        )
+    return monitor.strip(), mode
+
+
 @register_trainer("Default_trainer")
 def trainer(args_e, args_t, args_d, path):
-    """
-    设置训练器的配置，包括日志记录、回调函数和数据加载器等。
+    """Build one Lightning Trainer from the explicit trainer configuration."""
 
-    参数:
-    - args_t: 包含训练配置的对象
-    - args_d: 包含数据配置的对象
-    - path: 存储日志、检查点的路径
-
-    返回:
-    - trainer: 训练器对象
-    """
-    # 为兼容旧配置，填充 num_epochs / pruning 的合理默认值
+    # Historical spelling remains accepted, but the resulting value is explicit before
+    # Lightning construction.  This compatibility boundary does not choose a device,
+    # checkpoint metric, or selection direction.
     if not hasattr(args_t, "num_epochs"):
         setattr(args_t, "num_epochs", getattr(args_t, "max_epochs", 1))
     if not hasattr(args_t, "pruning"):
         setattr(args_t, "pruning", 0.0)
 
     accelerator, devices = resolve_device_request(args_t)
-
     callback_list = call_backs(args_t, path)
     log_list = [CSVLogger(path, name="logs")]
     use_wandb = getattr(args_e, "wandb", False)
@@ -68,7 +93,7 @@ def trainer(args_e, args_t, args_d, path):
     if not getattr(args_t, "log_every_n_steps", None):
         args_t.log_every_n_steps = 50
 
-    trainer = pl.Trainer(
+    return pl.Trainer(
         callbacks=callback_list,
         accelerator=accelerator,
         max_epochs=args_t.num_epochs,
@@ -78,17 +103,20 @@ def trainer(args_e, args_t, args_d, path):
         strategy="ddp_find_unused_parameters_true" if devices > 1 else "auto",
         deterministic=getattr(args_t, "deterministic", None),
     )
-    return trainer
 
 
 def call_backs(args, path):
-    """Build only callbacks that participate in training or checkpoint selection."""
+    """Build checkpoint and stopping callbacks from one selection contract."""
 
+    monitor, mode = resolve_selection_contract(args)
     checkpoint_callback = ModelCheckpoint(
-        monitor=args.monitor,
-        filename="model-{epoch:02d}-{val_loss:.4f}",
+        monitor=monitor,
+        # Do not embed a hard-coded metric such as val_loss in the filename.  The
+        # configured monitor may be any logged scalar and the callback itself owns the
+        # selected score.
+        filename="model-{epoch:02d}-{step}",
         save_top_k=getattr(args, "save_top_k", 1),
-        mode="min",
+        mode=mode,
         dirpath=path,
     )
 
@@ -99,8 +127,13 @@ def call_backs(args, path):
         callback_list.append(prune_callback)
 
     if getattr(args, "early_stopping", False):
-        early_stopping = create_early_stopping_callback(args)
-        callback_list.append(early_stopping)
+        callback_list.append(
+            create_early_stopping_callback(
+                args,
+                monitor=monitor,
+                mode=mode,
+            )
+        )
 
     return callback_list
 
@@ -118,29 +151,43 @@ def Prune_callback(args):
         return None
 
     if isinstance(args.pruning, (int, float)):
-        prune_callback = ModelPruning(
+        return ModelPruning(
             "l1_unstructured",
             parameter_names=["weight"],
             amount=args.pruning,
         )
-    elif isinstance(args.pruning, list):
-        prune_callback = ModelPruning(
+    if isinstance(args.pruning, list):
+        return ModelPruning(
             "l1_unstructured",
             parameter_names=["weight"],
             amount=compute_amount,
         )
-    else:
-        prune_callback = None
-    return prune_callback
+    return None
 
 
-def create_early_stopping_callback(args):
-    """创建并返回早期停止回调。"""
+def create_early_stopping_callback(
+    args,
+    *,
+    monitor: str | None = None,
+    mode: str | None = None,
+):
+    """Build EarlyStopping with the same explicit selection pair as checkpointing."""
+
+    if monitor is None or mode is None:
+        monitor, mode = resolve_selection_contract(args)
     return EarlyStopping(
-        monitor=args.monitor,
+        monitor=monitor,
         min_delta=float(getattr(args, "min_delta", 0.0)),
         patience=getattr(args, "patience", 10),
         verbose=True,
-        mode="min",
+        mode=mode,
         check_finite=True,
     )
+
+
+__all__ = [
+    "call_backs",
+    "create_early_stopping_callback",
+    "resolve_selection_contract",
+    "trainer",
+]

--- a/src/trainer_factory/README.md
+++ b/src/trainer_factory/README.md
@@ -21,7 +21,9 @@ trainer = build_trainer(
 )
 ```
 
-A successful call returns `pl.Trainer`. Import and construction failures raise with the requested trainer, module path, original cause, and repair guidance. The factory does not print an error and return `None`.
+A successful call returns `pl.Trainer`. Import and construction failures raise with the
+requested trainer, module path, original cause, and repair guidance. The factory does not
+print an error and return `None`.
 
 ## Configuration
 
@@ -32,11 +34,25 @@ trainer:
   device: "cpu"
   gpus: 1
   monitor: "val_loss"
+  monitor_mode: "min"
   early_stopping: true
   patience: 5
 ```
 
-`trainer.name` is the maintained selector. `trainer.trainer_name` remains a compatibility fallback only when `name` is absent.
+`trainer.name` is the maintained selector. `trainer.trainer_name` remains a compatibility
+fallback only when `name` is absent.
+
+For `Default_trainer`, checkpoint selection is an explicit two-field contract:
+
+```text
+trainer.monitor
++
+trainer.monitor_mode ∈ {min, max}
+```
+
+The pair is shared by `ModelCheckpoint` and `EarlyStopping`. The Trainer Factory does not
+guess direction from names such as `loss`, `acc`, `score`, or `error`, and does not use a
+hard-coded `val_loss` placeholder in checkpoint filenames.
 
 ## Resolution order
 
@@ -45,7 +61,8 @@ For `Default_trainer`, the factory:
 1. checks `TRAINER_REGISTRY`;
 2. imports `src.trainer_factory.Default_trainer`;
 3. checks the registry again so module decorators can register the builder;
-4. accepts the historical exported function name `trainer` when the module is not decorator-registered.
+4. accepts the historical exported function name `trainer` when the module is not
+   decorator-registered.
 
 It does not scan the package or guess alternative builder names.
 
@@ -76,26 +93,31 @@ def trainer(*, args_e, args_t, args_d, path):
     ...
 ```
 
-The builder must either return a valid `pl.Trainer` or raise. It must not catch a construction failure and return `None`.
+The builder must either return a valid `pl.Trainer` or raise. It must not catch a
+construction failure and return `None`.
 
 ## Developer expectations
 
 A trainer builder owns:
 
 - device and accelerator selection;
+- checkpoint metric and optimization direction;
 - callbacks such as checkpointing and early stopping;
 - loggers;
 - output/checkpoint paths;
 - Lightning `Trainer` options.
 
-It should not reinterpret the experiment YAML, replace the selected task/model, or silently switch hardware after an error.
+It should not reinterpret the experiment YAML, replace the selected task/model, infer
+checkpoint direction, or silently switch hardware after an error.
 
 ## Minimal validation
 
 ```bash
 python -m scripts.config_inspect --config <yaml> --dump targets
 python main.py --config <yaml> \
-  --override trainer.num_epochs=1 trainer.device=cpu data.num_workers=0
+  --override trainer.num_epochs=1 \
+  --override trainer.device=cpu \
+  --override data.num_workers=0
 ```
 
 Use the repository-shipped Dummy demo as the final compatibility check:
@@ -106,6 +128,11 @@ phmfactory demo
 
 ## Failure examples
 
-- `Cannot import trainer ...`: verify `trainer.name`, module path, and optional dependencies.
-- `does not register ... and does not expose 'trainer'`: add `@register_trainer(...)` or export the historical `trainer` function.
-- `Cannot construct trainer ...`: inspect the preserved cause, device availability, callback settings, and output path permissions.
+- `Cannot import trainer ...`: verify `trainer.name`, module path, and optional
+  dependencies.
+- `does not register ... and does not expose 'trainer'`: add
+  `@register_trainer(...)` or export the historical `trainer` function.
+- missing `trainer.monitor`: name the validation scalar logged by the Task.
+- missing or invalid `trainer.monitor_mode`: declare `min` or `max` explicitly.
+- Trainer construction exception: inspect the preserved cause, device availability,
+  callback settings, selected metric, and output-path permissions.

--- a/test/test_device_authority.py
+++ b/test/test_device_authority.py
@@ -6,6 +6,7 @@ import importlib
 import pytest
 import torch
 import torch.nn as nn
+from pytorch_lightning.callbacks import EarlyStopping, ModelCheckpoint
 
 
 def _default_task_module():
@@ -237,6 +238,7 @@ def test_default_trainer_passes_resolved_cpu_request_to_lightning(
             num_epochs=1,
             pruning=0.0,
             monitor="val_loss",
+            monitor_mode="min",
             log_every_n_steps=1,
         ),
         args_d=Namespace(),
@@ -396,3 +398,56 @@ def test_model_factory_rejects_non_boolean_checkpoint_strictness(
         match="model.weights_strict must be a boolean",
     ):
         module.model_factory(args_model, metadata=None)
+
+
+def test_checkpoint_and_early_stopping_share_explicit_direction(tmp_path) -> None:
+    module = _default_trainer_module()
+    callbacks = module.call_backs(
+        Namespace(
+            monitor="val_acc",
+            monitor_mode="max",
+            save_top_k=1,
+            pruning=0.0,
+            early_stopping=True,
+            patience=2,
+        ),
+        str(tmp_path),
+    )
+
+    checkpoint = next(item for item in callbacks if isinstance(item, ModelCheckpoint))
+    stopping = next(item for item in callbacks if isinstance(item, EarlyStopping))
+
+    assert checkpoint.monitor == stopping.monitor == "val_acc"
+    assert checkpoint.mode == stopping.mode == "max"
+    assert checkpoint.filename == "model-{epoch:02d}-{step}"
+
+
+@pytest.mark.parametrize(
+    ("args", "message"),
+    [
+        (Namespace(monitor_mode="min"), "trainer.monitor is required"),
+        (Namespace(monitor="val_loss"), "trainer.monitor_mode is required"),
+        (
+            Namespace(monitor="val_loss", monitor_mode="auto"),
+            "unsupported trainer.monitor_mode",
+        ),
+    ],
+)
+def test_checkpoint_selection_requires_explicit_monitor_and_direction(
+    args: Namespace,
+    message: str,
+) -> None:
+    module = _default_trainer_module()
+    with pytest.raises(ValueError, match=message):
+        module.resolve_selection_contract(args)
+
+
+def test_checkpoint_direction_is_not_guessed_from_metric_name() -> None:
+    module = _default_trainer_module()
+
+    assert module.resolve_selection_contract(
+        Namespace(monitor="val_acc", monitor_mode="min")
+    ) == ("val_acc", "min")
+    assert module.resolve_selection_contract(
+        Namespace(monitor="val_loss", monitor_mode="max")
+    ) == ("val_loss", "max")


### PR DESCRIPTION
## Objective

Ensure checkpoint selection, early stopping, and restored evaluation use the exact optimization direction declared by the user.

## Scientific invariant

```text
best checkpoint
=
arg{trainer.monitor_mode} trainer.monitor
```

`min` and `max` are explicit configuration semantics. PHMFactory must not infer direction from a metric name or force every metric to be minimized.

## Problems closed

- `ModelCheckpoint` no longer hard-codes `mode="min"`;
- `EarlyStopping` no longer hard-codes `mode="min"`;
- both callbacks consume one shared `trainer.monitor` / `trainer.monitor_mode` pair;
- missing or invalid selection fields fail before Lightning Trainer construction;
- checkpoint filenames no longer embed a hard-coded `val_loss` placeholder when another metric is monitored;
- the maintained trainer base declares `monitor_mode: min` explicitly.

## Changes

- add one small pure selection-contract function inside `Default_trainer`;
- pass the exact monitor and mode to checkpointing and early stopping;
- use a metric-independent checkpoint filename;
- add focused tests for shared `max` direction, missing fields, invalid mode, and absence of metric-name guessing;
- document the explicit checkpoint-selection contract in the maintained base and Trainer Factory guides.

## Boundaries

- no Task objective, metric implementation, Data Factory, split, model, run-summary, or MFPT protocol changes;
- no metric-name heuristics;
- no new manager, registry, factory, schema hierarchy, hash, checksum, digest, receipt, ledger, evidence, or attestation;
- no remote data/model download.

## Acceptance

- `monitor=val_acc, monitor_mode=max` configures both ModelCheckpoint and EarlyStopping with `max`;
- omitted `monitor` or `monitor_mode` fails clearly;
- unsupported mode such as `auto` fails clearly;
- intentionally unusual pairs remain exactly as requested rather than being rewritten;
- the offline Dummy lifecycle still fits, restores the selected checkpoint, tests, and reports finite metrics;
- existing core, public-package, layout, submodule, Pipeline 06, UXFD, Task, Data, and device contracts remain green.
