### PR TITLE
fix(runtime): create one result root per invocation

### DIFF
--- a/src/runtime/classification.py
+++ b/src/runtime/classification.py
@@ -4,9 +4,11 @@ from __future__ import annotations
 
 from collections.abc import Mapping
 from dataclasses import dataclass
+from datetime import datetime, timezone
 import os
 from pathlib import Path
 from typing import Any
+from uuid import uuid4
 
 import pandas as pd
 from pytorch_lightning import seed_everything
@@ -122,6 +124,45 @@ def _set_environment(args_environment: Any) -> None:
             print(f"[INFO] 设置环境变量: {key}={value}")
 
 
+def _build_experiment_label(configs: Any) -> str:
+    """Return the human-readable directory prefix for one experiment."""
+
+    dataset_name = Path(str(configs.data.metadata_file)).name
+    model_name = str(configs.model.name)
+    task_name = f"{configs.task.type}{configs.task.name}"
+    if model_name == "ISFM":
+        model_name = (
+            f"ISFM_{configs.model.embedding}_"
+            f"{configs.model.backbone}_{configs.model.task_head}"
+        )
+    return f"{dataset_name}/M_{model_name}/T_{task_name}"
+
+
+def _create_invocation_root(configs: Any) -> tuple[Path, str]:
+    """Create the one result root owned by this public invocation."""
+
+    output_dir = getattr(configs.environment, "output_dir", None)
+    if not isinstance(output_dir, str) or not output_dir.strip():
+        raise ValueError("environment.output_dir must be a non-empty string")
+
+    label = _build_experiment_label(configs)
+    invocation_id = (
+        datetime.now(timezone.utc).strftime("%Y%m%d-%H%M%S-%f")
+        + "-"
+        + uuid4().hex[:8]
+    )
+    name = f"{label}/{invocation_id}"
+    root = Path(output_dir).expanduser() / name
+    root.mkdir(parents=True, exist_ok=False)
+    return root.resolve(), name
+
+
+def _iteration_path(run_root: str | Path, iteration: int) -> Path:
+    """Return one iteration directory below an existing invocation root."""
+
+    return Path(run_root) / f"iter_{iteration}"
+
+
 def _close_data_factory(data_factory: Any) -> None:
     data = getattr(data_factory, "data", None)
     close = getattr(data, "close", None)
@@ -132,8 +173,8 @@ def _close_data_factory(data_factory: Any) -> None:
 def _result_row(result: Any) -> dict[str, float]:
     """Return one complete metric population from ``trainer.test``.
 
-    Lightning returns one mapping per test dataloader.  The maintained classification
-    estimator currently defines exactly one test population.  Multiple mappings are
+    Lightning returns one mapping per test dataloader. The maintained classification
+    estimator currently defines exactly one test population. Multiple mappings are
     therefore ambiguous and must be handled by an explicit multi-population protocol
     rather than silently discarding every item after the first.
     """
