### PR TITLE
release: promote Streamlit direct result binding

### DIFF
--- a/apps/streamlit/README.md
+++ b/apps/streamlit/README.md
@@ -38,8 +38,8 @@ does not trigger a different experiment.
 ## Edit a configuration
 
 **Quick Start** exposes common fields from `field_catalog.yaml`. **Advanced** also offers
-standalone YAML and one `key=value` override per line. Raw overrides have highest priority;
-the displayed command repeats `--override` for each value and is launched with `shell=False`.
+standalone YAML and one `key=value` override per line. Raw overrides have highest priority
+while the request is being inspected.
 
 The backend owns composition, strict types, Pipeline selection, and explicit local config.
 The UI does not auto-discover `configs/local/local.yaml`. Repository templates remain
@@ -61,7 +61,8 @@ outputs/streamlit/<run-id>/
 ```
 
 `run.json` records process state, command and timestamps. It is not a scientific evaluation
-or an integrity record. PHMFactory returns its own result paths in `run.log`:
+or an integrity record. PHMFactory returns its scientific result paths in the final CLI
+trailer written to `run.log`:
 
 ```text
 result_dir=...
@@ -72,32 +73,42 @@ primary_metrics=...
 run=completed
 ```
 
-Use those exact paths to confirm the current run. A training-only request does not have
-test metrics or a test summary. A non-zero exit remains failed even if partial files exist.
+The Metrics and Artifacts views bind to that exact `result_dir`. `test_metrics` and
+`run_summary` are consumed only when the reported files are inside the reported result
+directory. Headline cards come from the CLI `primary_metrics` summary, not from an arbitrary
+CSV row. Files elsewhere under the configured output root are never attributed to the run by
+mtime or filename. The Streamlit process directory remains available for its own YAML, log,
+and run record.
+
+A training-only request does not require test metrics or a test summary. A non-zero exit,
+cancelled run, or successful process without the final CLI trailer does not trigger a search
+for substitute results. The page keeps the process status and logs available and reports that
+direct scientific results are unavailable.
 
 The workspace can cancel its active process and repeat a prior configuration in a new run.
 One Streamlit worker manages one active experiment. Browser refresh does not submit a new
 run; a server restart may leave the child process detached and must not trigger automatic
 resubmission. Pause/resume and cluster scheduling are not supported.
 
-Current limitation: the Metrics/Artifacts views still discover files below the configured
-output root. Until direct-path result binding is implemented, do not use a shared-output
-view to attribute results from concurrent experiments. The per-run CLI log is authoritative.
-
 ## Troubleshooting
 
 A rejected configuration shows the inspector's original stderr. Copy the visible command
 and run it with the same Python and working directory. Use `phmfactory doctor` for environment
 issues. The Run action already executes `phmfactory preflight --config <execution.yaml>`
-before training; copy that saved YAML to reproduce the same preflight manually. Missing local data requires correcting the requested path; switching to
-the offline example is an explicit user action, never an automatic fallback.
+before training; copy that saved YAML to reproduce the same preflight manually. Missing local
+data requires correcting the requested path; switching to the offline example is an explicit
+user action, never an automatic fallback.
+
+If the process exits successfully but the page reports no direct results, inspect the full
+per-run `run.log`. The UI requires the public final trailer shown above and does not guess a
+result directory from adjacent files.
 
 ## Development and tests
 
 Keep changes within the existing services: `config_service.py` adapts the public inspector,
-`run_service.py` manages subprocesses, and `result_service.py` displays results. Field and
-template catalogues are UI metadata, not new experiment schemas. There is no experiment
-Agent or autonomous parameter search in this version.
+`run_service.py` manages subprocesses, and `result_service.py` consumes direct CLI results.
+Field and template catalogues are UI metadata, not new experiment schemas. There is no
+experiment Agent or autonomous parameter search in this version.
 
 ```bash
 python -m pytest -q \

--- a/apps/streamlit/result_service.py
+++ b/apps/streamlit/result_service.py
@@ -1,4 +1,10 @@
-"""Bounded result and artifact discovery for Streamlit experiment runs."""
+"""Direct PHMFactory result binding for Streamlit experiment runs.
+
+The public CLI is the scientific result authority. This module reads the final CLI
+trailer from the selected run log and only browses that exact ``result_dir`` plus the
+Streamlit process directory. It never scans a shared output root or uses mtime to guess
+which experiment produced a file.
+"""
 
 from __future__ import annotations
 
@@ -7,14 +13,16 @@ import json
 import math
 import os
 from collections import deque
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, List, Mapping, Optional, Sequence, Tuple
 
 try:
+    from .config_service import parse_yaml_text
     from .run_service import RunRecord
 except ImportError:  # pragma: no cover - Streamlit executes app.py as a script.
+    from config_service import parse_yaml_text  # type: ignore
     from run_service import RunRecord  # type: ignore
 
 
@@ -25,6 +33,7 @@ class DiscoveryLimits:
     max_files: int = 500
     max_metric_bytes: int = 2_000_000
     max_metric_rows: int = 500
+    max_log_bytes: int = 10_000_000
 
 
 @dataclass(frozen=True)
@@ -47,38 +56,36 @@ class MetricTable:
 
 
 @dataclass(frozen=True)
+class DirectResults:
+    completed: bool = False
+    result_dir: Optional[Path] = None
+    best_checkpoint: Optional[Path] = None
+    test_metrics: Optional[Path] = None
+    run_summary: Optional[Path] = None
+    primary_metrics: Mapping[str, Any] = field(default_factory=dict)
+    evaluation_requested: Optional[bool] = None
+    warnings: Tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
 class ResultBundle:
     run_id: str
     roots: Tuple[Path, ...]
     artifacts: Tuple[Artifact, ...]
     metrics: Tuple[MetricTable, ...]
+    direct: DirectResults = field(default_factory=DirectResults)
     warnings: Tuple[str, ...] = ()
     truncated: bool = False
 
 
 _IMAGE_EXTENSIONS = {".png", ".jpg", ".jpeg", ".webp"}
