### PR TITLE
fix(streamlit): synchronize Advanced fields with YAML

### DIFF
--- a/.github/workflows/streamlit-quality-gates.yml
+++ b/.github/workflows/streamlit-quality-gates.yml
@@ -151,8 +151,13 @@ jobs:
         run: python -m pytest test/test_streamlit_public_contract.py -q --junitxml=streamlit-public.xml
       - name: Exercise the actual page with AppTest
         run: python -m pytest test/test_streamlit_app.py -q --junitxml=streamlit-page.xml
+      - name: Confirm integration reports exist
+        run: |
+          test -s streamlit-public.xml
+          test -s streamlit-page.xml
       - name: Upload integration diagnostics
         if: always()
+        continue-on-error: true
         uses: actions/upload-artifact@v4
         with:
           name: streamlit-public-integration

--- a/apps/streamlit/ui_theme.py
+++ b/apps/streamlit/ui_theme.py
@@ -3,29 +3,33 @@
 from __future__ import annotations
 
 import difflib
-from typing import Any, Dict, Mapping, Tuple
+from typing import Any, Dict, Mapping, MutableMapping, Tuple
 
 import streamlit as st
 
 try:
     from .config_service import (
         Catalog,
+        ConfigServiceError,
         FieldSpec,
         RegistryEntry,
         ValidationReport,
         build_field_overrides,
         dump_yaml,
         field_value,
+        parse_yaml_text,
     )
 except ImportError:  # pragma: no cover
     from config_service import (  # type: ignore
         Catalog,
+        ConfigServiceError,
         FieldSpec,
         RegistryEntry,
         ValidationReport,
         build_field_overrides,
         dump_yaml,
         field_value,
+        parse_yaml_text,
     )
 
 
@@ -177,8 +181,41 @@ def _number_widget(spec: FieldSpec, current: Any, key: str) -> Any:
     )
 
 
-def _render_field(spec: FieldSpec, current: Any, template_id: str) -> Any:
-    widget_key = f"field::{template_id}::{spec.key}"
+def _advanced_field_context(
+    state: MutableMapping[str, Any],
+    resolved: Mapping[str, Any],
+    template_id: str,
+) -> Tuple[Mapping[str, Any], str]:
+    """Use the current Advanced YAML as the common-field source.
+
+    The integer revision exists only to refresh Streamlit widget keys when the YAML draft
+    or selected template changes. It is not an experiment identity or integrity value.
+    """
+
+    if state.get("ui_mode") != "Advanced":
+        return resolved, ""
+    yaml_text = str(state.get("advanced_yaml_text") or "")
+    parsed = parse_yaml_text(yaml_text, source="Advanced YAML draft")
+    active_key = "advanced_field_active_template"
+    source_key = f"advanced_field_source::{template_id}"
+    revision_key = f"advanced_field_revision::{template_id}"
+    if state.get(active_key) != template_id or state.get(source_key) != yaml_text:
+        state[active_key] = template_id
+        state[source_key] = yaml_text
+        state[revision_key] = int(state.get(revision_key, 0)) + 1
+    revision = int(state.get(revision_key, 0))
+    return parsed, f"advanced-{revision}"
+
+
+def _render_field(
+    spec: FieldSpec,
+    current: Any,
+    template_id: str,
+    *,
+    widget_scope: str = "",
+) -> Any:
+    scope = f"::{widget_scope}" if widget_scope else ""
+    widget_key = f"field::{template_id}{scope}::{spec.key}"
     if spec.widget == "select":
         options = list(spec.options)
         if current not in options:
@@ -214,6 +251,16 @@ def _render_fields(
     *,
     quick_only: bool,
 ) -> Tuple[Tuple[str, Any], ...]:
