### PR TITLE
fix(results): require complete repeated-run metrics

### DIFF
--- a/.github/workflows/core-quality-gates.yml
+++ b/.github/workflows/core-quality-gates.yml
@@ -224,7 +224,7 @@ jobs:
       - name: Record smoke environment
         run: python -m pip freeze > offline-smoke-environment.txt
 
-      - name: Run shared runtime, data, task, device, and Pipeline 02 contract tests
+      - name: Run shared runtime, data, task, device, result, and Pipeline 02 contract tests
         shell: bash
         run: |
           set -o pipefail
@@ -240,6 +240,7 @@ jobs:
             src/task_factory/Default_task.py \
             src/task_factory/task/pretrain/hse_contrastive.py \
             src/trainer_factory/Default_trainer.py \
+            src/utils/run_summary.py \
             src/runtime/classification.py \
             src/runtime/explainability.py \
             src/Pipeline_01_Fault_Diagnosis.py \
@@ -251,6 +252,7 @@ jobs:
             test/test_hse_objective_contract.py \
             test/test_per_sample_metadata.py \
             test/test_pipeline02_runtime.py \
+            test/test_run_summary.py \
             test/test_runtime_execution.py \
             test/test_split_scientific_truth.py \
             test/test_task_estimator_truth.py \
@@ -262,6 +264,7 @@ jobs:
             test/test_hse_objective_contract.py \
             test/test_per_sample_metadata.py \
             test/test_pipeline02_runtime.py \
+            test/test_run_summary.py \
             test/test_runtime_execution.py \
             test/test_split_scientific_truth.py \
             test/test_task_estimator_truth.py \
@@ -323,7 +326,7 @@ jobs:
           assert summary["iterations"] == 1
           assert summary["metrics"], summary
           for metric in summary["metrics"].values():
-              assert metric["count"] == 1
+              assert metric["count"] == summary["iterations"]
               assert math.isfinite(float(metric["mean"]))
 
           assert not list(result_dir.rglob(".phmfactory"))

--- a/src/runtime/classification.py
+++ b/src/runtime/classification.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from dataclasses import dataclass
 import os
 from pathlib import Path
@@ -22,7 +23,11 @@ from src.model_factory import build_model
 from src.task_factory import build_task
 from src.trainer_factory import build_trainer
 from src.utils.config_utils import apply_overrides_to_config, parse_overrides
-from src.utils.run_summary import write_run_summary
+from src.utils.run_summary import (
+    build_run_summary,
+    normalize_metric_result,
+    write_run_summary,
+)
 from src.utils.utils import close_lab, init_lab, load_best_model_checkpoint
 
 
@@ -124,12 +129,30 @@ def _close_data_factory(data_factory: Any) -> None:
         close()
 
 
-def _result_row(result: Any) -> dict[str, Any]:
-    if not isinstance(result, list) or not result or not isinstance(result[0], dict):
+def _result_row(result: Any) -> dict[str, float]:
+    """Return one complete metric population from ``trainer.test``.
+
+    Lightning returns one mapping per test dataloader.  The maintained classification
+    estimator currently defines exactly one test population.  Multiple mappings are
+    therefore ambiguous and must be handled by an explicit multi-population protocol
+    rather than silently discarding every item after the first.
+    """
+
+    if not isinstance(result, (list, tuple)) or len(result) != 1:
+        observed = len(result) if isinstance(result, (list, tuple)) else type(result).__name__
         raise RuntimeError(
-            "trainer.test must return a non-empty list whose first item is a mapping"
+            "trainer.test must return exactly one metric mapping for the maintained "
+            f"classification test population, observed={observed}"
         )
-    return dict(result[0])
+    if not isinstance(result[0], Mapping):
+        raise RuntimeError(
+            "trainer.test result 0 must be a metric mapping, "
+            f"got {type(result[0]).__name__}"
+        )
+    return normalize_metric_result(
+        result[0],
+        context="trainer.test result 0",
+    )
 
 
 def _best_checkpoint_path(trainer: Any) -> Path:
@@ -158,10 +181,17 @@ def _write_aggregate_outputs(
     run_seeds: list[int],
     configs: Any,
 ) -> dict[str, Any]:
