### PR TITLE
release: promote active-only Streamlit refresh

### DIFF
--- a/.github/workflows/streamlit-quality-gates.yml
+++ b/.github/workflows/streamlit-quality-gates.yml
@@ -114,6 +114,7 @@ jobs:
           test/test_streamlit_run_service.py
           test/test_streamlit_result_service.py
           test/test_streamlit_ui_imports.py
+          test/test_streamlit_refresh_policy.py
 
       - name: Upload focused Streamlit diagnostics
         if: always()

--- a/apps/streamlit/ui_runtime.py
+++ b/apps/streamlit/ui_runtime.py
@@ -1,4 +1,4 @@
-"""Live run, exact result, artifact, and log rendering."""
+"""Run status, exact-result, artifact, and log rendering."""
 
 from __future__ import annotations
 
@@ -117,6 +117,28 @@ def _render_overview(record: RunRecord, bundle: Any) -> None:
     if bundle.direct.best_checkpoint is not None:
         st.markdown("**Best checkpoint**")
         st.code(str(bundle.direct.best_checkpoint), language="text")
+    if record.error:
+        st.warning(record.error)
+    if record.metadata:
+        with st.expander("Run metadata"):
+            st.json(dict(record.metadata))
+
+
+def _render_active_overview(record: RunRecord) -> None:
+    """Render only process-owned facts while the CLI is still running."""
+
+    st.markdown("**Actual reproduction command**")
+    st.code(format_command(record.command), language="bash")
+    left, right = st.columns(2)
+    with left:
+        st.markdown("**Streamlit process directory**")
+        st.code(str(record.run_dir), language="text")
+    with right:
+        st.markdown("**Template / mode**")
+        st.write(f"{record.template_id or 'custom'} · {record.mode or 'unknown'}")
+    st.info(
+        "Metrics and artifacts are bound after the CLI finishes and reports exact result paths."
+    )
     if record.error:
         st.warning(record.error)
     if record.metadata:
@@ -276,15 +298,7 @@ def _render_run_actions(repo_root: Path, record: RunRecord) -> None:
         )
 
 
-@st.fragment(run_every="2s")
-def _render_live_run(repo_root_text: str, run_id: str) -> None:
-    repo_root = Path(repo_root_text)
-    try:
-        record = get_run(repo_root, run_id)
-    except RunServiceError as error:
-        _render_error("The selected run could not be loaded.", error)
-        return
-
+def _render_status(repo_root: Path, record: RunRecord) -> None:
     st.markdown(
         f'<span class="phm-status">{html.escape(_status_label(record))}</span> '
         f'<span class="phm-muted">{html.escape(record.run_id)}</span>',
@@ -300,6 +314,35 @@ def _render_live_run(repo_root_text: str, run_id: str) -> None:
     )
     _render_run_actions(repo_root, record)
 
+
+@st.fragment(run_every="2s")
+def _render_active_run(repo_root_text: str, run_id: str) -> None:
+    """Poll only process state and logs while a selected run is active."""
+
+    repo_root = Path(repo_root_text)
+    try:
+        record = get_run(repo_root, run_id)
+    except RunServiceError as error:
+        _render_error("The selected run could not be loaded.", error)
+        return
+
+    if record.is_terminal:
+        # Leave the timed fragment so terminal results become a static page section.
+        st.rerun()
+        return
+
+    _render_status(repo_root, record)
+    tabs = st.tabs(("Overview", "Logs"))
+    with tabs[0]:
+        _render_active_overview(record)
+    with tabs[1]:
+        _render_logs(record)
+
+
+def _render_terminal_run(repo_root: Path, record: RunRecord) -> None:
+    """Render terminal results without a periodic fragment rerun."""
+
+    _render_status(repo_root, record)
     try:
         bundle = discover_results(repo_root, record)
     except Exception as error:  # keep logs/actions available if result parsing fails.
