### PR TITLE
fix(runtime): require structured Pipeline success

### DIFF
--- a/.github/workflows/phmfactory-public-package.yml
+++ b/.github/workflows/phmfactory-public-package.yml
@@ -268,6 +268,8 @@ jobs:
           assert (data_root / "raw/Dummy_Data/dummy1.csv").is_file()
           assert (data_root / "raw/Dummy_Data/dummy2.csv").is_file()
 
+          expected = {"status": "succeeded", "dispatch": "wheel"}
+
           def pipeline(args):
               config = args.compiled_run_spec.runtime_config()
               assert config["data"]["metadata_file"] == "metadata_dummy.csv"
@@ -275,7 +277,7 @@ jobs:
               assert config["task"]["name"] == "classification"
               assert config["trainer"]["device"] == "cpu"
               assert args.effective_config_sha256 == args.compiled_run_spec.effective_config_sha256
-              return "wheel-dispatch-pass"
+              return expected
 
           real_import_module = cli.importlib.import_module
 
@@ -285,7 +287,7 @@ jobs:
               return real_import_module(name)
 
           with patch.object(cli.importlib, "import_module", side_effect=fake_import):
-              assert cli.main(["--config", "smoke"]) == "wheel-dispatch-pass"
+              assert cli.main(["--config", "smoke"]) == expected
 
           assert not Path("/tmp/results").exists()
           PY

--- a/configs/experiments/generative/dummy_generative_cfm.yaml
+++ b/configs/experiments/generative/dummy_generative_cfm.yaml
@@ -50,7 +50,7 @@ task:
 trainer:
   monitor: "val_loss"
   num_epochs: 1
-  gpus: 1
+  devices: 1
   device: "cpu"
   early_stopping: false
   log_every_n_steps: 1

--- a/phmfactory/cli.py
+++ b/phmfactory/cli.py
@@ -64,11 +64,9 @@ def _resolve_pipeline(args: argparse.Namespace, config_path: str) -> str:
     ).pipeline
 
 
-def _print_direct_outputs(result: Any) -> None:
+def _print_direct_outputs(result: Mapping[str, Any]) -> None:
     """Print canonical user outputs returned directly by a maintained Pipeline."""
 
-    if not isinstance(result, Mapping):
-        return
     for key in DIRECT_OUTPUT_KEYS:
         value = result.get(key)
         if value is not None:
@@ -86,7 +84,7 @@ def _print_direct_outputs(result: Any) -> None:
         )
 
 
-def run(args: argparse.Namespace) -> Any:
+def run(args: argparse.Namespace) -> Mapping[str, Any]:
     """Analyze, authorize, execute, and return one Pipeline invocation.
 
     Configuration composition occurs exactly once in :func:`analyze_config`. Protected
@@ -138,7 +136,7 @@ def run(args: argparse.Namespace) -> Any:
 
     result = envelope.execute(pipeline_module, args)
     _print_direct_outputs(result)
-    print("完成所有实验！")
+    print("run=completed")
     return result
 
 

--- a/phmfactory/runtime/execution.py
+++ b/phmfactory/runtime/execution.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from enum import Enum
@@ -28,6 +29,33 @@ def _utc_now() -> str:
     return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
 
 
+def _require_success_mapping(result: Any, *, pipeline: str) -> Mapping[str, Any]:
+    """Return one non-empty success mapping or reject an ambiguous result."""
+
+    if not isinstance(result, Mapping):
+        raise PipelineContractError(
+            f"Pipeline {pipeline!r} returned {type(result).__name__}; "
+            "successful Pipelines must return a non-empty result mapping"
+        )
+    if not result:
+        raise PipelineContractError(
+            f"Pipeline {pipeline!r} returned an empty result mapping"
+        )
+
+    status = result.get("status")
+    if status is not None and status != "succeeded":
+        raise PipelineContractError(
+            f"Pipeline {pipeline!r} returned status={status!r}; "
+            "failures must raise their original exception"
+        )
+    if "error" in result and status != "succeeded":
+        raise PipelineContractError(
+            f"Pipeline {pipeline!r} returned an error mapping; "
+            "failures must raise their original exception"
+        )
+    return result
+
+
 @dataclass
 class ExecutionEnvelope:
     """Enforce one Pipeline lifecycle while retaining the original failure."""
@@ -52,8 +80,8 @@ class ExecutionEnvelope:
         self.error_type = type(error).__name__
         self.error_message = str(error)
 
-    def execute(self, module: ModuleType | Any, args: Any) -> Any:
-        """Execute exactly once and reject missing or ambiguous success results."""
+    def execute(self, module: ModuleType | Any, args: Any) -> Mapping[str, Any]:
+        """Execute exactly once and require one structured success result."""
 
         if self.status is not ExecutionStatus.PENDING:
             raise PipelineContractError(
@@ -71,12 +99,10 @@ class ExecutionEnvelope:
         self.status = ExecutionStatus.RUNNING
         self.started_at = _utc_now()
         try:
-            result = entrypoint(args)
-            if result is None:
-                raise PipelineContractError(
-                    f"Pipeline {self.spec.pipeline!r} returned None; "
-                    "successful Pipelines must return an explicit result"
-                )
+            result = _require_success_mapping(
+                entrypoint(args),
+                pipeline=self.spec.pipeline,
+            )
         except BaseException as error:
             self.record_failure(error, stage="pipeline")
             raise

--- a/phmfactory/runtime/pipeline06_adapter.py
+++ b/phmfactory/runtime/pipeline06_adapter.py
@@ -1,13 +1,13 @@
 """Public compiled-config adapter for Pipeline 06.
 
 The scientific train/sample/eval implementation remains in
