### PR TITLE
release: promote Streamlit approved configuration snapshot

### DIFF
--- a/apps/streamlit/README.md
+++ b/apps/streamlit/README.md
@@ -30,9 +30,10 @@ digest is required. Validation stores the submitted YAML text and typed override
 for direct comparison. Editing either makes the old validation stale and disables Run
 until the new request is checked. Hidden machine-local files do not participate.
 
-Inspection is not a promise that training will succeed. It does not construct the training
-stack or perform every public preflight check. A missing dependency or unavailable device
-must remain a visible failure, not trigger a different experiment.
+Inspection resolves the requested experiment. Run then materializes that approved mapping as
+one `execution.yaml` and invokes the existing public preflight against that exact file before
+training starts. A missing dependency or unavailable device remains a visible failure and
+does not trigger a different experiment.
 
 ## Edit a configuration
 
@@ -44,9 +45,9 @@ The backend owns composition, strict types, Pipeline selection, and explicit loc
 The UI does not auto-discover `configs/local/local.yaml`. Repository templates remain
 unchanged when a run creates its own `execution.yaml`.
 
-Current limitation: downloaded YAML does not yet fold in separate overrides. Preserve
-both the configuration and the displayed override arguments when reproducing a run.
-A single checked/downloaded/executed snapshot is the next configuration improvement.
+After validation, all safe-field and raw override edits are folded into one resolved YAML.
+Download, public preflight, execution, and restart use that same snapshot without a second
+`--override` layer. Repository templates remain unchanged.
 
 ## Run and inspect
 
@@ -87,8 +88,8 @@ view to attribute results from concurrent experiments. The per-run CLI log is au
 
 A rejected configuration shows the inspector's original stderr. Copy the visible command
 and run it with the same Python and working directory. Use `phmfactory doctor` for environment
-issues, and `phmfactory preflight --config <yaml>` with the same overrides for public
-preflight checks. Missing local data requires correcting the requested path; switching to
+issues. The Run action already executes `phmfactory preflight --config <execution.yaml>`
+before training; copy that saved YAML to reproduce the same preflight manually. Missing local data requires correcting the requested path; switching to
 the offline example is an explicit user action, never an automatic fallback.
 
 ## Development and tests

--- a/apps/streamlit/run_service.py
+++ b/apps/streamlit/run_service.py
@@ -13,6 +13,7 @@ import os
 import shutil
 import signal
 import subprocess
+import sys
 import threading
 import time
 import uuid
@@ -25,6 +26,9 @@ try:
     from .config_service import (
         ConfigServiceError,
         build_main_command,
+        dump_yaml,
+        inspect_config,
+        inspect_yaml_text,
         normalize_overrides,
         parse_yaml_text,
     )
@@ -32,6 +36,9 @@ except ImportError:  # pragma: no cover - Streamlit executes app.py as a script.
     from config_service import (  # type: ignore
         ConfigServiceError,
         build_main_command,
+        dump_yaml,
+        inspect_config,
+        inspect_yaml_text,
         normalize_overrides,
         parse_yaml_text,
     )
@@ -185,6 +192,85 @@ def prepare_request(request: RunRequest) -> RunRequest:
     )
 
 
