### PR TITLE
fix(trainer): require one explicit device count

### DIFF
--- a/configs/base/trainer/README.md
+++ b/configs/base/trainer/README.md
@@ -1,21 +1,10 @@
-# `configs/base/trainer/`
+# Trainer configuration
 
-## 1) What This Block Controls
+The Trainer owns hardware selection, checkpoints, stopping, logging, and the fit/test
+lifecycle. Data, Model, and Task code must not move the model between devices or repair
+Trainer inputs.
 
-`trainer` configures PyTorch Lightning trainer behavior:
-
-- device and accelerator selection;
-- epoch count;
-- whether a classification Pipeline evaluates after fitting;
-- checkpoint selection and early stopping;
-- training log cadence.
-
-The Trainer Factory is the only device-placement authority. Data, Model, and Task
-Factories must not move a model to CPU or CUDA during construction.
-
-## 2) Minimal Examples
-
-CPU classification:
+## Minimal maintained configuration
 
 ```yaml
 trainer:
@@ -23,56 +12,44 @@ trainer:
   num_epochs: 10
   test_after_fit: true
   device: "cpu"
-  gpus: 1
+  devices: 1
   monitor: "val_loss"
   monitor_mode: "min"
+  early_stopping: true
+  patience: 5
 ```
 
-Explicit CUDA classification:
+Maintained classification Pipelines require explicit `num_epochs`, `test_after_fit`,
+`device`, and `devices` values. There is no hidden epoch count, evaluation policy, device
+mode, or device count.
 
-```yaml
-trainer:
-  name: "Default_trainer"
-  num_epochs: 10
-  test_after_fit: true
-  device: "cuda"
-  gpus: 1
-  monitor: "val_loss"
-  monitor_mode: "min"
-```
+## Device contract
 
-Explicit automatic device selection:
-
-```yaml
-trainer:
-  name: "Default_trainer"
-  num_epochs: 10
-  test_after_fit: true
-  device: "auto"
-  gpus: 1
-  monitor: "val_loss"
-  monitor_mode: "min"
-```
-
-`test_after_fit` is required by maintained classification Pipelines. Set it to `true`
-for fit → best-checkpoint restore → test, or explicitly set it to `false` for a
-training-only invocation. Pipeline 06 does not consume this classification lifecycle
-field, so its configuration must not add it merely to satisfy a shared base.
-
-## 3) Device Contract
-
-| `trainer.device` | Runtime behavior |
+| Field | Contract |
 |---|---|
-| `cpu` | Passes `accelerator="cpu"` to Lightning. CUDA availability is irrelevant. |
-| `cuda` | Passes `accelerator="gpu"`; fails before Trainer construction when CUDA or the requested device count is unavailable. |
-| `auto` | Selects from the hardware observed by PHMFactory only because the user explicitly wrote `auto`. |
+| `trainer.device` | Exactly `cpu`, `cuda`, or `auto`. |
+| `trainer.devices` | Positive integer passed to Lightning unchanged. |
 
-There is no implicit `cuda -> cpu` fallback. A CUDA request that cannot be satisfied is
-an invalid run request and terminates with a corrective error.
+Behavior:
 
-## 4) Checkpoint Selection Contract
+```text
+device=cpu
+→ use CPU; CUDA is not inspected
 
-`Default_trainer` requires an explicit pair:
+device=cuda
+→ require CUDA and the requested count; otherwise fail before Trainer creation
+
+device=auto
+→ inspect available hardware because the user explicitly requested automatic selection
+```
+
+`trainer.gpus` is no longer a public alias. Replace it with `trainer.devices`. PHMFactory
+does not compare, merge, or guess between two device-count fields, and a failed CUDA
+request never falls back to CPU.
+
+## Checkpoint selection
+
+The checkpoint metric and direction are explicit:
 
 ```yaml
 trainer:
@@ -80,7 +57,7 @@ trainer:
   monitor_mode: "min"
 ```
 
-or, for a metric that should be maximized:
+or:
 
 ```yaml
 trainer:
@@ -88,92 +65,44 @@ trainer:
   monitor_mode: "max"
 ```
 
-The exact same `monitor` and `monitor_mode` drive:
+`ModelCheckpoint` and `EarlyStopping` consume the same pair. PHMFactory does not infer the
+direction from the metric name.
 
-```text
-ModelCheckpoint
-EarlyStopping
-best-checkpoint restoration
-```
+## Common commands
 
