### PR TITLE
release: publish the reviewed Streamlit inspector correction

### DIFF
--- a/.github/workflows/streamlit-quality-gates.yml
+++ b/.github/workflows/streamlit-quality-gates.yml
@@ -6,6 +6,28 @@ on:
       - "apps/streamlit/**"
       - "test/test_streamlit_*.py"
       - "test/requirements.txt"
+      - "scripts/config_inspect.py"
+      - "main.py"
+      - "phmfactory/__main__.py"
+      - "phmfactory/cli.py"
+      - "phmfactory/config.py"
+      - "phmfactory/device.py"
+      - "phmfactory/pipelines.py"
+      - "phmfactory/commands/common.py"
+      - "phmfactory/runtime/**"
+      - "src/Pipeline_01_Fault_Diagnosis.py"
+      - "src/runtime/**"
+      - "src/*_factory/**"
+      - "src/configs/**"
+      - "src/config_schema/**"
+      - "src/utils/**"
+      - "configs/base/**"
+      - "configs/demo/00_smoke/**"
+      - "configs/config_registry.csv"
+      - "data/metadata_dummy.csv"
+      - "data/raw/Dummy_Data/**"
+      - "requirements.txt"
+      - "pyproject.toml"
       - ".github/workflows/streamlit-quality-gates.yml"
   push:
     branches:
@@ -14,6 +36,28 @@ on:
       - "apps/streamlit/**"
       - "test/test_streamlit_*.py"
       - "test/requirements.txt"
+      - "scripts/config_inspect.py"
+      - "main.py"
+      - "phmfactory/__main__.py"
+      - "phmfactory/cli.py"
+      - "phmfactory/config.py"
+      - "phmfactory/device.py"
+      - "phmfactory/pipelines.py"
+      - "phmfactory/commands/common.py"
+      - "phmfactory/runtime/**"
+      - "src/Pipeline_01_Fault_Diagnosis.py"
+      - "src/runtime/**"
+      - "src/*_factory/**"
+      - "src/configs/**"
+      - "src/config_schema/**"
+      - "src/utils/**"
+      - "configs/base/**"
+      - "configs/demo/00_smoke/**"
+      - "configs/config_registry.csv"
+      - "data/metadata_dummy.csv"
+      - "data/raw/Dummy_Data/**"
+      - "requirements.txt"
+      - "pyproject.toml"
       - ".github/workflows/streamlit-quality-gates.yml"
   workflow_dispatch:
 
@@ -77,4 +121,42 @@ jobs:
           name: streamlit-focused-${{ matrix.os }}
           path: streamlit-pytest-${{ matrix.os }}.xml
           if-no-files-found: error
+          retention-days: 7
+
+  public-integration:
+    name: Streamlit public inspector and Dummy integration
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    env:
+      MPLBACKEND: Agg
+      HF_HUB_OFFLINE: "1"
+      TRANSFORMERS_OFFLINE: "1"
+      WANDB_MODE: disabled
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+      - name: Install matching CPU Torch and torchvision
+        # timm requires torchvision; use the same binary family as CPU Torch.
+        run: python -m pip install --index-url https://download.pytorch.org/whl/cpu torch==2.6.0 torchvision==0.21.0
+      - name: Install PHMFactory and the minimum supported Streamlit
+        run: python -m pip install -e . "streamlit==1.37.0" "pytest>=7"
+      - name: Check installed dependencies
+        run: |
+          python -m pip check
+          python -c "import torch, torchvision; print(torch.__version__, torchvision.__version__)"
+      - name: Exercise current inspector and real Dummy subprocess
+        run: python -m pytest test/test_streamlit_public_contract.py -q --junitxml=streamlit-public.xml
+      - name: Exercise the actual page with AppTest
+        run: python -m pytest test/test_streamlit_app.py -q --junitxml=streamlit-page.xml
+      - name: Upload integration diagnostics
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: streamlit-public-integration
+          path: |
+            streamlit-public.xml
+            streamlit-page.xml
+          if-no-files-found: warn
           retention-days: 7

--- a/apps/streamlit/README.md
+++ b/apps/streamlit/README.md
@@ -1,120 +1,56 @@
 # PHMFactory Streamlit Experiment Workspace
 
-This optional browser workspace helps users select a maintained template, edit a bounded
-parameter surface, validate the exact configuration, launch the public CLI, and inspect
-logs and artifacts.
-
-It is an adapter around PHMFactory—not a second configuration parser, scheduler, or
-training framework.
+Select an experiment, edit its parameters, inspect the configuration, and launch the
+existing PHMFactory CLI from a browser. Training stays in a separate process; the UI
+never calls a Factory or Trainer directly.
 
 ## Install and start
 
-Install the core source checkout first, then the optional UI dependencies:
+Use the same Python environment for PHMFactory and Streamlit. From the checkout root:
 
 ```bash
 python -m pip install -e .
 python -m pip install -r apps/streamlit/requirements.txt
-streamlit run apps/streamlit/app.py
+python -m streamlit run apps/streamlit/app.py
 ```
 