+def approve_request(request: RunRequest) -> RunRequest:
+    """Resolve one request through the public config authority before launch."""
+
+    normalized = prepare_request(request)
+    report = (
+        inspect_config(
+            normalized.repo_root,
+            normalized.config_source,
+            normalized.overrides,
+        )
+        if normalized.config_source is not None
+        else inspect_yaml_text(
+            normalized.repo_root,
+            normalized.config_yaml,
+            normalized.overrides,
+        )
+    )
+    if not report.ok or not report.resolved:
+        detail = report.stderr.strip() or report.error or "Unknown configuration rejection."
+        raise RunServiceError(
+            "The public config inspector rejected this run request before launch.\n"
+            + detail
+        )
+    environment = report.resolved.get("environment")
+    output_root = (
+        str(environment.get("output_dir"))
+        if isinstance(environment, Mapping)
+        and isinstance(environment.get("output_dir"), str)
+        and environment.get("output_dir").strip()
+        else normalized.output_root
+    )
+    return RunRequest(
+        repo_root=normalized.repo_root,
+        template_id=normalized.template_id,
+        mode=normalized.mode,
+        config_yaml=dump_yaml(report.resolved),
+        overrides=(),
+        output_root=output_root,
+        metadata=normalized.metadata,
+    )
+
+
+def _run_public_preflight(repo_root: Path, config_path: Path, *, timeout: float = 90.0) -> None:
+    """Run the existing public preflight against the exact execution snapshot."""
+
+    display_path = config_path.resolve().relative_to(repo_root.resolve()).as_posix()
+    command = (
+        sys.executable,
+        "-m",
+        "phmfactory",
+        "preflight",
+        "--config",
+        display_path,
+    )
+    try:
+        completed = subprocess.run(
+            command,
+            cwd=str(repo_root),
+            text=True,
+            capture_output=True,
+            timeout=timeout,
+            check=False,
+        )
+    except subprocess.TimeoutExpired as error:
+        raise RunServiceError(
+            f"Public preflight timed out after {timeout:g} seconds."
+        ) from error
+    except OSError as error:
+        raise RunServiceError(f"Could not start public preflight: {error}") from error
+    if completed.returncode != 0:
+        detail = completed.stderr.strip() or completed.stdout.strip() or (
+            f"preflight exited with code {completed.returncode}"
+        )
+        raise RunServiceError(
+            "Public preflight rejected the approved execution.yaml before training.\n"
+            + detail
+        )
+
+
 def _atomic_write_json(path: Path, payload: Mapping[str, Any]) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     temp_path = path.with_name(f".{path.name}.{uuid.uuid4().hex}.tmp")
@@ -280,23 +366,23 @@ def _spawn_kwargs() -> Dict[str, Any]:
 
 
 def start_run(request: RunRequest) -> RunRecord:
-    """Create a durable run directory and launch the public PHM-Vibench CLI."""
+    """Approve, preflight, and launch one exact PHMFactory execution snapshot."""
 
-    normalized = prepare_request(request)
+    approved = approve_request(request)
     with _LOCK:
-        active = _active_managed_run(normalized.repo_root)
+        active = _active_managed_run(approved.repo_root)
         if active:
             raise RunConflictError(
                 f"This Streamlit worker already manages active run {active}. "
                 "Cancel or finish it before starting another experiment."
             )
-        run_root = _run_root(normalized.repo_root)
+        run_root = _run_root(approved.repo_root)
         if run_root.is_dir():
             for existing_dir in sorted(run_root.iterdir(), reverse=True):
                 if not existing_dir.is_dir() or not (existing_dir / "run.json").is_file():
                     continue
                 try:
-                    existing = get_run(normalized.repo_root, existing_dir.name)
+                    existing = get_run(approved.repo_root, existing_dir.name)
                 except RunServiceError:
                     continue
                 if existing.is_active:
@@ -306,32 +392,30 @@ def start_run(request: RunRequest) -> RunRecord:
                     )
 
         run_id = _new_run_id()
-        run_dir = _run_root(normalized.repo_root) / run_id
+        run_dir = _run_root(approved.repo_root) / run_id
         run_dir.mkdir(parents=True, exist_ok=False)
         config_path = run_dir / "execution.yaml"
-        if normalized.config_source is not None:
-            shutil.copyfile(normalized.config_source, config_path)
-        else:
-            config_path.write_text(normalized.config_yaml, encoding="utf-8")
+        config_path.write_text(approved.config_yaml, encoding="utf-8")
+        try:
+            _run_public_preflight(approved.repo_root, config_path)
+        except RunServiceError:
+            shutil.rmtree(run_dir)
+            raise
 
-        command = build_main_command(
-            normalized.repo_root,
-            config_path,
-            normalized.overrides,
-        )
+        command = build_main_command(approved.repo_root, config_path)
         log_path = run_dir / "run.log"
         created_at = _utc_now()