-_METRIC_NAMES = {
-    "metrics.json",
-    "results.json",
-    "summary.json",
-    "all_results.csv",
-}
 _CONFIG_NAMES = {"execution.yaml", "config.yaml", "config.yml", "hparams.yaml"}
 _TEXT_EXTENSIONS = {".txt", ".md"}
 _DATA_EXTENSIONS = {".csv", ".json", ".parquet", ".npy", ".npz"}
 _DOCUMENT_EXTENSIONS = {".pdf", ".svg", ".html"}
-
-
-def _parse_time(value: str) -> Optional[float]:
-    if not value:
-        return None
-    try:
-        dt = datetime.fromisoformat(value)
-    except ValueError:
-        return None
-    if dt.tzinfo is None:
-        dt = dt.replace(tzinfo=timezone.utc)
-    return dt.timestamp()
+_DIRECT_KEYS = frozenset(
+    {"result_dir", "best_checkpoint", "test_metrics", "run_summary", "primary_metrics"}
+)
 
 
 def _classify(path: Path) -> str:
@@ -86,7 +93,9 @@ def _classify(path: Path) -> str:
     suffix = path.suffix.lower()
     if suffix in _IMAGE_EXTENSIONS:
         return "image"
-    if name in _METRIC_NAMES or name.startswith("test_result") and suffix == ".csv":
+    if name in {"all_results.csv", "run_summary.json", "metrics.json"} or (
+        name.startswith("test_result") and suffix == ".csv"
+    ):
         return "metrics"
     if name in _CONFIG_NAMES or suffix in {".yaml", ".yml"}:
         return "config"
@@ -110,48 +119,177 @@ def format_bytes(size: int) -> str:
     return f"{value:.1f} TB"
 
 
-def _is_dangerous_root(repo_root: Path, candidate: Path) -> bool:
-    resolved = candidate.resolve()
-    anchor = Path(resolved.anchor)
-    if resolved == anchor or resolved == Path.home().resolve():
-        return True
-    repo = repo_root.resolve()
-    if resolved == repo:
-        return True
-    try:
-        repo.relative_to(resolved)
-        return True  # candidate is a parent of the repository
-    except ValueError:
-        return False
-
-
-def _output_root(repo_root: Path, value: str) -> Optional[Path]:
-    if not value or "{" in value or "}" in value:
-        return None
+def _resolve_cli_path(repo_root: Path, value: str) -> Path:
     raw = Path(value).expanduser()
     return raw.resolve() if raw.is_absolute() else (repo_root / raw).resolve()
 
 
-def result_roots(repo_root: Path, record: RunRecord) -> Tuple[Path, ...]:
-    roots: List[Path] = [record.run_dir.resolve()]
-    output = _output_root(repo_root.resolve(), record.output_root)
-    if output is not None and output not in roots:
-        roots.append(output)
-    return tuple(roots)
+def _is_within(path: Path, root: Path) -> bool:
+    try:
+        path.resolve().relative_to(root.resolve())
+        return True
+    except ValueError:
+        return False
+
+
+def _evaluation_requested(record: RunRecord) -> Optional[bool]:
+    config_path = record.run_dir / "execution.yaml"
+    if not config_path.is_file():
+        return None
+    try:
+        config = parse_yaml_text(
+            config_path.read_text(encoding="utf-8"), source=str(config_path)
+        )
+    except (OSError, RuntimeError):
+        return None
+    trainer = config.get("trainer")
+    value = trainer.get("test_after_fit") if isinstance(trainer, Mapping) else None
+    return value if isinstance(value, bool) else None
+
+
+def _read_log(record: RunRecord, *, max_bytes: int) -> Tuple[str, str]:
+    """Read a bounded log tail because the public result trailer is emitted last."""
+
+    path = record.run_dir / "run.log"
+    if not path.is_file():
+        return "", "Run log is not available."
+    try:
+        size = path.stat().st_size
+        with path.open("rb") as handle:
+            if size > max_bytes:
+                handle.seek(-max_bytes, os.SEEK_END)
+                handle.readline()  # discard a partial first line
+            data = handle.read()
+    except OSError as error:
+        return "", f"Could not read run log: {error}"
+    return data.decode("utf-8", errors="replace"), ""
+
+
+def _final_cli_trailer(text: str) -> Optional[Dict[str, str]]:
+    lines = text.splitlines()
+    try:
+        completed_index = max(
+            index for index, line in enumerate(lines) if line == "run=completed"
+        )
+    except ValueError:
+        return None
+
+    values: Dict[str, str] = {}
+    for line in reversed(lines[:completed_index]):
+        if not line:
+            continue
+        key, separator, value = line.partition("=")
+        if not separator or key not in _DIRECT_KEYS:
+            break
+        values.setdefault(key, value)
+    return values
+
+
+def parse_direct_results(
+    repo_root: Path,
+    record: RunRecord,
+    *,
+    limits: DiscoveryLimits = DiscoveryLimits(),
+) -> DirectResults:
+    evaluation_requested = _evaluation_requested(record)
+    if record.status != "succeeded" or record.exit_code not in {0, None}:
+        return DirectResults(
+            evaluation_requested=evaluation_requested,
+            warnings=(
+                "Direct scientific results are not accepted for a non-successful run.",
+            ),
+        )
+
+    text, log_warning = _read_log(record, max_bytes=limits.max_log_bytes)
+    if log_warning:
+        return DirectResults(
+            evaluation_requested=evaluation_requested, warnings=(log_warning,)
+        )
+    trailer = _final_cli_trailer(text)
+    if trailer is None:
+        return DirectResults(
+            evaluation_requested=evaluation_requested,
+            warnings=(
+                "The process succeeded but no final `run=completed` CLI trailer was found.",
+            ),
+        )
+
+    warnings: List[str] = []
+    raw_result_dir = trailer.get("result_dir", "").strip()
+    if not raw_result_dir:
+        return DirectResults(
+            completed=True,
+            evaluation_requested=evaluation_requested,
+            warnings=("The completed CLI trailer did not report result_dir.",),
+        )
+    result_dir = _resolve_cli_path(repo_root.resolve(), raw_result_dir)
+    if not result_dir.is_dir():
+        return DirectResults(
+            completed=True,
+            evaluation_requested=evaluation_requested,
+            warnings=(f"Reported result_dir is not a directory: {result_dir}",),
+        )
+
+    resolved_files: Dict[str, Optional[Path]] = {
+        "best_checkpoint": None,
+        "test_metrics": None,
+        "run_summary": None,
+    }
+    for key in resolved_files:
+        raw_value = trailer.get(key, "").strip()
+        if not raw_value:
+            continue
+        path = _resolve_cli_path(repo_root.resolve(), raw_value)
+        if not _is_within(path, result_dir):
+            warnings.append(f"Ignoring {key} outside reported result_dir: {path}")
+            continue
+        if not path.is_file():
+            warnings.append(f"Reported {key} does not exist: {path}")
+            continue
+        resolved_files[key] = path
+
+    primary_metrics: Mapping[str, Any] = {}
+    raw_primary = trailer.get("primary_metrics")
+    if raw_primary is not None:
+        try:
+            parsed = json.loads(raw_primary)
+        except json.JSONDecodeError as error:
+            warnings.append(f"Could not parse primary_metrics from the CLI trailer: {error}")
+        else:
+            if isinstance(parsed, dict):
+                primary_metrics = parsed
+            else:
+                warnings.append("primary_metrics from the CLI trailer is not a mapping.")
+
+    if evaluation_requested is True:
+        for key in ("test_metrics", "run_summary"):
+            if resolved_files[key] is None:
+                warnings.append(
+                    f"Evaluation was requested but the CLI did not provide usable {key}."
+                )
+
+    return DirectResults(
+        completed=True,
+        result_dir=result_dir,
+        best_checkpoint=resolved_files["best_checkpoint"],
+        test_metrics=resolved_files["test_metrics"],
+        run_summary=resolved_files["run_summary"],
+        primary_metrics=primary_metrics,
+        evaluation_requested=evaluation_requested,
+        warnings=tuple(warnings),
+    )
 
 
 def _discover_root(
     root: Path,
     *,
-    started_epoch: Optional[float],
     limits: DiscoveryLimits,
-    include_old: bool,
 ) -> Tuple[List[Artifact], List[str], bool]:
     artifacts: List[Artifact] = []
     warnings: List[str] = []
     truncated = False
     if not root.exists():