+    source = resolved
+    widget_scope = ""
+    if st.session_state.get("ui_mode") == "Advanced":
+        try:
+            source, widget_scope = _advanced_field_context(
+                st.session_state, resolved, template_id
+            )
+        except ConfigServiceError as error:
+            st.info("Fix the Advanced YAML draft before using common fields: " + str(error))
+            return ()
     specs = tuple(spec for spec in catalog.fields if spec.quick_start or not quick_only)
     values: Dict[str, Any] = {}
     columns = st.columns(min(4, max(1, len(specs))))
@@ -221,11 +268,12 @@ def _render_fields(
         with columns[index % len(columns)]:
             values[spec.key] = _render_field(
                 spec,
-                field_value(resolved, spec),
+                field_value(source, spec),
                 template_id,
+                widget_scope=widget_scope,
             )
     return build_field_overrides(
-        resolved,
+        source,
         catalog,
         values,
         quick_start_only=quick_only,

--- a/apps/streamlit/ui_theme.py
+++ b/apps/streamlit/ui_theme.py
@@ -10,6 +10,7 @@ import streamlit as st
 try:
     from .config_service import (
         Catalog,
+        ConfigFormatError,
         ConfigServiceError,
         FieldSpec,
         RegistryEntry,
@@ -22,6 +23,7 @@ try:
 except ImportError:  # pragma: no cover
     from config_service import (  # type: ignore
         Catalog,
+        ConfigFormatError,
         ConfigServiceError,
         FieldSpec,
         RegistryEntry,
@@ -153,11 +155,40 @@ def _render_template_summary(entry: RegistryEntry) -> None:
             st.code(entry.related_docs.replace(";", "\n"), language="text")
 
 
-def _number_widget(spec: FieldSpec, current: Any, key: str) -> Any:
+def _validated_widget_value(spec: FieldSpec, current: Any) -> Any:
+    """Reject values a Streamlit widget would otherwise coerce before validation."""
+
     if current is None:
         current = spec.default
-    if current is None:
-        current = 0
+    if spec.widget == "number":
+        if current is None:
+            current = 0
+        integer_widget = spec.step is not None and float(spec.step).is_integer()
+        if integer_widget:
+            if isinstance(current, bool) or not isinstance(current, int):
+                raise ConfigFormatError(
+                    f"{spec.paths[0]} must be an integer before it can be edited as {spec.label}."
+                )
+        elif isinstance(current, bool) or not isinstance(current, (int, float)):
+            raise ConfigFormatError(
+                f"{spec.paths[0]} must be numeric before it can be edited as {spec.label}."
+            )
+    elif spec.widget == "checkbox" and not isinstance(current, bool):
+        raise ConfigFormatError(
+            f"{spec.paths[0]} must be a boolean before it can be edited as {spec.label}."
+        )
+    elif spec.widget == "text":
+        if current is None:
+            current = ""
+        if not isinstance(current, str):
+            raise ConfigFormatError(
+                f"{spec.paths[0]} must be text before it can be edited as {spec.label}."
+            )
+    return current
+
+
+def _number_widget(spec: FieldSpec, current: Any, key: str) -> Any:
+    current = _validated_widget_value(spec, current)
     is_integer = isinstance(current, int) and not isinstance(current, bool)
     if is_integer or (spec.step is not None and float(spec.step).is_integer()):
         return st.number_input(
@@ -214,6 +245,7 @@ def _render_field(
     *,
     widget_scope: str = "",
 ) -> Any:
+    current = _validated_widget_value(spec, current)
     scope = f"::{widget_scope}" if widget_scope else ""
     widget_key = f"field::{template_id}{scope}::{spec.key}"
     if spec.widget == "select":
@@ -232,13 +264,13 @@ def _render_field(
     if spec.widget == "checkbox":
         return st.checkbox(
             spec.label,
-            value=bool(current),
+            value=current,
             help=spec.help or None,
             key=widget_key,
         )
     return st.text_input(
         spec.label,
-        value="" if current is None else str(current),
+        value=current,
         help=spec.help or None,
         key=widget_key,
     )
@@ -262,13 +294,22 @@ def _render_fields(
             st.info("Fix the Advanced YAML draft before using common fields: " + str(error))
             return ()
     specs = tuple(spec for spec in catalog.fields if spec.quick_start or not quick_only)
+    try:
+        current_values = {
+            spec.key: _validated_widget_value(spec, field_value(source, spec))
+            for spec in specs
+        }
+    except ConfigServiceError as error:
+        st.info("Fix the configuration before using common fields: " + str(error))
+        return ()
+
     values: Dict[str, Any] = {}
     columns = st.columns(min(4, max(1, len(specs))))
     for index, spec in enumerate(specs):
         with columns[index % len(columns)]:
             values[spec.key] = _render_field(
                 spec,
-                field_value(source, spec),
+                current_values[spec.key],
                 template_id,
                 widget_scope=widget_scope,
             )

--- a/doc/changelog/2026-09-08-streamlit-advanced-yaml-sync.md
+++ b/doc/changelog/2026-09-08-streamlit-advanced-yaml-sync.md
@@ -1,0 +1,17 @@
+# Streamlit Advanced fields follow the current YAML draft
+
+Date: 2026-09-08
+
+## User-visible correction
+
+Advanced mode no longer initializes its common-field controls from the original template after the user edits the full YAML draft. The current YAML is parsed first; common fields are then created from those values. Editing the YAML creates a new UI-only widget revision so an older widget value cannot silently overwrite the new YAML on the next validation.
+
+The revision counter is only Streamlit widget state. It is not a run identity, configuration digest, manifest, or scientific authority.
+
+If the Advanced YAML is invalid, common-field controls are withheld until the YAML is corrected. The public configuration inspector remains the authority for the approved experiment.
+
+## Validation
+
+Focused tests cover unchanged and changed YAML drafts, strict parse failure, Quick Start isolation, and widget revision changes. The real Streamlit AppTest changes `trainer.num_epochs` in the YAML, verifies the common field shows that value, applies a new common-field value through validation, then edits YAML again and verifies the previous widget cannot override it.
+
+No PHMFactory backend configuration, Factory, Pipeline, split, objective, metric, checkpoint, or experiment YAML logic changes in this correction.

--- a/test/test_streamlit_app.py
+++ b/test/test_streamlit_app.py
@@ -66,3 +66,24 @@ def test_advanced_yaml_resets_common_field_values_before_validation():
     assert new_revision > revision
     assert app.number_input(key=new_key).value == 9
     assert _button(app, 'Run experiment').disabled
+
+
+def test_advanced_yaml_invalid_integer_is_not_repaired_by_a_widget():
+    app = AppTest.from_file(str(ROOT / 'apps/streamlit/app.py'), default_timeout=90).run()
+    app.radio(key='ui_mode').set_value('Advanced').run()
+    assert not app.exception
+
+    config = yaml.safe_load(app.session_state['advanced_yaml_text'])
+    config['trainer']['num_epochs'] = 1.5
+    app.text_area(key='advanced_yaml_text').set_value(
+        yaml.safe_dump(config, sort_keys=False)
+    ).run()
+    assert not app.exception
+
+    _button(app, 'Validate configuration').click().run()
+    assert not app.exception
+    report = app.session_state['validation_report']
+    assert not report.ok
+    assert not report.resolved
+    assert 'num_epochs' in report.stderr
+    assert _button(app, 'Run experiment').disabled

--- a/test/test_streamlit_app.py
+++ b/test/test_streamlit_app.py
@@ -4,6 +4,7 @@ Run this separately from the optional-import stub tests.
 """
 from pathlib import Path
 
+import yaml
 from streamlit.testing.v1 import AppTest
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -33,3 +34,35 @@ def test_real_page_accepts_current_inspection_and_invalidates_edits():
     assert not _button(app, 'Run experiment').disabled
     assert app.session_state['validation_report'].resolved['trainer']['num_epochs'] == 2
     assert app.session_state['validated_inputs'] != checked
+
+
+def test_advanced_yaml_resets_common_field_values_before_validation():
+    app = AppTest.from_file(str(ROOT / 'apps/streamlit/app.py'), default_timeout=90).run()
+    app.radio(key='ui_mode').set_value('Advanced').run()
+    assert not app.exception
+
+    config = yaml.safe_load(app.session_state['advanced_yaml_text'])
+    config['trainer']['num_epochs'] = 7
+    edited = yaml.safe_dump(config, sort_keys=False)
+    app.text_area(key='advanced_yaml_text').set_value(edited).run()
+    assert not app.exception
+
+    revision = app.session_state['advanced_field_revision::demo_00_smoke_dummy_dg']
+    key = f'field::demo_00_smoke_dummy_dg::advanced-{revision}::epochs'
+    assert app.number_input(key=key).value == 7
+
+    app.number_input(key=key).set_value(8).run()
+    _button(app, 'Validate configuration').click().run()
+    assert not app.exception
+    assert app.session_state['validation_report'].ok
+    assert app.session_state['validation_report'].resolved['trainer']['num_epochs'] == 8
+
+    config['trainer']['num_epochs'] = 9
+    app.text_area(key='advanced_yaml_text').set_value(
+        yaml.safe_dump(config, sort_keys=False)
+    ).run()
+    new_revision = app.session_state['advanced_field_revision::demo_00_smoke_dummy_dg']
+    new_key = f'field::demo_00_smoke_dummy_dg::advanced-{new_revision}::epochs'
+    assert new_revision > revision
+    assert app.number_input(key=new_key).value == 9
+    assert _button(app, 'Run experiment').disabled

--- a/test/test_streamlit_ui_imports.py
+++ b/test/test_streamlit_ui_imports.py
@@ -145,3 +145,29 @@ def test_advanced_common_fields_reject_an_invalid_yaml_draft(monkeypatch):
 
     with pytest.raises(ui_theme.ConfigServiceError):
         ui_theme._advanced_field_context(state, {}, "demo")
+
+
+@pytest.mark.parametrize(
+    ("spec", "value"),
+    [
+        ({"widget": "number", "step": 1.0, "path": "trainer.num_epochs"}, 1.5),
+        ({"widget": "number", "step": 1.0, "path": "trainer.num_epochs"}, "2"),
+        ({"widget": "number", "step": 1.0, "path": "trainer.num_epochs"}, True),
+        ({"widget": "checkbox", "step": None, "path": "trainer.test_after_fit"}, "false"),
+        ({"widget": "text", "step": None, "path": "data.data_dir"}, 123),
+    ],
+)
+def test_common_fields_do_not_repair_invalid_yaml_types(monkeypatch, spec, value):
+    _install_streamlit_stub(monkeypatch)
+    sys.modules.pop("apps.streamlit.ui_theme", None)
+    ui_theme = importlib.import_module("apps.streamlit.ui_theme")
+    field = ui_theme.FieldSpec(
+        key="test",
+        label="Test",
+        widget=spec["widget"],
+        paths=(spec["path"],),
+        step=spec["step"],
+    )
+
+    with pytest.raises(ui_theme.ConfigServiceError):
+        ui_theme._validated_widget_value(field, value)

--- a/test/test_streamlit_ui_imports.py
+++ b/test/test_streamlit_ui_imports.py
@@ -5,6 +5,9 @@ from importlib.util import find_spec
 import sys
 import types
 
+import pytest
+import yaml
+
 
 class _Decorator:
     def __call__(self, *args, **kwargs):
@@ -19,6 +22,25 @@ def _install_streamlit_stub(monkeypatch) -> None:
     fake_streamlit.fragment = _Decorator()
     fake_streamlit.session_state = {}
     monkeypatch.setitem(sys.modules, "streamlit", fake_streamlit)
+
+
+def _advanced_yaml(epochs: int) -> str:
+    return yaml.safe_dump(
+        {
+            "environment": {"seed": 0, "iterations": 1, "output_dir": "results/demo"},
+            "data": {"batch_size": 4, "num_workers": 0},
+            "model": {"type": "Backbone", "name": "B_04_Dlinear"},
+            "task": {"lr": 0.001},
+            "trainer": {
+                "name": "Default_trainer",
+                "num_epochs": epochs,
+                "device": "cpu",
+                "devices": 1,
+                "test_after_fit": True,
+            },
+        },
+        sort_keys=False,
+    )
 
 
 def test_ui_modules_import_with_optional_streamlit_stub(monkeypatch):
@@ -88,3 +110,38 @@ def test_validation_snapshot_preserves_types_and_copies_nested_values(monkeypatc
     values.append(3)
     assert checked != capture("Advanced", "yaml", (("values", values),))
     assert checked == capture("Advanced", "yaml", (("values", [1, 2]),))
+
+
+def test_advanced_common_fields_follow_the_current_yaml_draft(monkeypatch):
+    _install_streamlit_stub(monkeypatch)
+    sys.modules.pop("apps.streamlit.ui_theme", None)
+    ui_theme = importlib.import_module("apps.streamlit.ui_theme")
+    fallback = yaml.safe_load(_advanced_yaml(1))
+    state = {"ui_mode": "Advanced", "advanced_yaml_text": _advanced_yaml(2)}
+
+    resolved, first_scope = ui_theme._advanced_field_context(state, fallback, "demo")
+    assert resolved["trainer"]["num_epochs"] == 2
+    assert first_scope == "advanced-1"
+
+    _, unchanged_scope = ui_theme._advanced_field_context(state, fallback, "demo")
+    assert unchanged_scope == first_scope
+
+    state["advanced_yaml_text"] = _advanced_yaml(3)
+    resolved, changed_scope = ui_theme._advanced_field_context(state, fallback, "demo")
+    assert resolved["trainer"]["num_epochs"] == 3
+    assert changed_scope == "advanced-2"
+
+    state["ui_mode"] = "Quick Start"
+    resolved, quick_scope = ui_theme._advanced_field_context(state, fallback, "demo")
+    assert resolved is fallback
+    assert quick_scope == ""
+
+
+def test_advanced_common_fields_reject_an_invalid_yaml_draft(monkeypatch):
+    _install_streamlit_stub(monkeypatch)
+    sys.modules.pop("apps.streamlit.ui_theme", None)
+    ui_theme = importlib.import_module("apps.streamlit.ui_theme")
+    state = {"ui_mode": "Advanced", "advanced_yaml_text": "trainer: ["}
+
+    with pytest.raises(ui_theme.ConfigServiceError):
+        ui_theme._advanced_field_context(state, {}, "demo")


### PR DESCRIPTION
## User problem

Advanced mode rendered common-field widgets from the original template even after the user edited the full YAML draft. Because Streamlit keeps widget state by key, an older common-field value could silently override a newer YAML value during validation.

## Invariant

In Advanced mode, common-field controls are initialized from the current YAML draft. A YAML or template change refreshes the UI widget keys before validation; stale widget state cannot overwrite the new draft.

## Minimal change

- Parse the current Advanced YAML before rendering common fields.
- Use a monotonically increasing UI-only widget revision when the YAML or template changes.
- If YAML is invalid, withhold common-field editing until it is corrected.
- Keep Quick Start behavior unchanged.
- Add focused state tests and a real Streamlit AppTest covering YAML → common field → validation → YAML replacement.

The revision is not an experiment identity, digest, manifest, or backend authority.

## Out of scope

No backend resolver, Factory, Pipeline, runtime, split, objective, metric, checkpoint, THU/MFPT, batch scheduler, Agent execution, release/tag/package, or research PR change.

## Acceptance

Streamlit quality gates, Core quality gates, Repository layout, and Submodule policy must pass on the final head. AppTest must demonstrate that a newer YAML value replaces an older common-field widget state. Rollback is reverting this bounded PR.