### PR TITLE
fix(config): share one strict public acceptance boundary

### DIFF
--- a/.github/workflows/core-quality-gates.yml
+++ b/.github/workflows/core-quality-gates.yml
@@ -213,6 +213,7 @@ jobs:
             "pytorch-lightning>=1.5" \
             "torchmetrics>=1.0" \
             "PyYAML>=6.0" \
+            "pydantic>=2.0" \
             "matplotlib" \
             "tensorboard" \
             "openpyxl" \

--- a/.github/workflows/phmfactory-public-package.yml
+++ b/.github/workflows/phmfactory-public-package.yml
@@ -7,6 +7,7 @@ on:
       - "scripts/config_inspect.py"
       - "scripts/validate_configs.py"
       - "src/configs/config_utils.py"
+      - "src/config_schema/**"
       - "src/runtime/classification.py"
       - "src/trainer_factory/Default_trainer.py"
       - "src/trainer_factory/extensions/**"
@@ -39,6 +40,7 @@ on:
       - "scripts/config_inspect.py"
       - "scripts/validate_configs.py"
       - "src/configs/config_utils.py"
+      - "src/config_schema/**"
       - "src/runtime/classification.py"
       - "src/trainer_factory/Default_trainer.py"
       - "src/trainer_factory/extensions/**"
@@ -97,6 +99,7 @@ jobs:
           scripts/config_inspect.py
           scripts/validate_configs.py
           src/configs/config_utils.py