-Run the command from the repository root. `apps/streamlit/app.py` is the only maintained
-web entrypoint.
+`apps/streamlit/app.py` is the maintained web entrypoint. Data paths refer to the machine
+running Streamlit, not to another computer opening the browser.
 
 ## First experiment
 
-Use **Use safe CPU smoke defaults** in the sidebar. It selects:
+1. Select **Use safe CPU smoke defaults**. This chooses the bundled Dummy template,
+   CPU, one epoch, and zero data workers.
+2. Review the visible parameters and click **Validate configuration**.
+3. Click **Run experiment** and inspect the process status and log below.
 
-```text
-Template: demo_00_smoke_dummy_dg
-Mode:     Quick Start
-Device:   cpu
-Epochs:   1
-Data:     repository-shipped Dummy files
-```
+The public inspector remains the configuration authority. The UI accepts its current
+`resolved`, `sources`, `targets`, `sanity`, and `local_config_path` output; no configuration
+digest is required. Validation stores the submitted YAML text and typed override argv
+for direct comparison. Editing either makes the old validation stale and disables Run
+until the new request is checked. Hidden machine-local files do not participate.
 
-The workspace then guides the user through four steps:
+Inspection is not a promise that training will succeed. It does not construct the training
+stack or perform every public preflight check. A missing dependency or unavailable device
+must remain a visible failure, not trigger a different experiment.
 
-1. select a maintained template;
-2. change only the parameters needed for this run;
-3. validate the exact effective configuration and launch it;
-4. inspect live logs, metrics, files, and the reproduction command.
+## Edit a configuration
 
-## One configuration truth
+**Quick Start** exposes common fields from `field_catalog.yaml`. **Advanced** also offers
+standalone YAML and one `key=value` override per line. Raw overrides have highest priority;
+the displayed command repeats `--override` for each value and is launched with `shell=False`.
 
-Streamlit delegates composition and validation to the same public inspector used by:
+The backend owns composition, strict types, Pipeline selection, and explicit local config.
+The UI does not auto-discover `configs/local/local.yaml`. Repository templates remain
+unchanged when a run creates its own `execution.yaml`.
 
-```text
-phmfactory preflight
-phmfactory run
-scripts.validate_configs
-scripts.config_inspect
-```
+Current limitation: downloaded YAML does not yet fold in separate overrides. Preserve
+both the configuration and the displayed override arguments when reproducing a run.
+A single checked/downloaded/executed snapshot is the next configuration improvement.
 
-The UI does not implement `base_configs` merging, Pipeline canonicalization, or hidden
-machine overrides itself.
+## Run and inspect
 
-The public precedence is:
-
-```text
-base_configs
-< selected experiment YAML
-< explicit local config, only when supplied by a CLI user
-< explicit overrides
-```
-
-The current UI intentionally does not auto-discover or silently apply
-`configs/local/local.yaml`. Quick Start and Advanced mode therefore have no invisible
-machine-local layer. Machine-specific values are edited in the standalone YAML or entered
-as explicit overrides. The planned command shown by the UI is the command that is
-launched.
-
-A successful validation report carries the same `effective_config_sha256` that CLI
-preflight and the final run manifest record. If the visible YAML or overrides change, the
-validation becomes stale and the Run button is disabled until validation runs again.
-
-## Quick Start mode
-
-Quick Start exposes only catalog-approved fields. The selected template is resolved once
-through the public inspector. UI values are converted into typed `key=value` argv tokens.
-
-Use this mode for:
-
-- the first offline smoke;
-- common epoch, device, worker, seed, or data-path changes;
-- users who do not need to edit the full YAML.
-
-## Advanced mode
-
-Advanced mode adds:
-
-- the same safe field catalog;
-- a standalone effective-YAML editor;
-- one typed override per line;
-- a configuration diff;
-- exact planned and actual reproduction commands.
-
-The YAML shown in this mode already contains the fully resolved base configuration. It
-has no hidden local layer. Raw overrides remain highest precedence and are passed as argv
-elements; the UI never builds a `shell=True` command.
-
-## Readiness and launch blockers
-
-Before launch, the workspace checks:
-
-- the repository entrypoint and configuration inventory;
-- required Python imports;
-- repository-shipped smoke assets;
-- output-directory writability;
-- selected template data and metadata availability;
-- public config inspection and sanity checks.
-
-A failed readiness check does not prevent users from inspecting the template or editing
-YAML, but execution remains disabled until the relevant environment, data, or config
-problem is fixed.
-
-## Run lifecycle
-
-Each UI run creates a managed workspace:
+Each UI run has a small process workspace:
 
 ```text
 outputs/streamlit/<run-id>/
@@ -123,107 +59,63 @@ outputs/streamlit/<run-id>/
 └── run.log
 ```
 
-The process then invokes the public command contract. PHMFactory's own runtime writes the
-invocation manifest below the configured experiment output directory:
+`run.json` records process state, command and timestamps. It is not a scientific evaluation
+or an integrity record. PHMFactory returns its own result paths in `run.log`:
 
 ```text
-<environment.output_dir>/.phmfactory/runs/<run-id>/run_manifest.json
+result_dir=...
+best_checkpoint=...
+test_metrics=...
+run_summary=...
+primary_metrics=...
+run=completed
 ```
 