-PHMFactory does not infer direction from the metric name. This is intentional: names
-such as `score`, `error`, `utility`, or custom metrics do not define a reliable direction.
-Writing `monitor_mode: "min"` means minimize the selected metric even when its name
-contains `acc`; writing `max` means maximize it even when its name contains `loss`.
-The configuration is authoritative.
-
-Checkpoint filenames contain only epoch and step. They do not embed a hard-coded
-`val_loss` field when another metric is selected.
-
-## 5) Key Fields
-
-| Field | Type | Notes |
-|---|---:|---|
-| `trainer.name` | str | Trainer implementation in `src/trainer_factory/`. |
-| `trainer.num_epochs` | positive int | Single public epoch-count authority; `max_epochs` is rejected. |
-| `trainer.test_after_fit` | bool | Required by maintained classification Pipelines; controls post-fit evaluation. |
-| `trainer.device` | str | Required: `cpu`, `cuda`, or `auto`. |
-| `trainer.gpus` | positive int | Compatibility name for the Lightning device count. |
-| `trainer.devices` | positive int | Preferred device-count spelling when present; takes precedence over `gpus`. |
-| `trainer.monitor` | non-empty str | Logged validation scalar used to select the checkpoint. |
-| `trainer.monitor_mode` | `min` or `max` | Explicit optimization direction; never inferred. |
-| `trainer.early_stopping` | bool | When true, stopping uses the same monitor pair as checkpointing. |
-| `trainer.patience` | positive int | Early-stopping patience when enabled. |
-
-## 6) Typical Overrides
+Run one CPU epoch and evaluate:
 
 ```bash
-python main.py --config <yaml> --override trainer.num_epochs=1
-python main.py --config <yaml> --override trainer.test_after_fit=false
-python main.py --config <yaml> \
+phmfactory --config <yaml> \
+  --override trainer.num_epochs=1 \
   --override trainer.device=cpu \
-  --override trainer.gpus=1
+  --override trainer.devices=1 \
+  --override trainer.test_after_fit=true
 ```
 
-To select by validation accuracy:
+Request CUDA explicitly:
 
 ```bash
-python main.py --config <yaml> \
-  --override trainer.monitor=val_acc_Dummy_Data \
-  --override trainer.monitor_mode=max
-```
-
-A GPU run must be requested explicitly:
-
-```bash
-python main.py --config <yaml> \
+phmfactory --config <yaml> \
   --override trainer.device=cuda \
-  --override trainer.gpus=1
+  --override trainer.devices=1
 ```
 
-## 7) Coupling Notes
+## Failure cases
 
-- Built by `src/trainer_factory/__init__.py:build_trainer`.
-- `Default_trainer` consumes `trainer.num_epochs` directly and does not translate
-  `trainer.max_epochs`.
-- Classification Runtime consumes `trainer.test_after_fit` before creating an output
-  path or Factory.
-- `Default_trainer` maps the explicit device request to the Lightning accelerator.
-- `Default_trainer` owns checkpoint and early-stopping selection semantics.
-- Task constructors preserve the model returned by Model Factory and do not inspect
-  CUDA availability.
+PHMFactory fails before training when:
 
-## 8) How to Extend
+- `trainer.device` or `trainer.devices` is missing;
+- `device` is not exactly `cpu`, `cuda`, or `auto`;
+- `devices` is boolean, non-integral, or non-positive;
+- the legacy `trainer.gpus` field is present;
+- CUDA is requested but unavailable;
+- the requested accelerator count exceeds the available count;
+- `monitor` or `monitor_mode` is absent or invalid.
 
-1. Add a trainer implementation under `src/trainer_factory/`.
-2. Point configs at it through `trainer.name`.
-3. Keep hardware and checkpoint selection in the trainer implementation.
-4. Do not add `.cuda()` calls or checkpoint selection to Tasks or Models.
+## Extension rule
 
-## 9) Common Failures
-
-1. `trainer.num_epochs` is absent, boolean, non-integral, or non-positive.
-2. Deprecated `trainer.max_epochs` is present as a second epoch authority.
-3. A maintained classification Pipeline omits `trainer.test_after_fit` or supplies a non-boolean value.
-4. `trainer.device` is absent or not one of `cpu`, `cuda`, `auto`.
-5. `trainer.device=cuda` is requested on a host without CUDA.
-6. The requested CUDA device count exceeds `torch.cuda.device_count()`.
-7. `trainer.gpus` or `trainer.devices` is zero, boolean, non-integral, or negative.
-8. `trainer.monitor` is absent, empty, or does not match a logged validation metric.
-9. `trainer.monitor_mode` is absent or is not exactly `min` or `max`.
-10. Early stopping and checkpoint selection are configured against a metric that the Task never logs.
+A new Trainer implementation belongs under `src/trainer_factory/` and is selected through
+`trainer.name`. Keep device and checkpoint behavior inside the Trainer. Do not add `.cuda()`
+operations to Models or Tasks, and do not add another device selector to the CLI or a
+Factory wrapper.

--- a/configs/base/trainer/default_multi_gpu.yaml
+++ b/configs/base/trainer/default_multi_gpu.yaml
@@ -2,7 +2,7 @@
 
 name: "Default_trainer"
 num_epochs: 10