-        restart_of = str(normalized.metadata.get("restart_of") or "")
+        restart_of = str(approved.metadata.get("restart_of") or "")
         payload: Dict[str, Any] = {
             "schema_version": 1,
             "run_id": run_id,
             "status": "starting",
-            "template_id": normalized.template_id,
-            "mode": normalized.mode,
-            "config_path": str(config_path.relative_to(normalized.repo_root)),
-            "log_path": str(log_path.relative_to(normalized.repo_root)),
-            "output_root": normalized.output_root,
-            "overrides": [[key, value] for key, value in normalized.overrides],
+            "template_id": approved.template_id,
+            "mode": approved.mode,
+            "config_path": str(config_path.relative_to(approved.repo_root)),
+            "log_path": str(log_path.relative_to(approved.repo_root)),
+            "output_root": approved.output_root,
+            "overrides": [],
             "command": list(command),
             "pid": None,
             "exit_code": None,
@@ -341,7 +425,7 @@ def start_run(request: RunRequest) -> RunRecord:
             "cancel_requested": False,
             "error": "",
             "restart_of": restart_of,
-            "metadata": dict(normalized.metadata),
+            "metadata": dict(approved.metadata),
         }
         _atomic_write_json(_manifest_path(run_dir), payload)
 
@@ -351,7 +435,7 @@ def start_run(request: RunRequest) -> RunRecord:
         try:
             process = subprocess.Popen(
                 list(command),
-                cwd=str(normalized.repo_root),
+                cwd=str(approved.repo_root),
                 env=env,
                 stdin=subprocess.DEVNULL,
                 stdout=log_handle,
@@ -373,16 +457,15 @@ def start_run(request: RunRequest) -> RunRecord:
         payload.update(status="running", pid=process.pid, started_at=_utc_now())
         _atomic_write_json(_manifest_path(run_dir), payload)
         managed = _ManagedProcess(process=process, log_handle=log_handle, run_dir=run_dir)
-        _PROCESSES[_key(normalized.repo_root, run_id)] = managed
+        _PROCESSES[_key(approved.repo_root, run_id)] = managed
         monitor = threading.Thread(
             target=_monitor_process,
-            args=(normalized.repo_root, run_id, managed),
+            args=(approved.repo_root, run_id, managed),
             name=f"phm-vibench-run-{run_id}",
             daemon=True,
         )
         monitor.start()
         return _record(payload, run_dir)
-
 
 def _monitor_process(repo_root: Path, run_id: str, managed: _ManagedProcess) -> None:
     return_code: Optional[int] = None

--- a/apps/streamlit/workspace.py
+++ b/apps/streamlit/workspace.py
@@ -419,19 +419,29 @@ def main() -> None:
     )
     if report_is_current:
         _render_validation(report)
+        if report.ok:
+            st.caption(
+                "Validated snapshot: approved edits are folded into the YAML used for "
+                "download, public preflight, execution, and restart."
+            )
     elif isinstance(report, ValidationReport):
         st.warning(
             "The configuration changed after validation. Validate it again before running."
         )
 