-        warnings.append(f"Result root does not exist yet: {root}")
+        warnings.append(f"Result root does not exist: {root}")
         return artifacts, warnings, truncated
     if not root.is_dir():
         warnings.append(f"Result root is not a directory: {root}")
@@ -166,8 +304,8 @@ def _discover_root(
             continue
         try:
             entries = list(os.scandir(directory))
-        except OSError as exc:
-            warnings.append(f"Could not scan {directory}: {exc}")
+        except OSError as error:
+            warnings.append(f"Could not scan {directory}: {error}")
             continue
         entries_seen += len(entries)
         if entries_seen > limits.max_entries:
@@ -188,12 +326,6 @@ def _discover_root(
                     continue
                 stat = entry.stat(follow_symlinks=False)
             except OSError:
-                continue
-            if (
-                not include_old
-                and started_epoch is not None
-                and stat.st_mtime < started_epoch - 5.0
-            ):
                 continue
             try:
                 relative = path.relative_to(root).as_posix()
@@ -229,8 +361,12 @@ def _rows_from_json(payload: Any) -> Tuple[List[Dict[str, Any]], str]:
         for key in ("metrics", "results", "summary"):
             candidate = payload.get(key)
             if isinstance(candidate, dict):
-                return [{str(k): _normalize_cell(v) for k, v in candidate.items()}], ""
-            if isinstance(candidate, list) and all(isinstance(item, dict) for item in candidate):
+                return [
+                    {str(k): _normalize_cell(v) for k, v in candidate.items()}
+                ], ""
+            if isinstance(candidate, list) and all(
+                isinstance(item, dict) for item in candidate
+            ):
                 return [
                     {str(k): _normalize_cell(v) for k, v in item.items()}
                     for item in candidate
@@ -238,17 +374,18 @@ def _rows_from_json(payload: Any) -> Tuple[List[Dict[str, Any]], str]:
         return [{str(k): _normalize_cell(v) for k, v in payload.items()}], ""
     if isinstance(payload, list) and all(isinstance(item, dict) for item in payload):
         return [
-            {str(k): _normalize_cell(v) for k, v in item.items()}
-            for item in payload
+            {str(k): _normalize_cell(v) for k, v in item.items()} for item in payload
         ], ""
     return [], "JSON metrics must be an object or a list of objects."
 
 
-def load_metric_table(path: Path, limits: DiscoveryLimits = DiscoveryLimits()) -> MetricTable:
+def load_metric_table(
+    path: Path, limits: DiscoveryLimits = DiscoveryLimits()
+) -> MetricTable:
     try:
         size = path.stat().st_size
-    except OSError as exc:
-        return MetricTable(source=path, warning=f"Could not stat metric file: {exc}")
+    except OSError as error:
+        return MetricTable(source=path, warning=f"Could not stat metric file: {error}")
     if size > limits.max_metric_bytes:
         return MetricTable(
             source=path,
@@ -275,8 +412,8 @@ def load_metric_table(path: Path, limits: DiscoveryLimits = DiscoveryLimits()) -
                         break
         else:
             return MetricTable(source=path, warning="Unsupported metric format.")
-    except (OSError, UnicodeDecodeError, csv.Error, json.JSONDecodeError) as exc:
-        return MetricTable(source=path, warning=f"Could not parse metrics: {exc}")
+    except (OSError, UnicodeDecodeError, csv.Error, json.JSONDecodeError) as error:
+        return MetricTable(source=path, warning=f"Could not parse metrics: {error}")
 
     truncated = len(rows) > limits.max_metric_rows
     if truncated:
@@ -298,15 +435,19 @@ def load_metric_table(path: Path, limits: DiscoveryLimits = DiscoveryLimits()) -
     )
 
 
-def _metric_priority(artifact: Artifact) -> Tuple[int, str]:
-    name = artifact.path.name.lower()
-    if name == "all_results.csv":
-        return (0, artifact.relative_path)
-    if name == "metrics.json":
-        return (1, artifact.relative_path)
-    if name.startswith("test_result"):
-        return (2, artifact.relative_path)
-    return (3, artifact.relative_path)
+def primary_metric_headlines(
+    primary_metrics: Mapping[str, Any], *, limit: int = 4
+) -> Tuple[Tuple[str, float], ...]:
+    values: List[Tuple[str, float]] = []
+    for name, raw in primary_metrics.items():
+        candidate = raw.get("mean") if isinstance(raw, Mapping) else raw
+        if isinstance(candidate, (int, float)) and not isinstance(candidate, bool):
+            value = float(candidate)
+            if math.isfinite(value):
+                values.append((str(name), value))
+                if len(values) >= limit:
+                    break
+    return tuple(values)
 
 
 def discover_results(
@@ -316,29 +457,20 @@ def discover_results(
     limits: DiscoveryLimits = DiscoveryLimits(),
 ) -> ResultBundle:
     repo = repo_root.resolve()
-    roots = result_roots(repo, record)
-    started_epoch = _parse_time(record.started_at)
-    artifacts: List[Artifact] = []
-    warnings: List[str] = []
-    truncated = False
-    accepted_roots: List[Path] = []
+    direct = parse_direct_results(repo, record, limits=limits)
+    roots: List[Path] = [record.run_dir.resolve()]
+    if direct.result_dir is not None and direct.result_dir not in roots:
+        roots.append(direct.result_dir)
 
+    artifacts: List[Artifact] = []
+    warnings: List[str] = list(direct.warnings)
+    truncated = False
     for root in roots:
-        if root != record.run_dir.resolve() and _is_dangerous_root(repo, root):
-            warnings.append(f"Refusing to scan overly broad result root: {root}")
-            continue
-        accepted_roots.append(root)
-        found, root_warnings, root_truncated = _discover_root(
-            root,
-            started_epoch=started_epoch,
-            limits=limits,
-            include_old=root == record.run_dir.resolve(),
-        )
+        found, root_warnings, root_truncated = _discover_root(root, limits=limits)
         artifacts.extend(found)
         warnings.extend(root_warnings)
         truncated = truncated or root_truncated
 
-    # De-duplicate the same physical file when roots overlap.
     unique: Dict[Path, Artifact] = {}
     for artifact in artifacts:
         try:
@@ -346,59 +478,23 @@ def discover_results(
         except OSError:
             key = artifact.path.absolute()
         unique.setdefault(key, artifact)
-    artifacts = sorted(unique.values(), key=lambda item: (item.kind, item.relative_path))
-
-    metric_artifacts = sorted(
-        (
-            item
-            for item in artifacts
-            if item.kind == "metrics"
-            or item.path.suffix.lower() in {".csv", ".json"}
-            and any(token in item.path.name.lower() for token in ("metric", "result", "summary"))
-        ),
-        key=_metric_priority,
+    artifacts = sorted(
+        unique.values(), key=lambda item: (item.kind, item.relative_path)
     )
-    metrics = tuple(load_metric_table(item.path, limits) for item in metric_artifacts[:12])
+
+    metric_paths = [
+        path for path in (direct.test_metrics, direct.run_summary) if path is not None
+    ]
+    metrics = tuple(load_metric_table(path, limits) for path in metric_paths)
     return ResultBundle(
         run_id=record.run_id,
-        roots=tuple(accepted_roots),
+        roots=tuple(roots),
         artifacts=tuple(artifacts),
         metrics=metrics,
+        direct=direct,
         warnings=tuple(dict.fromkeys(warnings)),
         truncated=truncated,
     )
-
-
-def headline_metrics(
-    tables: Sequence[MetricTable],
-    *,
-    limit: int = 4,
-) -> Tuple[Tuple[str, Any], ...]:
-    values: List[Tuple[str, Any]] = []
-    seen = set()
-    for table in tables:
-        if not table.rows:
-            continue
-        row = table.rows[-1]
-        for key, raw in row.items():
-            if key in seen or raw in (None, ""):
-                continue
-            value: Any = raw
-            if isinstance(raw, str):
-                try:
-                    value = float(raw)
-                except ValueError:
-                    continue
-            if (
-                isinstance(value, (int, float))
-                and not isinstance(value, bool)
-                and math.isfinite(float(value))
-            ):
-                seen.add(key)
-                values.append((str(key), value))
-                if len(values) >= limit:
-                    return tuple(values)
-    return tuple(values)
 
 
 def artifact_groups(bundle: ResultBundle) -> Mapping[str, Tuple[Artifact, ...]]:

--- a/apps/streamlit/ui_runtime.py
+++ b/apps/streamlit/ui_runtime.py
@@ -1,4 +1,4 @@
-"""Live run, result, artifact, and log rendering."""
+"""Live run, exact result, artifact, and log rendering."""
 
 from __future__ import annotations
 
@@ -14,7 +14,7 @@ try:
         artifact_groups,
         discover_results,
         format_bytes,
-        headline_metrics,
+        primary_metric_headlines,
     )
     from .run_service import (
         RunRecord,
@@ -33,7 +33,7 @@ except ImportError:  # pragma: no cover
         artifact_groups,
         discover_results,
         format_bytes,
-        headline_metrics,
+        primary_metric_headlines,
     )
     from run_service import (  # type: ignore
         RunRecord,
@@ -102,15 +102,21 @@ def _render_overview(record: RunRecord, bundle: Any) -> None:
     st.code(format_command(record.command), language="bash")
     left, right = st.columns(2)
     with left:
-        st.markdown("**Run directory**")
+        st.markdown("**Streamlit process directory**")
         st.code(str(record.run_dir), language="text")
-        st.markdown("**Output root**")
-        st.code(record.output_root or "save", language="text")
+        st.markdown("**CLI-reported result directory**")
+        st.code(
+            str(bundle.direct.result_dir) if bundle.direct.result_dir is not None else "Not reported",
+            language="text",
+        )
     with right:
         st.markdown("**Template / mode**")
         st.write(f"{record.template_id or 'custom'} · {record.mode or 'unknown'}")
-        st.markdown("**Discovered roots**")
-        st.code("\n".join(str(path) for path in bundle.roots) or "None", language="text")
+        st.markdown("**Exact result roots used by this page**")
+        st.code("\n".join(str(path) for path in bundle.roots), language="text")
+    if bundle.direct.best_checkpoint is not None:
+        st.markdown("**Best checkpoint**")
+        st.code(str(bundle.direct.best_checkpoint), language="text")
     if record.error:
         st.warning(record.error)
     if record.metadata:
@@ -121,16 +127,24 @@ def _render_overview(record: RunRecord, bundle: Any) -> None:
 def _render_metrics(bundle: Any) -> None:
     for warning in bundle.warnings:
         st.warning(warning)
-    headlines = headline_metrics(bundle.metrics)
+
+    headlines = primary_metric_headlines(bundle.direct.primary_metrics)
     if headlines:
         cols = st.columns(len(headlines))
         for col, (name, value) in zip(cols, headlines):
-            col.metric(name, f"{value:.5g}" if isinstance(value, float) else value)
-    if not bundle.metrics:
-        st.info(
-            "No structured metrics artifact was found. The run and raw logs remain available."
-        )
-        return
+            col.metric(name, f"{value:.5g}")
+
+    if bundle.direct.evaluation_requested is False:
+        st.info("This approved configuration was training-only; post-fit test metrics were not requested.")
+    elif bundle.direct.completed and not bundle.metrics:
+        st.info("The completed CLI did not provide a usable test-metrics or run-summary file.")
+    elif not bundle.direct.completed:
+        st.info("Direct metrics become available only after the selected CLI run completes successfully.")
+
+    if bundle.direct.primary_metrics:
+        with st.expander("Primary metric summary returned by PHMFactory"):
+            st.json(dict(bundle.direct.primary_metrics))
+
     for table in bundle.metrics:
         st.markdown(f"**{table.source.name}**")
         if table.warning:
@@ -143,7 +157,7 @@ def _render_artifacts(bundle: Any, run_id: str) -> None:
     groups = artifact_groups(bundle)
     images = groups.get("image", ())
     if images:
-        st.markdown("**Visual artifacts**")
+        st.markdown("**Visual artifacts from this exact run**")
         columns = st.columns(min(3, len(images)))
         for index, artifact in enumerate(images):
             with columns[index % len(columns)]:
@@ -153,8 +167,8 @@ def _render_artifacts(bundle: Any, run_id: str) -> None:
                         caption=artifact.relative_path,
                         use_container_width=True,
                     )
-                except Exception as exc:
-                    st.warning(f"Could not render {artifact.relative_path}: {exc}")
+                except Exception as error:
+                    st.warning(f"Could not render {artifact.relative_path}: {error}")
     rows = [
         {
             "type": artifact.kind,
@@ -168,7 +182,7 @@ def _render_artifacts(bundle: Any, run_id: str) -> None:
     if rows:
         st.dataframe(rows, use_container_width=True, hide_index=True)
     else:
-        st.info("No artifacts have been discovered yet.")
+        st.info("No artifacts are available for this run.")
 
     downloadable = [
         item
@@ -218,8 +232,8 @@ def _render_run_actions(repo_root: Path, record: RunRecord) -> None:
                 cancel_run(repo_root, record.run_id)
                 st.toast("Cancellation requested.")
                 st.rerun()
-            except RunServiceError as exc:
-                _render_error("The run could not be cancelled.", exc)
+            except RunServiceError as error:
+                _render_error("The run could not be cancelled.", error)
     else:
         left.button(
             "Cancel run",
@@ -239,10 +253,10 @@ def _render_run_actions(repo_root: Path, record: RunRecord) -> None:
                 restarted = restart_run(repo_root, record.run_id)
                 st.session_state.active_run_id = restarted.run_id
                 st.session_state.selected_run_id = restarted.run_id
-                st.toast("Experiment restarted from its immutable snapshot.")
+                st.toast("Experiment restarted from its approved snapshot.")
                 st.rerun()
-            except RunServiceError as exc:
-                _render_error("The run could not be restarted.", exc)
+            except RunServiceError as error:
+                _render_error("The run could not be restarted.", error)
     else:
         middle.button(
             "Restart same run",
@@ -251,13 +265,13 @@ def _render_run_actions(repo_root: Path, record: RunRecord) -> None:
             use_container_width=True,
         )
 
-    manifest = record.run_dir / "run.json"
-    if manifest.is_file():
+    record_path = record.run_dir / "run.json"
+    if record_path.is_file():
         right.download_button(
-            "Download run manifest",
-            data=manifest.read_bytes(),
+            "Download run record",
+            data=record_path.read_bytes(),
             file_name=f"{record.run_id}.json",
-            key=f"manifest::{record.run_id}",
+            key=f"run-record::{record.run_id}",
             use_container_width=True,
         )
 
@@ -267,8 +281,8 @@ def _render_live_run(repo_root_text: str, run_id: str) -> None:
     repo_root = Path(repo_root_text)
     try:
         record = get_run(repo_root, run_id)
-    except RunServiceError as exc:
-        _render_error("The selected run could not be loaded.", exc)
+    except RunServiceError as error:
+        _render_error("The selected run could not be loaded.", error)
         return
 
     st.markdown(
@@ -288,8 +302,8 @@ def _render_live_run(repo_root_text: str, run_id: str) -> None:
 
     try:
         bundle = discover_results(repo_root, record)
-    except Exception as exc:  # keep logs/actions available if artifact parsing fails.
-        st.warning(f"Result discovery failed without affecting the run: {exc}")
+    except Exception as error:  # keep logs/actions available if result parsing fails.
+        st.warning(f"Result binding failed without affecting the run: {error}")
         bundle = None
 
     tabs = st.tabs(("Overview", "Metrics", "Artifacts", "Logs"))

--- a/doc/changelog/2026-09-08-streamlit-direct-results.md
+++ b/doc/changelog/2026-09-08-streamlit-direct-results.md
@@ -1,0 +1,26 @@
+# Streamlit binds results to the selected CLI run
+
+## User-visible change
+
+The Streamlit Metrics and Artifacts views no longer scan the configured shared output root
+or use file modification time to infer which experiment produced a result. After a successful
+process, the UI reads the final public CLI trailer from that run's own `run.log` and accepts
+only the reported `result_dir`, `best_checkpoint`, `test_metrics`, `run_summary`, and
+`primary_metrics`.
+
+The reported metric and summary files must resolve inside the reported `result_dir` before
+the UI reads them. Headline metric cards use `primary_metrics` returned by PHMFactory rather
+than selecting numeric columns from a discovered table. The exact result directory may still
+be browsed for images and small artifacts; the Streamlit process directory remains separately
+available for `execution.yaml`, `run.json`, and `run.log`.
+
+A failed/cancelled process, a successful process without the final `run=completed` trailer,
+or a direct path outside `result_dir` does not trigger a fallback search. Training-only runs
+are identified from the approved `trainer.test_after_fit` value and do not require test files.
+
+## Scope
+
+Only the optional Streamlit result adapter, UI rendering, focused tests, integration test,
+and documentation change. PHMFactory result generation, metric mathematics, run summary,
+checkpoint selection, Factory/Pipeline behavior, and experiment configuration are unchanged.
+Batch experiments and Agent execution remain separate later work.

--- a/test/test_streamlit_public_contract.py
+++ b/test/test_streamlit_public_contract.py
@@ -8,6 +8,7 @@ import time
 from pathlib import Path
 
 from apps.streamlit import config_service as cs
+from apps.streamlit import result_service as results
 from apps.streamlit import run_service as rs
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -92,6 +93,22 @@ def test_ui_run_service_executes_real_dummy(monkeypatch):
             approved = cs.inspect_yaml_text(ROOT, snapshot_text)
             assert approved.ok, (approved.error, approved.stderr)
             assert approved.resolved == snapshot
+
+            # A newer-looking file elsewhere in the configured output root cannot be
+            # attributed to this run; the page binds only the CLI-reported result_dir.
+            foreign = directory / 'results' / 'foreign-run'
+            foreign.mkdir(parents=True)
+            (foreign / 'all_results.csv').write_text('acc\n1.0\n', encoding='utf-8')
+            bundle = results.discover_results(ROOT, record)
+            assert bundle.direct.completed
+            assert bundle.direct.result_dir == result_dir
+            assert bundle.direct.best_checkpoint == Path(values['best_checkpoint']).resolve()
+            assert bundle.direct.test_metrics == Path(values['test_metrics']).resolve()
+            assert bundle.direct.run_summary == Path(values['run_summary']).resolve()
+            assert bundle.direct.primary_metrics == metrics
+            assert bundle.roots == (record.run_dir.resolve(), result_dir)
+            assert all('foreign-run' not in str(item.path) for item in bundle.artifacts)
+            assert results.primary_metric_headlines(bundle.direct.primary_metrics)
         finally:
             if not rs.get_run(ROOT, record.run_id).is_terminal:
                 rs.cancel_run(ROOT, record.run_id, grace_seconds=1)

--- a/test/test_streamlit_result_service.py
+++ b/test/test_streamlit_result_service.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import json
+import os
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -7,94 +9,241 @@ from apps.streamlit.result_service import (
     DiscoveryLimits,
     artifact_groups,
     discover_results,
-    headline_metrics,
     load_metric_table,
+    parse_direct_results,
+    primary_metric_headlines,
 )
 from apps.streamlit.run_service import RunRecord
 
 
-def record(tmp_path: Path, *, output_root: str = 'results/demo') -> tuple[Path, RunRecord]:
-    repo = tmp_path / 'repo'
+CONFIG = '''\
+environment:
+  seed: 0
+  output_dir: results/demo
+data:
+  data_dir: data
+  metadata_file: dummy.csv
+model:
+  name: Dummy
+  type: Dummy
+task:
+  name: classification
+  type: DG
+trainer:
+  num_epochs: 1
+  device: cpu
+  test_after_fit: true
+'''
+
+
+def record(
+    tmp_path: Path,
+    *,
+    status: str = "succeeded",
+    exit_code: int | None = 0,
+    test_after_fit: bool = True,
+) -> tuple[Path, RunRecord]:
+    repo = tmp_path / "repo"
     repo.mkdir()
-    (repo / 'main.py').write_text('')
-    (repo / 'configs').mkdir()
-    run_dir = repo / 'outputs' / 'streamlit' / 'run-1'
+    (repo / "main.py").write_text("")
+    (repo / "configs").mkdir()
+    run_dir = repo / "outputs" / "streamlit" / "run-1"
     run_dir.mkdir(parents=True)
+    config = CONFIG.replace(
+        "  test_after_fit: true",
+        f"  test_after_fit: {'true' if test_after_fit else 'false'}",
+    )
+    (run_dir / "execution.yaml").write_text(config, encoding="utf-8")
     rec = RunRecord(
-        run_id='run-1',
-        status='succeeded',
+        run_id="run-1",
+        status=status,
         run_dir=run_dir,
-        command=('python', 'main.py'),
-        output_root=output_root,
+        command=("python", "main.py"),
+        output_root="results/demo",
         started_at=datetime.now(timezone.utc).isoformat(),
+        exit_code=exit_code,
     )
     return repo, rec
 
 
-def test_discovers_metrics_images_and_logs(tmp_path: Path):
-    repo, rec = record(tmp_path)
-    result_dir = repo / 'results' / 'demo' / 'exp' / 'iter_0'
+def write_direct_result(
+    repo: Path,
+    rec: RunRecord,
+    *,
+    result_name: str = "run-a",
+    include_evaluation: bool = True,
+) -> Path:
+    result_dir = repo / "results" / "demo" / result_name
     result_dir.mkdir(parents=True)
-    (result_dir / 'all_results.csv').write_text('acc,loss\n0.9,0.1\n', encoding='utf-8')
-    (result_dir / 'plot.png').write_bytes(b'png')
-    (rec.run_dir / 'run.log').write_text('done', encoding='utf-8')
+    checkpoint = result_dir / "iter_0" / "best.ckpt"
+    checkpoint.parent.mkdir()
+    checkpoint.write_text("checkpoint", encoding="utf-8")
+    lines = [
+        f"result_dir={result_dir}",
+        f"best_checkpoint={checkpoint}",
+    ]
+    if include_evaluation:
+        metrics = result_dir / "all_results.csv"
+        summary = result_dir / "run_summary.json"
+        metrics.write_text("acc,loss\n0.9,0.1\n", encoding="utf-8")
+        summary.write_text(
+            json.dumps({"iterations": 1, "metrics": {"acc": {"count": 1, "mean": 0.9}}}),
+            encoding="utf-8",
+        )
+        lines.extend((f"test_metrics={metrics}", f"run_summary={summary}"))
+        primary = {"acc": {"count": 1, "mean": 0.9, "sample_std": None}}
+    else:
+        primary = {}
+    lines.extend((f"primary_metrics={json.dumps(primary)}", "run=completed"))
+    (rec.run_dir / "run.log").write_text(
+        "training output\n" + "\n".join(lines) + "\n", encoding="utf-8"
+    )
+    return result_dir
+
+
+def test_direct_cli_result_is_the_only_scientific_root(tmp_path: Path):
+    repo, rec = record(tmp_path)
+    result_dir = write_direct_result(repo, rec)
+    (result_dir / "plot.png").write_bytes(b"png")
+
+    foreign = repo / "results" / "demo" / "newer-foreign-run"
+    foreign.mkdir(parents=True)
+    (foreign / "all_results.csv").write_text("acc\n0.01\n", encoding="utf-8")
+    (foreign / "foreign.png").write_bytes(b"foreign")
+    newer = (result_dir.stat().st_mtime + 60, result_dir.stat().st_mtime + 60)
+    os.utime(foreign / "all_results.csv", newer)
+    os.utime(foreign / "foreign.png", newer)
+
     bundle = discover_results(repo, rec)
+    assert bundle.direct.completed
+    assert bundle.direct.result_dir == result_dir.resolve()
+    assert bundle.roots == (rec.run_dir.resolve(), result_dir.resolve())
+    assert all("newer-foreign-run" not in str(item.path) for item in bundle.artifacts)
     groups = artifact_groups(bundle)
-    assert groups['image'][0].path.name == 'plot.png'
-    assert groups['log'][0].path.name == 'run.log'
-    assert bundle.metrics[0].rows[0]['acc'] == '0.9'
-    assert headline_metrics(bundle.metrics)[0] == ('acc', 0.9)
+    assert groups["image"][0].path.name == "plot.png"
+    assert bundle.metrics[0].rows[0]["acc"] == "0.9"
+    assert primary_metric_headlines(bundle.direct.primary_metrics) == (("acc", 0.9),)
+
+
+def test_cli_paths_outside_reported_result_dir_are_not_consumed(tmp_path: Path):
+    repo, rec = record(tmp_path)
+    result_dir = write_direct_result(repo, rec)
+    outside = repo / "results" / "demo" / "other" / "all_results.csv"
+    outside.parent.mkdir(parents=True)
+    outside.write_text("acc\n1.0\n", encoding="utf-8")
+    log = (rec.run_dir / "run.log").read_text(encoding="utf-8")
+    log = log.replace(
+        f"test_metrics={result_dir / 'all_results.csv'}", f"test_metrics={outside}"
+    )
+    (rec.run_dir / "run.log").write_text(log, encoding="utf-8")
+
+    bundle = discover_results(repo, rec)
+    assert bundle.direct.test_metrics is None
+    assert any("outside reported result_dir" in item for item in bundle.warnings)
+    assert all(table.source != outside.resolve() for table in bundle.metrics)
+
+
+def test_failed_run_does_not_accept_stale_success_lines(tmp_path: Path):
+    repo, rec = record(tmp_path, status="failed", exit_code=7)
+    result_dir = write_direct_result(repo, rec)
+    bundle = discover_results(repo, rec)
+    assert not bundle.direct.completed
+    assert bundle.direct.result_dir is None
+    assert bundle.roots == (rec.run_dir.resolve(),)
+    assert result_dir.resolve() not in bundle.roots
+    assert any("non-successful" in item for item in bundle.warnings)
+
+
+def test_success_without_final_trailer_does_not_scan_output_root(tmp_path: Path):
+    repo, rec = record(tmp_path)
+    foreign = repo / "results" / "demo" / "foreign"
+    foreign.mkdir(parents=True)
+    (foreign / "all_results.csv").write_text("acc\n1.0\n", encoding="utf-8")
+    (rec.run_dir / "run.log").write_text(
+        "training ended without public trailer\n", encoding="utf-8"
+    )
+    bundle = discover_results(repo, rec)
+    assert bundle.direct.result_dir is None
+    assert bundle.roots == (rec.run_dir.resolve(),)
+    assert not bundle.metrics
+    assert any("run=completed" in item for item in bundle.warnings)
+
+
+def test_training_only_run_does_not_require_test_files(tmp_path: Path):
+    repo, rec = record(tmp_path, test_after_fit=False)
+    result_dir = write_direct_result(repo, rec, include_evaluation=False)
+    direct = parse_direct_results(repo, rec)
+    assert direct.completed
+    assert direct.result_dir == result_dir.resolve()
+    assert direct.best_checkpoint is not None
+    assert direct.evaluation_requested is False
+    assert direct.test_metrics is None
+    assert direct.run_summary is None
+    assert not any("Evaluation was requested" in item for item in direct.warnings)
+
+
+def test_primary_metric_headlines_use_cli_primary_summary_not_arbitrary_columns():
+    primary = {
+        "test_f1_demo": {"count": 3, "mean": 0.81, "sample_std": 0.02},
+        "test_acc_demo": {"count": 3, "mean": 0.9, "sample_std": 0.01},
+        "bad": {"mean": float("nan")},
+    }
+    assert primary_metric_headlines(primary) == (
+        ("test_f1_demo", 0.81),
+        ("test_acc_demo", 0.9),
+    )
 
 
 def test_malformed_json_becomes_warning(tmp_path: Path):
-    path = tmp_path / 'metrics.json'
-    path.write_text('{bad', encoding='utf-8')
+    path = tmp_path / "metrics.json"
+    path.write_text("{bad", encoding="utf-8")
     table = load_metric_table(path)
     assert not table.rows
-    assert 'Could not parse metrics' in table.warning
+    assert "Could not parse metrics" in table.warning
 
 
 def test_large_metric_file_is_not_parsed(tmp_path: Path):
-    path = tmp_path / 'all_results.csv'
-    path.write_text('a\n' + ('1\n' * 100), encoding='utf-8')
+    path = tmp_path / "all_results.csv"
+    path.write_text("a\n" + ("1\n" * 100), encoding="utf-8")
     table = load_metric_table(path, DiscoveryLimits(max_metric_bytes=10))
-    assert 'parsing is limited' in table.warning
+    assert "parsing is limited" in table.warning
 
 
-def test_broad_output_root_is_refused(tmp_path: Path):
-    repo, rec = record(tmp_path, output_root='.')
-    bundle = discover_results(repo, rec)
-    assert any('Refusing to scan' in item for item in bundle.warnings)
-    assert bundle.roots == (rec.run_dir.resolve(),)
-
-
-def test_symlink_escape_is_skipped(tmp_path: Path):
+def test_symlink_escape_inside_direct_result_is_skipped(tmp_path: Path):
     repo, rec = record(tmp_path)
-    output = repo / 'results' / 'demo'
-    output.mkdir(parents=True)
-    outside = tmp_path / 'outside.json'
+    result_dir = write_direct_result(repo, rec)
+    outside = tmp_path / "outside.json"
     outside.write_text('{"secret": 1}')
     try:
-        (output / 'metrics.json').symlink_to(outside)
+        (result_dir / "extra.json").symlink_to(outside)
     except (OSError, NotImplementedError):
         return
     bundle = discover_results(repo, rec)
-    assert all(item.path.name != 'metrics.json' for item in bundle.artifacts)
+    assert all(item.path.name != "extra.json" for item in bundle.artifacts)
 
 
-def test_scan_limits_report_truncation(tmp_path: Path):
+def test_scan_limits_report_truncation_only_inside_exact_roots(tmp_path: Path):
     repo, rec = record(tmp_path)
-    output = repo / 'results' / 'demo'
-    output.mkdir(parents=True)
+    result_dir = write_direct_result(repo, rec)
     for index in range(8):
-        (output / f'{index}.txt').write_text('x')
+        (result_dir / f"{index}.txt").write_text("x")
     bundle = discover_results(repo, rec, limits=DiscoveryLimits(max_files=3))
     assert bundle.truncated
-    assert len(bundle.artifacts) <= 4  # run-dir manifest/log plus bounded output files
+    assert set(bundle.roots) == {rec.run_dir.resolve(), result_dir.resolve()}
 
 
-def test_headline_metrics_skips_non_finite_values(tmp_path: Path):
-    path = tmp_path / 'metrics.json'
-    path.write_text('{"loss": "nan", "acc": 0.8}', encoding='utf-8')
-    table = load_metric_table(path)
-    assert headline_metrics((table,)) == (('acc', 0.8),)
+def test_large_log_reads_bounded_tail_containing_cli_trailer(tmp_path: Path):
+    repo, rec = record(tmp_path)
+    result_dir = write_direct_result(repo, rec)
+    trailer = (rec.run_dir / "run.log").read_text(encoding="utf-8")
+    (rec.run_dir / "run.log").write_text(
+        ("verbose training line\n" * 5000) + trailer,
+        encoding="utf-8",
+    )
+    direct = parse_direct_results(
+        repo, rec, limits=DiscoveryLimits(max_log_bytes=2048)
+    )
+    assert direct.completed
+    assert direct.result_dir == result_dir.resolve()
+    assert direct.test_metrics is not None
+    assert direct.run_summary is not None


### PR DESCRIPTION
## Authorized promotion

Promote the single reviewed U3 commit currently on `dev` to the user-facing `main` branch.

Immediately before opening this PR, `main...dev` was verified as ahead by exactly 1 commit and behind by 0. The delta is only the six Streamlit U3 files from #242; research PR #230/#231 are not included.

## User invariant

For a selected Streamlit run, scientific results come only from that run's final public CLI trailer (`result_dir`, `best_checkpoint`, `test_metrics`, `run_summary`, `primary_metrics`, `run=completed`). The UI no longer scans a shared output root or uses mtime to infer result ownership.

## Evidence

PR #242 was squash-merged to `dev` as `0709c398193fc6e2539f7eb98d8c034001f791a1` after all final-head workflows passed. Codex review found one P2 on oversized logs; the branch was corrected to parse a bounded log tail, the counterexample was added, the thread was resolved, all final-head checks passed again, and the re-review completed with 👍 and no new findings.

## Scope boundary

No backend result generation, metric mathematics, aggregation, checkpoint selection, configuration, Pipeline/Factory behavior, THU/MFPT execution, benchmark claim, batch scheduler, Agent execution, version/tag/package publication, or research PR changes.

Use a merge commit for `dev` → `main` so the long-lived branch ancestry stays explicit; do not squash this promotion.