-    """Write repeated-run metrics and their deterministic summary."""
+    """Write repeated-run metrics only after the complete estimator validates."""
 
     if last_iteration_path is None or not all_results:
         raise ValueError("aggregate outputs require at least one completed iteration")
+
+    # Validate the complete repeated-run estimator before publishing aggregate CSVs.
+    build_run_summary(
+        results=all_results,
+        seeds=run_seeds,
+        config=configs,
+    )
 
     run_root_path = Path(run_root)
     iteration_path = Path(last_iteration_path)

--- a/src/utils/run_summary.py
+++ b/src/utils/run_summary.py
@@ -1,4 +1,4 @@
-"""Deterministic summaries for repeated experiment results."""
+"""Deterministic, complete summaries for repeated experiment results."""
 
 from __future__ import annotations
 
@@ -41,17 +41,67 @@ def resolved_config_sha256(config: Any) -> str:
     return hashlib.sha256(payload).hexdigest()
 
 
-def _numeric_value(value: Any) -> float | None:
+def _numeric_metric(value: Any, *, context: str) -> float:
+    """Return one finite scalar metric without silently dropping values."""
+
     if isinstance(value, bool):
-        return None
+        raise TypeError(f"{context} must be numeric, not boolean")
     if hasattr(value, "item"):
-        value = value.item()
-    if not isinstance(value, numbers.Real):
-        return None
+        try:
+            value = value.item()
+        except (RuntimeError, TypeError, ValueError) as exc:
+            raise TypeError(f"{context} must be a scalar numeric value") from exc
+    if isinstance(value, bool) or not isinstance(value, numbers.Real):
+        raise TypeError(
+            f"{context} must be a scalar real number, got {type(value).__name__}"
+        )
     number = float(value)
     if not math.isfinite(number):
-        raise ValueError("run results contain a non-finite numeric metric")
+        raise ValueError(f"{context} is not finite: {number!r}")
     return number
+
+
+def normalize_metric_result(
+    result: Mapping[str, Any],
+    *,
+    context: str = "run result",
+) -> dict[str, float]:
+    """Validate one complete metric mapping and return plain finite floats."""
+
+    if not isinstance(result, Mapping):
+        raise TypeError(f"{context} must be a metric mapping")
+    if not result:
+        raise ValueError(f"{context} must contain at least one metric")
+
+    normalized: dict[str, float] = {}
+    for raw_name, raw_value in result.items():
+        if not isinstance(raw_name, str) or not raw_name.strip():
+            raise TypeError(
+                f"{context} metric names must be non-empty strings, got {raw_name!r}"
+            )
+        name = raw_name.strip()
+        if name != raw_name:
+            raise ValueError(
+                f"{context} metric name {raw_name!r} contains surrounding whitespace"
+            )
+        if name in normalized:
+            raise ValueError(f"{context} contains duplicate metric name {name!r}")
+        normalized[name] = _numeric_metric(
+            raw_value,
+            context=f"{context} metric {name!r}",
+        )
+    return normalized
+
+
+def _normalized_seeds(seeds: Sequence[int]) -> list[int]:
+    normalized: list[int] = []
+    for index, seed in enumerate(seeds):
+        if isinstance(seed, bool) or not isinstance(seed, numbers.Integral):
+            raise TypeError(
+                f"seed {index} must be an integer, got {seed!r}"
+            )
+        normalized.append(int(seed))
+    return normalized
 
 
 def build_run_summary(
@@ -59,34 +109,43 @@ def build_run_summary(
     seeds: Sequence[int],
     config: Any,
 ) -> dict[str, Any]:
+    """Summarize one identical finite metric set across every completed seed."""
+
     if len(results) != len(seeds):
         raise ValueError("one seed must be recorded for every run result")
     if not results:
         raise ValueError("at least one run result is required")
 
-    metric_names = sorted({str(key) for result in results for key in result})
+    normalized_results = [
+        normalize_metric_result(result, context=f"run result {index}")
+        for index, result in enumerate(results)
+    ]
+    expected_names = set(normalized_results[0])
+    for index, result in enumerate(normalized_results[1:], start=1):
+        observed_names = set(result)
+        if observed_names != expected_names:
+            missing = sorted(expected_names - observed_names)
+            unexpected = sorted(observed_names - expected_names)
+            raise ValueError(
+                "every seed must report the same metric set: "
+                f"run={index}, missing={missing}, unexpected={unexpected}"
+            )
+
     metrics: dict[str, dict[str, Any]] = {}
-    for name in metric_names:
-        values = []
-        for result in results:
-            if name not in result:
-                continue
-            value = _numeric_value(result[name])
-            if value is not None:
-                values.append(value)
-        if not values:
-            continue
+    for name in sorted(expected_names):
+        values = [result[name] for result in normalized_results]
         metrics[name] = {
             "count": len(values),
             "mean": statistics.fmean(values),
             "sample_std": statistics.stdev(values) if len(values) >= 2 else None,
         }
 
+    normalized_seeds = _normalized_seeds(seeds)
     return {
         "schema_version": 1,
         "config_sha256": resolved_config_sha256(config),
-        "iterations": len(results),
-        "seeds": [int(seed) for seed in seeds],
+        "iterations": len(normalized_results),
+        "seeds": normalized_seeds,
         "metrics": metrics,
     }
 
@@ -106,3 +165,11 @@ def write_run_summary(
         encoding="utf-8",
     )
     return summary
+
+
+__all__ = [
+    "build_run_summary",
+    "normalize_metric_result",
+    "resolved_config_sha256",
+    "write_run_summary",
+]

--- a/test/test_run_summary.py
+++ b/test/test_run_summary.py
@@ -1,10 +1,14 @@
+from __future__ import annotations
+
 import json
 from types import SimpleNamespace
 
 import pytest
 
+from src.runtime.classification import _result_row
 from src.utils.run_summary import (
     build_run_summary,
+    normalize_metric_result,
     resolved_config_sha256,
     write_run_summary,
 )
@@ -18,18 +22,20 @@ def _config():
     )
 
 