-gpus: 2
+devices: 2
 device: "cuda"
 early_stopping: true
 patience: 5

--- a/configs/base/trainer/default_single_gpu.yaml
+++ b/configs/base/trainer/default_single_gpu.yaml
@@ -3,7 +3,7 @@ trainer:
   monitor: "val_loss"
   monitor_mode: "min"
   num_epochs: 10
-  gpus: 1
+  devices: 1
   device: "cuda"
   early_stopping: true
   patience: 5

--- a/configs/base/trainer/fast_debug.yaml
+++ b/configs/base/trainer/fast_debug.yaml
@@ -1,9 +1,8 @@
-# Base trainer config for fast debug runs (v0.1.0)
+# Minimal one-epoch Trainer configuration for local debugging.
 
 name: "Default_trainer"
 num_epochs: 1
-gpus: 1
-device: "cuda"
+device: "cpu"
+devices: 1
 early_stopping: false
 patience: 1
-

--- a/configs/baselines/01_mfpt/mfpt_global_average_linear.yaml
+++ b/configs/baselines/01_mfpt/mfpt_global_average_linear.yaml
@@ -1,6 +1,6 @@
-# First real-data baseline candidate.
-# Protocol: official provider train/test files; file-grouped train/validation split;
-# transparent one-channel temporal-mean linear classifier; three explicit seeds.
+# Real-data baseline candidate.
+# Protocol: official provider train/test files, file-grouped train/validation split,
+# transparent one-channel temporal-mean linear classifier, and three explicit seeds.
 
 pipeline: "Pipeline_01_Fault_Diagnosis"
 
@@ -63,7 +63,7 @@ task:
 trainer:
   name: "Default_trainer"
   device: "cpu"
-  gpus: 1
+  devices: 1
   num_epochs: 5
   test_after_fit: true
   early_stopping: true

--- a/configs/demo/00_smoke/dummy_dg.yaml
+++ b/configs/demo/00_smoke/dummy_dg.yaml
@@ -1,4 +1,4 @@
-# Smoke demo: runs end-to-end on repo-shipped dummy data (no external dataset required)
+# End-to-end smoke run on the repository-shipped Dummy data.
 
 pipeline: "Pipeline_01_Fault_Diagnosis"
 
@@ -13,7 +13,7 @@ environment:
   project: "demo_dummy_dg_smoke"
   seed: 0
   output_dir: "results/demo/dummy_dg_smoke"
-  notes: "Smoke test on repo-shipped dummy metadata + raw csv."
+  notes: "Smoke test on repository-shipped Dummy metadata and CSV signals."
 
 data:
   data_dir: "data"
@@ -32,4 +32,4 @@ trainer:
   num_epochs: 1
   test_after_fit: true
   device: "cpu"
-  gpus: 1
+  devices: 1

--- a/configs/demo/00_smoke/dummy_global_average_linear.yaml
+++ b/configs/demo/00_smoke/dummy_global_average_linear.yaml
@@ -1,5 +1,5 @@
-# Transparent-model smoke: same packaged Dummy data/task/trainer path as
-# dummy_dg.yaml, with only the Model Factory configuration replaced.
+# Transparent-model smoke on the same Dummy data, task, and Trainer path as dummy_dg.yaml.
+# Only the Model Factory configuration is replaced.
 
 pipeline: "Pipeline_01_Fault_Diagnosis"
 
@@ -37,4 +37,4 @@ trainer:
   num_epochs: 1
   test_after_fit: true
   device: "cpu"
-  gpus: 1
+  devices: 1

--- a/configs/demo/10_generative/dummy_generative_cfm.yaml
+++ b/configs/demo/10_generative/dummy_generative_cfm.yaml
@@ -1,5 +1,5 @@
-# Candidate CPU CFM runtime smoke on repository Dummy_Data.
-# No historical artifact is accepted as evidence for this locked-dev rebuild.
+# Candidate CPU CFM smoke on repository Dummy data.
+# This is software verification, not benchmark or paper evidence.
 
 pipeline: "Pipeline_06_Generative_Modeling"
 
@@ -47,8 +47,8 @@ task:
 trainer:
   monitor: "val_loss"
   num_epochs: 1
-  gpus: 1
   device: "cpu"
+  devices: 1
   early_stopping: false
   log_every_n_steps: 1
   save_top_k: 1

--- a/configs/demo/uxfd/20_smoke_tspn_uxfd_full_cpu.yaml
+++ b/configs/demo/uxfd/20_smoke_tspn_uxfd_full_cpu.yaml
@@ -1,7 +1,5 @@
 # UXFD CPU smoke for the #61 core contract.
-#
-# This config only exercises the existing opt-in modules. It is not evidence
-# that the P01/P05/P06/P07 scientific contracts have been satisfied.
+# This verifies the existing opt-in modules only; it is not benchmark or claim evidence.
 
 pipeline: "Pipeline_01_Fault_Diagnosis"
 