-The UI supports:
+Use those exact paths to confirm the current run. A training-only request does not have
+test metrics or a test summary. A non-zero exit remains failed even if partial files exist.
 
-- **Run** — start one experiment process;
-- **Cancel** — terminate the process group, then force-kill after a grace period;
-- **Restart same run** — reuse the immutable YAML and override snapshot.
+The workspace can cancel its active process and repeat a prior configuration in a new run.
+One Streamlit worker manages one active experiment. Browser refresh does not submit a new
+run; a server restart may leave the child process detached and must not trigger automatic
+resubmission. Pause/resume and cluster scheduling are not supported.
 
-Pause/resume is intentionally absent because it is not portable across Windows, CUDA,
-and data-loader subprocesses. One Streamlit worker manages one active experiment at a
-time; the workspace is not an implicit cluster scheduler.
+Current limitation: the Metrics/Artifacts views still discover files below the configured
+output root. Until direct-path result binding is implemented, do not use a shared-output
+view to attribute results from concurrent experiments. The per-run CLI log is authoritative.
 
-## Results
+## Troubleshooting
 
-Result discovery is bounded by directory depth, entry count, file count, metric file
-size, and row count. Symbolic links are skipped.
+A rejected configuration shows the inspector's original stderr. Copy the visible command
+and run it with the same Python and working directory. Use `phmfactory doctor` for environment
+issues, and `phmfactory preflight --config <yaml>` with the same overrides for public
+preflight checks. Missing local data requires correcting the requested path; switching to
+the offline example is an explicit user action, never an automatic fallback.
 
-The result views provide:
+## Development and tests
 
-- **Overview** — actual command, output roots, run metadata;
-- **Metrics** — headline values plus small CSV/JSON tables;
-- **Artifacts** — images, file inventory, and small-file downloads;
-- **Logs** — live tail and full-log download.
-
-Malformed optional artifacts do not erase the process status, command, run manifest, or
-raw log.
-
-## Extension boundaries
-
-Use declarative files rather than model-specific UI branches:
-
-- `configs/config_registry.csv` — maintained template identity and status;
-- `field_catalog.yaml` — editable fields, aliases, widgets, and template groups;
-- `template_profiles.yaml` — difficulty, data, device, and first-action guidance;
-- `config_service.py` — UI-safe serialization and public-inspector adapter;
-- `runtime_policy.py` — temporary standalone YAML inspection;
-- `run_service.py` — process lifecycle;
-- `result_service.py` — bounded artifact parsing;
-- `onboarding.py` — environment and data readiness;
-- `ui_*.py` — visual components only.
-
-New config semantics belong in `phmfactory.config`, not in Streamlit. New metrics formats
-belong in `result_service.py`. New safe fields belong in `field_catalog.yaml`.
-
-## Validation
+Keep changes within the existing services: `config_service.py` adapts the public inspector,
+`run_service.py` manages subprocesses, and `result_service.py` displays results. Field and
+template catalogues are UI metadata, not new experiment schemas. There is no experiment
+Agent or autonomous parameter search in this version.
 
 ```bash
-python -m py_compile apps/streamlit/*.py
-python -m pytest \
+python -m pytest -q \
   test/test_streamlit_config_service.py \
   test/test_streamlit_runtime_policy.py \
   test/test_streamlit_onboarding.py \
   test/test_streamlit_run_service.py \
   test/test_streamlit_result_service.py \
   test/test_streamlit_ui_imports.py
-python -m scripts.validate_configs
+
+# Full PHMFactory environment; actual inspector and Dummy CLI subprocess.
+python -m pytest test/test_streamlit_public_contract.py -q
+
+# Run separately from optional-import stub tests; requires real Streamlit.
+python -m pytest test/test_streamlit_app.py -q
 python -m scripts.validate_docs
-phmfactory preflight --config smoke
-phmfactory demo
 ```
 
-Focused UI tests run on both Linux and Windows through
-`.github/workflows/streamlit-quality-gates.yml`.
-
-## Troubleshooting
-
-### Validation and the CLI disagree
-
-Copy the planned command from the UI and run it in the same environment. Report:
-
-```text
-exact command
-UI effective_config_sha256
-CLI preflight effective_config_sha256
-complete stderr
-```
-
-Different hashes for the same visible YAML and overrides are a configuration-parity bug.
-
-### A local path is missing
-
-Use the offline smoke template to separate installation from external data availability.
-In Advanced mode, edit `data.data_dir` in the standalone YAML or add an explicit raw
-override. The UI does not read a hidden local file.
-
-### A dependency import fails
-
-Run `phmfactory doctor` in the same environment. The optional UI requirements do not
-replace the core training environment.
-
-### CUDA initialization fails
-
-Return to CPU smoke, then verify the installed PyTorch build, driver, and device outside
-PHMFactory before changing experiment code.
-
-### No structured metrics appear
-
-Inspect `run.log`, `run.json`, and the PHMFactory `run_manifest.json`. Optional parser
-failure does not invalidate those primary records.
+The existing Streamlit workflow runs lightweight service tests on Linux and Windows. A
+separate Ubuntu integration job uses real Streamlit, the public inspector and the actual
+Dummy lifecycle. AppTest verifies page behavior, not browser disconnection or cancellation
+of every operating-system child process.

