### PR TITLE
release: promote Streamlit current parameter controls

### DIFF
--- a/.github/workflows/streamlit-quality-gates.yml
+++ b/.github/workflows/streamlit-quality-gates.yml
@@ -108,6 +108,7 @@ jobs:
           python -m pytest -q
           --junitxml=streamlit-pytest-${{ matrix.os }}.xml
           test/test_streamlit_config_service.py
+          test/test_streamlit_field_catalog.py
           test/test_streamlit_runtime_policy.py
           test/test_streamlit_onboarding.py
           test/test_streamlit_run_service.py

--- a/apps/streamlit/field_catalog.yaml
+++ b/apps/streamlit/field_catalog.yaml
@@ -33,80 +33,111 @@ fields:
   device:
     label: "运行设备 | Device"
     widget: select
-    paths:
-      - trainer.device
-    options: [cpu, cuda]
+    paths: [trainer.device]
+    options: [cpu, cuda, auto]
     default: cpu
     quick_start: true
-    help: "CPU is the safest first run. Choose CUDA only when the core environment has a working GPU build."
+    help: "Exact trainer.device value. CPU is the safest first run; CUDA never falls back silently."
+
+  devices:
+    label: "设备数量 | Devices"
+    widget: number
+    paths: [trainer.devices]
+    min: 1
+    max: 16
+    step: 1
+    default: 1
+    quick_start: true
+    help: "Exact trainer.devices value. Request only hardware that is actually available."
 
   epochs:
     label: "训练轮数 | Epochs"
     widget: number
-    paths:
-      - trainer.num_epochs
-      - task.epochs
+    paths: [trainer.num_epochs]
     min: 1
     max: 1000
     step: 1
     default: 1
     quick_start: true
-    help: "Number of training epochs. Use 1 for smoke validation."
+    help: "Exact trainer.num_epochs value. Use 1 for smoke validation."
+
+  iterations:
+    label: "重复实验次数 | Iterations"
+    widget: number
+    paths: [environment.iterations]
+    min: 1
+    max: 100
+    step: 1
+    default: 1
+    quick_start: true
+    help: "Number of repeated experiment iterations owned by the backend runtime."
 
   seed:
-    label: "随机种子 | Random seed"
+    label: "基础随机种子 | Base seed"
     widget: number
-    paths:
-      - environment.seed
+    paths: [environment.seed]
     min: 0
     max: 2147483647
     step: 1
     default: 0
-    help: "Base seed used by the experiment iterations."
+    quick_start: true
+    help: "Exact environment.seed value used as the base seed for repeated iterations."
 
   batch_size:
     label: "批大小 | Batch size"
     widget: select
-    paths:
-      - data.batch_size
-      - task.batch_size
-      - trainer.batch_size
+    paths: [data.batch_size]
     options: [4, 8, 16, 32, 64, 128]
     default: 16
-    help: "The first existing alias is edited, so legacy and maintained configs remain compatible."
+    quick_start: true
+    help: "Exact data.batch_size value. The UI no longer searches Task or Trainer aliases."
 
   learning_rate:
     label: "学习率 | Learning rate"
     widget: number
-    paths:
-      - task.lr
-      - trainer.learning_rate
-      - trainer.lr
-      - model.learning_rate
+    paths: [task.lr]
     min: 0.000001
     max: 0.1
     step: 0.0001
     default: 0.001
-    help: "Learning-rate aliases are resolved from the selected configuration."
+    quick_start: true
+    help: "Exact task.lr value used by the maintained Task optimizer path."
 
   num_workers:
     label: "数据加载进程 | Data workers"
     widget: number
-    paths:
-      - data.num_workers
-      - task.num_workers
-      - trainer.num_workers
+    paths: [data.num_workers]
     min: 0
     max: 64
     step: 1
     default: 0
-    help: "Use 0 for the broadest Windows/Linux compatibility and for smoke runs."
+    quick_start: true
+    help: "Exact data.num_workers value. Use 0 for the broadest local compatibility."
+
+  test_after_fit:
+    label: "训练后测试 | Test after fit"
+    widget: checkbox
+    paths: [trainer.test_after_fit]
+    default: true
+    help: "When disabled, the run is training-only and test metrics are not expected."
+
+  data_dir:
+    label: "数据目录 | Data directory"
+    widget: text
+    paths: [data.data_dir]
+    default: data
+    help: "Path on the machine running Streamlit, not on a remote browser computer."
+
+  metadata_file:
+    label: "元数据文件 | Metadata file"
+    widget: text
+    paths: [data.metadata_file]
+    default: metadata.csv
+    help: "Metadata file interpreted relative to data.data_dir unless the backend config says otherwise."
 
   output_dir:
     label: "输出根目录 | Output directory"
     widget: text
-    paths:
-      - environment.output_dir
-      - output_dir
+    paths: [environment.output_dir]
     default: results/streamlit
-    help: "Prefer a repository-relative path. Machine-specific absolute paths belong in configs/local/local.yaml."
+    help: "Exact environment.output_dir value. Prefer an explicit writable path on the Streamlit host."