@@ -318,3 +361,19 @@ def _render_live_run(repo_root_text: str, run_id: str) -> None:
             _render_artifacts(bundle, record.run_id)
     with tabs[3]:
         _render_logs(record)
+
+
+def _render_live_run(repo_root_text: str, run_id: str) -> None:
+    """Use timed rendering only while the selected process is active."""
+
+    repo_root = Path(repo_root_text)
+    try:
+        record = get_run(repo_root, run_id)
+    except RunServiceError as error:
+        _render_error("The selected run could not be loaded.", error)
+        return
+
+    if record.is_active:
+        _render_active_run(repo_root_text, run_id)
+        return
+    _render_terminal_run(repo_root, record)

--- a/doc/changelog/2026-09-08-streamlit-active-refresh.md
+++ b/doc/changelog/2026-09-08-streamlit-active-refresh.md
@@ -1,0 +1,21 @@
+# Streamlit refreshes only active experiments
+
+Date: 2026-09-08
+
+## User-visible change
+
+The Streamlit workspace now reserves the two-second fragment refresh for active experiment processes. While a run is starting, running, cancelling, or detached, the page refreshes process status and the current log only. It does not repeatedly discover metrics or artifacts before PHMFactory reports exact result paths.
+
+When the selected process reaches a terminal state, the timed fragment triggers one normal app rerun. The terminal view then binds and renders exact PHMFactory results without another periodic timer.
+
+This reduces repeated file parsing and image/table work on completed runs and avoids pretending that in-progress files are scientific results.
+
+## Scientific boundary
+
+The frontend still treats the public CLI trailer as result authority. It does not compute metrics, scan a shared output root for the newest run, or promote process completion into benchmark validity. Training-only, failed, cancelled, and incomplete-result cases retain their existing semantics.
+
+No PHMFactory backend configuration, Factory, Pipeline, runtime, split, objective, metric, checkpoint selection, THU/MFPT experiment, or Agent execution logic changes.
+
+## Validation
+
+Focused policy tests verify that active rendering never calls `discover_results`, terminal transitions leave the timed fragment, the outer renderer uses the timer only for active records, and a terminal render performs one result discovery per page rerun. Existing Streamlit public integration and AppTest continue to exercise the real inspector, page, and Dummy CLI lifecycle.