@@ -35,7 +33,7 @@ trainer:
   num_epochs: 1
   test_after_fit: true
   device: "cpu"
-  gpus: 1
+  devices: 1
 
 model:
   device: "cpu"

--- a/configs/experiments/p07_xoan_operator_attention/g030_executable_operator_path_smoke.yaml
+++ b/configs/experiments/p07_xoan_operator_attention/g030_executable_operator_path_smoke.yaml
@@ -15,7 +15,7 @@ environment:
   notes: >-
     CPU-only method smoke for the typed continuous-sparsemax DAG, deterministic
     per-sample export, and independent discrete executor. It cannot support
-    C6-C9 because it uses dummy data, one seed, and no approved thresholds.
+    C6-C9 because it uses Dummy data, one seed, and no approved thresholds.
 
 data:
   data_dir: "data"
@@ -67,6 +67,6 @@ trainer:
   num_epochs: 1
   test_after_fit: true
   device: "cpu"
-  gpus: 1
+  devices: 1
   paper_id: "P07"
   preset_version: "p07-g030-method-smoke-v1"

--- a/phmfactory/device.py
+++ b/phmfactory/device.py
@@ -1,13 +1,12 @@
-"""Shared device-selection contract for preflight and Trainer construction.
+"""Resolve the one public device request used by preflight and Trainer creation.
 
-The module has no training-framework import at module load time. CPU-only preflight can
-therefore validate a configuration without importing PyTorch Lightning or the Trainer
-Factory package. Torch is loaded only when hardware inspection is actually required.
+CPU resolution does not import the training stack. CUDA and ``auto`` inspect hardware
+only because the user explicitly requested them. The resolver never changes the requested
+mode, falls back to another device, or reconciles legacy aliases.
 """
 
 from __future__ import annotations
 
-from numbers import Integral
 from typing import Any
 
 
@@ -15,7 +14,7 @@ DEVICE_MODES = ("cpu", "cuda", "auto")
 
 
 def _load_torch():
-    """Import torch only when CUDA/MPS inspection is required."""
+    """Import torch only when hardware inspection is required."""
 
     import torch
 
@@ -31,7 +30,7 @@ def _available_auto_accelerator() -> tuple[str, int | None]:
 
     mps = getattr(torch.backends, "mps", None)
     if mps is not None and callable(getattr(mps, "is_available", None)):
-        if bool(mps.is_available()):
+        if mps.is_available():
             return "mps", 1
 
     return "cpu", None
@@ -40,16 +39,14 @@ def _available_auto_accelerator() -> tuple[str, int | None]:
 def resolve_device_request(args_trainer: Any) -> tuple[str, int]:
     """Resolve one exact device mode and one exact positive device count.
 
-    ``trainer.device`` and ``trainer.devices`` are the only maintained public fields.
-    The historical ``trainer.gpus`` alias is rejected rather than reconciled with a
-    second value. ``cpu`` and ``cuda`` are exact requests; ``auto`` performs hardware
-    inspection only because the user explicitly selected it.
+    Maintained configurations use only ``trainer.device`` and ``trainer.devices``.
+    ``trainer.gpus`` is rejected rather than translated, because translation would leave
+    two authorities for the same runtime decision.
     """
 
     if hasattr(args_trainer, "gpus"):
         raise ValueError(
-            "trainer.gpus is unsupported; use the single public field "
-            "trainer.devices"
+            "trainer.gpus is unsupported; replace it with trainer.devices"
         )
 
     if not hasattr(args_trainer, "device"):
@@ -71,12 +68,15 @@ def resolve_device_request(args_trainer: Any) -> tuple[str, int]:
     if not hasattr(args_trainer, "devices"):
         raise ValueError("trainer.devices is required and must be a positive integer")
     devices = args_trainer.devices
-    if isinstance(devices, bool) or not isinstance(devices, Integral) or devices < 1:
-        raise ValueError(
-            "trainer.devices must be a positive integer, "
-            f"got {devices!r}"
+    if isinstance(devices, bool) or not isinstance(devices, int):
+        raise TypeError(
+            "trainer.devices must be an integer, "
+            f"got {type(devices).__name__}"
         )
-    devices = int(devices)
+    if devices < 1:
+        raise ValueError(
+            f"trainer.devices must be positive, got {devices}"
+        )
 
     if requested == "cpu":
         return "cpu", devices

--- a/phmfactory/device.py
+++ b/phmfactory/device.py
@@ -38,32 +38,42 @@ def _available_auto_accelerator() -> tuple[str, int | None]:
 
 
 def resolve_device_request(args_trainer: Any) -> tuple[str, int]:
-    """Resolve one explicit trainer device request without silent fallback.
+    """Resolve one exact device mode and one exact positive device count.
 
-    ``cpu`` and ``cuda`` are exact requests. ``auto`` performs hardware inspection only
-    because the user explicitly selected it. A CPU request is resolved without importing
-    torch, which keeps config-only inspection independent of the training stack.
+    ``trainer.device`` and ``trainer.devices`` are the only maintained public fields.
+    The historical ``trainer.gpus`` alias is rejected rather than reconciled with a
+    second value. ``cpu`` and ``cuda`` are exact requests; ``auto`` performs hardware
+    inspection only because the user explicitly selected it.
     """