--- a/apps/streamlit/REVIEW.md
+++ b/apps/streamlit/REVIEW.md
@@ -53,7 +53,7 @@ process/results.
 3. The official and only maintained entry point is `apps/streamlit/app.py`.
 4. The historical `app/` prototype and root launcher were archived in the personal
    fork and removed from the public framework.
-5. The Run button is enabled only for the exact signature that passed repository
+5. The Run button is enabled only for the same submitted inputs that passed repository
    inspection.
 
 ## Deferred

--- a/apps/streamlit/app.py
+++ b/apps/streamlit/app.py
@@ -1,9 +1,6 @@
-"""Maintained Streamlit entry point for PHM-Vibench."""
+"""Streamlit entrypoint; launch with python -m streamlit from the checkout root."""
 
-try:
-    from .workspace import main
-except ImportError:  # pragma: no cover - Streamlit executes this file as a script.
-    from workspace import main  # type: ignore
+from apps.streamlit.workspace import main
 
 
 if __name__ == "__main__":

--- a/apps/streamlit/config_service.py
+++ b/apps/streamlit/config_service.py
@@ -102,7 +102,6 @@ class ValidationReport:
     sources: Mapping[str, str] = field(default_factory=dict)
     targets: Mapping[str, Any] = field(default_factory=dict)
     sanity: Tuple[Mapping[str, Any], ...] = ()
-    effective_config_sha256: str = ""
     local_config_path: str | None = None
     stdout: str = ""
     stderr: str = ""
@@ -533,7 +532,7 @@ def inspect_config(
     python_executable: Optional[str] = None,
     local_config_path: Optional[Path] = None,
 ) -> ValidationReport:
-    """Invoke the public inspector and preserve its effective config identity."""
+    """Invoke the current public inspector without a second config identity."""
 
     command = [
         python_executable or sys.executable,
@@ -601,13 +600,16 @@ def inspect_config(
             stderr=completed.stderr,
             error="The config inspector returned an unexpected payload.",
         )
-    resolved = payload.get("resolved") or {}
-    sanity_raw = payload.get("sanity") or []
-    digest = str(payload.get("effective_config_sha256") or "")
+    resolved = payload.get("resolved")
+    sanity_raw = payload.get("sanity")
     if (
         not isinstance(resolved, dict)
         or not isinstance(sanity_raw, list)
-        or len(digest) != 64
+        or not sanity_raw
+        or not all(
+            isinstance(item, dict) and isinstance(item.get("ok"), bool)
+            for item in sanity_raw
+        )
     ):
         return ValidationReport(
             False,
@@ -616,8 +618,8 @@ def inspect_config(
             stderr=completed.stderr,
             error="The config inspector returned an incomplete payload.",
         )
-    sanity = tuple(item for item in sanity_raw if isinstance(item, dict))
-    passed = bool(sanity) and all(bool(item.get("ok")) for item in sanity)
+    sanity = tuple(sanity_raw)
+    passed = all(item["ok"] for item in sanity)
     return ValidationReport(
         passed,
         tuple(command),
@@ -625,7 +627,6 @@ def inspect_config(
         sources=payload.get("sources") or {},
         targets=payload.get("targets") or {},
         sanity=sanity,
-        effective_config_sha256=digest,
         local_config_path=payload.get("local_config_path"),
         stdout=completed.stdout,
         stderr=completed.stderr,

--- a/apps/streamlit/onboarding.py
+++ b/apps/streamlit/onboarding.py
@@ -219,7 +219,7 @@ def apply_safe_defaults(
             "advanced_yaml_text": "",
             "advanced_override_text": "",
             "validation_report": None,
-            "validation_signature": "",
+            "validated_inputs": None,
         }
     )
 

--- a/apps/streamlit/run_service.py
+++ b/apps/streamlit/run_service.py
@@ -63,7 +63,6 @@ class RunRequest:
     config_yaml: str = ""
     overrides: Tuple[Tuple[str, Any], ...] = ()
     output_root: str = "save"
-    validation_signature: str = ""
     metadata: Mapping[str, Any] = field(default_factory=dict)
 
 
@@ -79,7 +78,6 @@ class RunRecord:
     log_path: str = ""
     output_root: str = ""
     overrides: Tuple[Tuple[str, Any], ...] = ()
-    validation_signature: str = ""
     pid: Optional[int] = None
     exit_code: Optional[int] = None
     created_at: str = ""
@@ -183,7 +181,6 @@ def prepare_request(request: RunRequest) -> RunRequest:
         config_yaml=yaml_text,
         overrides=overrides,
         output_root=output_root,
-        validation_signature=str(request.validation_signature),
         metadata=metadata,
     )
 
@@ -242,7 +239,6 @@ def _record(payload: Mapping[str, Any], run_dir: Path) -> RunRecord:
         log_path=str(payload.get("log_path") or ""),
         output_root=str(payload.get("output_root") or ""),
         overrides=tuple(overrides),
-        validation_signature=str(payload.get("validation_signature") or ""),
         pid=int(pid) if isinstance(pid, int) else None,
         exit_code=int(exit_code) if isinstance(exit_code, int) else None,
         created_at=str(payload.get("created_at") or ""),
@@ -336,7 +332,6 @@ def start_run(request: RunRequest) -> RunRecord:
             "log_path": str(log_path.relative_to(normalized.repo_root)),
             "output_root": normalized.output_root,
             "overrides": [[key, value] for key, value in normalized.overrides],
-            "validation_signature": normalized.validation_signature,
             "command": list(command),
             "pid": None,
             "exit_code": None,
@@ -616,7 +611,6 @@ def restart_run(repo_root: Path, run_id: str) -> RunRecord:
             config_yaml=config_path.read_text(encoding="utf-8"),
             overrides=previous.overrides,
             output_root=previous.output_root,
-            validation_signature=previous.validation_signature,
             metadata=metadata,
         )
     )