-    can_download = bool(report_is_current and report.ok and not configuration_has_error)
+    approved_yaml_text = (
+        dump_yaml(report.resolved)
+        if report_is_current and report.ok and report.resolved
+        else ""
+    )
+    can_download = bool(approved_yaml_text and not configuration_has_error)
     can_run = bool(can_download and readiness.can_execute and data_status.ready)
     render_launch_blockers(readiness, data_status)
 
     if can_download:
         download_col.download_button(
             "Download execution YAML",
-            data=execution_yaml_text,
+            data=approved_yaml_text,
             file_name="phmfactory_config.yaml",
             mime="application/x-yaml",
             use_container_width=True,
@@ -461,8 +471,8 @@ def main() -> None:
                     repo_root=repo_root,
                     template_id=selected_id,
                     mode=mode,
-                    config_yaml=execution_yaml_text,
-                    overrides=overrides,
+                    config_yaml=approved_yaml_text,
+                    overrides=(),
                     output_root=str(resolved_output or "save"),
                     metadata={
                         "registry_path": entry.path,

--- a/doc/changelog/2026-09-08-streamlit-approved-config-preflight.md
+++ b/doc/changelog/2026-09-08-streamlit-approved-config-preflight.md
@@ -1,0 +1,21 @@
+# Streamlit uses one approved execution configuration
+
+## User-visible change
+
+After validation, Streamlit materializes the public inspector's resolved mapping as one
+`execution.yaml`. Download, public preflight, the real CLI process, and restart consume
+that snapshot. Safe-field and raw override values are folded into the YAML during approval;
+the training command no longer receives a second override list.
+
+The run service repeats public config inspection for programmatic callers, then runs the
+existing `phmfactory preflight` against the exact saved file before starting training. A
+preflight failure removes the unused UI run directory and propagates the real diagnostic.
+No alternative device, data source, Pipeline, or parameter value is selected.
+
+## Scope
+
+This is a Streamlit adapter correction. It does not modify PHMFactory configuration
+composition, Factory/Pipeline code, datasets, split logic, objectives, metrics, checkpoint
+selection, or release claims. Result binding remains separate work: Metrics/Artifacts may
+still scan the configured output root, while direct paths in `run.log` remain authoritative
+until U3.

--- a/test/test_streamlit_public_contract.py
+++ b/test/test_streamlit_public_contract.py
@@ -46,7 +46,9 @@ def test_ui_run_service_executes_real_dummy(monkeypatch):
         config['data'] = dict(config['data'], cache_dir=str(directory / 'cache'))
         record = rs.start_run(rs.RunRequest(
             repo_root=ROOT, template_id='demo_00_smoke_dummy_dg', mode='Quick Start',
-            config_yaml=cs.dump_yaml(config), output_root=config['environment']['output_dir'],
+            config_yaml=cs.dump_yaml(config),
+            overrides=(('environment.seed', 23),),
+            output_root=config['environment']['output_dir'],
         ))
         try:
             deadline = time.monotonic() + 120
@@ -80,7 +82,16 @@ def test_ui_run_service_executes_real_dummy(monkeypatch):
             summary = json.loads(Path(values['run_summary']).read_text())
             assert summary['iterations'] == 1
             assert all(value['count'] == 1 for value in summary['metrics'].values())
-            assert 'validation_signature' not in json.loads((record.run_dir / 'run.json').read_text())
+            manifest = json.loads((record.run_dir / 'run.json').read_text())
+            assert 'validation_signature' not in manifest
+            assert manifest['overrides'] == []
+            assert '--override' not in record.command
+            snapshot_text = (record.run_dir / 'execution.yaml').read_text()
+            snapshot = cs.parse_yaml_text(snapshot_text)
+            assert snapshot['environment']['seed'] == 23
+            approved = cs.inspect_yaml_text(ROOT, snapshot_text)
+            assert approved.ok, (approved.error, approved.stderr)
+            assert approved.resolved == snapshot
         finally:
             if not rs.get_run(ROOT, record.run_id).is_terminal:
                 rs.cancel_run(ROOT, record.run_id, grace_seconds=1)

--- a/test/test_streamlit_run_service.py
+++ b/test/test_streamlit_run_service.py
@@ -8,6 +8,7 @@ from types import SimpleNamespace
 import pytest
 
 from apps.streamlit import run_service as run_service_module
+from apps.streamlit.config_service import apply_overrides, dump_yaml, load_yaml_mapping, parse_yaml_text
 from apps.streamlit.run_service import (
     RunConflictError,
     RunRequest,
@@ -20,6 +21,34 @@ from apps.streamlit.run_service import (
     restart_run,
     start_run,
 )
+
+@pytest.fixture(autouse=True)
+def _stub_public_run_boundaries(monkeypatch):
+    """Keep unit tests lightweight; real public subprocesses run in integration tests."""
+
+    def approve(request):
+        normalized = prepare_request(request)
+        config = (
+            load_yaml_mapping(normalized.config_source)
+            if normalized.config_source is not None
+            else parse_yaml_text(normalized.config_yaml)
+        )
+        config = apply_overrides(config, normalized.overrides)
+        environment = config.get('environment') or {}
+        output_root = str(environment.get('output_dir') or normalized.output_root)
+        return RunRequest(
+            repo_root=normalized.repo_root,
+            template_id=normalized.template_id,
+            mode=normalized.mode,
+            config_yaml=dump_yaml(config),
+            overrides=(),
+            output_root=output_root,
+            metadata=normalized.metadata,
+        )
+
+    monkeypatch.setattr(run_service_module, 'approve_request', approve)
+    monkeypatch.setattr(run_service_module, '_run_public_preflight', lambda root, path: None)
+
 
 CONFIG = '''\
 environment:
@@ -107,7 +136,7 @@ def test_successful_run_writes_manifest_and_log(tmp_path: Path):
             template_id='demo',
             mode='Quick Start',
             config_source=repo / 'configs' / 'demo.yaml',
-            overrides=(('trainer.num_epochs', 1),),
+            overrides=(('trainer.num_epochs', 2),),
             output_root='results/demo',
         )
     )
@@ -124,7 +153,11 @@ def test_successful_run_writes_manifest_and_log(tmp_path: Path):
     ]
     log = read_log_tail(final)
     assert 'CONFIG=outputs/streamlit/' in log
-    assert 'trainer.num_epochs' in log
+    assert 'OVERRIDES=None' in log
+    snapshot = (final.run_dir / 'execution.yaml').read_text(encoding='utf-8')
+    assert 'num_epochs: 2' in snapshot
+    assert '--override' not in final.command
+    assert final.overrides == ()
 
 
 def test_failed_process_is_recorded(tmp_path: Path):
@@ -257,3 +290,23 @@ def test_detached_manifest_blocks_a_second_run_on_posix(tmp_path: Path):
         start_run(
             RunRequest(repo_root=repo, template_id='demo', mode='Advanced', config_yaml=CONFIG)
         )
+
+
+def test_public_preflight_failure_does_not_launch_training(monkeypatch, tmp_path: Path):
+    repo = make_repo(tmp_path)
+
+    def fail_preflight(root, path):
+        raise RunServiceError('Public preflight rejected the approved execution.yaml before training.')
+
+    monkeypatch.setattr(run_service_module, '_run_public_preflight', fail_preflight)
+    with pytest.raises(RunServiceError, match='Public preflight rejected'):
+        start_run(
+            RunRequest(
+                repo_root=repo,
+                template_id='demo',
+                mode='Advanced',
+                config_yaml=CONFIG,
+            )
+        )
+    run_root = repo / 'outputs' / 'streamlit'
+    assert not run_root.exists() or not any(run_root.iterdir())


### PR DESCRIPTION
## Authorized promotion

Promote the single reviewed U2 commit currently on `dev` to the user-facing `main` branch.

`main...dev` was checked immediately before opening this PR: `dev` is ahead by exactly 1 commit and behind by 0. The delta contains only the six Streamlit U2 files from #240; research PR #231 is not included.

## User invariant

For Streamlit:

`approved config = downloaded YAML = public preflight config = executed config = restart config`

The UI folds safe-field/raw overrides into the inspector-resolved YAML. The existing public preflight runs on that exact saved file before training. There is no second override layer in the actual run.

## Scope boundary

No backend Factory/Pipeline/config-composition change, no data/split/objective/metric/checkpoint change, no THU/MFPT execution, no benchmark/release claim change, no batch scheduler, no Agent execution, no version/tag/package publication. U3 result-path binding remains separate.

## Evidence

PR #240 was squash-merged to `dev` as `58e38fa1c90c97ea76cadc906bda50817b4b94f4` after all five PR workflows succeeded. Codex review completed with no inline findings.

Use a merge commit for this `dev`→`main` promotion so the long-lived branch ancestry remains explicit. Do not squash this promotion.