### PR TITLE
refactor(runtime): remove hashes from user-visible results

### DIFF
--- a/.github/workflows/core-quality-gates.yml
+++ b/.github/workflows/core-quality-gates.yml
@@ -291,7 +291,12 @@ jobs:
         run: |
           set -o pipefail
           phmfactory preflight --config smoke 2>&1 | tee offline-preflight.log
-          grep -E '^effective_config_sha256=[0-9a-f]{64}$' offline-preflight.log
+          grep -F 'status=passed' offline-preflight.log
+          grep -F 'pipeline=Pipeline_01_Fault_Diagnosis' offline-preflight.log
+          if grep -qi 'sha256' offline-preflight.log; then
+            echo 'preflight must not expose digest fields' >&2
+            exit 1
+          fi
           test ! -e results/demo/dummy_dg_smoke
 
       - name: Run the documented offline demo command
@@ -334,6 +339,7 @@ jobs:
           summary = json.loads(summary_path.read_text(encoding="utf-8"))
           assert summary["iterations"] == 1
           assert summary["metrics"], summary
+          assert "config_sha256" not in summary
           for metric in summary["metrics"].values():
               assert metric["count"] == summary["iterations"]
               assert math.isfinite(float(metric["mean"]))

--- a/.github/workflows/phmfactory-public-package.yml
+++ b/.github/workflows/phmfactory-public-package.yml
@@ -9,6 +9,7 @@ on:
       - "src/configs/config_utils.py"
       - "src/config_schema/**"
       - "src/runtime/classification.py"
+      - "src/utils/run_summary.py"
       - "src/trainer_factory/Default_trainer.py"
       - "src/trainer_factory/extensions/**"
       - "main.py"
@@ -27,8 +28,10 @@ on:
       - "test/test_phmfactory_commands.py"
       - "test/test_phmfactory_entrypoints.py"
       - "test/test_phmfactory_config_resolver.py"
+      - "test/test_pipeline01_run_summary.py"
       - "test/test_pipeline_name_migration.py"
       - "test/test_pipeline_maturity.py"
+      - "test/test_run_summary.py"
       - "test/test_runtime_control_plane.py"
       - "test/test_runtime_execution.py"
       - ".github/workflows/phmfactory-public-package.yml"
@@ -42,6 +45,7 @@ on:
       - "src/configs/config_utils.py"
       - "src/config_schema/**"
       - "src/runtime/classification.py"
+      - "src/utils/run_summary.py"
       - "src/trainer_factory/Default_trainer.py"
       - "src/trainer_factory/extensions/**"
       - "main.py"
@@ -60,8 +64,10 @@ on:
       - "test/test_phmfactory_commands.py"
       - "test/test_phmfactory_entrypoints.py"
       - "test/test_phmfactory_config_resolver.py"
+      - "test/test_pipeline01_run_summary.py"
       - "test/test_pipeline_name_migration.py"
       - "test/test_pipeline_maturity.py"
+      - "test/test_run_summary.py"
       - "test/test_runtime_control_plane.py"
       - "test/test_runtime_execution.py"
       - ".github/workflows/phmfactory-public-package.yml"