-def test_summary_records_hash_seeds_and_sample_statistics():
+def test_summary_records_complete_seed_statistics():
     results = [
-        {"test_acc": 0.5, "test_loss": 2.0, "label": "ignored"},
-        {"test_acc": 0.7, "test_loss": 4.0, "label": "ignored"},
+        {"test_acc": 0.5, "test_loss": 2.0},
+        {"test_acc": 0.7, "test_loss": 4.0},
     ]
     summary = build_run_summary(results, seeds=[42, 43], config=_config())
 
     assert summary["config_sha256"] == resolved_config_sha256(_config())
+    assert summary["iterations"] == 2
     assert summary["seeds"] == [42, 43]
+    assert set(summary["metrics"]) == {"test_acc", "test_loss"}
+    assert summary["metrics"]["test_acc"]["count"] == 2
     assert summary["metrics"]["test_acc"]["mean"] == pytest.approx(0.6)
     assert summary["metrics"]["test_acc"]["sample_std"] == pytest.approx(2**0.5 / 10)
-    assert "label" not in summary["metrics"]
 
 
 def test_single_run_uses_null_std_and_writes_strict_json(tmp_path):
@@ -38,6 +44,7 @@ def test_single_run_uses_null_std_and_writes_strict_json(tmp_path):
     payload = json.loads(output.read_text(encoding="utf-8"))
 
     assert payload["iterations"] == 1
+    assert payload["metrics"]["test_acc"]["count"] == 1
     assert payload["metrics"]["test_acc"]["sample_std"] is None
     assert output.read_text(encoding="utf-8").endswith("\n")
 
@@ -45,5 +52,69 @@ def test_single_run_uses_null_std_and_writes_strict_json(tmp_path):
 def test_summary_rejects_missing_seed_and_nonfinite_metrics():
     with pytest.raises(ValueError, match="one seed"):
         build_run_summary([{"value": 1.0}], [], _config())
-    with pytest.raises(ValueError, match="non-finite"):
+    with pytest.raises(ValueError, match="not finite"):
         build_run_summary([{"value": float("nan")}], [42], _config())
