### PR TITLE
feat: common-intervention primitives for finite-budget explanations

### DIFF
--- a/doc/FINITE_BUDGET_PRIMITIVES.md
+++ b/doc/FINITE_BUDGET_PRIMITIVES.md
@@ -1,0 +1,31 @@
+# Common-intervention numerical primitives
+
+`phmfactory.finite_budget` supplies small functions consumed by the P02 industrial
+representation study and P20 general finite-budget study. It does not import either
+paper, load their data, choose a checkpoint, run a training workflow or claim a
+real-data baseline.
+
+- `orthogonal_basis`: identity, real orthonormal DCT, complete Haar packet levels.
+- `truncate`: deterministic global scalar-coordinate budget.
+- `exact_sparse_risk`: exhaustive second-moment oracle, dimension at most 16.
+- `sparse_response_fit`: greedy least squares using calibration queries only.
+- `coefficients`: signed gradient, path-average gradient and central secant.
+
+The dense basis implementation is bounded to windows of at most 4096 samples.
+It is a reference primitive, not an optimized FFT/wavelet backend. The matrix acts
+on time within each channel. Channels are never silently flattened or reordered.
+
+The input model is already loaded and in evaluation mode. Targets and path
+baselines are explicit. Outputs are sensitivities, not interchangeable with IG
+contributions, occlusion effects or Grad-CAM heatmaps. `path_gradient` returns the
+mean IG integrand; it does not claim to be vanilla IG. No division by a baseline
+coordinate is used. Evaluation interventions are supplied by the consumer and
+must not be the calibration queries used to fit an explanation.
+
+```bash
+python -m pytest test/test_finite_budget.py -q
+```
+
+The tests establish numerical semantics on analytic functions. They do not
+establish an industrial diagnosis, explanation or forecast baseline. The module
+has no new registry, CLI, optional backend or fallback path.