--- a/apps/streamlit/ui_theme.py
+++ b/apps/streamlit/ui_theme.py
@@ -94,7 +94,7 @@ def _render_hero() -> None:
     <span class="phm-chip">Config-first</span>
     <span class="phm-chip">CPU smoke ready</span>
     <span class="phm-chip">No shell execution</span>
-    <span class="phm-chip">Reproducible run manifest</span>
+    <span class="phm-chip">Public CLI execution</span>
   </div>
 </div>
 <div class="phm-steps">
@@ -238,7 +238,7 @@ def _ensure_advanced_yaml(template_id: str, resolved: Mapping[str, Any]) -> None
         st.session_state.advanced_yaml_text = dump_yaml(resolved)
         st.session_state.advanced_override_text = ""
         st.session_state.validation_report = None
-        st.session_state.validation_signature = ""
+        st.session_state.validated_inputs = None
 
 
 def _render_diff(before: str, after: str) -> None:

--- a/apps/streamlit/workspace.py
+++ b/apps/streamlit/workspace.py
@@ -7,7 +7,6 @@ Pipeline, or define a second training framework.
 
 from __future__ import annotations
 
-import hashlib
 from pathlib import Path
 from typing import Any, Mapping, Sequence, Tuple
 
@@ -31,6 +30,7 @@ try:
         load_catalog,
         load_registry,
         normalize_overrides,
+        override_args,
         parse_override_lines,
         parse_yaml_text,
         resolve_repo_path,
@@ -83,6 +83,7 @@ except ImportError:  # pragma: no cover - Streamlit may execute app.py as a scri
         load_catalog,
         load_registry,
         normalize_overrides,
+        override_args,
         parse_override_lines,
         parse_yaml_text,
         resolve_repo_path,
@@ -152,11 +153,16 @@ def _cached_inspection(
     return inspect_config(Path(repo_root), Path(config_path), overrides)
 
 
-def _signature(mode: str, source: str, overrides: Sequence[Tuple[str, Any]]) -> str:
-    """Identify the visible UI inputs that were validated."""
+def _validation_inputs(
+    mode: str, source: str, overrides: Sequence[Tuple[str, Any]]
+) -> Tuple[str, str, Tuple[str, ...]]:
+    """Keep the submitted text and typed argv values for direct comparison.
 
-    payload = repr((mode, source, tuple(overrides))).encode("utf-8")
-    return hashlib.sha256(payload).hexdigest()
+    Serializing through the existing CLI adapter separates True from 1 and
+    freezes nested override values without inventing another config identity.
+    """
+
+    return mode, source, override_args(overrides)
 
 
 def _initialize_state() -> None:
@@ -168,7 +174,7 @@ def _initialize_state() -> None:
         "advanced_yaml_text": "",
         "advanced_override_text": "",
         "validation_report": None,
-        "validation_signature": "",
+        "validated_inputs": None,
         "active_run_id": "",
         "selected_run_id": "",
     }
@@ -296,7 +302,7 @@ def main() -> None:
             selected_id,
             quick_only=True,
         )
-        source_for_signature = standalone_yaml
+        source_for_validation = standalone_yaml
     else:
         _ensure_advanced_yaml(selected_id, baseline_resolved)
         tabs = st.tabs(("Safe fields", "Full YAML", "Raw overrides"))
@@ -338,7 +344,7 @@ def main() -> None:
             _render_error("Raw overrides are invalid.", error)
             overrides = safe_overrides
             configuration_has_error = True
-        source_for_signature = advanced_yaml_text
+        source_for_validation = advanced_yaml_text
         execution_yaml_text = advanced_yaml_text
 
     st.header("3. 验证并运行 | Validate and launch")
@@ -384,7 +390,7 @@ def main() -> None:
         else:
             st.warning("Fix the configuration before validation.")
 