+
+
+def test_summary_rejects_metric_key_drift_across_seeds():
+    with pytest.raises(
+        ValueError,
+        match=r"same metric set.*missing=\['test_f1'\]",
+    ):
+        build_run_summary(
+            [
+                {"test_acc": 0.5, "test_f1": 0.4},
+                {"test_acc": 0.7},
+            ],
+            seeds=[42, 43],
+            config=_config(),
+        )
+
+    with pytest.raises(
+        ValueError,
+        match=r"same metric set.*unexpected=\['test_f1'\]",
+    ):
+        build_run_summary(
+            [
+                {"test_acc": 0.5},
+                {"test_acc": 0.7, "test_f1": 0.6},
+            ],
+            seeds=[42, 43],
+            config=_config(),
+        )
+
+
+def test_metric_result_rejects_empty_nonnumeric_boolean_and_nonscalar_values():
+    with pytest.raises(ValueError, match="at least one metric"):
+        normalize_metric_result({})
+    with pytest.raises(TypeError, match="scalar real number"):
+        normalize_metric_result({"test_acc": "0.5"})
+    with pytest.raises(TypeError, match="not boolean"):
+        normalize_metric_result({"test_acc": True})
+
+    class VectorLike:
+        def item(self):
+            raise ValueError("more than one element")
+
+    with pytest.raises(TypeError, match="scalar numeric value"):
+        normalize_metric_result({"test_acc": VectorLike()})
+
+
+def test_summary_rejects_noninteger_seed_values():
+    with pytest.raises(TypeError, match="seed 0 must be an integer"):
+        build_run_summary([{"test_acc": 0.5}], [42.5], _config())
+    with pytest.raises(TypeError, match="seed 0 must be an integer"):
+        build_run_summary([{"test_acc": 0.5}], [True], _config())
+
+
+def test_trainer_test_requires_exactly_one_explicit_population():
+    assert _result_row([{"test_acc": 0.5}]) == {"test_acc": 0.5}
+
+    with pytest.raises(RuntimeError, match="exactly one metric mapping"):
+        _result_row([])
+    with pytest.raises(RuntimeError, match="exactly one metric mapping"):
+        _result_row([{"test_acc": 0.5}, {"test_acc": 0.7}])
+    with pytest.raises(RuntimeError, match="result 0 must be a metric mapping"):
+        _result_row([[0.5]])
+    with pytest.raises(TypeError, match="scalar real number"):
+        _result_row([{"test_acc": "0.5"}])


### PR DESCRIPTION
## Objective

Make repeated-run summaries and test-population handling represent one complete, identical estimator across every seed.

## Scientific invariant

```text
for every seed s:
metric_keys(s) = K
and every metric in K is one finite scalar
```

The maintained classification path currently defines one test population. Multiple `trainer.test()` result mappings must be handled by an explicit multi-population protocol rather than silently discarding all but the first.

## Problems closed

- non-numeric metrics are no longer silently omitted;
- empty metric mappings fail;
- boolean, non-scalar, NaN, and Inf values fail;
- every seed must report the exact same metric key set;
- every summary metric has `count == iterations` by construction;
- non-integer seeds fail instead of being coerced;
- multiple test result mappings fail explicitly instead of using only item zero;
- aggregate CSV publication occurs only after the complete repeated-run estimator validates.

## Changes

- add one small metric-result normalizer in the existing run-summary module;
- validate all per-seed metric mappings and their key equality before aggregation;
- require exactly one maintained classification test-population mapping;
- add counterexample tests for missing/unexpected keys, nonnumeric values, booleans, nonscalar values, invalid seeds, and multiple test populations;
- include result-summary tests in the existing offline core gate and verify every metric count equals the reported iteration count.

## Boundaries

- no Task loss/metric implementation, Trainer checkpoint, Data Factory, split, model, MFPT protocol, or hyperparameter changes;
- no new manager, registry, factory, schema hierarchy, hash, checksum, digest, receipt, ledger, evidence, or attestation;
- no remote data/model download;
- no implicit merging or renaming of metrics across seeds or test populations.

## Acceptance

- `[acc,f1]`, `[acc]` across two seeds fails with the missing key;
- `[acc]`, `[acc,f1]` fails with the unexpected key;
- every successful summary metric has `count == iterations`;
- multiple `trainer.test()` mappings fail instead of being truncated;
- the offline Dummy lifecycle still fits, restores the selected checkpoint, tests, writes CSV/JSON, and reports finite complete metrics;
- existing core, public-package, layout, submodule, Pipeline 06, UXFD, Task, Trainer, Data, and device contracts remain green.
