### PR TITLE
fix(config): require explicit environment execution fields

### DIFF
--- a/.github/workflows/core-quality-gates.yml
+++ b/.github/workflows/core-quality-gates.yml
@@ -248,6 +248,7 @@ jobs:
             src/Pipeline_02_Pretraining_Few_Shot.py \
             src/Pipeline_05_Explainable_Fault_Diagnosis.py \
             test/test_classification_runtime.py \
+            test/test_environment_execution_contract.py \
             test/test_data_cache_contract.py \
             test/test_device_authority.py \
             test/test_hse_objective_contract.py \
@@ -260,6 +261,7 @@ jobs:
             test/test_transform_truth.py
           python -m pytest \
             test/test_classification_runtime.py \
+            test/test_environment_execution_contract.py \
             test/test_data_cache_contract.py \
             test/test_device_authority.py \
             test/test_hse_objective_contract.py \

--- a/src/config_schema/models.py
+++ b/src/config_schema/models.py
@@ -10,9 +10,9 @@ class EnvironmentConfig(BaseModel):
     model_config = ConfigDict(extra="allow")
 
     project: str = Field(..., description="Experiment short name, used in output organization.")
-    seed: int = Field(42, description="Global random seed.")
+    seed: int = Field(..., description="Required global random seed.")
     output_dir: str = Field(..., description="Base output directory (prefer repo-relative).")
-    iterations: int = Field(1, ge=1, description="Repeat runs with different seeds.")
+    iterations: int = Field(..., ge=1, description="Required number of repeated runs.")
     notes: str = Field("", description="Free-form notes.")
 
     @model_validator(mode="after")