+
+    if hasattr(args_trainer, "gpus"):
+        raise ValueError(
+            "trainer.gpus is unsupported; use the single public field "
+            "trainer.devices"
+        )
 
     if not hasattr(args_trainer, "device"):
         raise ValueError(
             "trainer.device is required and must be one of: cpu, cuda, auto"
         )
-    requested = str(args_trainer.device).strip().lower()
+    requested = args_trainer.device
+    if not isinstance(requested, str):
+        raise TypeError(
+            "trainer.device must be a string chosen from: cpu, cuda, auto; "
+            f"got {type(requested).__name__}"
+        )
     if requested not in DEVICE_MODES:
         raise ValueError(
-            f"unsupported trainer.device {args_trainer.device!r}; expected one of: "
+            f"unsupported trainer.device {requested!r}; expected one of: "
             + ", ".join(DEVICE_MODES)
         )
 
-    devices = getattr(
-        args_trainer,
-        "devices",
-        getattr(args_trainer, "gpus", 1),
-    )
+    if not hasattr(args_trainer, "devices"):
+        raise ValueError("trainer.devices is required and must be a positive integer")
+    devices = args_trainer.devices
     if isinstance(devices, bool) or not isinstance(devices, Integral) or devices < 1:
         raise ValueError(
-            "trainer.devices/trainer.gpus must be a positive integer, "
+            "trainer.devices must be a positive integer, "
             f"got {devices!r}"
         )
     devices = int(devices)

--- a/src/config_schema/models.py
+++ b/src/config_schema/models.py
@@ -286,9 +286,8 @@ class TrainerConfig(BaseModel):
 
     name: str = Field(..., description="Trainer implementation name under trainer_factory.")
     num_epochs: int = Field(..., ge=1)
-    device: Optional[Literal["cpu", "cuda", "auto"]] = None
-    gpus: Optional[int] = Field(None, ge=1)
-    devices: Optional[int] = Field(None, ge=1)
+    device: Literal["cpu", "cuda", "auto"] = Field(...)
+    devices: int = Field(..., ge=1)
     test_after_fit: Optional[bool] = None
     monitor: Optional[str] = None
     monitor_mode: Optional[Literal["min", "max"]] = None
@@ -301,11 +300,17 @@ class TrainerConfig(BaseModel):
     )
 
     @model_validator(mode="after")
-    def _reject_legacy_epoch_alias(self) -> "TrainerConfig":
-        if "max_epochs" in (self.model_extra or {}):
+    def _reject_legacy_aliases(self) -> "TrainerConfig":
+        extras = self.model_extra or {}
+        if "max_epochs" in extras:
             raise ValueError(
                 "trainer.max_epochs is unsupported; use the single public field "
                 "trainer.num_epochs"
+            )
+        if "gpus" in extras:
+            raise ValueError(
+                "trainer.gpus is unsupported; use the single public field "
+                "trainer.devices"
             )
         return self
 

--- a/src/trainer_factory/README.md
+++ b/src/trainer_factory/README.md
@@ -1,18 +1,10 @@
-# Trainer Factory (`src/trainer_factory/`)
+# Trainer Factory
 
-The Trainer Factory builds the `pytorch_lightning.Trainer` selected by `trainer.name`.
-
-```text
-resolved environment + trainer + data config + run path
-→ one trainer builder
-→ configured pl.Trainer
-```
-
-The public contract is:
+`src.trainer_factory.build_trainer(...)` resolves `trainer.name` and returns one
+`pytorch_lightning.Trainer`. Import or construction failures raise; the factory never
+prints an error and returns `None`.
 
 ```python
-from src.trainer_factory import build_trainer
-
 trainer = build_trainer(
     args_environment,
     args_trainer,
@@ -21,54 +13,40 @@ trainer = build_trainer(
 )
 ```
 
-A successful call returns `pl.Trainer`. Import and construction failures raise with the
-requested trainer, module path, original cause, and repair guidance. The factory does not
-print an error and return `None`.
-
-## Configuration
+## Maintained configuration
 
 ```yaml
 trainer:
   name: "Default_trainer"
   num_epochs: 10
+  test_after_fit: true
   device: "cpu"
-  gpus: 1
+  devices: 1
   monitor: "val_loss"
   monitor_mode: "min"
   early_stopping: true
   patience: 5
 ```
 