@@ -208,7 +249,7 @@ def _write_aggregate_outputs(
 
 def _public_result(
     *,
-    final_path: Path,
+    run_root: Path,
     best_checkpoints: list[Path],
     all_results: list[dict[str, Any]],
     summary: dict[str, Any] | None,
@@ -218,7 +259,16 @@ def _public_result(
     if not best_checkpoints:
         raise RuntimeError("classification completed without a best checkpoint")
 
-    result_root = final_path.parent.resolve()
+    result_root = run_root.resolve()
+    resolved_checkpoints = [path.resolve() for path in best_checkpoints]
+    for checkpoint in resolved_checkpoints:
+        try:
+            checkpoint.relative_to(result_root)
+        except ValueError as exc:
+            raise RuntimeError(
+                f"best checkpoint is outside result_dir: {checkpoint}"
+            ) from exc
+
     test_metrics = result_root / "all_results.csv"
     run_summary = result_root / "run_summary.json"
     if summary is not None:
@@ -230,8 +280,8 @@ def _public_result(
     return {
         "status": "succeeded",
         "result_dir": str(result_root),
-        "best_checkpoint": str(best_checkpoints[-1]),
-        "best_checkpoints": [str(path) for path in best_checkpoints],
+        "best_checkpoint": str(resolved_checkpoints[-1]),
+        "best_checkpoints": [str(path) for path in resolved_checkpoints],
         "test_metrics": str(test_metrics) if summary is not None else None,
         "run_summary": str(run_summary) if summary is not None else None,
         "primary_metrics": dict(summary.get("metrics", {})) if summary else {},
@@ -289,10 +339,11 @@ def run_classification_pipeline(
         raise TypeError("trainer.test_after_fit must be a boolean")
     _set_environment(args_environment)
 
+    run_root, name = _create_invocation_root(configs)
     all_results: list[dict[str, Any]] = []
     run_seeds: list[int] = []
     best_checkpoints: list[Path] = []
-    final_path: Path | None = None
+    last_iteration_path: Path | None = None
 
     for iteration in range(iterations):
         print(
@@ -300,10 +351,9 @@ def run_classification_pipeline(
             f"[INFO] 开始实验迭代 {iteration + 1}/{iterations}\n"
             f"{'=' * 50}"
         )
-        raw_path, name = path_name(configs, iteration)
-        path = Path(raw_path)
-        path.mkdir(parents=True, exist_ok=True)
-        final_path = path
+        path = _iteration_path(run_root, iteration)
+        path.mkdir(exist_ok=False)
+        last_iteration_path = path
         args_trainer.logger_name = name
 
         current_seed = base_seed + iteration
@@ -321,7 +371,7 @@ def run_classification_pipeline(
             args_trainer=args_trainer,
             iteration=iteration,
             path=path,
-            name=str(name),
+            name=name,
         )
         lab_started = False
         try:
@@ -387,27 +437,27 @@ def run_classification_pipeline(
             if lab_started:
                 close_lab()
 
-    if final_path is None:
+    if last_iteration_path is None:
         raise RuntimeError("classification Pipeline produced no iteration path")
     if not test_after_fit:
         print(f"\n{'=' * 50}\n[INFO] 训练完成；配置禁止测试\n{'=' * 50}")
         return _public_result(
-            final_path=final_path,
+            run_root=run_root,
             best_checkpoints=best_checkpoints,
             all_results=all_results,
             summary=None,
         )
 
     summary = _write_aggregate_outputs(
-        final_path.parent,
-        final_path,
+        run_root,
+        last_iteration_path,
         all_results,
         run_seeds,
         configs,
     )
     print(f"\n{'=' * 50}\n[INFO] 所有实验已完成\n{'=' * 50}")
     return _public_result(
-        final_path=final_path,
+        run_root=run_root,
         best_checkpoints=best_checkpoints,
         all_results=all_results,
         summary=summary,

--- a/src/runtime/classification.py
+++ b/src/runtime/classification.py
@@ -261,14 +261,6 @@ def _public_result(
 
     result_root = run_root.resolve()
     resolved_checkpoints = [path.resolve() for path in best_checkpoints]
-    for checkpoint in resolved_checkpoints:
-        try:
-            checkpoint.relative_to(result_root)
-        except ValueError as exc:
-            raise RuntimeError(
-                f"best checkpoint is outside result_dir: {checkpoint}"
-            ) from exc
-
     test_metrics = result_root / "all_results.csv"
     run_summary = result_root / "run_summary.json"
     if summary is not None:

--- a/test/test_run_summary.py
+++ b/test/test_run_summary.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
 import json
+from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
 
+from src.runtime import classification
 from src.runtime.classification import _result_row
 from src.utils.run_summary import (
     build_run_summary,
@@ -19,6 +21,22 @@ def _config():
         pipeline="Pipeline_01_Fault_Diagnosis",
         environment=SimpleNamespace(seed=42, iterations=2),
         model=SimpleNamespace(type="Transformer", name="TSLTransformer"),
+    )
+
+
+def _runtime_config(tmp_path: Path, *, iterations: int = 3) -> SimpleNamespace:
+    return SimpleNamespace(
+        pipeline="Pipeline_01_Fault_Diagnosis",
+        environment=SimpleNamespace(
+            project="runtime-test",
+            seed=7,
+            iterations=iterations,
+            output_dir=str(tmp_path),
+        ),
+        data=SimpleNamespace(data_dir=str(tmp_path), metadata_file="dummy.csv"),
+        model=SimpleNamespace(type="dummy", name="dummy"),
+        task=SimpleNamespace(type="DG", name="classification"),
+        trainer=SimpleNamespace(test_after_fit=True),
     )
 
 
@@ -118,3 +136,101 @@ def test_trainer_test_requires_exactly_one_explicit_population():
         _result_row([[0.5]])
     with pytest.raises(TypeError, match="scalar real number"):
         _result_row([{"test_acc": "0.5"}])
+
+
+def test_invocation_root_is_unique_and_owns_iteration_paths(tmp_path):
+    config = _runtime_config(tmp_path)
+
+    first_root, first_name = classification._create_invocation_root(config)
+    second_root, second_name = classification._create_invocation_root(config)
+
+    assert first_root.is_dir()
+    assert second_root.is_dir()
+    assert first_root != second_root
+    assert first_name != second_name
+    assert {
+        classification._iteration_path(first_root, index).parent
+        for index in range(3)
+    } == {first_root}
+
+
+def test_pipeline_creates_one_root_for_all_iterations(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config = _runtime_config(tmp_path)
+    run_root = tmp_path / "one-run"
+    root_calls = 0
+    trainer_calls = 0
+
+    class DataFactory:
+        data = SimpleNamespace(close=lambda: None)
+
+        def get_metadata(self):
+            return {0: {"Label": 0, "Domain_id": 0}}
+
+        def get_dataloader(self, split: str):
+            return split
+
+    class Trainer:
+        def __init__(self, path: str, value: float):
+            self.value = value
+            self.checkpoint = Path(path) / "best.ckpt"
+            self.checkpoint.write_text("checkpoint\n", encoding="utf-8")
+
+        def fit(self, *args):
+            return None
+
+        def test(self, *args):
+            return [{"test_acc": self.value}]
+
+    def create_root(configs):
+        nonlocal root_calls
+        assert configs is config
+        root_calls += 1
+        run_root.mkdir()
+        return run_root, "one-run"
+
+    def build_trainer(*args):
+        nonlocal trainer_calls
+        trainer_calls += 1
+        return Trainer(args[-1], float(trainer_calls))
+
+    monkeypatch.setattr(classification, "load_runtime_config", lambda args: config)
+    monkeypatch.setattr(classification, "_create_invocation_root", create_root)
+    monkeypatch.setattr(classification, "seed_everything", lambda seed: None)
+    monkeypatch.setattr(classification, "init_lab", lambda *args: None)
+    monkeypatch.setattr(classification, "close_lab", lambda: None)
+    monkeypatch.setattr(classification, "build_data", lambda *args: DataFactory())
+    monkeypatch.setattr(
+        classification,
+        "build_model",
+        lambda *args, **kwargs: object(),
+    )
+    monkeypatch.setattr(classification, "build_task", lambda **kwargs: object())
+    monkeypatch.setattr(classification, "build_trainer", build_trainer)
+    monkeypatch.setattr(
+        classification,
+        "load_best_model_checkpoint",
+        lambda task, trainer: task,
+    )
+    monkeypatch.setattr(
+        classification,
+        "_best_checkpoint_path",
+        lambda trainer: trainer.checkpoint.resolve(),
+    )
+
+    result = classification.run_classification_pipeline(object())
+
+    assert root_calls == 1
+    assert trainer_calls == 3
+    assert result["result_dir"] == str(run_root.resolve())
+    assert [path.name for path in sorted(run_root.glob("iter_*"))] == [
+        "iter_0",
+        "iter_1",
+        "iter_2",
+    ]
+    assert (run_root / "all_results.csv").is_file()
+    assert (run_root / "run_summary.json").is_file()
+    for checkpoint in result["best_checkpoints"]:
+        Path(checkpoint).resolve().relative_to(run_root.resolve())


### PR DESCRIPTION
## Fact

The maintained classification runtime called `path_name()` inside the iteration loop. Because that helper generated a fresh timestamp on every call, one repeated run could place `iter_0`, `iter_1`, and `iter_2` under different roots.

## Invariant

```text
one public invocation
→ one invocation root
→ root/iter_0, root/iter_1, ...
```

## Change

- create the invocation root once after visible runtime fields validate;
- derive every iteration path from that root;
- use microsecond time plus a short UUID only for ordinary directory-name uniqueness;
- return the exact root as `result_dir`;
- add focused tests for root uniqueness and three-iteration ownership.

## Out of scope

- no change to data, split, model, objective, metric, Trainer, scheduler, or MFPT protocol;
- no hash, manifest, ledger, Manager, or fallback changes;
- no new checkpoint-location policy;
- legacy direct-Pipeline config loading remains unchanged for a separate bounded cleanup.

## Acceptance

- root creation occurs once for three iterations;
- `iter_0/1/2` share the same parent;
- aggregate outputs remain under the invocation root;
- `result_dir` is the invocation root rather than the parent of the final iteration;
- existing training-only and failure cleanup contracts remain intact.

## Rollback

Revert the single squash commit.