### PR TITLE
refactor(config): remove public hash identities

### DIFF
--- a/.github/workflows/core-quality-gates.yml
+++ b/.github/workflows/core-quality-gates.yml
@@ -291,7 +291,6 @@ jobs:
         run: |
           set -o pipefail
           phmfactory preflight --config smoke 2>&1 | tee offline-preflight.log
-          grep -E '^effective_config_sha256=[0-9a-f]{64}$' offline-preflight.log
           test ! -e results/demo/dummy_dg_smoke
 
       - name: Run the documented offline demo command
@@ -334,6 +333,7 @@ jobs:
           summary = json.loads(summary_path.read_text(encoding="utf-8"))
           assert summary["iterations"] == 1
           assert summary["metrics"], summary
+          assert "config_sha256" not in summary
           for metric in summary["metrics"].values():
               assert metric["count"] == summary["iterations"]
               assert math.isfinite(float(metric["mean"]))

--- a/.github/workflows/phmfactory-public-package.yml
+++ b/.github/workflows/phmfactory-public-package.yml
@@ -9,6 +9,7 @@ on:
       - "src/configs/config_utils.py"
       - "src/config_schema/**"
       - "src/runtime/classification.py"
+      - "src/utils/run_summary.py"
       - "src/trainer_factory/Default_trainer.py"
       - "src/trainer_factory/extensions/**"
       - "main.py"
@@ -42,6 +43,7 @@ on:
       - "src/configs/config_utils.py"
       - "src/config_schema/**"
       - "src/runtime/classification.py"
+      - "src/utils/run_summary.py"
       - "src/trainer_factory/Default_trainer.py"
       - "src/trainer_factory/extensions/**"
       - "main.py"
