### PR TITLE
fix(cli): require explicit public experiment selection

### DIFF
--- a/phmfactory/commands/common.py
+++ b/phmfactory/commands/common.py
@@ -10,8 +10,7 @@ from __future__ import annotations
 import argparse
 from pathlib import Path
 from uuid import uuid4
-
-from phmfactory.config import DEFAULT_CONFIG
+import warnings
 
 
 def add_config_arguments(
@@ -19,20 +18,22 @@ def add_config_arguments(
     *,
     include_notes: bool = False,
     include_experimental: bool = True,
+    require_config: bool = True,
 ) -> None:
-    """Add the maintained config, explicit local layer, and override surface."""
+    """Add one explicit config selector, local layer, and override surface."""
 
-    parser.add_argument(
+    selector = parser.add_mutually_exclusive_group(required=require_config)
+    selector.add_argument(
         "--config",
         type=str,
         default=None,
-        help="Configuration path or maintained preset name.",
+        help="Required configuration path or maintained preset name.",
     )
-    parser.add_argument(
+    selector.add_argument(
         "--config_path",
         type=str,
         default=None,
-        help="Deprecated alias for --config.",
+        help="Deprecated alias for --config; the two options are mutually exclusive.",
     )
     parser.add_argument(
         "--local-config",
@@ -60,13 +61,25 @@ def add_config_arguments(
 
 
 def requested_config(args: argparse.Namespace) -> str:
-    """Return the preferred config argument while preserving the legacy alias."""
+    """Return the single explicit config selector or fail before analysis."""
 
-    if getattr(args, "config", None) is not None:
-        return str(args.config)
-    if getattr(args, "config_path", None) is not None:
-        return str(args.config_path)
-    return DEFAULT_CONFIG
+    config = getattr(args, "config", None)
+    legacy = getattr(args, "config_path", None)
+    if config is not None and legacy is not None:
+        raise ValueError("--config and --config_path are mutually exclusive")
+    if config is not None:
+        return str(config)
+    if legacy is not None:
+        warnings.warn(
+            "--config_path is deprecated; use --config instead.",
+            FutureWarning,
+            stacklevel=2,
+        )
+        return str(legacy)
+    raise ValueError(
+        "An explicit experiment configuration is required. "
+        "Use --config <preset-or-yaml>."
+    )
 
 
 def requested_local_config(args: argparse.Namespace) -> str | None:

--- a/phmfactory/config.py
+++ b/phmfactory/config.py
@@ -41,6 +41,22 @@ MAINTAINED_PRESETS: dict[str, str] = {
 }
 
 
+def _explicit_source(source: str | Path | None) -> str:
+    """Return one non-empty public config selector or fail without fallback."""
+
+    if source is None:
+        raise ValueError(
+            "An explicit experiment configuration is required. "
+            "Pass a maintained preset name or YAML path."
+        )
+    requested = str(source).strip()
+    if not requested:
+        raise ValueError(
+            "Experiment configuration source must be a non-empty preset name or YAML path."
+        )
+    return requested
+
+
 @dataclass(frozen=True)
 class ResolvedConfig:
     """Backward-compatible resolved configuration payload.
@@ -200,17 +216,17 @@ def validate_complete_experiment(config: Mapping[str, Any]) -> None:
 
 
 def analyze_config(
-    source: str | Path | None = None,
+    source: str | Path,
     *,
     override_values: Sequence[str] | None = None,
     local_config: str | Path | None = None,
 ) -> ConfigAnalysis:
-    """Resolve and strictly validate one public experiment.
+    """Resolve and strictly validate one explicitly selected public experiment.
 
     Parameters
     ----------
     source:
-        Maintained preset name or YAML path. ``None`` selects ``DEFAULT_CONFIG``.
+        Required maintained preset name or YAML path.
     override_values:
         Repeatable dotted ``key=value`` tokens applied last.
     local_config:
@@ -231,8 +247,8 @@ def analyze_config(
         creation, or Factory construction.
     """
 
-    requested = str(source or DEFAULT_CONFIG)
-    path = resolve_config_path(source)
+    requested = _explicit_source(source)
+    path = resolve_config_path(requested)
     data, sources, files = _load_recursive_with_sources(
         path,
         stack=(),
@@ -284,7 +300,7 @@ def analyze_config(
 
 
 def resolve_config(
-    source: str | Path | None = None,
+    source: str | Path,
     *,
     override_values: Sequence[str] | None = None,
     local_config: str | Path | None = None,
@@ -344,10 +360,10 @@ def _resolve_explicit_local_path(source: str | Path) -> Path:
     )
 
 
-def resolve_config_path(source: str | Path | None) -> Path:
-    """Resolve a public preset or YAML path from a checkout or installed wheel."""
+def resolve_config_path(source: str | Path) -> Path:
+    """Resolve one explicit public preset or YAML path from checkout or wheel."""
 
-    requested = str(source or DEFAULT_CONFIG)
+    requested = _explicit_source(source)
     mapped = MAINTAINED_PRESETS.get(requested, requested)
     try:
         return _resolve_existing_config_path(mapped)

--- a/test/test_phmfactory_config_resolver.py
+++ b/test/test_phmfactory_config_resolver.py
@@ -5,6 +5,7 @@ from pathlib import Path
 import pytest
 from phmfactory.config import (
     MAINTAINED_PRESETS,
+    analyze_config,
     load_config_dict,
     parse_overrides,
     resolve_config,
@@ -151,6 +152,26 @@ def test_non_utf8_config_fails_without_encoding_fallback(tmp_path: Path) -> None
 def test_resolve_config_rejects_missing_source(tmp_path: Path) -> None:
     with pytest.raises(FileNotFoundError):
         resolve_config(tmp_path / "missing.yaml")
+
+
+def test_public_config_apis_reject_implicit_or_empty_source() -> None:
+    with pytest.raises(TypeError):
+        analyze_config()
+    with pytest.raises(TypeError):
+        resolve_config()
+    with pytest.raises(TypeError):
+        resolve_config_path()
+
+    for call in (
+        lambda: analyze_config(None),
+        lambda: resolve_config(None),
+        lambda: resolve_config_path(None),
+        lambda: analyze_config(""),
+        lambda: resolve_config(""),
+        lambda: resolve_config_path(""),
+    ):
+        with pytest.raises(ValueError, match="explicit|non-empty"):
+            call()
 
 
 @pytest.mark.parametrize("preset, relative_path", sorted(MAINTAINED_PRESETS.items()))

--- a/test/test_phmfactory_entrypoints.py
+++ b/test/test_phmfactory_entrypoints.py
@@ -69,14 +69,26 @@ def test_parser_accepts_explicit_local_config() -> None:
     assert args.local_config == "machine.yaml"
 
 
-def test_config_takes_precedence_over_legacy_alias() -> None:
+def test_config_and_legacy_alias_are_mutually_exclusive() -> None:
     args = argparse.Namespace(
         config="public.yaml",
         config_path="legacy.yaml",
         notes="",
         override=None,
     )
-    assert cli._resolve_config_path(args) == "public.yaml"
+    with pytest.raises(ValueError, match="mutually exclusive"):
+        cli._resolve_config_path(args)
+
+
+def test_legacy_alias_selection_emits_visible_warning() -> None:
+    args = argparse.Namespace(
+        config=None,
+        config_path="legacy.yaml",
+        notes="",
+        override=None,
+    )
+    with pytest.warns(FutureWarning, match="--config_path is deprecated"):
+        assert cli._resolve_config_path(args) == "legacy.yaml"
 
 
 def test_process_entrypoint_discards_structured_success(
@@ -300,6 +312,46 @@ def test_python_process_entrypoints_return_nonzero_for_invalid_config(
     )
     assert completed.returncode != 0
     assert "was not found" in completed.stderr
+
+
+@pytest.mark.parametrize(
+    "arguments",
+    (
+        ["--notes", "missing-config"],
+        ["--allow-experimental"],
+        ["--override", "trainer.num_epochs=2"],
+        ["--config", "smoke", "--config_path", "smoke"],
+    ),
+)
+def test_root_experiment_selection_fails_before_analysis_or_import(
+    arguments: list[str],
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    target = tmp_path / "must-not-exist"
+    analyzed = 0
+    imported = 0
+
+    def fail_analysis(*args, **kwargs):
+        nonlocal analyzed
+        analyzed += 1
+        pytest.fail("argument selection must fail before analyze_config")
+
+    def fail_import(*args, **kwargs):
+        nonlocal imported
+        imported += 1
+        pytest.fail("argument selection must fail before Pipeline import")
+
+    monkeypatch.setattr(cli, "analyze_config", fail_analysis)
+    monkeypatch.setattr(cli.importlib, "import_module", fail_import)
+
+    with pytest.raises(SystemExit) as error:
+        cli.main(arguments)
+
+    assert error.value.code == 2
+    assert analyzed == 0
+    assert imported == 0
+    assert not target.exists()
 
 
 def test_root_main_is_only_a_process_wrapper(

--- a/test/test_phmfactory_entrypoints.py
+++ b/test/test_phmfactory_entrypoints.py
@@ -11,6 +11,7 @@ import pytest
 
 from examples import cwru_quickstart
 from phmfactory import __version__, cli
+from phmfactory.commands import preflight
 from phmfactory.config import (
     MAINTAINED_PRESETS,
     ConfigAnalysis,
@@ -321,6 +322,7 @@ def test_python_process_entrypoints_return_nonzero_for_invalid_config(
         ["--allow-experimental"],
         ["--override", "trainer.num_epochs=2"],
         ["--config", "smoke", "--config_path", "smoke"],
+        ["preflight"],
     ),
 )
 def test_root_experiment_selection_fails_before_analysis_or_import(
@@ -343,6 +345,7 @@ def test_root_experiment_selection_fails_before_analysis_or_import(
         pytest.fail("argument selection must fail before Pipeline import")
 
     monkeypatch.setattr(cli, "analyze_config", fail_analysis)
+    monkeypatch.setattr(preflight, "analyze_config", fail_analysis)
     monkeypatch.setattr(cli.importlib, "import_module", fail_import)
 
     with pytest.raises(SystemExit) as error:


### PR DESCRIPTION
## Objective

Require every public experiment-selection action to name exactly one configuration before configuration analysis, Pipeline discovery, output probing, or Factory construction.

## Selection invariant

```text
count(--config, --config_path) = 1
```

The only bounded commands that own a built-in configuration remain:

```text
phmfactory demo   -> explicitly binds smoke
phmfactory doctor -> explicitly checks smoke
```

## Changes

- make `--config` and deprecated `--config_path` a required mutually exclusive group for root experiments and `preflight`;
- remove the CWRU fallback from `requested_config()` itself;
- emit a visible `FutureWarning` for alias-only `--config_path` use;
- require an explicit non-empty source in `analyze_config`, `resolve_config`, and `resolve_config_path`;
- add process and API counterexamples for missing config, conflicting selectors, preflight without config, and `None`/empty Python API sources;
- assert selection failures occur before config analysis and Pipeline import.

## User-visible behavior

```bash
phmfactory
# help only

phmfactory --notes test
phmfactory --allow-experimental
phmfactory --override trainer.num_epochs=2
phmfactory preflight
# argparse exit 2; no experiment selected

phmfactory --config smoke
phmfactory preflight --config smoke
# accepted

phmfactory --config_path smoke
# temporarily accepted with a deprecation warning

phmfactory --config smoke --config_path smoke
# argparse exit 2
```

## Boundaries

- no change to configuration composition, strict Schema acceptance, Pipeline runtime, Factories, data, model, objective, estimator, result paths, or MFPT protocol;
- no new manager, wrapper, registry, schema, manifest, hash, ledger, receipt, or fallback;
- Q0b behavior-default closure remains verified-open and is not claimed by this PR.

## Focused validation

```bash
python -m pytest -q \
  test/test_phmfactory_entrypoints.py \
  test/test_phmfactory_config_resolver.py \
  test/test_phmfactory_commands.py
python -m scripts.validate_configs
python -m scripts.validate_docs
phmfactory preflight --config smoke
phmfactory demo
```

## Rollback

Revert the single squash commit.