### PR TITLE
fix(model-factory): keep concrete model imports lightweight

### DIFF
--- a/src/model_factory/__init__.py
+++ b/src/model_factory/__init__.py
@@ -1,35 +1,27 @@
-"""Public API for the model factory package."""
+"""Public API for model construction.
+
+Importing a concrete model module must not initialize the full training stack.
+The factory implementation is therefore loaded only when a factory function is
+called.
+"""
+
+from __future__ import annotations
 
 from typing import Any
 
-from .model_factory import (
-    model_factory,
-    resolve_model_module,
-)
+
+def resolve_model_module(args_model: Any) -> str:
+    """Return the import path for the requested model module."""
+    from .model_factory import resolve_model_module as _resolve_model_module
+
+    return _resolve_model_module(args_model)
 
 
 def build_model(args: Any, metadata: Any = None) -> Any:
-    """Instantiate a model from configuration.
-
-    Parameters
-    ----------
-    args : Any
-        Namespace or dictionary with model options.
-    metadata : Any, optional
-        Dataset metadata used to compute ``num_classes``.
-
-    Returns
-    -------
-    Any
-        Instantiated model object.
-    """
+    """Instantiate a configured model, optionally using dataset metadata."""
+    from .model_factory import model_factory
 
     return model_factory(args, metadata=metadata)
 
 
-
-# public exports
-__all__ = [
-    "build_model",
-    "resolve_model_module",
-]
+__all__ = ["build_model", "resolve_model_module"]

--- a/src/model_factory/__init__.py
+++ b/src/model_factory/__init__.py
@@ -1,7 +1,7 @@
 """Public API for model construction.
 
 Importing a concrete model module must not initialize the full training stack.
-Factory internals are therefore loaded only when a factory function is called.
+Factory internals are therefore loaded only when a public function is called.
 """
 
 from __future__ import annotations
@@ -11,21 +11,16 @@ from typing import Any
 
 def resolve_model_module(args_model: Any) -> str:
     """Return the import path for the requested model module."""
-    from .model_factory import resolve_model_module as _resolve_model_module
+    from .model_factory import resolve_model_module as implementation
 
-    return _resolve_model_module(args_model)
-
-
-def model_factory(args_model: Any, metadata: Any = None) -> Any:
-    """Instantiate a configured model without eager package initialization."""
-    from .model_factory import model_factory as _model_factory
-
-    return _model_factory(args_model, metadata=metadata)
+    return implementation(args_model)
 
 
 def build_model(args: Any, metadata: Any = None) -> Any:
     """Instantiate a configured model, optionally using dataset metadata."""
-    return model_factory(args, metadata=metadata)
+    from .model_factory import model_factory as implementation
+
+    return implementation(args, metadata=metadata)
 
 
-__all__ = ["build_model", "model_factory", "resolve_model_module"]
+__all__ = ["build_model", "resolve_model_module"]

--- a/src/model_factory/__init__.py
+++ b/src/model_factory/__init__.py
@@ -1,8 +1,7 @@
 """Public API for model construction.
 
 Importing a concrete model module must not initialize the full training stack.
-The factory implementation is therefore loaded only when a factory function is
-called.
+Factory internals are therefore loaded only when a factory function is called.
 """
 
 from __future__ import annotations
@@ -17,11 +16,16 @@ def resolve_model_module(args_model: Any) -> str:
     return _resolve_model_module(args_model)
 
 
+def model_factory(args_model: Any, metadata: Any = None) -> Any:
+    """Instantiate a configured model without eager package initialization."""
+    from .model_factory import model_factory as _model_factory
+
+    return _model_factory(args_model, metadata=metadata)
+
+
 def build_model(args: Any, metadata: Any = None) -> Any:
     """Instantiate a configured model, optionally using dataset metadata."""
-    from .model_factory import model_factory
-
     return model_factory(args, metadata=metadata)
 
 
-__all__ = ["build_model", "resolve_model_module"]
+__all__ = ["build_model", "model_factory", "resolve_model_module"]


### PR DESCRIPTION
## Problem

Importing a concrete module such as `src.model_factory.MoE.M_04_RoleConstrainedMoE` first executed `src.model_factory.__init__`, which eagerly imported the general model factory and initialized unrelated configuration and training packages. A focused model-semantic test therefore failed during import before any model assertion ran.

## Change

- load the general factory implementation only when `build_model` or `resolve_model_module` is called;
- keep concrete model imports independent of the training environment;
- preserve the documented public API while avoiding a package/submodule name collision.

## Boundary

No model, objective, configuration, checkpoint, or post-factory runtime behavior changes. The change only removes eager package initialization.