@@ -100,6 +102,7 @@ jobs:
           scripts/validate_configs.py
           src/configs/config_utils.py
           src/config_schema/*.py
+          src/utils/run_summary.py
           main.py
           test/test_config_analysis_parity.py
           test/test_phmfactory_commands.py
@@ -276,7 +279,8 @@ jobs:
               assert config["model"]["name"] == "M_01_ISFM"
               assert config["task"]["name"] == "classification"
               assert config["trainer"]["device"] == "cpu"
-              assert args.effective_config_sha256 == args.compiled_run_spec.effective_config_sha256
+              assert not hasattr(args, "effective_config_sha256")
+              assert not hasattr(args, "run_spec_sha256")
               return expected
 
           real_import_module = cli.importlib.import_module

--- a/phmfactory/cli.py
+++ b/phmfactory/cli.py
@@ -110,8 +110,6 @@ def run(args: argparse.Namespace) -> Mapping[str, Any]:
     args.config_analysis = analysis
     args.compiled_run_spec = compiled
     args.resolved_config_data = compiled.runtime_config()
-    args.effective_config_sha256 = analysis.effective_config_sha256
-    args.run_spec_sha256 = compiled.sha256
 
     module_name = pipeline_module_name(analysis.pipeline, warn=False)
     envelope = ExecutionEnvelope(spec=compiled, pipeline_module=module_name)

--- a/phmfactory/commands/preflight.py
+++ b/phmfactory/commands/preflight.py
@@ -16,7 +16,6 @@ from phmfactory.commands.common import (
 from phmfactory.config import analyze_config
 from phmfactory.device import resolve_device_request
 from phmfactory.pipelines import pipeline_module_name, require_pipeline_access
-from phmfactory.runtime import CompiledRunSpec
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -51,7 +50,6 @@ def run(argv: Sequence[str]) -> dict[str, Any]:
         detail = "; ".join(f"{item.field}: {item.message}" for item in errors)
         raise ValueError(f"configuration analysis failed: {detail}")
 
-    compiled = CompiledRunSpec.compile(analysis.to_resolved_config())
     descriptor = require_pipeline_access(
         analysis.pipeline,
         allow_experimental=bool(args.allow_experimental),
@@ -70,9 +68,7 @@ def run(argv: Sequence[str]) -> dict[str, Any]:
     trainer_config = analysis.effective_config.get("trainer")
     if not isinstance(trainer_config, dict):
         raise ValueError("trainer configuration must be a mapping for preflight")
-    accelerator, devices = resolve_device_request(
-        argparse.Namespace(**trainer_config)
-    )
+    accelerator, devices = resolve_device_request(argparse.Namespace(**trainer_config))
 
     result = {
         "status": "passed",
@@ -83,8 +79,6 @@ def run(argv: Sequence[str]) -> dict[str, Any]:
             if analysis.local_config_path is not None
             else "none"
         ),
-        "effective_config_sha256": analysis.effective_config_sha256,
-        "run_spec_sha256": compiled.sha256,
         "pipeline": analysis.pipeline,
         "pipeline_module": module_name,
         "maturity": descriptor.maturity,

--- a/src/runtime/classification.py
+++ b/src/runtime/classification.py
@@ -17,7 +17,6 @@ from pytorch_lightning.callbacks import ModelCheckpoint
 from src.configs.config_utils import (
     dict_to_namespace,
     merge_with_local_override,
-    path_name,
     transfer_namespace,
 )
 from src.data_factory import build_data
@@ -220,31 +219,19 @@ def _write_aggregate_outputs(
     last_iteration_path: str | Path | None,
     all_results: list[dict[str, Any]],
     run_seeds: list[int],
-    configs: Any,
 ) -> dict[str, Any]:
-    """Write repeated-run metrics only after the complete estimator validates."""
+    """Validate once, then publish the complete repeated-run estimator."""
 
     if last_iteration_path is None or not all_results:
         raise ValueError("aggregate outputs require at least one completed iteration")
 
-    # Validate the complete repeated-run estimator before publishing aggregate CSVs.
-    build_run_summary(
-        results=all_results,
-        seeds=run_seeds,
-        config=configs,
-    )
-
+    summary = build_run_summary(results=all_results, seeds=run_seeds)
     run_root_path = Path(run_root)
     iteration_path = Path(last_iteration_path)
     results = pd.DataFrame(all_results)
     results.to_csv(iteration_path / "all_results.csv", index=False)
     results.to_csv(run_root_path / "all_results.csv", index=False)
-    return write_run_summary(
-        run_root_path / "run_summary.json",
-        results=all_results,
-        seeds=run_seeds,
-        config=configs,
-    )
+    return write_run_summary(run_root_path / "run_summary.json", summary)
 
 
 def _public_result(
@@ -445,7 +432,6 @@ def run_classification_pipeline(
         last_iteration_path,
         all_results,
         run_seeds,
-        configs,
     )
     print(f"\n{'=' * 50}\n[INFO] 所有实验已完成\n{'=' * 50}")
     return _public_result(

--- a/src/utils/run_summary.py
+++ b/src/utils/run_summary.py
@@ -2,43 +2,12 @@
 
 from __future__ import annotations
 
-import hashlib
 import json
 import math
 import numbers
 import statistics
 from pathlib import Path
-from types import SimpleNamespace
 from typing import Any, Mapping, Sequence
-
-
-def _to_builtin(value: Any) -> Any:
-    if isinstance(value, SimpleNamespace):
-        return {key: _to_builtin(item) for key, item in vars(value).items()}
-    if isinstance(value, Mapping):
-        return {str(key): _to_builtin(item) for key, item in value.items()}
-    if isinstance(value, (list, tuple)):
-        return [_to_builtin(item) for item in value]
-    if isinstance(value, Path):
-        return str(value)
-    if value is None or isinstance(value, (str, int, float, bool)):
-        return value
-    if hasattr(value, "item"):
-        scalar = value.item()
-        if scalar is not value:
-            return _to_builtin(scalar)
-    raise TypeError(f"unsupported resolved config value: {type(value).__name__}")
-
-
-def resolved_config_sha256(config: Any) -> str:
-    payload = json.dumps(
-        _to_builtin(config),
-        sort_keys=True,
-        separators=(",", ":"),
-        ensure_ascii=True,
-        allow_nan=False,
-    ).encode("utf-8")
-    return hashlib.sha256(payload).hexdigest()
 
 
 def _numeric_metric(value: Any, *, context: str) -> float:
@@ -97,9 +66,7 @@ def _normalized_seeds(seeds: Sequence[int]) -> list[int]:
     normalized: list[int] = []
     for index, seed in enumerate(seeds):
         if isinstance(seed, bool) or not isinstance(seed, numbers.Integral):
-            raise TypeError(
-                f"seed {index} must be an integer, got {seed!r}"
-            )
+            raise TypeError(f"seed {index} must be an integer, got {seed!r}")
         normalized.append(int(seed))
     return normalized
 
@@ -107,7 +74,6 @@ def _normalized_seeds(seeds: Sequence[int]) -> list[int]:
 def build_run_summary(
     results: Sequence[Mapping[str, Any]],
     seeds: Sequence[int],
-    config: Any,
 ) -> dict[str, Any]:
     """Summarize one identical finite metric set across every completed seed."""
 
@@ -140,36 +106,33 @@ def build_run_summary(
             "sample_std": statistics.stdev(values) if len(values) >= 2 else None,
         }
 
-    normalized_seeds = _normalized_seeds(seeds)
     return {
         "schema_version": 1,
-        "config_sha256": resolved_config_sha256(config),
         "iterations": len(normalized_results),
-        "seeds": normalized_seeds,
+        "seeds": _normalized_seeds(seeds),
         "metrics": metrics,
     }
 
 
 def write_run_summary(
     output_path: str | Path,
-    results: Sequence[Mapping[str, Any]],
-    seeds: Sequence[int],
-    config: Any,
+    summary: Mapping[str, Any],
 ) -> dict[str, Any]:
-    summary = build_run_summary(results=results, seeds=seeds, config=config)
+    """Write one already validated summary without recomputing it."""
+
+    payload = dict(summary)
     path = Path(output_path)
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(
-        json.dumps(summary, indent=2, sort_keys=True, ensure_ascii=True, allow_nan=False)
+        json.dumps(payload, indent=2, sort_keys=True, ensure_ascii=True, allow_nan=False)
         + "\n",
         encoding="utf-8",
     )
-    return summary
+    return payload
 
 
 __all__ = [
     "build_run_summary",
     "normalize_metric_result",
-    "resolved_config_sha256",
     "write_run_summary",
 ]

--- a/test/test_config_analysis_parity.py
+++ b/test/test_config_analysis_parity.py
@@ -192,7 +192,7 @@ def test_resolve_config_is_a_compatibility_view_of_analysis() -> None:
     assert resolved.path == analysis.path
 
 
-def test_inspector_and_public_analysis_return_same_config_and_hash(
+def test_inspector_and_public_analysis_return_same_config(
     tmp_path: Path,
 ) -> None:
     override = f"environment.output_dir={tmp_path / 'output'}"
@@ -200,14 +200,13 @@ def test_inspector_and_public_analysis_return_same_config_and_hash(
     inspected = inspect_config("smoke", overrides=[override])
 
     assert inspected.resolved == analysis.effective_config
-    assert inspected.effective_config_sha256 == analysis.effective_config_sha256
 
 
 def test_validator_accepts_the_same_maintained_smoke_config() -> None:
     assert validate_one(SMOKE_CONFIG) == []
 
 
-def test_preflight_reports_the_same_effective_hash(
+def test_preflight_reports_the_same_semantic_fields(
     tmp_path: Path,
 ) -> None:
     override = f"environment.output_dir={tmp_path / 'preflight'}"
@@ -215,8 +214,10 @@ def test_preflight_reports_the_same_effective_hash(
 
     report = preflight.run(["--config", "smoke", "--override", override])
 
-    assert report["effective_config_sha256"] == expected.effective_config_sha256
+    assert report["requested_config"] == "smoke"
+    assert report["resolved_config_path"] == str(expected.path)
     assert report["pipeline"] == expected.pipeline
+    assert not any("sha256" in key for key in report)
     assert not (tmp_path / "preflight").exists()
 
 

--- a/test/test_phmfactory_commands.py
+++ b/test/test_phmfactory_commands.py
@@ -136,12 +136,13 @@ def test_preflight_uses_single_analysis_without_importing_pipeline(
     result = preflight.run(["--config", "smoke"])
 
     assert result["status"] == "passed"
+    assert result["requested_config"] == "smoke"
+    assert result["resolved_config_path"] == str(analysis.path)
     assert result["pipeline"] == "Pipeline_01_Fault_Diagnosis"
-    assert result["effective_config_sha256"] == analysis.effective_config_sha256
-    assert len(result["run_spec_sha256"]) == 64
     assert result["requested_device"] == "cpu"
     assert result["resolved_accelerator"] == "cpu"
     assert result["resolved_devices"] == 1
+    assert not any("sha256" in key for key in result)
     assert not (tmp_path / "new").exists()
 
 
@@ -159,9 +160,7 @@ def test_preflight_rejects_unavailable_cuda_before_training(
     monkeypatch.setattr(
         device_contract,
         "_load_torch",
-        lambda: SimpleNamespace(
-            cuda=SimpleNamespace(is_available=lambda: False)
-        ),
+        lambda: SimpleNamespace(cuda=SimpleNamespace(is_available=lambda: False)),
     )
 
     with pytest.raises(RuntimeError, match="CUDA is unavailable.*no CPU fallback"):

--- a/test/test_phmfactory_entrypoints.py
+++ b/test/test_phmfactory_entrypoints.py
@@ -131,8 +131,6 @@ def test_run_dispatches_analyzed_canonical_module(
         observed["config_analysis"] = args.config_analysis
         observed["compiled_run_spec"] = args.compiled_run_spec
         observed["resolved_config_data"] = args.resolved_config_data
-        observed["effective_config_sha256"] = args.effective_config_sha256
-        observed["run_spec_sha256"] = args.run_spec_sha256
         observed["notes"] = args.notes
         return expected
 
@@ -160,11 +158,9 @@ def test_run_dispatches_analyzed_canonical_module(
     assert cli.run(args) == expected
     compiled = observed.pop("compiled_run_spec")
     resolved_data = observed.pop("resolved_config_data")
-    run_spec_sha256 = observed.pop("run_spec_sha256")
     config_analysis = observed.pop("config_analysis")
     assert compiled.pipeline == "Pipeline_04_Unified_Evaluation"
     assert resolved_data == analysis.effective_config
-    assert run_spec_sha256 == compiled.sha256
     assert config_analysis is analysis
     assert observed == {
         "module": "src.Pipeline_04_Unified_Evaluation",
@@ -172,9 +168,10 @@ def test_run_dispatches_analyzed_canonical_module(
         "config_path": str(analysis.path),
         "resolved_config_path": str(analysis.path),
         "resolved_pipeline": "Pipeline_04_Unified_Evaluation",
-        "effective_config_sha256": analysis.effective_config_sha256,
         "notes": "entrypoint-parity",
     }
+    assert not hasattr(args, "effective_config_sha256")
+    assert not hasattr(args, "run_spec_sha256")
     assert not hasattr(args, "run_manifest_path")
     assert not (tmp_path / "runs").exists()
 
@@ -191,7 +188,6 @@ def test_run_passes_maintained_preset_path_to_runtime(
     def pipeline(args: argparse.Namespace) -> dict[str, str]:
         observed["requested_config"] = args.requested_config
         observed["config_path"] = args.config_path
-        observed["effective_config_sha256"] = args.effective_config_sha256
         return expected
 
     monkeypatch.setattr(
@@ -210,7 +206,8 @@ def test_run_passes_maintained_preset_path_to_runtime(
     assert cli.run(args) == expected
     assert observed["requested_config"] == preset
     assert Path(str(observed["config_path"])) == resolve_config_path(preset)
-    assert len(str(observed["effective_config_sha256"])) == 64
+    assert not hasattr(args, "effective_config_sha256")
+    assert not hasattr(args, "run_spec_sha256")
     assert not hasattr(args, "run_manifest_path")
     assert not (tmp_path / "runs").exists()
 
@@ -290,7 +287,8 @@ def test_python_process_entrypoints_return_zero_for_preflight(
     )
     assert completed.returncode == 0, completed.stderr
     assert "status=passed" in completed.stdout
-    assert "effective_config_sha256=" in completed.stdout
+    assert "pipeline=Pipeline_01_Fault_Diagnosis" in completed.stdout
+    assert "sha256" not in completed.stdout.lower()
     assert not target.exists()
 
 
@@ -411,5 +409,7 @@ def test_run_dispatches_packaged_base_configs_outside_checkout(
         "task": "classification",
         "trainer": "cpu",
     }
+    assert not hasattr(args, "effective_config_sha256")
+    assert not hasattr(args, "run_spec_sha256")
     assert not hasattr(args, "run_manifest_path")
     assert not (tmp_path / "results").exists()

--- a/test/test_pipeline01_run_summary.py
+++ b/test/test_pipeline01_run_summary.py
@@ -1,18 +1,9 @@
 import json
-from types import SimpleNamespace
 
 import pandas as pd
 import pytest
 
 from src.runtime.classification import _write_aggregate_outputs
-
-
-def _config():
-    return SimpleNamespace(
-        pipeline="Pipeline_01_Fault_Diagnosis",
-        environment=SimpleNamespace(seed=7, iterations=2),
-        model=SimpleNamespace(type="Transformer", name="TSLTransformer"),
-    )
 
 
 def test_aggregate_outputs_bind_all_iterations_and_seeds(tmp_path):
@@ -26,7 +17,6 @@ def test_aggregate_outputs_bind_all_iterations_and_seeds(tmp_path):
         last_iteration,
         results,
         [7, 8],
-        _config(),
     )
 
     assert pd.read_csv(run_root / "all_results.csv")["test_acc"].tolist() == [
@@ -41,8 +31,9 @@ def test_aggregate_outputs_bind_all_iterations_and_seeds(tmp_path):
     assert stored == summary
     assert stored["seeds"] == [7, 8]
     assert stored["metrics"]["test_acc"]["mean"] == pytest.approx(0.6)
+    assert "config_sha256" not in stored
 
 
 def test_aggregate_outputs_reject_vacuous_runs(tmp_path):
     with pytest.raises(ValueError, match="at least one completed iteration"):
-        _write_aggregate_outputs(tmp_path, None, [], [], _config())
+        _write_aggregate_outputs(tmp_path, None, [], [])

--- a/test/test_run_summary.py
+++ b/test/test_run_summary.py
@@ -11,17 +11,8 @@ from src.runtime.classification import _result_row
 from src.utils.run_summary import (
     build_run_summary,
     normalize_metric_result,
-    resolved_config_sha256,
     write_run_summary,
 )
-
-
-def _config():
-    return SimpleNamespace(
-        pipeline="Pipeline_01_Fault_Diagnosis",
-        environment=SimpleNamespace(seed=42, iterations=2),
-        model=SimpleNamespace(type="Transformer", name="TSLTransformer"),
-    )
 
 
 def _runtime_config(tmp_path: Path, *, iterations: int = 3) -> SimpleNamespace:
@@ -45,9 +36,9 @@ def test_summary_records_complete_seed_statistics():
         {"test_acc": 0.5, "test_loss": 2.0},
         {"test_acc": 0.7, "test_loss": 4.0},
     ]
-    summary = build_run_summary(results, seeds=[42, 43], config=_config())
+    summary = build_run_summary(results, seeds=[42, 43])
 
-    assert summary["config_sha256"] == resolved_config_sha256(_config())
+    assert "config_sha256" not in summary
     assert summary["iterations"] == 2
     assert summary["seeds"] == [42, 43]
     assert set(summary["metrics"]) == {"test_acc", "test_loss"}
@@ -58,20 +49,22 @@ def test_summary_records_complete_seed_statistics():
 
 def test_single_run_uses_null_std_and_writes_strict_json(tmp_path):
     output = tmp_path / "run_summary.json"
-    write_run_summary(output, [{"test_acc": 0.5}], [42], _config())
+    summary = build_run_summary([{"test_acc": 0.5}], [42])
+    write_run_summary(output, summary)
     payload = json.loads(output.read_text(encoding="utf-8"))
 
     assert payload["iterations"] == 1
     assert payload["metrics"]["test_acc"]["count"] == 1
     assert payload["metrics"]["test_acc"]["sample_std"] is None
+    assert "config_sha256" not in payload
     assert output.read_text(encoding="utf-8").endswith("\n")
 
 
 def test_summary_rejects_missing_seed_and_nonfinite_metrics():
     with pytest.raises(ValueError, match="one seed"):
-        build_run_summary([{"value": 1.0}], [], _config())
+        build_run_summary([{"value": 1.0}], [])
     with pytest.raises(ValueError, match="not finite"):
-        build_run_summary([{"value": float("nan")}], [42], _config())
+        build_run_summary([{"value": float("nan")}], [42])
 
 
 def test_summary_rejects_metric_key_drift_across_seeds():
@@ -85,7 +78,6 @@ def test_summary_rejects_metric_key_drift_across_seeds():
                 {"test_acc": 0.7},
             ],
             seeds=[42, 43],
-            config=_config(),
         )
 
     with pytest.raises(
@@ -98,7 +90,6 @@ def test_summary_rejects_metric_key_drift_across_seeds():
                 {"test_acc": 0.7, "test_f1": 0.6},
             ],
             seeds=[42, 43],
-            config=_config(),
         )
 
 
@@ -120,9 +111,9 @@ def test_metric_result_rejects_empty_nonnumeric_boolean_and_nonscalar_values():
 
 def test_summary_rejects_noninteger_seed_values():
     with pytest.raises(TypeError, match="seed 0 must be an integer"):
-        build_run_summary([{"test_acc": 0.5}], [42.5], _config())
+        build_run_summary([{"test_acc": 0.5}], [42.5])
     with pytest.raises(TypeError, match="seed 0 must be an integer"):
-        build_run_summary([{"test_acc": 0.5}], [True], _config())
+        build_run_summary([{"test_acc": 0.5}], [True])
 
 
 def test_trainer_test_requires_exactly_one_explicit_population():
@@ -232,5 +223,7 @@ def test_pipeline_creates_one_root_for_all_iterations(
     ]
     assert (run_root / "all_results.csv").is_file()
     assert (run_root / "run_summary.json").is_file()
+    stored = json.loads((run_root / "run_summary.json").read_text(encoding="utf-8"))
+    assert "config_sha256" not in stored
     for checkpoint in result["best_checkpoints"]:
         Path(checkpoint).resolve().relative_to(run_root.resolve())


### PR DESCRIPTION
Superseded by merged PR #218 (`refactor(runtime): remove hashes from user-visible results`).

The current `dev` branch already removes configuration digests from preflight, config inspection, public CLI arguments, repeated-run summaries, and the related user-facing tests. The remaining internal `ConfigAnalysis` / `CompiledRunSpec` identity fields require a separate usage audit and a fresh bounded branch; this stale branch mixes pre-merge assumptions and is closed rather than rebased into a larger cleanup.