--- a/test/test_streamlit_refresh_policy.py
+++ b/test/test_streamlit_refresh_policy.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+from contextlib import nullcontext
+import importlib
+import sys
+import types
+
+
+class _Decorator:
+    def __call__(self, *args, **kwargs):
+        if len(args) == 1 and callable(args[0]) and not kwargs:
+            return args[0]
+        return lambda function: function
+
+
+def _load_runtime(monkeypatch):
+    fake_streamlit = types.ModuleType("streamlit")
+    fake_streamlit.fragment = _Decorator()
+    fake_streamlit.session_state = types.SimpleNamespace(
+        selected_run_id=None,
+        active_run_id=None,
+    )
+    monkeypatch.setitem(sys.modules, "streamlit", fake_streamlit)
+    sys.modules.pop("apps.streamlit.ui_runtime", None)
+    return importlib.import_module("apps.streamlit.ui_runtime")
+
+
+def _tabs(monkeypatch, runtime, count: int) -> None:
+    monkeypatch.setattr(
+        runtime.st,
+        "tabs",
+        lambda labels: tuple(nullcontext() for _ in range(count)),
+        raising=False,
+    )
+
+
+def test_active_run_never_discovers_results(monkeypatch) -> None:
+    runtime = _load_runtime(monkeypatch)
+    record = types.SimpleNamespace(is_terminal=False)
+    monkeypatch.setattr(runtime, "get_run", lambda repo_root, run_id: record)
+    monkeypatch.setattr(runtime, "_render_status", lambda *args: None)
+    monkeypatch.setattr(runtime, "_render_active_overview", lambda *args: None)
+    monkeypatch.setattr(runtime, "_render_logs", lambda *args: None)
+    monkeypatch.setattr(
+        runtime,
+        "discover_results",
+        lambda *args: (_ for _ in ()).throw(AssertionError("active run scanned results")),
+    )
+    _tabs(monkeypatch, runtime, 2)
+
+    runtime._render_active_run("/tmp/repo", "run-active")
+
+
+def test_active_fragment_leaves_timer_when_run_becomes_terminal(monkeypatch) -> None:
+    runtime = _load_runtime(monkeypatch)
+    record = types.SimpleNamespace(is_terminal=True)
+    reruns = []
+    monkeypatch.setattr(runtime, "get_run", lambda repo_root, run_id: record)
+    monkeypatch.setattr(runtime.st, "rerun", lambda: reruns.append(True), raising=False)
+    monkeypatch.setattr(
+        runtime,
+        "discover_results",
+        lambda *args: (_ for _ in ()).throw(AssertionError("transition scanned results")),
+    )
+
+    runtime._render_active_run("/tmp/repo", "run-finished")
+
+    assert reruns == [True]
+
+
+def test_outer_renderer_uses_timer_only_for_active_runs(monkeypatch) -> None:
+    runtime = _load_runtime(monkeypatch)
+    active = types.SimpleNamespace(is_active=True)
+    terminal = types.SimpleNamespace(is_active=False)
+    active_calls = []
+    terminal_calls = []
+    monkeypatch.setattr(runtime, "_render_active_run", lambda *args: active_calls.append(args))
+    monkeypatch.setattr(runtime, "_render_terminal_run", lambda *args: terminal_calls.append(args))
+
+    monkeypatch.setattr(runtime, "get_run", lambda repo_root, run_id: active)
+    runtime._render_live_run("/tmp/repo", "active")
+    assert len(active_calls) == 1
+    assert terminal_calls == []
+
+    monkeypatch.setattr(runtime, "get_run", lambda repo_root, run_id: terminal)
+    runtime._render_live_run("/tmp/repo", "terminal")
+    assert len(terminal_calls) == 1
+    assert len(active_calls) == 1
+
+
+def test_terminal_renderer_discovers_results_once(monkeypatch) -> None:
+    runtime = _load_runtime(monkeypatch)
+    record = types.SimpleNamespace(run_id="terminal")
+    bundle = object()
+    discovered = []
+    monkeypatch.setattr(runtime, "_render_status", lambda *args: None)
+    monkeypatch.setattr(
+        runtime,
+        "discover_results",
+        lambda repo_root, selected: discovered.append((repo_root, selected)) or bundle,
+    )
+    monkeypatch.setattr(runtime, "_render_overview", lambda *args: None)
+    monkeypatch.setattr(runtime, "_render_metrics", lambda *args: None)
+    monkeypatch.setattr(runtime, "_render_artifacts", lambda *args: None)
+    monkeypatch.setattr(runtime, "_render_logs", lambda *args: None)
+    _tabs(monkeypatch, runtime, 4)
+
+    runtime._render_terminal_run(types.SimpleNamespace(), record)
+
+    assert len(discovered) == 1
+    assert discovered[0][1] is record


### PR DESCRIPTION
## Authorized promotion

Promote the reviewed U4c Streamlit refresh policy from `dev` to `main`.

## User invariant

Periodic refresh is process monitoring only. Active runs refresh status/logs without scientific result discovery; terminal runs render exact CLI-bound results without a two-second timer.

## Evidence

PR #248 passed Streamlit quality gates, Core quality gates, Repository layout, and Submodule policy. Focused Linux/Windows tests and the real inspector/Dummy/AppTest integration remained green. No unresolved review thread remains.

## Scope

Frontend rendering, focused tests, workflow test registration, and changelog only. No backend resolver, Factory, Pipeline, runtime, data/split, objective, metric, checkpoint, THU/MFPT, batch scheduler, Agent execution, research PR, tag, or package publication change.

Use a merge commit for the long-lived `dev` → `main` promotion.