--- a/phmfactory/finite_budget.py
+++ b/phmfactory/finite_budget.py
@@ -1,0 +1,169 @@
+"""Small numerical primitives for fixed-model, common-intervention explanations.
+
+Coefficients are sensitivities, not normalized heatmaps or IG contributions.
+The caller owns data splitting, experiment selection, checkpoints and reporting.
+"""
+from itertools import combinations
+import numpy as np
+
+
+def orthogonal_basis(length: int, name: str) -> np.ndarray:
+    """Return a real square basis; dense storage is intended for bounded windows."""
+    if not isinstance(length, int) or not 1 <= length <= 4096:
+        raise ValueError("dense basis requires an integer length in [1, 4096]")
+    eye = np.eye(length)
+    if name == "identity":
+        return eye
+    if name == "dct":
+        n = np.arange(length)
+        matrix = np.cos(np.pi * (n[None, :] + 0.5) * n[:, None] / length)
+        matrix *= np.sqrt(2.0 / length)
+        matrix[0] /= np.sqrt(2.0)
+        return matrix
+    if name.startswith("haar_packet:"):
+        depth = int(name.split(":", 1)[1])
+        if depth < 1 or length % (2 ** depth):
+            raise ValueError("Haar packet depth must divide the declared window length")
+        bands = [eye]
+        for _ in range(depth):
+            bands = [part for band in bands for part in
+                     ((band[::2] + band[1::2]) / np.sqrt(2),
+                      (band[::2] - band[1::2]) / np.sqrt(2))]
+        return np.concatenate(bands, axis=0)
+    raise ValueError(f"unsupported representation: {name}")
+
+
+def truncate(coefficients: np.ndarray, k: int) -> np.ndarray:
+    """Keep k scalar coordinates over all channels, with deterministic ties."""
+    coefficients = np.asarray(coefficients, dtype=float)
+    if not np.isfinite(coefficients).all() or not 1 <= k <= coefficients.size:
+        raise ValueError("finite coefficients and 1 <= k <= number of coordinates required")
+    ids = np.argsort(-np.abs(coefficients.ravel()), kind="stable")[:k]
+    result = np.zeros(coefficients.size)
+    result[ids] = coefficients.ravel()[ids]
+    return result.reshape(coefficients.shape)
+
+
+def exact_sparse_risk(basis: np.ndarray, second_moment: np.ndarray,
+                      cross_moment: np.ndarray, response_second_moment: float,
+                      k: int) -> tuple[float, np.ndarray]:
+    """Exact subset oracle for small problems, not a scalable explainer.
+
+M=E[v v^T], b=E[v d(v)], c=E[d(v)^2]. M is not a centred covariance.
+"""
+    basis = np.asarray(basis, dtype=float)
+    p = basis.shape[0]
+    if basis.shape != (p, p) or p > 16 or not 1 <= k <= p:
+        raise ValueError("exact oracle requires square p<=16 and 1<=k<=p")
+    moment = np.asarray(second_moment, dtype=float)
+    cross = np.asarray(cross_moment, dtype=float)
+    if moment.shape != (p, p) or cross.shape != (p,):
+        raise ValueError("second moment or cross moment has incompatible dimensions")
+    if not np.allclose(moment, moment.T) or np.linalg.eigvalsh(moment).min() < -1e-10:
+        raise ValueError("second moment must be symmetric positive semidefinite")
+    gram, transformed = basis @ moment @ basis.T, basis @ cross
+    best, answer = float("inf"), None
+    for support in combinations(range(p), k):
+        ids = np.array(support)
+        block = gram[np.ix_(ids, ids)]
+        coeff = np.linalg.pinv(block, hermitian=True) @ transformed[ids]
+        if not np.allclose(block @ coeff, transformed[ids], atol=1e-8):
+            raise ValueError("cross moment is outside the Gram range; invalid moments")
+        risk = float(response_second_moment - transformed[ids] @ coeff)
+        if risk < -1e-8:
+            raise ValueError("moments imply negative squared error")
+        if risk < best:
+            best = max(0.0, risk)  # Roundoff only; inconsistent moments fail above.
+            answer = np.zeros(p)
+            answer[ids] = coeff
+    return best, answer
+
+
+def sparse_response_fit(displacements: np.ndarray, responses: np.ndarray,
+                        k: int) -> np.ndarray:
+    """Greedy sparse least squares on calibration queries, never scoring queries."""
+    design = np.asarray(displacements, dtype=float)
+    response = np.asarray(responses, dtype=float)
+    if design.ndim != 2 or response.shape != (len(design),):
+        raise ValueError("expected calibration design [Q,p] and response [Q]")
+    if not np.isfinite(design).all() or not np.isfinite(response).all():
+        raise ValueError("calibration values must be finite")
+    if not 1 <= k <= min(design.shape):
+        raise ValueError("sparse fit requires 1 <= k <= min(Q,p)")
+    residual, support = response.copy(), []
+    norms = np.linalg.norm(design, axis=0)
+    if np.count_nonzero(norms) < k:
+        raise ValueError("fewer than k nonzero calibration directions")
+    for _ in range(k):
+        gain = np.full(design.shape[1], -np.inf)
+        eligible = norms > 0
+        gain[eligible] = np.abs(design[:, eligible].T @ residual) / norms[eligible]
+        gain[support] = -np.inf
+        support.append(int(np.argmax(gain)))
+        coeff = np.linalg.lstsq(design[:, support], response, rcond=None)[0]
+        residual = response - design[:, support] @ coeff
+    answer = np.zeros(design.shape[1])
+    answer[support] = coeff
+    return answer
+
+
+def coefficients(model, x, target: int, basis, *, method: str,
+                 baseline=None, steps: int = 32, radius: float = 0.01):
+    """Return [C,T] sensitivity coefficients and counted model-example visits.
+
+x is a single [C,T] tensor. The model must return [batch, classes].
+path_gradient is the IG integrand average, not vanilla IG attribution.
+secant uses declared finite differences and is not reported as Occlusion.
+"""
+    import torch
+    if x.ndim != 2 or not torch.isfinite(x).all():
+        raise ValueError("x must be a finite [C,T] tensor")
+    if not isinstance(target, int) or target < 0:
+        raise ValueError("an explicit nonnegative target index is required")
+    if model.training:
+        raise ValueError("model must be frozen in eval mode")
+    matrix = torch.as_tensor(basis, dtype=x.dtype, device=x.device)
+    if matrix.shape != (x.shape[-1], x.shape[-1]):
+        raise ValueError("basis length does not match the declared time coordinates")
+
+    def score(sample):
+        output = model(sample.unsqueeze(0))
+        if output.ndim != 2 or output.shape[0] != 1 or target >= output.shape[1]:
+            raise ValueError("model output must be [1, classes] and contain the fixed target")
+        value = output[0, target]
+        if not torch.isfinite(value):
+            raise ValueError("nonfinite fixed-target model output")
+        return value
+
+    if method in {"gradient", "path_gradient"}:
+        if method == "gradient":
+            points = [x]
+        else:
+            if baseline is None or baseline.shape != x.shape or steps < 1:
+                raise ValueError("path_gradient requires an explicit same-shape baseline and steps>=1")
+            # Midpoint quadrature; the baseline and step count define the path method.
+            points = [baseline + ((i + 0.5) / steps) * (x - baseline)
+                      for i in range(steps)]
+        gradients = []
+        with torch.enable_grad():
+            for point in points:
+                query = point.detach().requires_grad_(True)
+                gradients.append(torch.autograd.grad(score(query), query)[0].detach())
+        raw = torch.stack(gradients).mean(dim=0) @ matrix.T
+        visits = {"forward": len(points), "backward": len(points)}
+    elif method == "secant":
+        if radius <= 0:
+            raise ValueError("positive finite-difference radius required")
+        raw = torch.empty_like(x)
+        with torch.no_grad():
+            for channel in range(x.shape[0]):
+                for coordinate in range(x.shape[1]):
+                    step = torch.zeros_like(x)
+                    step[channel] = radius * matrix[coordinate]
+                    raw[channel, coordinate] = (score(x + step) - score(x - step)) / (2 * radius)
+        visits = {"forward": 2 * x.numel(), "backward": 0}
+    else:
+        raise ValueError(f"no response-decoder implementation for method {method!r}")
+    if not torch.isfinite(raw).all():
+        raise ValueError("nonfinite sensitivity coefficients")
+    return raw.cpu().numpy(), visits