@@ -100,13 +106,16 @@ jobs:
           scripts/validate_configs.py
           src/configs/config_utils.py
           src/config_schema/*.py
+          src/utils/run_summary.py
           main.py
           test/test_config_analysis_parity.py
           test/test_phmfactory_commands.py
           test/test_phmfactory_entrypoints.py
           test/test_phmfactory_config_resolver.py
+          test/test_pipeline01_run_summary.py
           test/test_pipeline_name_migration.py
           test/test_pipeline_maturity.py
+          test/test_run_summary.py
           test/test_runtime_control_plane.py
           test/test_runtime_execution.py
 
@@ -118,8 +127,10 @@ jobs:
           test/test_phmfactory_commands.py
           test/test_phmfactory_entrypoints.py
           test/test_phmfactory_config_resolver.py
+          test/test_pipeline01_run_summary.py
           test/test_pipeline_name_migration.py
           test/test_pipeline_maturity.py
+          test/test_run_summary.py
           test/test_runtime_control_plane.py
           test/test_runtime_execution.py
 
@@ -276,7 +287,8 @@ jobs:
               assert config["model"]["name"] == "M_01_ISFM"
               assert config["task"]["name"] == "classification"
               assert config["trainer"]["device"] == "cpu"
-              assert args.effective_config_sha256 == args.compiled_run_spec.effective_config_sha256
+              assert not hasattr(args, "effective_config_sha256")
+              assert not hasattr(args, "run_spec_sha256")
               return expected
 
           real_import_module = cli.importlib.import_module

--- a/.github/workflows/phmfactory-public-package.yml
+++ b/.github/workflows/phmfactory-public-package.yml
@@ -112,10 +112,8 @@ jobs:
           test/test_phmfactory_commands.py
           test/test_phmfactory_entrypoints.py
           test/test_phmfactory_config_resolver.py
-          test/test_pipeline01_run_summary.py
           test/test_pipeline_name_migration.py
           test/test_pipeline_maturity.py
-          test/test_run_summary.py
           test/test_runtime_control_plane.py
           test/test_runtime_execution.py
 
@@ -127,10 +125,8 @@ jobs:
           test/test_phmfactory_commands.py
           test/test_phmfactory_entrypoints.py
           test/test_phmfactory_config_resolver.py
-          test/test_pipeline01_run_summary.py
           test/test_pipeline_name_migration.py
           test/test_pipeline_maturity.py
-          test/test_run_summary.py
           test/test_runtime_control_plane.py
           test/test_runtime_execution.py
 

--- a/phmfactory/cli.py
+++ b/phmfactory/cli.py
@@ -110,8 +110,6 @@ def run(args: argparse.Namespace) -> Mapping[str, Any]:
     args.config_analysis = analysis
     args.compiled_run_spec = compiled
     args.resolved_config_data = compiled.runtime_config()
-    args.effective_config_sha256 = analysis.effective_config_sha256
-    args.run_spec_sha256 = compiled.sha256
 
     module_name = pipeline_module_name(analysis.pipeline, warn=False)
     envelope = ExecutionEnvelope(spec=compiled, pipeline_module=module_name)

--- a/phmfactory/commands/preflight.py
+++ b/phmfactory/commands/preflight.py
@@ -16,7 +16,6 @@ from phmfactory.commands.common import (
 from phmfactory.config import analyze_config
 from phmfactory.device import resolve_device_request
 from phmfactory.pipelines import pipeline_module_name, require_pipeline_access
-from phmfactory.runtime import CompiledRunSpec
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -51,7 +50,6 @@ def run(argv: Sequence[str]) -> dict[str, Any]:
         detail = "; ".join(f"{item.field}: {item.message}" for item in errors)
         raise ValueError(f"configuration analysis failed: {detail}")
 
-    compiled = CompiledRunSpec.compile(analysis.to_resolved_config())
     descriptor = require_pipeline_access(
         analysis.pipeline,
         allow_experimental=bool(args.allow_experimental),
@@ -70,9 +68,7 @@ def run(argv: Sequence[str]) -> dict[str, Any]:
     trainer_config = analysis.effective_config.get("trainer")
     if not isinstance(trainer_config, dict):
         raise ValueError("trainer configuration must be a mapping for preflight")
-    accelerator, devices = resolve_device_request(
-        argparse.Namespace(**trainer_config)
-    )
+    accelerator, devices = resolve_device_request(argparse.Namespace(**trainer_config))
 
     result = {
         "status": "passed",
@@ -83,8 +79,6 @@ def run(argv: Sequence[str]) -> dict[str, Any]:
             if analysis.local_config_path is not None
             else "none"
         ),
-        "effective_config_sha256": analysis.effective_config_sha256,
-        "run_spec_sha256": compiled.sha256,
         "pipeline": analysis.pipeline,
         "pipeline_module": module_name,
         "maturity": descriptor.maturity,

--- a/scripts/config_inspect.py
+++ b/scripts/config_inspect.py
@@ -1,8 +1,8 @@
 """Inspect a PHMFactory configuration without defining a second resolver.
 
 The script is a presentation adapter over :func:`phmfactory.config.analyze_config`.
-Composition, explicit local configuration, CLI overrides, canonical Pipeline naming, and
-the semantic hash therefore match the real runtime and ``phmfactory preflight``.
+Composition, explicit local configuration, CLI overrides, and canonical Pipeline naming
+therefore match the real runtime and ``phmfactory preflight``.
 """
 
 from __future__ import annotations
@@ -33,7 +33,6 @@ class InspectResult:
     sources: Dict[str, str]
     targets: Dict[str, Any]
     sanity: List[Dict[str, Any]]
-    effective_config_sha256: str
     local_config_path: str | None
 
 
@@ -264,7 +263,6 @@ def inspect_config(
         sources=dict(analysis.sources),
         targets=targets,
         sanity=_sanity_checks(analysis, targets),
-        effective_config_sha256=analysis.effective_config_sha256,
         local_config_path=(
             str(analysis.local_config_path)
             if analysis.local_config_path is not None
@@ -279,7 +277,6 @@ def _has_failed_sanity(result: InspectResult) -> bool:
 
 def _payload(result: InspectResult, dump: DumpMode) -> Dict[str, Any]:
     payload: Dict[str, Any] = {
-        "effective_config_sha256": result.effective_config_sha256,
         "local_config_path": result.local_config_path,
     }
     if dump in ("resolved", "all"):
@@ -295,7 +292,6 @@ def _payload(result: InspectResult, dump: DumpMode) -> Dict[str, Any]:
 
 def _render_md(result: InspectResult, dump: DumpMode) -> str:
     parts = [
-        f"effective_config_sha256: `{result.effective_config_sha256}`",
         f"explicit_local_config: `{result.local_config_path or 'none'}`",
         "",
     ]

--- a/src/utils/run_summary.py
+++ b/src/utils/run_summary.py
@@ -2,43 +2,12 @@
 
 from __future__ import annotations
 
-import hashlib
 import json
 import math
 import numbers
 import statistics
 from pathlib import Path
-from types import SimpleNamespace
 from typing import Any, Mapping, Sequence
-
-
-def _to_builtin(value: Any) -> Any:
-    if isinstance(value, SimpleNamespace):
-        return {key: _to_builtin(item) for key, item in vars(value).items()}
-    if isinstance(value, Mapping):
-        return {str(key): _to_builtin(item) for key, item in value.items()}
-    if isinstance(value, (list, tuple)):
-        return [_to_builtin(item) for item in value]
-    if isinstance(value, Path):
-        return str(value)
-    if value is None or isinstance(value, (str, int, float, bool)):
-        return value
-    if hasattr(value, "item"):
-        scalar = value.item()
-        if scalar is not value:
-            return _to_builtin(scalar)
-    raise TypeError(f"unsupported resolved config value: {type(value).__name__}")
-
-
-def resolved_config_sha256(config: Any) -> str:
-    payload = json.dumps(
-        _to_builtin(config),
-        sort_keys=True,
-        separators=(",", ":"),
-        ensure_ascii=True,
-        allow_nan=False,
-    ).encode("utf-8")
-    return hashlib.sha256(payload).hexdigest()
 
 
 def _numeric_metric(value: Any, *, context: str) -> float:
@@ -97,9 +66,7 @@ def _normalized_seeds(seeds: Sequence[int]) -> list[int]:
     normalized: list[int] = []
     for index, seed in enumerate(seeds):
         if isinstance(seed, bool) or not isinstance(seed, numbers.Integral):
-            raise TypeError(
-                f"seed {index} must be an integer, got {seed!r}"
-            )
+            raise TypeError(f"seed {index} must be an integer, got {seed!r}")
         normalized.append(int(seed))
     return normalized
 
@@ -107,10 +74,16 @@ def _normalized_seeds(seeds: Sequence[int]) -> list[int]:
 def build_run_summary(
     results: Sequence[Mapping[str, Any]],
     seeds: Sequence[int],
-    config: Any,
+    config: Any | None = None,
 ) -> dict[str, Any]:
-    """Summarize one identical finite metric set across every completed seed."""
+    """Summarize one identical finite metric set across every completed seed.
 
+    ``config`` remains as a temporary compatibility argument for current callers. It is
+    deliberately not serialized or converted into a digest; run validity comes from the
+    reported estimator and direct result paths.
+    """
+
+    del config
     if len(results) != len(seeds):
         raise ValueError("one seed must be recorded for every run result")
     if not results:
@@ -143,7 +116,6 @@ def build_run_summary(
     normalized_seeds = _normalized_seeds(seeds)
     return {
         "schema_version": 1,
-        "config_sha256": resolved_config_sha256(config),
         "iterations": len(normalized_results),
         "seeds": normalized_seeds,
         "metrics": metrics,
@@ -154,7 +126,7 @@ def write_run_summary(
     output_path: str | Path,
     results: Sequence[Mapping[str, Any]],
     seeds: Sequence[int],
-    config: Any,
+    config: Any | None = None,
 ) -> dict[str, Any]:
     summary = build_run_summary(results=results, seeds=seeds, config=config)
     path = Path(output_path)
@@ -170,6 +142,5 @@ def write_run_summary(
 __all__ = [
     "build_run_summary",
     "normalize_metric_result",
-    "resolved_config_sha256",
     "write_run_summary",
 ]

--- a/test/test_config_analysis_parity.py
+++ b/test/test_config_analysis_parity.py
@@ -12,7 +12,6 @@ from phmfactory.config import (
     analyze_config,
     load_config_dict,
     resolve_config,
-    semantic_config_sha256,
     validate_complete_experiment,
 )
 from scripts.config_inspect import inspect_config
@@ -62,15 +61,14 @@ def _remove_yaml_field(path: Path, field: str) -> None:
     path.write_text("\n".join(kept) + "\n", encoding="utf-8")
 
 
-def test_preset_and_explicit_path_have_same_effective_identity() -> None:
+def test_preset_and_explicit_path_have_same_effective_config() -> None:
     preset = analyze_config("smoke")
     explicit = analyze_config(SMOKE_CONFIG)
 
     assert preset.effective_config == explicit.effective_config
-    assert preset.effective_config_sha256 == explicit.effective_config_sha256
 
 
-def test_equivalent_yaml_and_cli_override_have_same_effective_identity(
+def test_equivalent_yaml_and_cli_override_have_same_effective_config(
     tmp_path: Path,
 ) -> None:
     direct = tmp_path / "direct.yaml"
@@ -85,10 +83,6 @@ def test_equivalent_yaml_and_cli_override_have_same_effective_identity(
     )
 
     assert direct_analysis.effective_config == override_analysis.effective_config
-    assert (
-        direct_analysis.effective_config_sha256
-        == override_analysis.effective_config_sha256
-    )
 
 
 def test_precedence_is_base_then_config_then_explicit_local_then_cli(
@@ -192,31 +186,28 @@ def test_resolve_config_is_a_compatibility_view_of_analysis() -> None:
     assert resolved.path == analysis.path
 
 
-def test_inspector_and_public_analysis_return_same_config_and_hash(
-    tmp_path: Path,
-) -> None:
+def test_inspector_and_public_analysis_return_same_config(tmp_path: Path) -> None:
     override = f"environment.output_dir={tmp_path / 'output'}"
     analysis = analyze_config("smoke", override_values=[override])
     inspected = inspect_config("smoke", overrides=[override])
 
     assert inspected.resolved == analysis.effective_config
-    assert inspected.effective_config_sha256 == analysis.effective_config_sha256
+    assert not hasattr(inspected, "effective_config_sha256")
 
 
 def test_validator_accepts_the_same_maintained_smoke_config() -> None:
     assert validate_one(SMOKE_CONFIG) == []
 
 
-def test_preflight_reports_the_same_effective_hash(
-    tmp_path: Path,
-) -> None:
+def test_preflight_reports_same_pipeline_without_hashes(tmp_path: Path) -> None:
     override = f"environment.output_dir={tmp_path / 'preflight'}"
     expected = analyze_config("smoke", override_values=[override])
 
     report = preflight.run(["--config", "smoke", "--override", override])
 
-    assert report["effective_config_sha256"] == expected.effective_config_sha256
     assert report["pipeline"] == expected.pipeline
+    assert "effective_config_sha256" not in report
+    assert "run_spec_sha256" not in report
     assert not (tmp_path / "preflight").exists()
 
 
@@ -347,9 +338,3 @@ def test_grouped_split_coupling_fails_at_the_shared_public_boundary(
 
     with pytest.raises(ValidationError, match="requires test_policy=task_defined"):
         analyze_config(config)
-
-
-def test_semantic_hash_is_stable_for_mapping_order() -> None:
-    left = {"pipeline": "P", "trainer": {"device": "cpu", "epochs": 1}}
-    right = {"trainer": {"epochs": 1, "device": "cpu"}, "pipeline": "P"}
-    assert semantic_config_sha256(left) == semantic_config_sha256(right)

--- a/test/test_phmfactory_commands.py
+++ b/test/test_phmfactory_commands.py
@@ -9,7 +9,7 @@ import pytest
 from phmfactory import cli
 from phmfactory.commands import demo, doctor, preflight
 from phmfactory.commands.common import check_writable_directory
-from phmfactory.config import ConfigAnalysis, ResolvedConfig, semantic_config_sha256
+from phmfactory.config import ConfigAnalysis, ResolvedConfig
 import phmfactory.device as device_contract
 
 
@@ -52,7 +52,7 @@ def _analysis(
         source_files=(path,),
         sources={},
         diagnostics=(),
-        effective_config_sha256=semantic_config_sha256(config),
+        effective_config_sha256="unused-in-user-output",
     )
 
 
@@ -137,8 +137,8 @@ def test_preflight_uses_single_analysis_without_importing_pipeline(
 
     assert result["status"] == "passed"
     assert result["pipeline"] == "Pipeline_01_Fault_Diagnosis"
-    assert result["effective_config_sha256"] == analysis.effective_config_sha256
-    assert len(result["run_spec_sha256"]) == 64
+    assert "effective_config_sha256" not in result
+    assert "run_spec_sha256" not in result
     assert result["requested_device"] == "cpu"
     assert result["resolved_accelerator"] == "cpu"
     assert result["resolved_devices"] == 1
@@ -159,9 +159,7 @@ def test_preflight_rejects_unavailable_cuda_before_training(
     monkeypatch.setattr(
         device_contract,
         "_load_torch",
-        lambda: SimpleNamespace(
-            cuda=SimpleNamespace(is_available=lambda: False)
-        ),
+        lambda: SimpleNamespace(cuda=SimpleNamespace(is_available=lambda: False)),
     )
 
     with pytest.raises(RuntimeError, match="CUDA is unavailable.*no CPU fallback"):

--- a/test/test_phmfactory_entrypoints.py
+++ b/test/test_phmfactory_entrypoints.py
@@ -12,12 +12,7 @@ import pytest
 from examples import cwru_quickstart
 from phmfactory import __version__, cli
 from phmfactory.commands import preflight
-from phmfactory.config import (
-    MAINTAINED_PRESETS,
-    ConfigAnalysis,
-    resolve_config_path,
-    semantic_config_sha256,
-)
+from phmfactory.config import MAINTAINED_PRESETS, ConfigAnalysis, resolve_config_path
 
 
 REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
@@ -45,7 +40,7 @@ def _analysis(
         source_files=(path,),
         sources={},
         diagnostics=(),
-        effective_config_sha256=semantic_config_sha256(config),
+        effective_config_sha256="internal-only",
     )
 
 
@@ -131,8 +126,6 @@ def test_run_dispatches_analyzed_canonical_module(
         observed["config_analysis"] = args.config_analysis
         observed["compiled_run_spec"] = args.compiled_run_spec
         observed["resolved_config_data"] = args.resolved_config_data
-        observed["effective_config_sha256"] = args.effective_config_sha256
-        observed["run_spec_sha256"] = args.run_spec_sha256
         observed["notes"] = args.notes
         return expected
 
@@ -160,11 +153,9 @@ def test_run_dispatches_analyzed_canonical_module(
     assert cli.run(args) == expected
     compiled = observed.pop("compiled_run_spec")
     resolved_data = observed.pop("resolved_config_data")
-    run_spec_sha256 = observed.pop("run_spec_sha256")
     config_analysis = observed.pop("config_analysis")
     assert compiled.pipeline == "Pipeline_04_Unified_Evaluation"
     assert resolved_data == analysis.effective_config
-    assert run_spec_sha256 == compiled.sha256
     assert config_analysis is analysis
     assert observed == {
         "module": "src.Pipeline_04_Unified_Evaluation",
@@ -172,9 +163,10 @@ def test_run_dispatches_analyzed_canonical_module(
         "config_path": str(analysis.path),
         "resolved_config_path": str(analysis.path),
         "resolved_pipeline": "Pipeline_04_Unified_Evaluation",
-        "effective_config_sha256": analysis.effective_config_sha256,
         "notes": "entrypoint-parity",
     }
+    assert not hasattr(args, "effective_config_sha256")
+    assert not hasattr(args, "run_spec_sha256")
     assert not hasattr(args, "run_manifest_path")
     assert not (tmp_path / "runs").exists()
 
@@ -191,7 +183,6 @@ def test_run_passes_maintained_preset_path_to_runtime(
     def pipeline(args: argparse.Namespace) -> dict[str, str]:
         observed["requested_config"] = args.requested_config
         observed["config_path"] = args.config_path
-        observed["effective_config_sha256"] = args.effective_config_sha256
         return expected
 
     monkeypatch.setattr(
@@ -210,7 +201,8 @@ def test_run_passes_maintained_preset_path_to_runtime(
     assert cli.run(args) == expected
     assert observed["requested_config"] == preset
     assert Path(str(observed["config_path"])) == resolve_config_path(preset)
-    assert len(str(observed["effective_config_sha256"])) == 64
+    assert not hasattr(args, "effective_config_sha256")
+    assert not hasattr(args, "run_spec_sha256")
     assert not hasattr(args, "run_manifest_path")
     assert not (tmp_path / "runs").exists()
 
@@ -290,7 +282,7 @@ def test_python_process_entrypoints_return_zero_for_preflight(
     )
     assert completed.returncode == 0, completed.stderr
     assert "status=passed" in completed.stdout
-    assert "effective_config_sha256=" in completed.stdout
+    assert "sha256" not in completed.stdout.lower()
     assert not target.exists()
 
 
@@ -411,5 +403,7 @@ def test_run_dispatches_packaged_base_configs_outside_checkout(
         "task": "classification",
         "trainer": "cpu",
     }
+    assert not hasattr(args, "effective_config_sha256")
+    assert not hasattr(args, "run_spec_sha256")
     assert not hasattr(args, "run_manifest_path")
     assert not (tmp_path / "results").exists()

--- a/test/test_pipeline_maturity.py
+++ b/test/test_pipeline_maturity.py
@@ -7,7 +7,7 @@ from types import SimpleNamespace
 import pytest
 
 from phmfactory import cli
-from phmfactory.config import ConfigAnalysis, semantic_config_sha256
+from phmfactory.config import ConfigAnalysis
 from phmfactory.pipelines import (
     PipelineMaturityError,
     pipeline_descriptor,
@@ -32,7 +32,7 @@ def _analysis(tmp_path: Path, pipeline: str) -> ConfigAnalysis:
         source_files=(path,),
         sources={},
         diagnostics=(),
-        effective_config_sha256=semantic_config_sha256(data),
+        effective_config_sha256="internal-only",
     )
 
 
@@ -106,7 +106,9 @@ def test_cli_explicit_opt_in_allows_experimental_import(
     monkeypatch.setattr(
         cli.importlib,
         "import_module",
-        lambda name: SimpleNamespace(pipeline=lambda args: {"experimental": True}),
+        lambda name: SimpleNamespace(
+            pipeline=lambda args: {"status": "succeeded", "experimental": True}
+        ),
     )
     args = argparse.Namespace(
         config="maturity-test",
@@ -117,7 +119,7 @@ def test_cli_explicit_opt_in_allows_experimental_import(
         allow_experimental=True,
     )
 
-    assert cli.run(args) == {"experimental": True}
+    assert cli.run(args) == {"status": "succeeded", "experimental": True}
     assert args.pipeline_descriptor.maturity == "experimental"
     assert args.execution_envelope.status is ExecutionStatus.SUCCEEDED
     assert not hasattr(args, "run_manifest_path")

--- a/test/test_run_summary.py
+++ b/test/test_run_summary.py
@@ -11,7 +11,6 @@ from src.runtime.classification import _result_row
 from src.utils.run_summary import (
     build_run_summary,
     normalize_metric_result,
-    resolved_config_sha256,
     write_run_summary,
 )
 
@@ -47,7 +46,7 @@ def test_summary_records_complete_seed_statistics():
     ]
     summary = build_run_summary(results, seeds=[42, 43], config=_config())
 
-    assert summary["config_sha256"] == resolved_config_sha256(_config())
+    assert "config_sha256" not in summary
     assert summary["iterations"] == 2
     assert summary["seeds"] == [42, 43]
     assert set(summary["metrics"]) == {"test_acc", "test_loss"}
@@ -64,6 +63,7 @@ def test_single_run_uses_null_std_and_writes_strict_json(tmp_path):
     assert payload["iterations"] == 1
     assert payload["metrics"]["test_acc"]["count"] == 1
     assert payload["metrics"]["test_acc"]["sample_std"] is None
+    assert "config_sha256" not in payload
     assert output.read_text(encoding="utf-8").endswith("\n")
 
 

--- a/test/test_runtime_execution.py
+++ b/test/test_runtime_execution.py
@@ -7,7 +7,7 @@ from types import SimpleNamespace
 import pytest
 
 from phmfactory import cli
-from phmfactory.config import ConfigAnalysis, ResolvedConfig, semantic_config_sha256
+from phmfactory.config import ConfigAnalysis, ResolvedConfig
 from phmfactory.runtime import (
     CompiledRunSpec,
     ExecutionEnvelope,
@@ -151,7 +151,7 @@ def test_cli_does_not_print_completion_when_pipeline_result_is_invalid(
         source_files=(path,),
         sources={},
         diagnostics=(),
-        effective_config_sha256=semantic_config_sha256(data),
+        effective_config_sha256="internal-only",
     )
     monkeypatch.setattr(cli, "analyze_config", lambda *args, **kwargs: analysis)
     monkeypatch.setattr(


### PR DESCRIPTION
## Fact

The maintained public path printed or serialized configuration digests in preflight, config inspection, CLI runtime arguments, and `run_summary.json`. These values did not change data selection, Pipeline dispatch, checkpoint choice, metric computation, or any user action.

## Invariant

```text
run validity and user navigation
=
visible config + direct result paths + selected checkpoint + finite metrics
```

A digest that has no decision consumer is not part of the public run contract.

## Change

- remove config/run digest fields from preflight output;
- stop attaching digest fields to public CLI runtime arguments;
- remove the digest from config-inspection output;
- remove `config_sha256` and its conversion code from repeated-run summaries;
- replace digest-only tests and workflow assertions with direct mapping, Pipeline, path, and metric checks;
- keep normal errors and existing fail-fast behavior unchanged.

## Out of scope

- `ConfigAnalysis` and `CompiledRunSpec` still contain internal identity fields pending a separate usage audit;
- split manifests, data bundles, Streamlit, and experimental Pipeline 06 are not changed here;
- no renaming to fingerprint, receipt, proof, token, or other equivalent identity concept;
- no Data, Model, Task, Trainer, split, metric, checkpoint, or MFPT protocol change.

## Acceptance

- `phmfactory preflight --config smoke` reports config path, Pipeline, device, and output path without `sha256` fields;
- config inspection exposes the resolved mapping, sources, targets, and sanity checks without a digest;
- public experiment arguments do not expose config/run hashes;
- `run_summary.json` contains iterations, seeds, and metric statistics without a config digest;
- focused package, config, runtime, result, and offline Dummy checks pass.

## Rollback

Revert the single squash commit.