+          src/config_schema/*.py
           main.py
           test/test_config_analysis_parity.py
           test/test_phmfactory_commands.py
@@ -166,6 +169,8 @@ jobs:
               "phmfactory/runtime/pipeline06_adapter.py",
               "src/__init__.py",
               "src/configs/config_utils.py",
+              "src/config_schema/__init__.py",
+              "src/config_schema/models.py",
               "configs/__init__.py",
               "configs/demo/00_smoke/dummy_dg.yaml",
               "configs/base/environment/base.yaml",
@@ -196,7 +201,7 @@ jobs:
             /tmp/results
           python -m venv /tmp/phmfactory-wheel
           /tmp/phmfactory-wheel/bin/python -m pip install --no-deps dist/*.whl
-          /tmp/phmfactory-wheel/bin/python -m pip install PyYAML
+          /tmp/phmfactory-wheel/bin/python -m pip install "PyYAML>=6" "pydantic>=2"
           /tmp/phmfactory-wheel/bin/python -c "import phmfactory, phmfactory.commands, phmfactory.config, phmfactory.runtime, src; print(phmfactory.__version__)"
 
       - name: Verify clean installed root help

--- a/phmfactory/config.py
+++ b/phmfactory/config.py
@@ -6,11 +6,10 @@ This module owns the complete maintained precedence chain:
 
 Every public caller—run, preflight, inspection, validation, support generation, and the
 optional Streamlit UI—must use :func:`analyze_config` or the compatibility wrapper
-:func:`resolve_config`.  The module deliberately does not import a Pipeline, model,
-task, trainer, or dataset.  It resolves user intent into one immutable analysis object
-without starting training or creating output directories.
+:func:`resolve_config`. The module deliberately does not import a Pipeline, model, task,
+trainer, or dataset before the exact visible experiment has been composed and validated.
 
-Machine-local configuration is never discovered implicitly.  A local YAML file affects
+Machine-local configuration is never discovered implicitly. A local YAML file affects
 an invocation only when the caller supplies it explicitly.
 """
 
@@ -83,7 +82,7 @@ class ConfigDiagnostic:
 class ConfigAnalysis:
     """Immutable description of the exact effective configuration.
 
-    ``effective_config_sha256`` hashes only the canonical effective configuration.  It
+    ``effective_config_sha256`` hashes only the canonical effective configuration. It
     excludes the requested alias, source paths, installation path, and override spelling,
     so semantically identical invocations compare equal across checkouts and entrypoints.
     """
@@ -180,23 +179,43 @@ def semantic_config_sha256(config: Mapping[str, Any]) -> str:
     return sha256(payload).hexdigest()
 
 
+def validate_complete_experiment(config: Mapping[str, Any]) -> None:
+    """Validate one fully composed public experiment without rewriting it.
+
+    Base fragments remain free to contain only their owned block. This function is
+    called only after the public precedence chain has produced a complete experiment.
+    Pydantic is used as an acceptance boundary, not as a second configuration compiler:
+    defaults are not written back and no converted ``model_dump`` replaces the visible
+    mapping.
+    """
+
+    from src.config_schema import ExperimentConfig
+
+    before = deepcopy(config)
+    ExperimentConfig.model_validate(config, strict=True)
+    if config != before:
+        raise RuntimeError(
+            "ExperimentConfig validation mutated the visible effective configuration"
+        )
+
+
 def analyze_config(
     source: str | Path | None = None,
     *,
     override_values: Sequence[str] | None = None,
     local_config: str | Path | None = None,
 ) -> ConfigAnalysis:
-    """Resolve one public configuration through the single maintained authority.
+    """Resolve and strictly validate one public experiment.
 
     Parameters
     ----------
     source:
-        Maintained preset name or YAML path.  ``None`` selects ``DEFAULT_CONFIG``.
+        Maintained preset name or YAML path. ``None`` selects ``DEFAULT_CONFIG``.
     override_values:
         Repeatable dotted ``key=value`` tokens applied last.
     local_config:
         Optional YAML path applied explicitly between the experiment YAML and CLI
-        overrides.  No default local file is searched when this argument is omitted.
+        overrides. No default local file is searched when this argument is omitted.
 
     Returns
     -------
@@ -205,9 +224,11 @@ def analyze_config(
 
     Raises
     ------
-    FileNotFoundError, TypeError, ValueError, UnicodeError, yaml.YAMLError
-        The original configuration error is propagated; there is no fallback to another
-        config or Pipeline.
+    FileNotFoundError, TypeError, ValueError, UnicodeError, yaml.YAMLError,
+    pydantic.ValidationError
+        The original configuration error is propagated. There is no fallback to another
+        config or Pipeline, and invalid experiments fail before Pipeline import, output
+        creation, or Factory construction.
     """
 
     requested = str(source or DEFAULT_CONFIG)
@@ -247,6 +268,7 @@ def analyze_config(
     data["pipeline"] = pipeline
 
     effective = _json_compatible(deepcopy(data))
+    validate_complete_experiment(effective)
     return ConfigAnalysis(
         requested=requested,
         path=path,

--- a/scripts/validate_configs.py
+++ b/scripts/validate_configs.py
@@ -1,8 +1,8 @@
 """Validate maintained configs through PHMFactory's single public resolver.
 
-The validator intentionally shares composition and override semantics with ``run`` and
-``preflight``.  It never calls the legacy namespace loader and never auto-discovers a
-machine-local YAML file.
+The validator shares composition, strict schema acceptance, and override semantics with
+``run``, inspection, and ``preflight``. It never calls the legacy namespace loader and
+never auto-discovers a machine-local YAML file.
 """
 
 from __future__ import annotations
@@ -12,10 +12,7 @@ import csv
 from pathlib import Path
 from typing import Dict, Iterable, List, Optional, Set
 
-from pydantic import ValidationError
-
 from phmfactory.config import analyze_config
-from src.config_schema import ExperimentConfig
 
 
 def iter_demo_configs() -> Iterable[Path]:
@@ -39,14 +36,14 @@ def iter_registry_active_configs(registry_path: Path) -> Iterable[Path]:
 
 
 def validate_one(path: Path) -> List[str]:
-    """Return user-readable resolution and schema failures for one config."""
+    """Return user-readable resolution or strict-schema failures for one config."""
 
     try:
         analysis = analyze_config(path)
     except Exception as error:
-        return [f"- resolution: {type(error).__name__}: {error}"]
+        return [f"- config: {type(error).__name__}: {error}"]
 
-    lines = [
+    return [
         (
             f"- {item.field or 'config'}: {item.message} "
             f"[{item.code}]"
@@ -54,24 +51,11 @@ def validate_one(path: Path) -> List[str]:
         for item in analysis.diagnostics
         if item.severity == "error"
     ]
-    if lines:
-        return lines
-
-    try:
-        ExperimentConfig.model_validate(analysis.effective_config)
-        return []
-    except ValidationError as error:
-        for item in error.errors():
-            location = ".".join(str(value) for value in item.get("loc", []))
-            message = item.get("msg", "")
-            error_type = item.get("type", "")
-            lines.append(f"- {location}: {message} ({error_type})")
-        return lines
 
 
 def main(argv: Optional[List[str]] = None) -> int:
     parser = argparse.ArgumentParser(
-        description="Validate maintained configs with the public resolver and schema"
+        description="Validate maintained configs through the public strict boundary"
     )
     parser.add_argument(
         "--registry",
@@ -109,7 +93,7 @@ def main(argv: Optional[List[str]] = None) -> int:
         return 1
 
     print(
-        f"[OK] {len(paths)}/{len(paths)} configs passed public resolution and schema validation."
+        f"[OK] {len(paths)}/{len(paths)} configs passed the public strict acceptance boundary."
     )
     return 0
 

--- a/src/config_schema/models.py
+++ b/src/config_schema/models.py
@@ -286,6 +286,12 @@ class TrainerConfig(BaseModel):
 
     name: str = Field(..., description="Trainer implementation name under trainer_factory.")
     num_epochs: Optional[int] = Field(None, ge=1)
+    device: Optional[Literal["cpu", "cuda", "auto"]] = None
+    gpus: Optional[int] = Field(None, ge=1)
+    devices: Optional[int] = Field(None, ge=1)
+    test_after_fit: Optional[bool] = None
+    monitor: Optional[str] = None
+    monitor_mode: Optional[Literal["min", "max"]] = None
     extensions: Optional[Dict[str, Any]] = Field(
         default=None,
         description=(

--- a/test/test_config_analysis_parity.py
+++ b/test/test_config_analysis_parity.py
@@ -1,12 +1,19 @@
 from __future__ import annotations
 
+from copy import deepcopy
 from pathlib import Path
 
+from pydantic import ValidationError
+import pytest
+
+from phmfactory import cli as public_cli
 from phmfactory.commands import preflight
 from phmfactory.config import (
     analyze_config,
+    load_config_dict,
     resolve_config,
     semantic_config_sha256,
+    validate_complete_experiment,
 )
 from scripts.config_inspect import inspect_config
 from scripts.validate_configs import validate_one
@@ -20,14 +27,29 @@ def _minimal_config(path: Path, *, epochs: int) -> None:
     path.write_text(
         "pipeline: Pipeline_01_Fault_Diagnosis\n"
         "environment:\n"
+        "  project: config-parity-test\n"
         "  seed: 0\n"
         "  iterations: 1\n"
         "  output_dir: results/test\n"
-        "data: {}\n"
-        "model: {}\n"
-        "task: {}\n"
+        "data:\n"
+        "  data_dir: data\n"
+        "  metadata_file: metadata_dummy.csv\n"
+        "model:\n"
+        "  type: Baseline\n"
+        "  name: GlobalAverageLinear\n"
+        "task:\n"
+        "  type: DG\n"
+        "  name: classification\n"
+        "  target_system_id: [0]\n"
+        "  loss: CE\n"
         "trainer:\n"
-        f"  num_epochs: {epochs}\n",
+        "  name: Default_trainer\n"
+        f"  num_epochs: {epochs}\n"
+        "  device: cpu\n"
+        "  gpus: 1\n"
+        "  monitor: val_loss\n"
+        "  monitor_mode: min\n"
+        "  test_after_fit: true\n",
         encoding="utf-8",
     )
 
@@ -68,9 +90,29 @@ def test_precedence_is_base_then_config_then_explicit_local_then_cli(
     config = tmp_path / "config.yaml"
     local = tmp_path / "machine.yaml"
     base.write_text(
-        "environment: {seed: 0, iterations: 1, output_dir: results/test}\n"
-        "data: {}\nmodel: {}\ntask: {}\n"
-        "trainer: {num_epochs: 1, device: cpu}\n",
+        "environment:\n"
+        "  project: config-precedence-test\n"
+        "  seed: 0\n"
+        "  iterations: 1\n"
+        "  output_dir: results/test\n"
+        "data:\n"
+        "  data_dir: data\n"
+        "  metadata_file: metadata_dummy.csv\n"
+        "model:\n"
+        "  type: Baseline\n"
+        "  name: GlobalAverageLinear\n"
+        "task:\n"
+        "  type: DG\n"
+        "  name: classification\n"
+        "  target_system_id: [0]\n"
+        "  loss: CE\n"
+        "trainer:\n"
+        "  name: Default_trainer\n"
+        "  num_epochs: 1\n"
+        "  device: cpu\n"
+        "  gpus: 1\n"
+        "  monitor: val_loss\n"
+        "  monitor_mode: min\n",
         encoding="utf-8",
     )
     config.write_text(
@@ -88,14 +130,10 @@ def test_precedence_is_base_then_config_then_explicit_local_then_cli(
         override_values=["trainer.num_epochs=4"],
     )
 
-    assert local_only.effective_config["trainer"] == {
-        "num_epochs": 3,
-        "device": "cuda",
-    }
-    assert final.effective_config["trainer"] == {
-        "num_epochs": 4,
-        "device": "cuda",
-    }
+    assert local_only.effective_config["trainer"]["num_epochs"] == 3
+    assert local_only.effective_config["trainer"]["device"] == "cuda"
+    assert final.effective_config["trainer"]["num_epochs"] == 4
+    assert final.effective_config["trainer"]["device"] == "cuda"
     assert final.sources["trainer.num_epochs"] == "cli:--override"
     assert final.sources["trainer.device"] == f"local:{local.resolve()}"
     assert final.local_config_path == local.resolve()
@@ -117,6 +155,22 @@ def test_unmentioned_local_yaml_is_not_an_input(
     assert analysis.local_config_path is None
     assert analysis.effective_config["trainer"]["num_epochs"] == 2
     assert hidden not in analysis.source_files
+
+
+def test_base_fragment_loader_remains_separate_from_complete_experiment_validation(
+    tmp_path: Path,
+) -> None:
+    fragment = tmp_path / "trainer.yaml"
+    fragment.write_text(
+        "trainer:\n  name: Default_trainer\n  num_epochs: 1\n",
+        encoding="utf-8",
+    )
+
+    assert load_config_dict(fragment) == {
+        "trainer": {"name": "Default_trainer", "num_epochs": 1}
+    }
+    with pytest.raises(ValueError, match="must declare `pipeline`"):
+        analyze_config(fragment)
 
 
 def test_resolve_config_is_a_compatibility_view_of_analysis() -> None:
@@ -155,6 +209,94 @@ def test_preflight_reports_the_same_effective_hash(
     assert report["effective_config_sha256"] == expected.effective_config_sha256
     assert report["pipeline"] == expected.pipeline
     assert not (tmp_path / "preflight").exists()
+
+
+def test_strict_validation_does_not_rewrite_the_visible_mapping() -> None:
+    config = analyze_config("smoke").runtime_config()
+    before = deepcopy(config)
+
+    validate_complete_experiment(config)
+
+    assert config == before
+
+
+@pytest.mark.parametrize(
+    "invalid_override",
+    [
+        'environment.iterations="1"',
+        'trainer.test_after_fit="false"',
+        'data.num_workers="0"',
+    ],
+)
+def test_public_entrypoints_share_strict_type_rejection_without_side_effects(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    invalid_override: str,
+) -> None:
+    output_dir = tmp_path / "must-not-exist"
+    output_override = f"environment.output_dir={output_dir}"
+    overrides = [output_override, invalid_override]
+
+    def fail_pipeline_import(*args, **kwargs):
+        del args, kwargs
+        pytest.fail("invalid config must fail before Pipeline import")
+
+    monkeypatch.setattr(public_cli.importlib, "import_module", fail_pipeline_import)
+
+    calls = [
+        lambda: analyze_config("smoke", override_values=overrides),
+        lambda: inspect_config("smoke", overrides=overrides),
+        lambda: preflight.run(
+            [
+                "--config",
+                "smoke",
+                "--override",
+                output_override,
+                "--override",
+                invalid_override,
+            ]
+        ),
+        lambda: public_cli.run(
+            public_cli.build_parser().parse_args(
+                [
+                    "--config",
+                    "smoke",
+                    "--override",
+                    output_override,
+                    "--override",
+                    invalid_override,
+                ]
+            )
+        ),
+    ]
+
+    for call in calls:
+        with pytest.raises(ValidationError):
+            call()
+
+    assert not output_dir.exists()
+
+
+def test_grouped_split_coupling_fails_at_the_shared_public_boundary(
+    tmp_path: Path,
+) -> None:
+    config = tmp_path / "invalid-grouped.yaml"
+    _minimal_config(config, epochs=1)
+    with config.open("a", encoding="utf-8") as handle:
+        handle.write(
+            "data:\n"
+            "  data_dir: data\n"
+            "  metadata_file: metadata_dummy.csv\n"
+            "  split:\n"
+            "    strategy: grouped_metadata\n"
+            "    group_key: File\n"
+            "    manifest_path: results/split.json\n"
+            "    test_policy: partition\n"
+            "    fractions: {train: 0.8, val: 0.1, test: 0.1}\n"
+        )
+
+    with pytest.raises(ValidationError, match="requires test_policy=task_defined"):
+        analyze_config(config)
 
 
 def test_semantic_hash_is_stable_for_mapping_order() -> None:

--- a/test/test_phmfactory_config_resolver.py
+++ b/test/test_phmfactory_config_resolver.py
@@ -13,6 +13,45 @@ from phmfactory.config import (
 from phmfactory.pipelines import PipelineNameDeprecationWarning
 
 
+def _write_complete_experiment(
+    path: Path,
+    *,
+    pipeline: str | None,
+    max_epochs: int = 5,
+) -> None:
+    lines = []
+    if pipeline is not None:
+        lines.append(f"pipeline: {pipeline}")
+    lines.extend(
+        [
+            "environment:",
+            "  project: config-resolver-test",
+            "  seed: 0",
+            "  iterations: 1",
+            "  output_dir: results/test",
+            "data:",
+            "  data_dir: data",
+            "  metadata_file: metadata_dummy.csv",
+            "model:",
+            "  type: Baseline",
+            "  name: GlobalAverageLinear",
+            "task:",
+            "  type: DG",
+            "  name: classification",
+            "  target_system_id: [0]",
+            "  loss: CE",
+            "trainer:",
+            "  name: Default_trainer",
+            f"  max_epochs: {max_epochs}",
+            "  device: cpu",
+            "  gpus: 1",
+            "  monitor: val_loss",
+            "  monitor_mode: min",
+        ]
+    )
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
 def test_parse_overrides_expands_dotted_keys_and_yaml_types() -> None:
     assert parse_overrides(
         ["trainer.max_epochs=2", "task.enabled=true", "labels=[1, 2]"]
@@ -57,9 +96,10 @@ def test_resolve_config_canonicalizes_pipeline_and_applies_override(
     tmp_path: Path,
 ) -> None:
     config = tmp_path / "config.yaml"
-    config.write_text(
-        "pipeline: Pipeline_01_default\ntrainer:\n  max_epochs: 5\n",
-        encoding="utf-8",
+    _write_complete_experiment(
+        config,
+        pipeline="Pipeline_01_default",
+        max_epochs=5,
     )
 
     with pytest.warns(PipelineNameDeprecationWarning):
@@ -79,7 +119,7 @@ def test_resolve_config_canonicalizes_pipeline_and_applies_override(
 
 def test_explicit_config_requires_pipeline(tmp_path: Path) -> None:
     config = tmp_path / "config.yaml"
-    config.write_text("trainer:\n  max_epochs: 1\n", encoding="utf-8")
+    _write_complete_experiment(config, pipeline=None, max_epochs=1)
 
     with pytest.raises(ValueError, match="must declare `pipeline`"):
         resolve_config(config)
@@ -87,7 +127,7 @@ def test_explicit_config_requires_pipeline(tmp_path: Path) -> None:
 
 def test_pipeline_may_be_supplied_by_explicit_override(tmp_path: Path) -> None:
     config = tmp_path / "config.yaml"
-    config.write_text("trainer:\n  max_epochs: 1\n", encoding="utf-8")
+    _write_complete_experiment(config, pipeline=None, max_epochs=1)
 
     resolved = resolve_config(
         config,


### PR DESCRIPTION
## Objective

Make validation, inspection, preflight, and execution invoke the same strict acceptance boundary for one fully composed experiment configuration.

## Proven invariant

Let

```text
A_x^schema = {C* | the current strict ExperimentConfig accepts C* at entrypoint x}
```

Then this PR establishes:

```text
A_validate^schema
= A_inspect^schema
= A_preflight^schema
= A_run^schema
```

This is **Schema-acceptance parity**, not a claim that all later runtime acceptance conditions are identical.

## Implementation

- compose the visible configuration once in `analyze_config()`;
- validate that complete mapping through the existing `ExperimentConfig` in strict mode;
- do not replace the visible/runtime mapping with `model_dump()` output;
- do not write Schema defaults back into the visible mapping;
- verify that validation does not mutate its input;
- keep incomplete base fragments valid for composition through `load_config_dict()`;
- make `scripts.validate_configs` reuse the public acceptance boundary;
- type the Trainer fields needed for the bounded quoted integer/boolean counterexamples.

## Actual changed-file scope

PR #208 changed **7 files**:

```text
.github/workflows/core-quality-gates.yml
.github/workflows/phmfactory-public-package.yml
phmfactory/config.py
scripts/validate_configs.py
src/config_schema/models.py
test/test_config_analysis_parity.py
test/test_phmfactory_config_resolver.py
```

Core implementation is concentrated in `phmfactory/config.py` and `scripts/validate_configs.py`; the remaining files provide strict Trainer typing, resolver regressions, and the declared Pydantic package/CI boundary.

## Verified result

- all invalid configurations recognized by the current complete Schema are rejected before Pipeline import by validate, inspect, preflight, and run;
- fields explicitly typed by the current Schema reject ambiguous quoted integer/boolean values;
- validation leaves the visible effective mapping unchanged;
- fragment composition remains separate from complete-experiment validation.

## Not established by this PR

- every behavior-affecting field is explicitly covered by the Schema;
- Schema defaults equal runtime missing-value defaults;
- visible values equal all values later interpreted or supplied by Runtime/Factories;
- every runtime-invalid scientific experiment fails before Pipeline import;
- diagnostic presentation is identical across all public tools.

Accordingly:

```text
Q0a Shared strict public schema acceptance boundary
-> MERGED

Q0b Visible behavior-default closure
-> VERIFIED OPEN
```

Known Q0b counterexamples include `environment.iterations`, `environment.seed`, and optional Trainer behavior fields whose Schema defaults or optionality differ from later runtime defaults.

## Boundaries

- no `SchemaV2`, `ConfigManager`, runtime wrapper, manager, registry, manifest, ledger, receipt, or attestation;
- no Schema-default materialization;
- no `model_dump()` replacement of the visible configuration;
- no Data, Model, Task, Trainer runtime, Pipeline, result, scheduler, or MFPT protocol change;
- no modification of base-fragment loading semantics.

## Validation performed before merge

```bash
python -m pytest test/test_config_analysis_parity.py -q
python -m scripts.validate_configs
python -m scripts.validate_docs
phmfactory preflight --config smoke
phmfactory demo
```

All PR checks passed before squash merge.

## Rollback

Revert the squash commit.