--- a/phmfactory/finite_budget.py
+++ b/phmfactory/finite_budget.py
@@ -1,4 +1,4 @@
-"""Small numerical primitives for fixed-model, common-intervention explanations.
+"""Numerical primitives for fixed-model, common-intervention explanations.
 
 Coefficients are sensitivities, not normalized heatmaps or IG contributions.
 The caller owns data splitting, experiment selection, checkpoints and reporting.
@@ -52,6 +52,10 @@ def exact_sparse_risk(basis: np.ndarray, second_moment: np.ndarray,
 M=E[v v^T], b=E[v d(v)], c=E[d(v)^2]. M is not a centred covariance.
 """
     basis = np.asarray(basis, dtype=float)
+    if basis.ndim != 2 or not np.isfinite(basis).all():
+        raise ValueError("basis must be a finite matrix")
+    if not np.isfinite(response_second_moment):
+        raise ValueError("response second moment must be finite")
     p = basis.shape[0]
     if basis.shape != (p, p) or p > 16 or not 1 <= k <= p:
         raise ValueError("exact oracle requires square p<=16 and 1<=k<=p")
@@ -59,6 +63,8 @@ M=E[v v^T], b=E[v d(v)], c=E[d(v)^2]. M is not a centred covariance.
     cross = np.asarray(cross_moment, dtype=float)
     if moment.shape != (p, p) or cross.shape != (p,):
         raise ValueError("second moment or cross moment has incompatible dimensions")
+    if not np.isfinite(moment).all() or not np.isfinite(cross).all():
+        raise ValueError("all response moments must be finite")
     if not np.allclose(moment, moment.T) or np.linalg.eigvalsh(moment).min() < -1e-10:
         raise ValueError("second moment must be symmetric positive semidefinite")
     gram, transformed = basis @ moment @ basis.T, basis @ cross
@@ -109,11 +115,10 @@ def sparse_response_fit(displacements: np.ndarray, responses: np.ndarray,
 
 def coefficients(model, x, target: int, basis, *, method: str,
                  baseline=None, steps: int = 32, radius: float = 0.01):
-    """Return [C,T] sensitivity coefficients and counted model-example visits.
+    """Return [C,T] sensitivities and counted model-example visits.
 
-x is a single [C,T] tensor. The model must return [batch, classes].
-path_gradient is the IG integrand average, not vanilla IG attribution.
-secant uses declared finite differences and is not reported as Occlusion.
+x is [C,T]; model output is [batch,classes]. path_gradient is the IG integrand
+average, not vanilla IG. secant is a finite difference, not Occlusion.
 """
     import torch
     if x.ndim != 2 or not torch.isfinite(x).all():
@@ -141,7 +146,7 @@ secant uses declared finite differences and is not reported as Occlusion.
         else:
             if baseline is None or baseline.shape != x.shape or steps < 1:
                 raise ValueError("path_gradient requires an explicit same-shape baseline and steps>=1")
-            # Midpoint quadrature; the baseline and step count define the path method.
+            # Midpoint quadrature; baseline and step count define the path method.
             points = [baseline + ((i + 0.5) / steps) * (x - baseline)
                       for i in range(steps)]
         gradients = []

--- a/phmfactory/finite_budget_evaluation.py
+++ b/phmfactory/finite_budget_evaluation.py
@@ -7,10 +7,11 @@ def response_errors(model, x, targets, basis_names, methods, budgets, *,
                     baseline, evaluation_displacements, calibration_displacements,
                     forward_budget: int, backward_budget: int,
                     steps: int = 32, radius: float = 0.01):
-    """Evaluate held-out responses; return rows without choosing a representation.
+    """Score responses on distinct held-out displacement values.
 
-All tensors share original input coordinates. The caller must supply disjoint
-calibration/scoring perturbation banks. Forward visits count examples, not batches.
+The reference finite-grid protocol splits candidate perturbations before queries.
+The caller owns the sampling law; distinct values alone do not prove independence.
+Forward visits count examples, not batches. Visits reused across k are not summed.
 """
     import torch
     if model.training:
@@ -31,6 +32,10 @@ calibration/scoring perturbation banks. Forward visits count examples, not batch
             raise ValueError("nonfinite perturbation bank")
     if torch.equal(evaluation_displacements, calibration_displacements):
         raise ValueError("calibration and scoring banks must not be reused")
+    for cal, scoring in zip(calibration_displacements, evaluation_displacements):
+        for displacement in cal:
+            if torch.any(torch.all(scoring == displacement, dim=(1, 2))):
+                raise ValueError("overlapping calibration/scoring displacement rows")
     matrices = {name: orthogonal_basis(x.shape[-1], name) for name in basis_names}
     rows = []
     for n, sample in enumerate(x):
@@ -52,7 +57,7 @@ calibration/scoring perturbation banks. Forward visits count examples, not batch
         for name, matrix in matrices.items():
             a = torch.as_tensor(matrix, dtype=x.dtype, device=x.device)
             with torch.no_grad():
-                # Preservation is checked on both ends of the same intervention.
+                # Check preservation at both endpoints of the same intervention.
                 points = torch.cat((sample[None], sample[None] - ve), dim=0)
                 restored = (points @ a.T) @ a
                 if not torch.allclose(restored, points, atol=2e-5, rtol=2e-5):

--- a/phmfactory/finite_budget_evaluation.py
+++ b/phmfactory/finite_budget_evaluation.py
@@ -1,0 +1,74 @@
+"""Evaluate fixed-model responses without paper-specific selection or I/O."""
+import numpy as np
+from .finite_budget import orthogonal_basis, coefficients, truncate, sparse_response_fit
+
+
+def response_errors(model, x, targets, basis_names, methods, budgets, *,
+                    baseline, evaluation_displacements, calibration_displacements,
+                    forward_budget: int, backward_budget: int,
+                    steps: int = 32, radius: float = 0.01):
+    """Evaluate held-out responses; return rows without choosing a representation.
+
+All tensors share original input coordinates. The caller must supply disjoint
+calibration/scoring perturbation banks. Forward visits count examples, not batches.
+"""
+    import torch
+    if x.ndim != 3 or baseline.shape != x.shape or len(targets) != len(x):
+        raise ValueError("expected x/baseline [N,C,T] and explicit targets [N]")
+    for bank in (evaluation_displacements, calibration_displacements):
+        if bank.ndim != 4 or bank.shape[0] != len(x) or bank.shape[2:] != x.shape[1:]:
+            raise ValueError("perturbation banks must be [N,Q,C,T] in original coordinates")
+        if not torch.isfinite(bank).all():
+            raise ValueError("nonfinite perturbation bank")
+    if torch.equal(evaluation_displacements, calibration_displacements):
+        raise ValueError("calibration and scoring banks must not be reused")
+    matrices = {name: orthogonal_basis(x.shape[-1], name) for name in basis_names}
+    rows = []
+    for n, sample in enumerate(x):
+        target = int(targets[n])
+        if target < 0:
+            raise ValueError("negative target index")
+        ve, vc = evaluation_displacements[n], calibration_displacements[n]
+        with torch.no_grad():
+            original = model(sample[None])
+            scored = model(sample[None] - ve)
+            if original.ndim != 2 or scored.shape != (len(ve), original.shape[1]) or target >= original.shape[1]:
+                raise ValueError("model output or frozen target incompatible")
+            truth = (original[0, target] - scored[:, target]).cpu().numpy()
+            cal_response = None
+            if "surrogate" in methods:
+                cal_response = (original[0, target] - model(sample[None] - vc)[:, target]).cpu().numpy()
+            if not np.isfinite(truth).all() or (cal_response is not None and not np.isfinite(cal_response).all()):
+                raise ValueError("nonfinite intervention response")
+        for name, matrix in matrices.items():
+            a = torch.as_tensor(matrix, dtype=x.dtype, device=x.device)
+            with torch.no_grad():
+                # Preservation is checked on both ends of the same intervention.
+                points = torch.cat((sample[None], sample[None] - ve), dim=0)
+                restored = (points @ a.T) @ a
+                if not torch.allclose(restored, points, atol=2e-5, rtol=2e-5):
+                    raise ValueError("representation failed reconstruction")
+                if not torch.allclose(model(restored), model(points), atol=2e-5, rtol=2e-5):
+                    raise ValueError("representation failed fixed-model-output preservation")
+            design_eval = (ve @ a.T).flatten(1).cpu().numpy()
+            design_cal = (vc @ a.T).flatten(1).cpu().numpy()
+            for method in methods:
+                counts = ({"forward": len(vc) + 1, "backward": 0} if method == "surrogate"
+                          else {"forward": 1 if method == "gradient" else steps if method == "path_gradient" else 2 * sample.numel(),
+                                "backward": 1 if method == "gradient" else steps if method == "path_gradient" else 0})
+                if counts["forward"] > forward_budget or counts["backward"] > backward_budget:
+                    raise ValueError(f"{method} exceeds the declared forward/backward query budget")
+                raw = None
+                if method != "surrogate":
+                    raw, counts = coefficients(model, sample, target, matrix, method=method,
+                        baseline=baseline[n], steps=steps, radius=radius)
+                for k in budgets:
+                    vector = (sparse_response_fit(design_cal, cal_response, k) if method == "surrogate"
+                              else truncate(raw, k).ravel())
+                    error = float(np.mean((design_eval @ vector - truth) ** 2))
+                    if not np.isfinite(error):
+                        raise ValueError("nonfinite response error")
+                    rows.append(dict(sample=n, representation=name, method=method, k=int(k),
+                        mse=error, forward=counts["forward"], backward=counts["backward"],
+                        evaluation_forward=1 + len(ve), output_kind="sensitivity_response"))
+    return rows

--- a/phmfactory/finite_budget_evaluation.py
+++ b/phmfactory/finite_budget_evaluation.py
@@ -13,6 +13,15 @@ All tensors share original input coordinates. The caller must supply disjoint
 calibration/scoring perturbation banks. Forward visits count examples, not batches.
 """
     import torch
+    if model.training:
+        raise ValueError("model must be frozen in eval mode")
+    if not torch.isfinite(x).all() or not torch.isfinite(baseline).all():
+        raise ValueError("input and baseline must be finite")
+    target_array = np.asarray(targets)
+    if target_array.ndim != 1 or not np.issubdtype(target_array.dtype, np.integer):
+        raise ValueError("targets must be a one-dimensional integer array")
+    if not methods or not set(methods) <= {"gradient", "path_gradient", "secant", "surrogate"}:
+        raise ValueError("requested response method is not implemented")
     if x.ndim != 3 or baseline.shape != x.shape or len(targets) != len(x):
         raise ValueError("expected x/baseline [N,C,T] and explicit targets [N]")
     for bank in (evaluation_displacements, calibration_displacements):
@@ -70,5 +79,5 @@ calibration/scoring perturbation banks. Forward visits count examples, not batch
                         raise ValueError("nonfinite response error")
                     rows.append(dict(sample=n, representation=name, method=method, k=int(k),
                         mse=error, forward=counts["forward"], backward=counts["backward"],
-                        evaluation_forward=1 + len(ve), output_kind="sensitivity_response"))
+                        evaluation_forward=1 + len(ve), validation_forward=2 * (1 + len(ve)), output_kind="sensitivity_response"))
     return rows