-    current_signature = _signature(mode, source_for_signature, overrides)
+    current_inputs = _validation_inputs(mode, source_for_validation, overrides)
     validate_col, download_col, run_col = st.columns(3)
     if validate_col.button(
         "Validate configuration",
@@ -400,16 +406,16 @@ def main() -> None:
                     else inspect_execution_yaml(repo_root, advanced_yaml_text, overrides)
                 )
             st.session_state.validation_report = report
-            st.session_state.validation_signature = current_signature
+            st.session_state.validated_inputs = current_inputs
         except ConfigServiceError as error:
             st.session_state.validation_report = None
-            st.session_state.validation_signature = ""
+            st.session_state.validated_inputs = None
             _render_error("Validation could not start.", error)
 
     report = st.session_state.validation_report
     report_is_current = (
         isinstance(report, ValidationReport)
-        and st.session_state.validation_signature == current_signature
+        and st.session_state.validated_inputs == current_inputs
     )
     if report_is_current:
         _render_validation(report)
@@ -458,7 +464,6 @@ def main() -> None:
                     config_yaml=execution_yaml_text,
                     overrides=overrides,
                     output_root=str(resolved_output or "save"),
-                    validation_signature=current_signature,
                     metadata={
                         "registry_path": entry.path,
                         "pipeline": entry.pipeline or "Pipeline_01_Fault_Diagnosis",

--- a/doc/changelog/2026-09-08-streamlit-inspector-parity.md
+++ b/doc/changelog/2026-09-08-streamlit-inspector-parity.md
@@ -1,0 +1,29 @@
+# Streamlit accepts the current public inspector
+
+## User-visible correction
+
+The workspace no longer rejects a valid inspector response because it lacks a
+configuration digest. It compares the submitted YAML and typed override arguments directly
+to the inputs last checked. A changed request requires another check before Run is enabled.
+The unused validation signature has been removed from the UI process records as well.
+
+The app entrypoint now imports the workspace by its package path. Launch from the checkout
+root with `python -m streamlit run apps/streamlit/app.py`; the entrypoint no longer retries
+an ambiguous top-level import when executed outside package context.
+
+A regression uses the real `scripts.config_inspect` process rather than a mock that supplies
+a retired field. The integration checks also exercise the actual Dummy CLI through the
+existing run service and the page's validate/edit/revalidate sequence through AppTest.
+The Streamlit workflow triggers on both inspector/configuration dependencies and the
+CLI, runtime, factories and bundled data exercised by that integration. Its CPU environment
+installs matching Torch and torchvision binaries before normal dependency resolution.
+
+## Scope and limits
+
+Only the optional frontend, its tests, workflow and documentation change. No backend
+configuration, Pipeline, Factory, model, split, objective, metric or checkpoint behavior
+changes. No THU or other external-data experiment is required.
+
+This closes the configuration-inspection blocker, not the whole frontend plan. Folding
+all edits into one downloaded/executed configuration, public preflight at the submission
+boundary, exact result-path binding, batch execution and Agent tools remain separate work.

--- a/test/test_streamlit_app.py
+++ b/test/test_streamlit_app.py
@@ -1,0 +1,35 @@
+"""Real Streamlit rendering with the current public inspector.
+
+Run this separately from the optional-import stub tests.
+"""
+from pathlib import Path
+
+from streamlit.testing.v1 import AppTest
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _button(app, label):
+    return next(button for button in app.button if button.label == label)
+
+
+def test_real_page_accepts_current_inspection_and_invalidates_edits():
+    app = AppTest.from_file(str(ROOT / 'apps/streamlit/app.py'), default_timeout=90).run()
+    assert not app.exception
+    assert not app.error, [error.value for error in app.error]
+    assert _button(app, 'Run experiment').disabled
+    _button(app, 'Validate configuration').click().run()
+    assert not app.exception
+    assert not app.error, [error.value for error in app.error]
+    assert not _button(app, 'Run experiment').disabled
+    assert app.session_state['validation_report'].ok
+    checked = app.session_state['validated_inputs']
+    app.number_input(key='field::demo_00_smoke_dummy_dg::epochs').set_value(2).run()
+    assert not app.exception
+    assert _button(app, 'Run experiment').disabled
+    assert app.session_state['validated_inputs'] == checked
+    _button(app, 'Validate configuration').click().run()
+    assert not app.exception
+    assert not _button(app, 'Run experiment').disabled
+    assert app.session_state['validation_report'].resolved['trainer']['num_epochs'] == 2
+    assert app.session_state['validated_inputs'] != checked

--- a/test/test_streamlit_config_service.py
+++ b/test/test_streamlit_config_service.py
@@ -10,8 +10,6 @@ import yaml
 from apps.streamlit import config_service as cs
 
 
-DIGEST = "a" * 64
-
 
 def _repo(tmp_path: Path) -> Path:
     (tmp_path / "main.py").write_text("# test\n", encoding="utf-8")
@@ -25,7 +23,6 @@ def _write_registry(root: Path, body: str) -> None:
 
 def _inspector_payload() -> dict:
     return {
-        "effective_config_sha256": DIGEST,
         "local_config_path": None,
         "resolved": {block: {} for block in cs.CONFIG_BLOCKS},
         "sources": {},
@@ -226,7 +223,7 @@ def test_inspect_config_parses_success(
 
     assert report.ok is True
     assert report.resolved == payload["resolved"]
-    assert report.effective_config_sha256 == DIGEST
+    assert "effective_config_sha256" not in vars(report)
     assert report.local_config_path is None
 
 
@@ -365,3 +362,26 @@ def test_inspect_config_passes_only_an_explicit_local_config(
 
     assert report.ok is True
     assert report.local_config_path == str(local.resolve())
+
+
+@pytest.mark.parametrize("sanity", [[], None, [{}], [{"ok": "false"}], [True]])
+def test_inspector_rejects_incomplete_or_untyped_checks(monkeypatch, tmp_path, sanity):
+    root = _repo(tmp_path)
+    payload = _inspector_payload()
+    payload["sanity"] = sanity
+    monkeypatch.setattr(cs.subprocess, "run", lambda *args, **kwargs: SimpleNamespace(
+        returncode=0, stdout=json.dumps(payload), stderr=""))
+    report = cs.inspect_config(root, root / "configs/demo/demo.yaml")
+    assert not report.ok
+    assert "incomplete payload" in report.error
+
+
+def test_inspector_preserves_a_failed_check(monkeypatch, tmp_path):
+    root = _repo(tmp_path)
+    payload = _inspector_payload()
+    payload["sanity"] = [{"check": "device", "ok": False, "message": "Rejected."}]
+    monkeypatch.setattr(cs.subprocess, "run", lambda *args, **kwargs: SimpleNamespace(
+        returncode=0, stdout=json.dumps(payload), stderr=""))
+    report = cs.inspect_config(root, root / "configs/demo/demo.yaml")
+    assert not report.ok
+    assert report.failed_checks[0]["message"] == "Rejected."

--- a/test/test_streamlit_public_contract.py
+++ b/test/test_streamlit_public_contract.py
@@ -1,0 +1,86 @@
+"""UI adapters exercised against the real public CLI, not a fabricated response."""
+from __future__ import annotations
+
+import json
+import math
+import tempfile
+import time
+from pathlib import Path
+
+from apps.streamlit import config_service as cs
+from apps.streamlit import run_service as rs
+
+ROOT = Path(__file__).resolve().parents[1]
+SMOKE = ROOT / 'configs/demo/00_smoke/dummy_dg.yaml'
+
+
+def test_real_inspector_response_without_digest_is_accepted():
+    report = cs.inspect_config(ROOT, SMOKE, [('trainer.num_epochs', 2)])
+    assert report.ok, (report.error, report.stderr, report.stdout)
+    payload = json.loads(report.stdout)
+    assert 'effective_config_sha256' not in payload
+    assert report.resolved == payload['resolved']
+    assert report.resolved['trainer']['num_epochs'] == 2
+    assert report.resolved['trainer']['devices'] == 1
+    assert report.local_config_path is None
+
+
+def test_real_inspector_keeps_strict_type_failure():
+    report = cs.inspect_config(ROOT, SMOKE, [('trainer.num_epochs', '2')])
+    assert not report.ok
+    assert not report.resolved
+    assert 'num_epochs' in report.stderr
+
+
+def test_ui_run_service_executes_real_dummy(monkeypatch):
+    report = cs.inspect_config(ROOT, SMOKE)
+    assert report.ok, (report.error, report.stderr)
+    # UI workspaces are checkout-local; all test-created inputs and outputs are temporary.
+    output_parent = ROOT / 'outputs'
+    output_parent.mkdir(exist_ok=True)
+    with tempfile.TemporaryDirectory(prefix='ui-contract-', dir=output_parent) as directory:
+        directory = Path(directory)
+        monkeypatch.setattr(rs, '_run_root', lambda root: directory / 'runs')
+        config = dict(report.resolved)
+        config['environment'] = dict(config['environment'], output_dir=str(directory / 'results'))
+        config['data'] = dict(config['data'], cache_dir=str(directory / 'cache'))
+        record = rs.start_run(rs.RunRequest(
+            repo_root=ROOT, template_id='demo_00_smoke_dummy_dg', mode='Quick Start',
+            config_yaml=cs.dump_yaml(config), output_root=config['environment']['output_dir'],
+        ))
+        try:
+            deadline = time.monotonic() + 120
+            while not record.is_terminal and time.monotonic() < deadline:
+                time.sleep(0.1)
+                record = rs.get_run(ROOT, record.run_id)
+            log = (record.run_dir / 'run.log').read_text(encoding='utf-8')
+            assert record.status == 'succeeded', log
+            assert record.exit_code == 0
+            assert 'run=completed' in log.splitlines()
+            keys = {'result_dir', 'best_checkpoint', 'test_metrics', 'run_summary'}
+            values = {}
+            for line in log.splitlines():
+                key, sep, value = line.partition('=')
+                if sep and key in keys | {'primary_metrics'}:
+                    values[key] = value
+            assert keys | {'primary_metrics'} <= values.keys(), log
+            result_dir = Path(values['result_dir']).resolve()
+            assert result_dir.is_relative_to(directory)
+            assert result_dir.is_dir()
+            for key in keys - {'result_dir'}:
+                path = Path(values[key]).resolve()
+                assert path.is_file(), (key, path)
+                assert path.is_relative_to(result_dir), (key, path)
+            metrics = json.loads(values['primary_metrics'])
+            assert metrics
+            for metric in metrics.values():
+                assert metric['count'] == 1
+                assert math.isfinite(metric['mean'])
+                assert metric['sample_std'] is None
+            summary = json.loads(Path(values['run_summary']).read_text())
+            assert summary['iterations'] == 1
+            assert all(value['count'] == 1 for value in summary['metrics'].values())
+            assert 'validation_signature' not in json.loads((record.run_dir / 'run.json').read_text())
+        finally:
+            if not rs.get_run(ROOT, record.run_id).is_terminal:
+                rs.cancel_run(ROOT, record.run_id, grace_seconds=1)

--- a/test/test_streamlit_ui_imports.py
+++ b/test/test_streamlit_ui_imports.py
@@ -45,14 +45,14 @@ def test_legacy_root_streamlit_launcher_is_removed() -> None:
     assert find_spec("streamlit_app") is None
 
 
-def test_validation_signature_uses_only_visible_ui_inputs(monkeypatch, tmp_path):
+def test_validation_snapshot_uses_only_visible_ui_inputs(monkeypatch, tmp_path):
     """An unmentioned local YAML must not invalidate or alter UI validation."""
 
     _install_streamlit_stub(monkeypatch)
     sys.modules.pop("apps.streamlit.workspace", None)
     workspace = importlib.import_module("apps.streamlit.workspace")
 
-    visible = workspace._signature(
+    visible = workspace._validation_inputs(
         "Quick Start",
         "effective yaml",
         (("trainer.device", "cpu"),),
@@ -61,12 +61,12 @@ def test_validation_signature_uses_only_visible_ui_inputs(monkeypatch, tmp_path)
     local_dir.mkdir(parents=True)
     local_path = local_dir / "local.yaml"
     local_path.write_text("trainer:\n  device: cuda\n", encoding="utf-8")
-    after_hidden_file = workspace._signature(
+    after_hidden_file = workspace._validation_inputs(
         "Quick Start",
         "effective yaml",
         (("trainer.device", "cpu"),),
     )
-    changed_visible_input = workspace._signature(
+    changed_visible_input = workspace._validation_inputs(
         "Quick Start",
         "effective yaml",
         (("trainer.device", "cuda"),),
@@ -74,3 +74,17 @@ def test_validation_signature_uses_only_visible_ui_inputs(monkeypatch, tmp_path)
 
     assert visible == after_hidden_file
     assert visible != changed_visible_input
+
+
+def test_validation_snapshot_preserves_types_and_copies_nested_values(monkeypatch):
+    _install_streamlit_stub(monkeypatch)
+    sys.modules.pop("apps.streamlit.workspace", None)
+    workspace = importlib.import_module("apps.streamlit.workspace")
+    capture = workspace._validation_inputs
+    assert capture("Advanced", "yaml", (("value", True),)) != capture("Advanced", "yaml", (("value", 1),))
+    assert capture("Advanced", "yaml", (("value", 1),)) != capture("Advanced", "yaml", (("value", "1"),))
+    values = [1, 2]
+    checked = capture("Advanced", "yaml", (("values", values),))
+    values.append(3)
+    assert checked != capture("Advanced", "yaml", (("values", values),))
+    assert checked == capture("Advanced", "yaml", (("values", [1, 2]),))


### PR DESCRIPTION
## Scope
Promote only merged PR #238 (ffaaf925) to the user-facing main branch under the user's existing implementation/merge authorization. main…dev contains exactly one commit and 14 frontend/test/docs/workflow paths; research PR #231 is excluded.

## User-visible result
The Streamlit workspace accepts the current public inspector without retired config digests, uses package-qualified startup, and invalidates checked inputs after typed edits. The existing subprocess path remains unchanged. README and doc/changelog/2026-09-08-streamlit-inspector-parity.md record the change and the remaining U2–U6 scope.

## Verified on the topic candidate
Four workflows passed: Streamlit quality gates (Linux/Windows focused suites and real inspector/Dummy/AppTest integration), Core quality gates, Repository layout and Submodule policy. The external review comment on lifecycle trigger coverage was fixed and resolved. Promotion checks must pass on this candidate as well.

## Boundaries
No backend, experiment configuration, metric/split/checkpoint, THU, benchmark status, tag or publication change. No claim that batch/Agent execution or exact result-path binding is complete. Temporary transport workflow is absent from the promoted tree.

Merge using a merge commit to retain long-lived branch ancestry. After verifying no intervening dev changes, fast-forward dev to the resulting main merge. Do not include unrelated work.