--- a/src/runtime/classification.py
+++ b/src/runtime/classification.py
@@ -260,10 +260,26 @@ def run_classification_pipeline(
         args_data.task_list = args_task.task_list
         args_model.task_list = args_task.task_list
 
-    iterations = int(getattr(args_environment, "iterations", 0))
+    if not hasattr(args_environment, "iterations"):
+        raise ValueError("environment.iterations is required")
+    iterations = args_environment.iterations
+    if isinstance(iterations, bool) or not isinstance(iterations, int):
+        raise TypeError(
+            "environment.iterations must be an integer, "
+            f"got {type(iterations).__name__}"
+        )
     if iterations <= 0:
         raise ValueError(f"environment.iterations must be positive, got {iterations}")
-    base_seed = int(getattr(args_environment, "seed", 0))
+
+    if not hasattr(args_environment, "seed"):
+        raise ValueError("environment.seed is required")
+    base_seed = args_environment.seed
+    if isinstance(base_seed, bool) or not isinstance(base_seed, int):
+        raise TypeError(
+            "environment.seed must be an integer, "
+            f"got {type(base_seed).__name__}"
+        )
+
     test_after_fit = getattr(args_trainer, "test_after_fit", True)
     if not isinstance(test_after_fit, bool):
         raise TypeError(

--- a/test/test_config_analysis_parity.py
+++ b/test/test_config_analysis_parity.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from copy import deepcopy
 from pathlib import Path
-from types import SimpleNamespace
 
 from pydantic import ValidationError
 import pytest
@@ -18,7 +17,6 @@ from phmfactory.config import (
 )
 from scripts.config_inspect import inspect_config
 from scripts.validate_configs import validate_one
-from src.runtime import classification
 
 
 REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
@@ -324,82 +322,6 @@ def test_environment_execution_fields_are_required_at_the_shared_boundary(
     for call in calls:
         with pytest.raises(ValidationError):
             call()
-
-    assert not output_dir.exists()
-
-
-@pytest.mark.parametrize("field", ("seed", "iterations"))
-def test_classification_runtime_has_no_missing_environment_fallback(
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-    field: str,
-) -> None:
-    output_dir = tmp_path / "must-not-exist"
-    environment = SimpleNamespace(
-        project="runtime-environment-contract",
-        seed=7,
-        iterations=1,
-        output_dir=str(output_dir),
-    )
-    delattr(environment, field)
-    configs = SimpleNamespace(
-        environment=environment,
-        data=SimpleNamespace(),
-        model=SimpleNamespace(),
-        task=SimpleNamespace(name="classification"),
-        trainer=SimpleNamespace(test_after_fit=True),
-    )
-    monkeypatch.setattr(classification, "load_runtime_config", lambda args: configs)
-    monkeypatch.setattr(
-        classification,
-        "build_data",
-        lambda *args, **kwargs: pytest.fail(
-            "missing environment field must fail before Data Factory construction"
-        ),
-    )
-
-    with pytest.raises(ValueError, match=rf"environment\.{field} is required"):
-        classification.run_classification_pipeline(object())
-
-    assert not output_dir.exists()
-
-
-@pytest.mark.parametrize(
-    "field,value",
-    (("seed", "7"), ("iterations", "1")),
-)
-def test_classification_runtime_does_not_coerce_environment_strings(
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-    field: str,
-    value: str,
-) -> None:
-    output_dir = tmp_path / "must-not-exist"
-    environment = SimpleNamespace(
-        project="runtime-environment-contract",
-        seed=7,
-        iterations=1,
-        output_dir=str(output_dir),
-    )
-    setattr(environment, field, value)
-    configs = SimpleNamespace(
-        environment=environment,
-        data=SimpleNamespace(),
-        model=SimpleNamespace(),
-        task=SimpleNamespace(name="classification"),
-        trainer=SimpleNamespace(test_after_fit=True),
-    )
-    monkeypatch.setattr(classification, "load_runtime_config", lambda args: configs)
-    monkeypatch.setattr(
-        classification,
-        "build_data",
-        lambda *args, **kwargs: pytest.fail(
-            "invalid environment type must fail before Data Factory construction"
-        ),
-    )
-
-    with pytest.raises(TypeError, match=rf"environment\.{field} must be an integer"):
-        classification.run_classification_pipeline(object())
 
     assert not output_dir.exists()
 

--- a/test/test_config_analysis_parity.py
+++ b/test/test_config_analysis_parity.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from copy import deepcopy
 from pathlib import Path
+from types import SimpleNamespace
 
 from pydantic import ValidationError
 import pytest
@@ -17,6 +18,7 @@ from phmfactory.config import (
 )
 from scripts.config_inspect import inspect_config
 from scripts.validate_configs import validate_one
+from src.runtime import classification
 
 
 REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
@@ -52,6 +54,14 @@ def _minimal_config(path: Path, *, epochs: int) -> None:
         "  test_after_fit: true\n",
         encoding="utf-8",
     )
+
+
+def _remove_yaml_field(path: Path, field: str) -> None:
+    prefix = f"  {field}:"
+    lines = path.read_text(encoding="utf-8").splitlines()
+    kept = [line for line in lines if not line.startswith(prefix)]
+    assert len(kept) == len(lines) - 1, field
+    path.write_text("\n".join(kept) + "\n", encoding="utf-8")
 
 
 def test_preset_and_explicit_path_have_same_effective_identity() -> None:
@@ -273,6 +283,123 @@ def test_public_entrypoints_share_strict_type_rejection_without_side_effects(
     for call in calls:
         with pytest.raises(ValidationError):
             call()
+
+    assert not output_dir.exists()
+
+
+@pytest.mark.parametrize("field", ("seed", "iterations"))
+def test_environment_execution_fields_are_required_at_the_shared_boundary(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    field: str,
+) -> None:
+    config = tmp_path / f"missing-{field}.yaml"
+    _minimal_config(config, epochs=1)
+    output_dir = tmp_path / "must-not-exist"
+    text = config.read_text(encoding="utf-8").replace(
+        "  output_dir: results/test",
+        f"  output_dir: {output_dir}",
+    )
+    config.write_text(text, encoding="utf-8")
+    _remove_yaml_field(config, field)
+
+    def fail_pipeline_import(*args, **kwargs):
+        del args, kwargs
+        pytest.fail("missing environment field must fail before Pipeline import")
+
+    monkeypatch.setattr(public_cli.importlib, "import_module", fail_pipeline_import)
+
+    validation_errors = validate_one(config)
+    assert validation_errors
+    assert f"environment.{field}" in "\n".join(validation_errors)
+
+    calls = [
+        lambda: analyze_config(config),
+        lambda: inspect_config(config),
+        lambda: preflight.run(["--config", str(config)]),
+        lambda: public_cli.run(
+            public_cli.build_parser().parse_args(["--config", str(config)])
+        ),
+    ]
+    for call in calls:
+        with pytest.raises(ValidationError):
+            call()
+
+    assert not output_dir.exists()
+
+
+@pytest.mark.parametrize("field", ("seed", "iterations"))
+def test_classification_runtime_has_no_missing_environment_fallback(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    field: str,
+) -> None:
+    output_dir = tmp_path / "must-not-exist"
+    environment = SimpleNamespace(
+        project="runtime-environment-contract",
+        seed=7,
+        iterations=1,
+        output_dir=str(output_dir),
+    )
+    delattr(environment, field)
+    configs = SimpleNamespace(
+        environment=environment,
+        data=SimpleNamespace(),
+        model=SimpleNamespace(),
+        task=SimpleNamespace(name="classification"),
+        trainer=SimpleNamespace(test_after_fit=True),
+    )
+    monkeypatch.setattr(classification, "load_runtime_config", lambda args: configs)
+    monkeypatch.setattr(
+        classification,
+        "build_data",
+        lambda *args, **kwargs: pytest.fail(
+            "missing environment field must fail before Data Factory construction"
+        ),
+    )
+
+    with pytest.raises(ValueError, match=rf"environment\.{field} is required"):
+        classification.run_classification_pipeline(object())
+
+    assert not output_dir.exists()
+
+
+@pytest.mark.parametrize(
+    "field,value",
+    (("seed", "7"), ("iterations", "1")),
+)
+def test_classification_runtime_does_not_coerce_environment_strings(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    field: str,
+    value: str,
+) -> None:
+    output_dir = tmp_path / "must-not-exist"
+    environment = SimpleNamespace(
+        project="runtime-environment-contract",
+        seed=7,
+        iterations=1,
+        output_dir=str(output_dir),
+    )
+    setattr(environment, field, value)
+    configs = SimpleNamespace(
+        environment=environment,
+        data=SimpleNamespace(),
+        model=SimpleNamespace(),
+        task=SimpleNamespace(name="classification"),
+        trainer=SimpleNamespace(test_after_fit=True),
+    )
+    monkeypatch.setattr(classification, "load_runtime_config", lambda args: configs)
+    monkeypatch.setattr(
+        classification,
+        "build_data",
+        lambda *args, **kwargs: pytest.fail(
+            "invalid environment type must fail before Data Factory construction"
+        ),
+    )
+
+    with pytest.raises(TypeError, match=rf"environment\.{field} must be an integer"):
+        classification.run_classification_pipeline(object())
 
     assert not output_dir.exists()
 

--- a/test/test_environment_execution_contract.py
+++ b/test/test_environment_execution_contract.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from src.runtime import classification
+
+
+def _runtime_config(output_dir: Path) -> SimpleNamespace:
+    return SimpleNamespace(
+        environment=SimpleNamespace(
+            project="runtime-environment-contract",
+            seed=7,
+            iterations=1,
+            output_dir=str(output_dir),
+        ),
+        data=SimpleNamespace(),
+        model=SimpleNamespace(),
+        task=SimpleNamespace(name="classification"),
+        trainer=SimpleNamespace(test_after_fit=True),
+    )
+
+
+def _fail_if_data_factory_runs(*args, **kwargs):
+    del args, kwargs
+    pytest.fail(
+        "invalid environment execution fields must fail before Data Factory construction"
+    )
+
+
+@pytest.mark.parametrize("field", ("seed", "iterations"))
+def test_classification_runtime_has_no_missing_environment_fallback(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    field: str,
+) -> None:
+    output_dir = tmp_path / "must-not-exist"
+    configs = _runtime_config(output_dir)
+    delattr(configs.environment, field)
+    monkeypatch.setattr(classification, "load_runtime_config", lambda args: configs)
+    monkeypatch.setattr(classification, "build_data", _fail_if_data_factory_runs)
+
+    with pytest.raises(ValueError, match=rf"environment\.{field} is required"):
+        classification.run_classification_pipeline(object())
+
+    assert not output_dir.exists()
+
+
+@pytest.mark.parametrize(
+    "field,value",
+    (("seed", "7"), ("iterations", "1")),
+)
+def test_classification_runtime_does_not_coerce_environment_strings(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    field: str,
+    value: str,
+) -> None:
+    output_dir = tmp_path / "must-not-exist"
+    configs = _runtime_config(output_dir)
+    setattr(configs.environment, field, value)
+    monkeypatch.setattr(classification, "load_runtime_config", lambda args: configs)
+    monkeypatch.setattr(classification, "build_data", _fail_if_data_factory_runs)
+
+    with pytest.raises(TypeError, match=rf"environment\.{field} must be an integer"):
+        classification.run_classification_pipeline(object())
+
+    assert not output_dir.exists()


### PR DESCRIPTION
## Objective

Close the verified `environment.seed` / `environment.iterations` default split without materializing Schema defaults or adding a second runtime mapping.

## Invariant

For maintained public classification runs:

```text
Schema accepts environment.seed / environment.iterations
iff
those exact visible integer values are present for Runtime consumption
```

More narrowly:

```text
C_visible.environment.{seed,iterations}
=
C_post-validation.environment.{seed,iterations}
=
C_classification-runtime.environment.{seed,iterations}
```

This PR does not claim that all Trainer or extra fields have reached visible/executed parity.

## Changes

- make `environment.seed` and `environment.iterations` required in the current `EnvironmentConfig`;
- retain `environment.output_dir` and `environment.project` as already-required fields;
- remove Runtime missing-value fallbacks `getattr(..., 0)`;
- remove Runtime integer coercion through `int(...)`;
- reject missing or non-integer values before output-path creation and Data Factory construction;
- add shared-boundary counterexamples across validation, inspection, preflight, and run;
- add direct classification Runtime counterexamples so legacy/direct callers cannot recover the deleted defaults.

## Actual changed-file scope

```text
src/config_schema/models.py
src/runtime/classification.py
test/test_config_analysis_parity.py
test/test_environment_execution_contract.py
.github/workflows/core-quality-gates.yml
```

The workflow change only places the Runtime-specific test in the existing full-dependency offline smoke job. The dependency-light config parity job remains free of pandas/Torch imports.

## Maintained-config compatibility

All public maintained presets compose `configs/base/environment/base.yaml`, which explicitly declares:

```yaml
environment:
  project: default_exp
  seed: 0
  iterations: 3
  output_dir: results
```

No per-demo default injection is introduced.

## Boundaries

- no Trainer default closure;
- no change to `test_after_fit`, epoch, device, monitor, scheduler, checkpoint, result-root, data, model, task, metric, or MFPT semantics;
- no Schema-default materialization and no `model_dump()` runtime replacement;
- no new manager, adapter, registry, manifest, hash, ledger, receipt, retry, or fallback;
- base fragments remain valid as composition fragments.

## Validation

```bash
python -m pytest -q test/test_config_analysis_parity.py
python -m pytest -q test/test_environment_execution_contract.py
python -m scripts.validate_configs
python -m scripts.validate_docs
phmfactory preflight --config smoke
phmfactory demo
```

## Status after merge

```text
Q0b-A Explicit environment execution contract
-> CLOSED

Q0b-B Explicit Trainer lifecycle contract
-> VERIFIED OPEN
```

## Rollback

Revert the single squash commit.