--- a/test/test_finite_budget.py
+++ b/test/test_finite_budget.py
@@ -1,0 +1,49 @@
+import numpy as np
+import pytest
+import torch
+from phmfactory.finite_budget import (
+    orthogonal_basis, truncate, exact_sparse_risk, sparse_response_fit, coefficients,
+)
+
+@pytest.mark.parametrize("name", ["identity", "dct", "haar_packet:1", "haar_packet:3"])
+def test_exact_coordinates(name):
+    a = orthogonal_basis(8, name)
+    np.testing.assert_allclose(a.T @ a, np.eye(8), atol=1e-12)
+
+def test_haar_help_and_harm():
+    a = orthogonal_basis(2, "haar_packet:1")
+    for w in [np.array([1., 1.]) / np.sqrt(2), np.array([1., 0.])]:
+        risk, _ = exact_sparse_risk(a, np.eye(2), w, w @ w, 1)
+        expected = np.sum((a @ w - truncate(a @ w, 1)) ** 2)
+        assert risk == pytest.approx(expected, abs=1e-12)
+
+def test_noncentred_second_moment_and_full_budget():
+    a = orthogonal_basis(2, "dct")
+    m = np.array([[5., 2.], [2., 2.]])
+    w = np.array([1., -2.])
+    risk, coeff = exact_sparse_risk(a, m, m @ w, w @ m @ w, 2)
+    assert risk < 1e-10
+    np.testing.assert_allclose(a.T @ coeff, w, atol=1e-10)
+
+def test_sparse_calibration_fit():
+    v = np.eye(4)
+    coeff = sparse_response_fit(v, np.array([0., 2., 0., -1.]), 2)
+    np.testing.assert_allclose(coeff, [0., 2., 0., -1.])
+
+class Model(torch.nn.Module):
+    def forward(self, x):
+        s = x.flatten(1).sum(1)
+        return torch.stack([s, -s], 1)
+
+@pytest.mark.parametrize("method", ["gradient", "path_gradient", "secant"])
+def test_fixed_target_and_sign(method):
+    x = torch.ones(1, 4, dtype=torch.float64)
+    a = orthogonal_basis(4, "dct")
+    raw, counts = coefficients(Model().eval(), x, 1, a, method=method,
+                               baseline=torch.zeros_like(x), steps=8)
+    np.testing.assert_allclose(raw @ a, -np.ones((1, 4)), atol=1e-10)
+    assert counts["forward"] > 0
+
+def test_reject_unknown_explainer():
+    with pytest.raises(ValueError, match="no response-decoder"):
+        coefficients(Model().eval(), torch.ones(1, 4), 0, np.eye(4), method="shap")