-``src.Pipeline_06_Generative_Modeling``.  This adapter owns only the public control-plane
+``src.Pipeline_06_Generative_Modeling``. This adapter owns only the public control-plane
 boundary: it consumes ``CompiledRunSpec.runtime_config()`` exactly once and delegates the
 selected stage without re-reading YAML, reapplying CLI overrides, or discovering a local
 machine file.
 
 Direct legacy imports of the original ``src`` module retain its explicit compatibility
-loader.  The maintained CLI resolves Pipeline 06 to this adapter.
+loader. The maintained CLI resolves Pipeline 06 to this adapter.
 """
 
 from __future__ import annotations
@@ -40,8 +40,8 @@ def _runtime_config(args: Any, implementation: Any) -> Any:
     return configs
 
 
-def pipeline(args: Any) -> list[Any]:
-    """Dispatch one explicit Pipeline 06 stage from the compiled config contract."""
+def pipeline(args: Any) -> dict[str, Any]:
+    """Dispatch one explicit Pipeline 06 stage and return a public result mapping."""
 
     import src.Pipeline_06_Generative_Modeling as implementation
 
@@ -74,4 +74,8 @@ def pipeline(args: Any) -> list[Any]:
             except Exception as ledger_error:
                 raise error from ledger_error
             raise
-    return results
+    return {
+        "status": "succeeded",
+        "stage": mode,
+        "iterations": results,
+    }

--- a/test/generative/test_pipeline06_compiled_config.py
+++ b/test/generative/test_pipeline06_compiled_config.py
@@ -78,6 +78,10 @@ def test_adapter_dispatches_compiled_stage_without_reparse(monkeypatch) -> None:
 
     result = pipeline06_adapter.pipeline(args)
 
-    assert result == [{"stage": "train", "iteration": 0}]
+    assert result == {
+        "status": "succeeded",
+        "stage": "train",
+        "iterations": [{"stage": "train", "iteration": 0}],
+    }
     assert len(calls) == 1
     assert calls[0][0].task.generative.mode == "train"

--- a/test/test_phmfactory_entrypoints.py
+++ b/test/test_phmfactory_entrypoints.py
@@ -121,8 +121,9 @@ def test_run_dispatches_analyzed_canonical_module(
         pipeline="Pipeline_04_Unified_Evaluation",
         overrides={"pipeline": "Pipeline_04_unified_metric"},
     )
+    expected = {"status": "succeeded", "marker": "sentinel"}
 
-    def pipeline(args: argparse.Namespace) -> str:
+    def pipeline(args: argparse.Namespace) -> dict[str, str]:
         observed["requested_config"] = args.requested_config
         observed["config_path"] = args.config_path
         observed["resolved_config_path"] = args.resolved_config_path
@@ -133,7 +134,7 @@ def test_run_dispatches_analyzed_canonical_module(
         observed["effective_config_sha256"] = args.effective_config_sha256
         observed["run_spec_sha256"] = args.run_spec_sha256
         observed["notes"] = args.notes
-        return "sentinel"
+        return expected
 
     def fake_import(name: str) -> SimpleNamespace:
         observed["module"] = name
@@ -156,7 +157,7 @@ def test_run_dispatches_analyzed_canonical_module(
         allow_experimental=True,
     )
 
-    assert cli.run(args) == "sentinel"
+    assert cli.run(args) == expected
     compiled = observed.pop("compiled_run_spec")
     resolved_data = observed.pop("resolved_config_data")
     run_spec_sha256 = observed.pop("run_spec_sha256")
@@ -185,12 +186,13 @@ def test_run_passes_maintained_preset_path_to_runtime(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     observed: dict[str, object] = {}
+    expected = {"status": "succeeded"}
 
-    def pipeline(args: argparse.Namespace) -> bool:
+    def pipeline(args: argparse.Namespace) -> dict[str, str]:
         observed["requested_config"] = args.requested_config
         observed["config_path"] = args.config_path
         observed["effective_config_sha256"] = args.effective_config_sha256
-        return True
+        return expected
 
     monkeypatch.setattr(
         cli.importlib,
@@ -205,7 +207,7 @@ def test_run_passes_maintained_preset_path_to_runtime(
         override=[f"environment.output_dir={tmp_path / 'runs'}"],
     )
 
-    assert cli.run(args) is True
+    assert cli.run(args) == expected
     assert observed["requested_config"] == preset
     assert Path(str(observed["config_path"])) == resolve_config_path(preset)
     assert len(str(observed["effective_config_sha256"])) == 64
@@ -375,14 +377,15 @@ def test_run_dispatches_packaged_base_configs_outside_checkout(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     observed: dict[str, object] = {}
+    expected = {"status": "succeeded", "dispatch": "packaged"}
 
-    def pipeline(args: argparse.Namespace) -> str:
+    def pipeline(args: argparse.Namespace) -> dict[str, str]:
         config = args.compiled_run_spec.runtime_config()
         observed["data"] = config["data"]["metadata_file"]
         observed["model"] = config["model"]["name"]
         observed["task"] = config["task"]["name"]
         observed["trainer"] = config["trainer"]["device"]
-        return "dispatched"
+        return expected
 
     real_import_module = cli.importlib.import_module
 
@@ -401,7 +404,7 @@ def test_run_dispatches_packaged_base_configs_outside_checkout(
         override=None,
     )
 
-    assert cli.run(args) == "dispatched"
+    assert cli.run(args) == expected
     assert observed == {
         "data": "metadata_dummy.csv",
         "model": "M_01_ISFM",

--- a/test/test_runtime_execution.py
+++ b/test/test_runtime_execution.py
@@ -28,30 +28,61 @@ def _spec() -> CompiledRunSpec:
     )
 
 
-def test_envelope_records_success() -> None:
+def test_envelope_records_structured_success() -> None:
     envelope = ExecutionEnvelope(
         spec=_spec(),
         pipeline_module="src.Pipeline_01_Fault_Diagnosis",
     )
-    result = envelope.execute(SimpleNamespace(pipeline=lambda args: ["ok"]), object())
+    expected = {"status": "succeeded", "result_dir": "/tmp/run"}
+    result = envelope.execute(
+        SimpleNamespace(pipeline=lambda args: expected),
+        object(),
+    )
 
-    assert result == ["ok"]
+    assert result == expected
     assert envelope.status is ExecutionStatus.SUCCEEDED
     assert envelope.started_at is not None
     assert envelope.finished_at is not None
     assert envelope.error_type is None
 
 
-def test_envelope_rejects_none_as_ambiguous_success() -> None:
+@pytest.mark.parametrize(
+    "result",
+    (None, True, False, "success", [], (), {}),
+)
+def test_envelope_rejects_ambiguous_success_values(result) -> None:
     envelope = ExecutionEnvelope(spec=_spec(), pipeline_module="src.invalid")
 
-    with pytest.raises(PipelineContractError, match="returned None"):
-        envelope.execute(SimpleNamespace(pipeline=lambda args: None), object())
+    with pytest.raises(PipelineContractError, match="must return|empty result"):
+        envelope.execute(
+            SimpleNamespace(pipeline=lambda args: result),
+            object(),
+        )
 
     assert envelope.status is ExecutionStatus.FAILED
     assert envelope.failure_stage == "pipeline"
     assert envelope.error_type == "PipelineContractError"
     assert envelope.finished_at is not None
+
+
+@pytest.mark.parametrize(
+    "result",
+    (
+        {"status": "failed", "error": "training failed"},
+        {"error": "training failed"},
+    ),
+)
+def test_envelope_rejects_returned_failure_mappings(result) -> None:
+    envelope = ExecutionEnvelope(spec=_spec(), pipeline_module="src.invalid")
+
+    with pytest.raises(PipelineContractError, match="failures must raise"):
+        envelope.execute(
+            SimpleNamespace(pipeline=lambda args: result),
+            object(),
+        )
+
+    assert envelope.status is ExecutionStatus.FAILED
+    assert envelope.failure_stage == "pipeline"
 
 
 def test_envelope_rejects_missing_entrypoint() -> None:
@@ -81,13 +112,26 @@ def test_envelope_records_and_reraises_pipeline_error() -> None:
 
 def test_envelope_cannot_execute_twice() -> None:
     envelope = ExecutionEnvelope(spec=_spec(), pipeline_module="src.valid")
-    envelope.execute(SimpleNamespace(pipeline=lambda args: True), object())
+    envelope.execute(
+        SimpleNamespace(
+            pipeline=lambda args: {"status": "succeeded", "result_dir": "/tmp/run"}
+        ),
+        object(),
+    )
 
     with pytest.raises(PipelineContractError, match="cannot run from status"):
-        envelope.execute(SimpleNamespace(pipeline=lambda args: True), object())
+        envelope.execute(
+            SimpleNamespace(
+                pipeline=lambda args: {
+                    "status": "succeeded",
+                    "result_dir": "/tmp/run",
+                }
+            ),
+            object(),
+        )
 
 
-def test_cli_does_not_print_completion_when_pipeline_returns_none(
+def test_cli_does_not_print_completion_when_pipeline_result_is_invalid(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
     capsys: pytest.CaptureFixture[str],
@@ -113,7 +157,7 @@ def test_cli_does_not_print_completion_when_pipeline_returns_none(
     monkeypatch.setattr(
         cli.importlib,
         "import_module",
-        lambda name: SimpleNamespace(pipeline=lambda args: None),
+        lambda name: SimpleNamespace(pipeline=lambda args: "success"),
     )
 
     args = argparse.Namespace(
@@ -126,7 +170,9 @@ def test_cli_does_not_print_completion_when_pipeline_returns_none(
     with pytest.raises(PipelineContractError):
         cli.run(args)
 
-    assert "完成所有实验" not in capsys.readouterr().out
+    output = capsys.readouterr().out
+    assert "run=completed" not in output
+    assert "完成所有实验" not in output
     assert args.execution_envelope.status is ExecutionStatus.FAILED
     assert not hasattr(args, "run_manifest_path")
     assert not (tmp_path / "outputs").exists()


### PR DESCRIPTION
## Fact

The public execution boundary treated every non-`None` Python object as success. A Pipeline could therefore return `True`, a string, a list, an empty mapping, or a returned failure object and still leave the envelope in `SUCCEEDED`.

## Invariant

```text
success
→ one non-empty result mapping

failure
→ raise the original exception
```

## Change

- require every public Pipeline result to be a non-empty mapping;
- reject bool, string, list, tuple, empty mapping, `status != succeeded`, and returned error mappings;
- keep Pipeline exceptions as the primary failure mechanism;
- make the public Pipeline 06 adapter return a mapping instead of a bare list;
- migrate its exploratory CFM config from rejected `trainer.gpus` to the existing public `trainer.devices` field;
- replace the duplicate prose completion message with `run=completed`;
- update focused tests and package mocks to use structured results.

## Out of scope

- this PR does not yet require every compatibility Pipeline to expose `run_kind`, metric paths, or one universal field set;
- no change to Data, Model, Task, Trainer, checkpoint selection, metrics, split, or MFPT;
- no ResultManager, manifest, hash, ledger, or fallback layer.

## Acceptance

- `None`, bool, string, sequence, and empty mapping fail;
- returned `status=failed` or error mappings fail;
- a non-empty success mapping completes once;
- Pipeline 06 public dispatch remains usable through a structured mapping;
- the exploratory CFM config passes the current public device schema without a legacy alias;
- CLI prints direct fields and one concise completion signal only;
- original Pipeline exceptions still propagate.

## Rollback

Revert the single squash commit.