--- a/doc/changelog/2026-09-08-streamlit-current-parameter-controls.md
+++ b/doc/changelog/2026-09-08-streamlit-current-parameter-controls.md
@@ -1,0 +1,44 @@
+# Streamlit uses current PHMFactory parameter paths
+
+Date: 2026-09-08
+
+## User-visible change
+
+The Streamlit common-parameter catalogue now edits the maintained PHMFactory fields directly instead of searching historical aliases in Task, Trainer, Model, or root-level configuration namespaces.
+
+Quick Start exposes the small reproducible surface needed for ordinary experiments:
+
+- `trainer.device`
+- `trainer.devices`
+- `trainer.num_epochs`
+- `environment.iterations`
+- `environment.seed`
+- `data.batch_size`
+- `task.lr`
+- `data.num_workers`
+
+Advanced mode additionally exposes `trainer.test_after_fit`, `data.data_dir`, `data.metadata_file`, and `environment.output_dir`.
+
+## Removed UI aliases
+
+The UI no longer treats these legacy or non-maintained paths as equivalent controls:
+
+```text
+task.epochs
+task.batch_size
+task.num_workers
+trainer.learning_rate
+trainer.lr
+trainer.batch_size
+trainer.num_workers
+model.learning_rate
+output_dir
+```
+
+This is a frontend-catalog change only. The backend configuration resolver, Data/Model/Task/Trainer factories, split, objective, metric, checkpoint selection, and experiment YAML files are unchanged.
+
+## Validation
+
+`test/test_streamlit_field_catalog.py` protects the exact public paths and the Quick Start field set. The existing Streamlit quality workflow runs this test on Linux and Windows, while the existing public-integration job continues to exercise the real inspector, Streamlit page, and Dummy CLI lifecycle.
+
+This change does not add batch scheduling or Agent execution. Advanced YAML/common-field synchronization and terminal refresh cost remain separate frontend work.

--- a/test/test_streamlit_field_catalog.py
+++ b/test/test_streamlit_field_catalog.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from apps.streamlit import config_service as cs
+
+
+CATALOG = Path(__file__).parents[1] / "apps" / "streamlit" / "field_catalog.yaml"
+
+
+def test_common_controls_use_only_current_maintained_paths() -> None:
+    catalog = cs.load_catalog(CATALOG)
+    paths = {spec.key: spec.paths for spec in catalog.fields}
+
+    assert paths == {
+        "device": ("trainer.device",),
+        "devices": ("trainer.devices",),
+        "epochs": ("trainer.num_epochs",),
+        "iterations": ("environment.iterations",),
+        "seed": ("environment.seed",),
+        "batch_size": ("data.batch_size",),
+        "learning_rate": ("task.lr",),
+        "num_workers": ("data.num_workers",),
+        "test_after_fit": ("trainer.test_after_fit",),
+        "data_dir": ("data.data_dir",),
+        "metadata_file": ("data.metadata_file",),
+        "output_dir": ("environment.output_dir",),
+    }
+
+
+def test_quick_start_exposes_the_small_reproducible_surface() -> None:
+    catalog = cs.load_catalog(CATALOG)
+    quick = {spec.key for spec in catalog.fields if spec.quick_start}
+
+    assert quick == {
+        "device",
+        "devices",
+        "epochs",
+        "iterations",
+        "seed",
+        "batch_size",
+        "learning_rate",
+        "num_workers",
+    }
+
+
+def test_legacy_parameter_aliases_are_not_public_controls() -> None:
+    catalog = cs.load_catalog(CATALOG)
+    public_paths = {path for spec in catalog.fields for path in spec.paths}
+
+    assert public_paths.isdisjoint(
+        {
+            "task.epochs",
+            "task.batch_size",
+            "task.num_workers",
+            "trainer.learning_rate",
+            "trainer.lr",
+            "trainer.batch_size",
+            "trainer.num_workers",
+            "model.learning_rate",
+            "output_dir",
+        }
+    )


### PR DESCRIPTION
## Authorized promotion

Promote the single reviewed U4a Streamlit parameter-control commit currently on `dev` to the user-facing `main` branch.

Immediately before this PR, `dev` was one commit ahead of `main` and contained only the bounded #244 change. Research PR #231 is not included.

## User invariant

Common Streamlit controls map only to current maintained PHMFactory configuration paths. Historical Task/Trainer/Model aliases are no longer presented as equivalent user controls.

## Evidence

PR #244 passed Streamlit quality gates, Core quality gates, Repository layout, and Submodule policy on its final head, with no unresolved review threads. The existing public integration still exercises the real inspector, Streamlit page, and Dummy CLI lifecycle.

## Scope boundary

No backend config resolver, Factory, runtime, Pipeline, data/split, objective, metric, checkpoint selection, THU/MFPT, batch scheduler, Agent execution, tag, package release, or research PR change.

Use a merge commit for `dev` → `main` so long-lived branch ancestry remains explicit.