--- a/test/test_finite_budget_evaluation.py
+++ b/test/test_finite_budget_evaluation.py
@@ -1,0 +1,26 @@
+import pytest
+import torch
+from phmfactory.finite_budget_evaluation import response_errors
+
+
+class Model(torch.nn.Module):
+    def forward(self, x):
+        s = x.flatten(1).sum(1)
+        return torch.stack([s, -s], 1)
+
+
+def test_held_out_response_evaluation():
+    x = torch.ones(2, 1, 4)
+    generator = torch.Generator().manual_seed(7)
+    vc = torch.randn(2, 8, 1, 4, generator=generator) * 0.01
+    ve = torch.randn(2, 9, 1, 4, generator=generator) * 0.01
+    rows = response_errors(Model().eval(), x, [0, 1], ["identity", "dct"],
+        ["gradient", "path_gradient", "secant", "surrogate"], [1, 4],
+        baseline=torch.zeros_like(x), evaluation_displacements=ve,
+        calibration_displacements=vc, forward_budget=16, backward_budget=8, steps=8)
+    assert len(rows) == 32
+    assert max(row["mse"] for row in rows if row["k"] == 4) < 1e-9
+    with pytest.raises(ValueError, match="must not be reused"):
+        response_errors(Model().eval(), x, [0, 1], ["identity"], ["gradient"], [1],
+            baseline=torch.zeros_like(x), evaluation_displacements=vc,
+            calibration_displacements=vc, forward_budget=1, backward_budget=1)