-`trainer.name` is the maintained selector. `trainer.trainer_name` remains a compatibility
-fallback only when `name` is absent.
+`trainer.device` and `trainer.devices` are the only maintained hardware fields. The
+legacy `trainer.gpus` field is rejected. A CUDA request that cannot be satisfied fails;
+it never changes to CPU.
 
-For `Default_trainer`, checkpoint selection is an explicit two-field contract:
+`trainer.monitor` and `trainer.monitor_mode` are consumed by both `ModelCheckpoint` and
+`EarlyStopping`. The direction is not inferred from the metric name.
 
-```text
-trainer.monitor
-+
-trainer.monitor_mode ∈ {min, max}
-```
+## Resolution
 
-The pair is shared by `ModelCheckpoint` and `EarlyStopping`. The Trainer Factory does not
-guess direction from names such as `loss`, `acc`, `score`, or `error`, and does not use a
-hard-coded `val_loss` placeholder in checkpoint filenames.
+The factory uses a narrow resolution path:
 
-## Resolution order
+1. check `TRAINER_REGISTRY`;
+2. import `src.trainer_factory.<trainer.name>`;
+3. check the registry again for a decorator-registered builder;
+4. accept the historical exported `trainer` function only as a compatibility boundary.
 
-For `Default_trainer`, the factory:
+It does not scan packages, guess names, select another Trainer, or repair its inputs.
 
-1. checks `TRAINER_REGISTRY`;
-2. imports `src.trainer_factory.Default_trainer`;
-3. checks the registry again so module decorators can register the builder;
-4. accepts the historical exported function name `trainer` when the module is not
-   decorator-registered.
-
-It does not scan the package or guess alternative builder names.
-
-## Adding a trainer
-
-Preferred implementation:
+## Adding a Trainer
 
 ```python
 from src.trainer_factory import register_trainer
@@ -77,62 +55,29 @@ from src.trainer_factory import register_trainer
 @register_trainer("MyTrainer")
 def build_my_trainer(*, args_e, args_t, args_d, path):
     ...
-    return trainer
 ```
 
-Place it at:
+Place the implementation at `src/trainer_factory/MyTrainer.py`. A new Trainer owns device
+selection, callbacks, checkpoint selection, logging, and the Lightning lifecycle. It must
+not change the selected data, model, task, loss, or metric.
 
-```text
-src/trainer_factory/MyTrainer.py
-```
-
-A historical module may instead export:
-
-```python
-def trainer(*, args_e, args_t, args_d, path):
-    ...
-```
-
-The builder must either return a valid `pl.Trainer` or raise. It must not catch a
-construction failure and return `None`.
-
-## Developer expectations
-
-A trainer builder owns:
-
-- device and accelerator selection;
-- checkpoint metric and optimization direction;
-- callbacks such as checkpointing and early stopping;
-- loggers;
-- output/checkpoint paths;
-- Lightning `Trainer` options.
-
-It should not reinterpret the experiment YAML, replace the selected task/model, infer
-checkpoint direction, or silently switch hardware after an error.
-
-## Minimal validation
+## Validation
 
 ```bash
-python -m scripts.config_inspect --config <yaml> --dump targets
-python main.py --config <yaml> \
+phmfactory preflight --config <yaml>
+phmfactory --config <yaml> \
   --override trainer.num_epochs=1 \
   --override trainer.device=cpu \
+  --override trainer.devices=1 \
   --override data.num_workers=0
 ```
 
-Use the repository-shipped Dummy demo as the final compatibility check:
+For the packaged user path:
 
 ```bash
 phmfactory demo
 ```
 
-## Failure examples
-
-- `Cannot import trainer ...`: verify `trainer.name`, module path, and optional
-  dependencies.
-- `does not register ... and does not expose 'trainer'`: add
-  `@register_trainer(...)` or export the historical `trainer` function.
-- missing `trainer.monitor`: name the validation scalar logged by the Task.
-- missing or invalid `trainer.monitor_mode`: declare `min` or `max` explicitly.
-- Trainer construction exception: inspect the preserved cause, device availability,
-  callback settings, selected metric, and output-path permissions.
+Common failures are missing or invalid `device`/`devices`, unavailable CUDA, an unknown
+Trainer module, an absent checkpoint monitor, or a monitor name that the Task never logs.
+The original error remains the primary diagnostic.

--- a/test/test_config_analysis_parity.py
+++ b/test/test_config_analysis_parity.py
@@ -46,7 +46,7 @@ def _minimal_config(path: Path, *, epochs: int) -> None:
         "  name: Default_trainer\n"
         f"  num_epochs: {epochs}\n"
         "  device: cpu\n"
-        "  gpus: 1\n"
+        "  devices: 1\n"
         "  monitor: val_loss\n"
         "  monitor_mode: min\n"
         "  test_after_fit: true\n",
