### PR TITLE
release: promote finite Streamlit batch planning

### DIFF
--- a/.github/workflows/streamlit-quality-gates.yml
+++ b/.github/workflows/streamlit-quality-gates.yml
@@ -109,6 +109,7 @@ jobs:
           --junitxml=streamlit-pytest-${{ matrix.os }}.xml
           test/test_streamlit_config_service.py
           test/test_streamlit_field_catalog.py
+          test/test_streamlit_batch_service.py
           test/test_streamlit_runtime_policy.py
           test/test_streamlit_onboarding.py
           test/test_streamlit_run_service.py

--- a/apps/streamlit/batch_service.py
+++ b/apps/streamlit/batch_service.py
@@ -1,0 +1,161 @@
+"""Finite experiment-grid planning for the optional Streamlit workspace.
+
+This module plans approved parameter combinations only. It does not launch a process,
+select a scientific objective, or inspect test results. Execution remains owned by the
+existing single-run service.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from itertools import product
+from typing import Any, Iterable, Mapping, Sequence, Tuple
+
+try:
+    from .config_service import apply_overrides, dump_yaml
+except ImportError:  # pragma: no cover
+    from config_service import apply_overrides, dump_yaml  # type: ignore
+
+
+DEFAULT_MAX_TRIALS = 16
+DEFAULT_MAX_FITS = 64
+
+
+class BatchPlanError(ValueError):
+    """Raised when a requested finite batch is ambiguous or exceeds its budget."""
+
+
+@dataclass(frozen=True)
+class TrialPlan:
+    """One concrete configuration in a finite user-approved batch."""
+
+    index: int
+    trial_id: str
+    overrides: Tuple[Tuple[str, Any], ...]
+    config_yaml: str
+    fit_count: int
+
+
+@dataclass(frozen=True)
+class BatchPlan:
+    """A deterministic Cartesian product and its explicit execution cost."""
+
+    varying_paths: Tuple[str, ...]
+    trials: Tuple[TrialPlan, ...]
+    total_fits: int
+    max_trials: int
+    max_fits: int
+
+
+def _positive_int(value: Any, *, name: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+        raise BatchPlanError(f"{name} must be a positive integer.")
+    return value
+
+
+def _same_value(left: Any, right: Any) -> bool:
+    if type(left) is not type(right):
+        return False
+    try:
+        result = left == right
+    except Exception:
+        return False
+    return isinstance(result, bool) and result
+
+
+def _normalized_values(path: str, values: Sequence[Any]) -> Tuple[Any, ...]:
+    if isinstance(values, (str, bytes)) or not isinstance(values, Sequence):
+        raise BatchPlanError(f"Grid values for {path} must be a finite sequence.")
+    copied = tuple(values)
+    if not copied:
+        raise BatchPlanError(f"Grid values for {path} cannot be empty.")
+    for index, value in enumerate(copied):
+        if any(_same_value(value, previous) for previous in copied[:index]):
+            raise BatchPlanError(
+                f"Grid values for {path} contain a duplicate value: {value!r}."
+            )
+    return copied
+
+
+def _fit_count(config: Mapping[str, Any]) -> int:
+    environment = config.get("environment")
+    if not isinstance(environment, Mapping):
+        raise BatchPlanError("Resolved batch configuration must contain environment.")
+    return _positive_int(environment.get("iterations"), name="environment.iterations")
+
+
+def plan_grid(
+    base_config: Mapping[str, Any],
+    grid: Mapping[str, Sequence[Any]],
+    *,
+    allowed_paths: Iterable[str],
+    max_trials: int = DEFAULT_MAX_TRIALS,
+    max_fits: int = DEFAULT_MAX_FITS,
+) -> BatchPlan:
+    """Expand one bounded Cartesian product without executing any experiment.
+
+    ``allowed_paths`` is supplied by the current UI catalogue or a future bounded Agent
+    tool. The planner never invents a new config field and never changes seed/iterations
+    semantics. ``fit_count`` is the resolved ``environment.iterations`` for each trial,
+    so a user can see the real multiplicative cost before authorizing execution.
+    """
+
+    max_trials = _positive_int(max_trials, name="max_trials")
+    max_fits = _positive_int(max_fits, name="max_fits")
+    if not isinstance(base_config, Mapping) or not base_config:
+        raise BatchPlanError("base_config must be a non-empty resolved configuration.")
+    if not isinstance(grid, Mapping) or not grid:
+        raise BatchPlanError("At least one varying parameter is required.")
+
+    allowed = set(allowed_paths)
+    varying_paths = tuple(grid)
+    if any(not isinstance(path, str) or not path.strip() for path in varying_paths):
+        raise BatchPlanError("Every grid path must be a non-empty string.")
+    unknown = tuple(path for path in varying_paths if path not in allowed)
+    if unknown:
+        raise BatchPlanError(
+            "Batch grid contains fields that are not approved UI controls: "
+            + ", ".join(unknown)
+        )
+
+    dimensions = tuple(_normalized_values(path, grid[path]) for path in varying_paths)
+    trial_count = 1
+    for values in dimensions:
+        trial_count *= len(values)
+    if trial_count > max_trials:
+        raise BatchPlanError(
+            f"Batch requests {trial_count} trials, exceeding max_trials={max_trials}."
+        )
+
+    trials = []
+    total_fits = 0
+    for index, combination in enumerate(product(*dimensions), start=1):
+        overrides = tuple(zip(varying_paths, combination))
+        try:
+            resolved = apply_overrides(base_config, overrides)
+        except Exception as error:
+            raise BatchPlanError(f"Could not apply trial {index} overrides: {error}") from error
+        fit_count = _fit_count(resolved)
+        total_fits += fit_count
+        if total_fits > max_fits:
+            raise BatchPlanError(
+                f"Batch requires {total_fits} fits by trial {index}, exceeding "
+                f"max_fits={max_fits}."
+            )
+        trials.append(
+            TrialPlan(
+                index=index,
+                trial_id=f"trial-{index:03d}",
+                overrides=overrides,
+                config_yaml=dump_yaml(resolved),
+                fit_count=fit_count,
+            )
+        )
+
+    return BatchPlan(
+        varying_paths=varying_paths,
+        trials=tuple(trials),
+        total_fits=total_fits,
+        max_trials=max_trials,
+        max_fits=max_fits,
+    )

--- a/doc/changelog/2026-09-08-streamlit-finite-batch-plans.md
+++ b/doc/changelog/2026-09-08-streamlit-finite-batch-plans.md
@@ -1,0 +1,21 @@
+# Streamlit can plan finite experiment batches
+
+Date: 2026-09-08
+
+## Frontend capability
+
+The optional Streamlit workspace now contains a small deterministic batch-planning service. It expands a user-approved Cartesian product of current configuration fields without launching a process or introducing another training runtime.
+
+The planner requires an explicit allow-list of fields, rejects empty or duplicate values, and enforces visible `max_trials` and `max_fits` budgets before execution. Each planned trial contains the concrete YAML that would be submitted through the existing single-run path.
+
+`total_fits` is computed from each trial's resolved `environment.iterations`. The planner therefore does not silently replace the backend repeated-run contract when a user varies `environment.seed`: three seed-valued trials with `iterations: 3` are reported as nine fits, not repaired into three.
+
+## Boundary
+
+This change is planning only. It does not start a batch, choose a best trial, read a test metric, schedule parallel jobs, persist a new scientific manifest, or grant an Agent execution permission. Serial execution and user authorization remain separate frontend work.
+
+No PHMFactory config resolver, Factory, Pipeline, runtime, split, objective, metric, checkpoint selection, THU/MFPT experiment, tag, release, or package publication changes.
+
+## Validation
+
+Focused tests cover multi-dimensional grid order, true fit counts, base-config immutability, unknown/empty/duplicate fields, trial limits, fit limits, and seed/iteration multiplication. The existing Streamlit workflow runs the planner tests on Linux and Windows while the real inspector/Dummy/AppTest integration remains unchanged.

--- a/test/test_streamlit_batch_service.py
+++ b/test/test_streamlit_batch_service.py
@@ -1,0 +1,142 @@
+from __future__ import annotations
+
+from copy import deepcopy
+
+import pytest
+import yaml
+
+from apps.streamlit.batch_service import BatchPlanError, plan_grid
+
+
+@pytest.fixture
+def base_config():
+    return {
+        "pipeline": "Pipeline_01_Fault_Diagnosis",
+        "environment": {"seed": 0, "iterations": 3, "output_dir": "results/demo"},
+        "data": {"batch_size": 16, "num_workers": 0},
+        "model": {"type": "Backbone", "name": "B_04_Dlinear"},
+        "task": {"lr": 0.001, "metrics": ["acc", "f1"]},
+        "trainer": {
+            "name": "Default_trainer",
+            "device": "cpu",
+            "devices": 1,
+            "num_epochs": 1,
+            "test_after_fit": True,
+        },
+    }
+
+
+ALLOWED = {
+    "task.lr",
+    "data.batch_size",
+    "trainer.num_epochs",
+    "environment.seed",
+    "environment.iterations",
+}
+
+
+def _resolved(trial):
+    return yaml.safe_load(trial.config_yaml)
+
+
+def test_two_dimensional_grid_reports_trials_and_real_fit_cost(base_config):
+    plan = plan_grid(
+        base_config,
+        {"task.lr": [0.001, 0.0005, 0.0001], "data.batch_size": [16, 32]},
+        allowed_paths=ALLOWED,
+    )
+
+    assert len(plan.trials) == 6
+    assert plan.total_fits == 18
+    assert plan.varying_paths == ("task.lr", "data.batch_size")
+    assert [_resolved(trial)["task"]["lr"] for trial in plan.trials] == [
+        0.001,
+        0.001,
+        0.0005,
+        0.0005,
+        0.0001,
+        0.0001,
+    ]
+    assert [_resolved(trial)["data"]["batch_size"] for trial in plan.trials] == [
+        16,
+        32,
+        16,
+        32,
+        16,
+        32,
+    ]
+    assert all(trial.fit_count == 3 for trial in plan.trials)
+
+
+def test_iterations_are_counted_per_trial_without_seed_repair(base_config):
+    plan = plan_grid(
+        base_config,
+        {"environment.seed": [17, 18, 19]},
+        allowed_paths=ALLOWED,
+    )
+    assert len(plan.trials) == 3
+    assert plan.total_fits == 9
+    assert [_resolved(trial)["environment"]["iterations"] for trial in plan.trials] == [3, 3, 3]
+    assert [_resolved(trial)["environment"]["seed"] for trial in plan.trials] == [17, 18, 19]
+
+
+def test_iterations_grid_changes_visible_fit_cost(base_config):
+    plan = plan_grid(
+        base_config,
+        {"environment.iterations": [1, 2, 4]},
+        allowed_paths=ALLOWED,
+    )
+    assert [trial.fit_count for trial in plan.trials] == [1, 2, 4]
+    assert plan.total_fits == 7
+
+
+def test_planning_does_not_mutate_base_config(base_config):
+    before = deepcopy(base_config)
+    plan_grid(base_config, {"trainer.num_epochs": [1, 2]}, allowed_paths=ALLOWED)
+    assert base_config == before
+
+
+@pytest.mark.parametrize(
+    ("grid", "message"),
+    [
+        ({}, "At least one"),
+        ({"unknown.path": [1]}, "not approved"),
+        ({"task.lr": []}, "cannot be empty"),
+        ({"task.lr": [0.001, 0.001]}, "duplicate"),
+        ({"task.lr": "0.001"}, "finite sequence"),
+    ],
+)
+def test_invalid_grid_fails_before_execution(base_config, grid, message):
+    with pytest.raises(BatchPlanError, match=message):
+        plan_grid(base_config, grid, allowed_paths=ALLOWED)
+
+
+def test_trial_budget_fails_before_producing_an_oversized_plan(base_config):
+    with pytest.raises(BatchPlanError, match="exceeding max_trials=4"):
+        plan_grid(
+            base_config,
+            {"task.lr": [0.001, 0.0005, 0.0001], "data.batch_size": [16, 32]},
+            allowed_paths=ALLOWED,
+            max_trials=4,
+        )
+
+
+def test_fit_budget_accounts_for_backend_iterations(base_config):
+    with pytest.raises(BatchPlanError, match="exceeding max_fits=5"):
+        plan_grid(
+            base_config,
+            {"task.lr": [0.001, 0.0005]},
+            allowed_paths=ALLOWED,
+            max_fits=5,
+        )
+
+
+@pytest.mark.parametrize("budget", [0, -1, True, 1.5])
+def test_budgets_must_be_positive_integers(base_config, budget):
+    with pytest.raises(BatchPlanError, match="positive integer"):
+        plan_grid(
+            base_config,
+            {"task.lr": [0.001]},
+            allowed_paths=ALLOWED,
+            max_trials=budget,
+        )


### PR DESCRIPTION
## Authorized promotion

Promote the reviewed U5a finite batch-planning primitive from `dev` to `main`.

## User invariant

A human or future Agent can preview a finite Cartesian product only over explicitly approved configuration fields, with the exact number of CLI trials and underlying backend fits visible before any execution authorization.

## Evidence

PR #250 passed Streamlit quality gates, Core quality gates, Repository layout, and Submodule policy. The existing real inspector/Dummy/AppTest integration remained green and no review thread remained.

## Scope

Streamlit-side pure batch planning, focused tests, workflow test registration, and changelog only. No batch execution, scheduler, adaptive search, Agent tools, backend resolver, Factory, Pipeline, runtime, split, objective, metric, checkpoint, THU/MFPT, research PR, tag, or package publication change.

Use a merge commit for long-lived `dev` → `main` ancestry.