--- a/test/test_finite_budget_regressions.py
+++ b/test/test_finite_budget_regressions.py
@@ -1,0 +1,28 @@
+import numpy as np
+import pytest
+import torch
+from phmfactory.finite_budget import exact_sparse_risk
+from phmfactory.finite_budget_evaluation import response_errors
+
+
+@pytest.mark.parametrize("value", [float("nan"), float("inf")])
+def test_nonfinite_response_moment(value):
+    with pytest.raises(ValueError, match="second moment must be finite"):
+        exact_sparse_risk(np.eye(2), np.eye(2), np.zeros(2), value, 1)
+
+
+class Model(torch.nn.Module):
+    def forward(self, x):
+        score = x.flatten(1).sum(1)
+        return torch.stack([score, -score], 1)
+
+
+def test_partial_query_overlap():
+    x = torch.ones(1, 1, 4)
+    cal = torch.randn(1, 2, 1, 4)
+    scoring = torch.randn(1, 3, 1, 4)
+    scoring[0, 2] = cal[0, 0]
+    with pytest.raises(ValueError, match="overlapping"):
+        response_errors(Model().eval(), x, [0], ["identity"], ["gradient"], [1],
+            baseline=torch.zeros_like(x), evaluation_displacements=scoring,
+            calibration_displacements=cal, forward_budget=1, backward_budget=1)


### PR DESCRIPTION
## User-visible change
Two current paper consumers (P02 industrial representations and P20 general theory) need the same numerical operations without importing a paper into PHMFactory. Add one direct public numerical module, not a new pipeline or registry.

## Scope
Identity/DCT/Haar-packet reference bases, exact small-dimensional moment oracle, sparse calibration-response fitting, and explicit fixed-target gradient/path-gradient/secant coefficients. The module does not load checkpoints or datasets, select a paper protocol, or run training.

## Scientific boundary
M is the uncentred second moment. IG contributions are not silently converted into sensitivities. A full gradient and an IG path average are separately named. Evaluation queries must be held out from fitting. Dense bases are a bounded reference implementation.

## Validation
Local CPU: `python -m pytest test/test_finite_budget.py -q` — 11 passed. Tests use analytic functions only; no real-data or GPU baseline claimed. Full existing runtime checks remain subject to Actions.

## Non-goals
No changes to protected factories, model loading, data selection, existing explainers, CLI, fallback behavior or release readiness. No custom integrity machinery.

Rollback: revert this PR.