@@ -119,7 +119,7 @@ def test_precedence_is_base_then_config_then_explicit_local_then_cli(
         "  num_epochs: 1\n"
         "  test_after_fit: true\n"
         "  device: cpu\n"
-        "  gpus: 1\n"
+        "  devices: 1\n"
         "  monitor: val_loss\n"
         "  monitor_mode: min\n",
         encoding="utf-8",

--- a/test/test_device_authority.py
+++ b/test/test_device_authority.py
@@ -58,8 +58,8 @@ def test_default_task_preserves_model_device_and_trainer_config(
     )
 
     network = TrackingNetwork()
-    args_trainer = Namespace(device="cuda", gpus=1)
-    trainer_config_before = vars(args_trainer).copy()
+    args_trainer = Namespace(device="cuda", devices=1)
+    before = vars(args_trainer).copy()
 
     task = module.Default_task(
         network=network,
@@ -80,25 +80,15 @@ def test_default_task_preserves_model_device_and_trainer_config(
     assert task.network is network
     assert network.cuda_calls == 0
     assert next(task.network.parameters()).device.type == "cpu"
-    assert vars(args_trainer) == trainer_config_before
+    assert vars(args_trainer) == before
 
 
-@pytest.mark.parametrize(
-    ("device", "devices", "expected"),
-    [
-        ("cpu", 1, ("cpu", 1)),
-        ("cpu", 3, ("cpu", 3)),
-    ],
-)
-def test_device_resolver_honors_explicit_cpu(
-    device: str,
-    devices: int,
-    expected: tuple[str, int],
-) -> None:
+@pytest.mark.parametrize("devices", [1, 3])
+def test_device_resolver_honors_explicit_cpu(devices: int) -> None:
     module = _device_module()
     assert module.resolve_device_request(
-        Namespace(device=device, gpus=devices)
-    ) == expected
+        Namespace(device="cpu", devices=devices)
+    ) == ("cpu", devices)
 
 
 def test_cpu_resolution_does_not_import_torch(
@@ -156,7 +146,7 @@ def test_device_resolver_rejects_excess_auto_devices(
         lambda: ("gpu", 1),
     )
 
-    with pytest.raises(RuntimeError, match="accelerator=gpu, requested=2, available=1"):
+    with pytest.raises(RuntimeError, match="requested=2, available=1"):
         module.resolve_device_request(Namespace(device="auto", devices=2))
 
 
@@ -172,7 +162,7 @@ def test_device_resolver_rejects_unavailable_cuda_without_cpu_fallback(
     )
 
     with pytest.raises(RuntimeError, match="no CPU fallback"):
-        module.resolve_device_request(Namespace(device="cuda", gpus=1))
+        module.resolve_device_request(Namespace(device="cuda", devices=1))
 
 
 def test_device_resolver_accepts_available_cuda(
@@ -183,7 +173,7 @@ def test_device_resolver_accepts_available_cuda(
     monkeypatch.setattr(torch.cuda, "device_count", lambda: 2)
 
     assert module.resolve_device_request(
-        Namespace(device="cuda", gpus=2)
+        Namespace(device="cuda", devices=2)
     ) == ("gpu", 2)
 
 
@@ -195,23 +185,32 @@ def test_device_resolver_rejects_excess_cuda_devices(
     monkeypatch.setattr(torch.cuda, "device_count", lambda: 1)
 
     with pytest.raises(RuntimeError, match="requested=2, available=1"):
-        module.resolve_device_request(Namespace(device="cuda", gpus=2))
+        module.resolve_device_request(Namespace(device="cuda", devices=2))
 
 
 @pytest.mark.parametrize(
-    "args_trainer",
+    ("args_trainer", "error_type", "message"),
     [
-        Namespace(gpus=1),
-        Namespace(device="gpu", gpus=1),
-        Namespace(device="cuda", gpus=0),
-        Namespace(device="cpu", devices=True),
+        (Namespace(devices=1), ValueError, "trainer.device is required"),
+        (Namespace(device="cpu"), ValueError, "trainer.devices is required"),
+        (Namespace(device="CPU", devices=1), ValueError, "unsupported trainer.device"),
+        (Namespace(device="cpu", devices="1"), TypeError, "must be an integer"),
+        (Namespace(device="cpu", devices=True), TypeError, "must be an integer"),
+        (Namespace(device="cpu", devices=0), ValueError, "must be positive"),
+        (
+            Namespace(device="cpu", devices=1, gpus=1),
+            ValueError,
+            "trainer.gpus is unsupported",
+        ),
     ],
 )
 def test_device_resolver_rejects_ambiguous_or_invalid_requests(
     args_trainer: Namespace,
+    error_type: type[Exception],
+    message: str,
 ) -> None:
     module = _device_module()
-    with pytest.raises(ValueError):
+    with pytest.raises(error_type, match=message):
         module.resolve_device_request(args_trainer)
 
 
@@ -234,12 +233,13 @@ def test_default_trainer_passes_resolved_cpu_request_to_lightning(
         args_e=Namespace(wandb=False, swanlab=False),
         args_t=Namespace(
             device="cpu",
-            gpus=1,
+            devices=1,
             num_epochs=1,
             pruning=0.0,
             monitor="val_loss",
             monitor_mode="min",
             log_every_n_steps=1,
+            deterministic=True,
         ),
         args_d=Namespace(),
         path=str(tmp_path),
@@ -285,10 +285,7 @@ def test_model_factory_preserves_constructor_exception_type(
         weights_path=None,
     )
 
-    with pytest.raises(
-        ModelConstructorFailure,
-        match="invalid model dimensions",
-    ):
+    with pytest.raises(ModelConstructorFailure, match="invalid model dimensions"):
         module.model_factory(args_model, metadata=None)
 
 
@@ -322,10 +319,7 @@ def test_model_factory_preserves_checkpoint_exception_type(
         weights_strict=True,
     )
 
-    with pytest.raises(
-        CheckpointLoadFailure,
-        match="checkpoint tensor layout is invalid",
-    ):
+    with pytest.raises(CheckpointLoadFailure, match="checkpoint tensor layout is invalid"):
         module.model_factory(args_model, metadata=None)
 
 
@@ -360,7 +354,6 @@ def test_model_factory_passes_explicit_checkpoint_strictness(
     )
 
     module.model_factory(args_model, metadata=None)
-
     assert observed == [strict]
 
 
@@ -393,10 +386,7 @@ def test_model_factory_rejects_non_boolean_checkpoint_strictness(
         weights_strict="false",
     )
 
-    with pytest.raises(
-        TypeError,
-        match="model.weights_strict must be a boolean",
-    ):
+    with pytest.raises(TypeError, match="model.weights_strict must be a boolean"):
         module.model_factory(args_model, metadata=None)
 
 

--- a/test/test_phmfactory_commands.py
+++ b/test/test_phmfactory_commands.py
@@ -30,7 +30,7 @@ def _config(
         "data": {},
         "model": {},
         "task": {},
-        "trainer": {"device": device, "gpus": 1},
+        "trainer": {"device": device, "devices": 1},
     }
 
 

--- a/test/test_phmfactory_config_resolver.py
+++ b/test/test_phmfactory_config_resolver.py
@@ -47,7 +47,7 @@ def _write_complete_experiment(
             f"  num_epochs: {num_epochs}",
             "  test_after_fit: true",
             "  device: cpu",
-            "  gpus: 1",
+            "  devices: 1",
             "  monitor: val_loss",
             "  monitor_mode: min",
         ]
@@ -206,6 +206,7 @@ def test_installed_style_resolution_works_outside_repository(
     assert resolved.path.as_posix().endswith("configs/demo/00_smoke/dummy_dg.yaml")
     assert resolved.data["data"]["metadata_file"] == "metadata_dummy.csv"
     assert resolved.data["trainer"]["device"] == "cpu"
+    assert resolved.data["trainer"]["devices"] == 1
     assert resolved.data["trainer"]["num_epochs"] == 1
     assert resolved.data["trainer"]["test_after_fit"] is True
 


### PR DESCRIPTION
## Fact

The maintained path still accepts three device-count authorities: `trainer.devices`, the legacy `trainer.gpus`, and an implicit count of `1`. Several maintained smoke and baseline configs still use `gpus`.

## Problem

A visible device request can be reinterpreted after strict config validation. That makes preflight and Lightning construction depend on fallback order rather than one declared value.

## Invariant

```text
visible trainer.device + trainer.devices
=
preflight accelerator request
=
Lightning Trainer request
```

## Change

- require strict `trainer.device` and positive integer `trainer.devices` values;
- reject `trainer.gpus` rather than translating or reconciling it;
- remove lowercasing and integer conversion of user configuration in the runtime resolver;
- migrate maintained Dummy, MFPT, UXFD, P07, generative, and debug configs;
- update focused tests and replace legacy device guidance with one concise contract.

## Out of scope

- checkpoint and early-stopping defaults;
- pruning and logging defaults;
- scheduler semantics;
- Data Factory, metrics, result paths, MFPT protocol, packaging, Streamlit;
- hash, manifest, ledger, Manager, or second-schema work.

## Acceptance

- missing `device` or `devices` fails before Trainer construction;
- `gpus`, quoted counts, booleans, zero counts, and case-normalized device names fail;
- explicit CPU does not inspect CUDA;
- explicit CUDA never falls back to CPU;
- preflight and `Default_trainer` use the same resolver;
- packaged Dummy smoke and current MFPT candidate configs validate with `devices`.

## Rollback

Revert the single squash commit.