### PR TITLE
release: promote Streamlit batches and recovery fixes to main

### DIFF
--- a/.github/workflows/streamlit-quality-gates.yml
+++ b/.github/workflows/streamlit-quality-gates.yml
@@ -110,6 +110,7 @@ jobs:
           test/test_streamlit_config_service.py
           test/test_streamlit_field_catalog.py
           test/test_streamlit_batch_service.py
+          test/test_streamlit_batch_execution.py
           test/test_streamlit_runtime_policy.py
           test/test_streamlit_onboarding.py
           test/test_streamlit_run_service.py

--- a/apps/streamlit/README.md
+++ b/apps/streamlit/README.md
@@ -130,6 +130,19 @@ After a server restart the batch is marked **interrupted** and pending trials ar
 automatically resubmitted. Inspect the individual child runs before creating another plan.
 There is no cross-process scheduler, crash recovery, parallel execution or adaptive search.
 
+## Recover a detached run
+
+Viewing a detached run or submitting another experiment rechecks its recorded PID. If a
+POSIX probe confirms absence, the record becomes `orphaned` and no longer reserves the
+worker. Its final exit status remains unknown; files are not removed or relabelled as a
+successful evaluation. A saved cancellation request alone is not proof of exit.
+
+A present or unverifiable PID stays reserved and is never adopted or killed. Use **Recheck
+process** after checking the operating system. When this platform cannot probe safely,
+**Release finished run** requires explicit confirmation that the original run stopped.
+Windows does not use `os.kill(pid, 0)` to probe a process. This is record reconciliation,
+not automatic training recovery.
+
 ## Troubleshooting
 
 A rejected configuration shows the inspector's original stderr. Copy the visible command

--- a/apps/streamlit/README.md
+++ b/apps/streamlit/README.md
@@ -88,7 +88,47 @@ direct scientific results are unavailable.
 The workspace can cancel its active process and repeat a prior configuration in a new run.
 One Streamlit worker manages one active experiment. Browser refresh does not submit a new
 run; a server restart may leave the child process detached and must not trigger automatic
-resubmission. Pause/resume and cluster scheduling are not supported.
+resubmission. Pausing/resuming a running training process and cluster scheduling are not supported.
+
+## Finite batches
+
+Validate the base experiment, then open **Plan parameter combinations**. Enter a small
+YAML grid, for example:
+
+```yaml
+task.lr: [0.001, 0.0005]
+data.batch_size: [16, 32]
+```
+
+Click **Preview batch** to see every trial, its exact YAML and the total number of fits.
+The first UI supports learning rate, batch size, epochs, seed and iterations; it does not
+vary datasets, splits, model identity or devices. The UI caps a plan at 16 CLI calls and
+64 fits; lower limits can be chosen. Seed grids preserve `environment.iterations`: four
+trials with three iterations mean twelve fits, not four.
+
+**Run batch** explicitly submits that preview. Every snapshot is checked by the existing
+public inspector before any trial starts. Each trial then goes through the same public
+preflight and CLI used for a single run. Snapshots are not rewritten and failures do not
+trigger retries, parameter changes or substitute experiments.
+
+One server worker executes one trial at a time and reserves its run slot between trials.
+The first failed or cancelled trial pauses the remaining work. **Continue remaining trials**
+is an explicit decision to run only the pending items; earlier failures stay visible and
+the batch cannot become successful if any trial failed. **Cancel batch** stops the current
+managed child using the existing cancellation service and cancels pending items. A paused
+batch must be continued or cancelled before another run can start.
+
+Batch state and planned configurations are saved in
+`outputs/streamlit/batches/<batch-id>/batch.json`. This is a scheduling record, not a new
+scientific result format. Each trial has its own ordinary run record, log and CLI-reported
+results; **View trial** opens that run. Batch progress describes process completion and
+never claims benchmark validity.
+
+Page refresh only monitors the worker; it never submits the next trial. A disconnected
+browser does not stop already submitted work while the server process remains alive.
+After a server restart the batch is marked **interrupted** and pending trials are not
+automatically resubmitted. Inspect the individual child runs before creating another plan.
+There is no cross-process scheduler, crash recovery, parallel execution or adaptive search.
 
 ## Troubleshooting
 
@@ -116,6 +156,8 @@ python -m pytest -q \
   test/test_streamlit_runtime_policy.py \
   test/test_streamlit_onboarding.py \
   test/test_streamlit_run_service.py \
+  test/test_streamlit_batch_service.py \
+  test/test_streamlit_batch_execution.py \
   test/test_streamlit_result_service.py \
   test/test_streamlit_ui_imports.py
 

--- a/apps/streamlit/README.md
+++ b/apps/streamlit/README.md
@@ -130,6 +130,15 @@ After a server restart the batch is marked **interrupted** and pending trials ar
 automatically resubmitted. Inspect the individual child runs before creating another plan.
 There is no cross-process scheduler, crash recovery, parallel execution or adaptive search.
 
+## Keep existing runs visible
+
+**Runs and batches** appears before the new-experiment editor. A broken catalogue,
+missing template, empty category or invalid draft can block a new submission but cannot
+hide existing logs, cancellation, paused-batch controls or historical results. Batch
+history does not require a validated base configuration; only planning and submitting a
+new batch does. An inaccessible historical run displays its own error without disabling
+batches or the editor. Changing pages or inputs never submits a run.
+
 ## Recover a detached run
 
 Viewing a detached run or submitting another experiment rechecks its recorded PID. If a

--- a/apps/streamlit/run_service.py
+++ b/apps/streamlit/run_service.py
@@ -1,6 +1,6 @@
 """Cross-platform process lifecycle for the optional Streamlit experiment console.
 
-The service owns subprocess state, durable run manifests, and log files. It does
+The service owns subprocess state, scheduling records, and log files. It does
 not import Streamlit and never calls a PHM-Vibench Pipeline directly. Every run
 executes the public CLI contract through ``main.py --config``.
 """
@@ -17,10 +17,12 @@ import sys
 import threading
 import time
 import uuid
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, List, Mapping, Optional, TextIO, Tuple
+
+from .batch_service import BatchPlan, _fit_count, _positive_int
 
 try:
     from .config_service import (
@@ -113,6 +115,35 @@ class _ManagedProcess:
 
 _LOCK = threading.RLock()
 _PROCESSES: Dict[str, _ManagedProcess] = {}
+
+
+@dataclass(frozen=True)
+class BatchRecord:
+    """Process scheduling facts; each trial keeps its own public CLI results."""
+
+    batch_id: str
+    status: str
+    batch_dir: Path
+    trials: Tuple[Mapping[str, Any], ...]
+    total_fits: int
+    error: str = ""
+
+    @property
+    def is_terminal(self) -> bool:
+        return self.status in {"succeeded", "failed", "cancelled", "interrupted"}
+
+
+@dataclass
+class _ManagedBatch:
+    request: RunRequest
+    batch_id: str
+    batch_dir: Path
+    cancel: threading.Event = field(default_factory=threading.Event)
+
+
+# Reserve the same single-run slot between trials and while failure is paused.
+# This is deliberately process-local: a restarted service never auto-resubmits.
+_BATCHES: Dict[Path, _ManagedBatch] = {}
 
 
 def _utc_now() -> str:
@@ -365,32 +396,45 @@ def _spawn_kwargs() -> Dict[str, Any]:
     return {"start_new_session": True}
 
 
-def start_run(request: RunRequest) -> RunRecord:
+def _require_available(root: Path, batch_id: Optional[str] = None) -> None:
+    """Called under _LOCK for both ordinary runs and a batch's next trial."""
+
+    batch = _BATCHES.get(root)
+    if batch is not None and batch.batch_id != batch_id:
+        raise RunConflictError(
+            f"Batch {batch.batch_id} owns this worker. Finish, continue or cancel it first."
+        )
+    if batch_id is not None:
+        if batch is None or batch.batch_id != batch_id:
+            raise RunConflictError("The batch no longer owns this worker.")
+        if batch.cancel.is_set():
+            raise RunServiceError("Batch cancelled before training started.")
+    active = _active_managed_run(root)
+    if active:
+        raise RunConflictError(f"Run {active} is active. Finish or cancel it first.")
+    run_root = _run_root(root)
+    if run_root.is_dir():
+        for directory in sorted(run_root.iterdir(), reverse=True):
+            if not directory.is_dir() or not (directory / "run.json").is_file():
+                continue
+            try:
+                existing = get_run(root, directory.name)
+            except RunServiceError:
+                continue
+            if existing.is_active:
+                raise RunConflictError(
+                    f"Run {existing.run_id} is still {existing.status}. Resolve it first."
+                )
+
+
+def start_run(request: RunRequest, *, _batch_id: Optional[str] = None) -> RunRecord:
     """Approve, preflight, and launch one exact PHMFactory execution snapshot."""
 
     approved = approve_request(request)
+    if _batch_id is not None and approved.config_yaml != request.config_yaml:
+        raise RunServiceError("Public analysis changed the approved batch snapshot; inspect it again.")
     with _LOCK:
-        active = _active_managed_run(approved.repo_root)
-        if active:
-            raise RunConflictError(
-                f"This Streamlit worker already manages active run {active}. "
-                "Cancel or finish it before starting another experiment."
-            )
-        run_root = _run_root(approved.repo_root)
-        if run_root.is_dir():
-            for existing_dir in sorted(run_root.iterdir(), reverse=True):
-                if not existing_dir.is_dir() or not (existing_dir / "run.json").is_file():
-                    continue
-                try:
-                    existing = get_run(approved.repo_root, existing_dir.name)
-                except RunServiceError:
-                    continue
-                if existing.is_active:
-                    raise RunConflictError(
-                        f"Run {existing.run_id} is still {existing.status}. Resolve it before "
-                        "starting another experiment."
-                    )
-
+        _require_available(approved.repo_root, _batch_id)
         run_id = _new_run_id()
         run_dir = _run_root(approved.repo_root) / run_id
         run_dir.mkdir(parents=True, exist_ok=False)
@@ -398,6 +442,8 @@ def start_run(request: RunRequest) -> RunRecord:
         config_path.write_text(approved.config_yaml, encoding="utf-8")
         try:
             _run_public_preflight(approved.repo_root, config_path)
+            if _batch_id is not None and _BATCHES[approved.repo_root].cancel.is_set():
+                raise RunServiceError("Batch cancelled before training started.")
         except RunServiceError:
             shutil.rmtree(run_dir)
             raise
@@ -716,3 +762,206 @@ def elapsed_seconds(record: RunRecord, *, now: Optional[datetime] = None) -> flo
     if end.tzinfo is None:
         end = end.replace(tzinfo=timezone.utc)
     return max(0.0, (end - start).total_seconds())
+
+
+# Batch records contain only approved configurations and scheduling state. There
+# is no second evaluator; all subprocess, preflight and cancellation behavior
+# remains in start_run/get_run/cancel_run above.
+def _batch_root(root: Path) -> Path:
+    return _run_root(root) / "batches"
+
+
+def _batch_payload(directory: Path) -> Dict[str, Any]:
+    return json.loads((directory / "batch.json").read_text(encoding="utf-8"))
+
+
+def _save_batch(directory: Path, payload: Mapping[str, Any]) -> None:
+    _atomic_write_json(directory / "batch.json", payload)
+
+
+def _batch_record(directory: Path, payload: Mapping[str, Any]) -> BatchRecord:
+    return BatchRecord(
+        batch_id=directory.name, status=payload["status"], batch_dir=directory,
+        trials=tuple(copy.deepcopy(payload["trials"])), total_fits=payload["total_fits"],
+        error=payload.get("error", ""),
+    )
+
+
+def start_batch(request: RunRequest, plan: BatchPlan) -> BatchRecord:
+    """Submit one explicitly approved finite plan, preserving every trial and seed.
+
+    Resolve every snapshot before any trial starts. Execution then reuses the
+    ordinary public preflight and CLI one trial at a time. No automatic retries.
+    """
+
+    root = _ensure_repo_root(request.repo_root)
+    if not isinstance(plan, BatchPlan) or not plan.trials:
+        raise RunServiceError("A non-empty BatchPlan is required.")
+    if len(plan.trials) > _positive_int(plan.max_trials, name="max_trials"):
+        raise RunServiceError("Batch exceeds its approved trial budget.")
+    fits = [_fit_count(parse_yaml_text(trial.config_yaml)) for trial in plan.trials]
+    if (sum(fits) != plan.total_fits or sum(fits) > _positive_int(plan.max_fits, name="max_fits")
+            or any(count != trial.fit_count for count, trial in zip(fits, plan.trials))):
+        raise RunServiceError("Batch fit count differs from its approved configurations or budget.")
+    with _LOCK:
+        _require_available(root)
+    trials = []
+    for index, trial in enumerate(plan.trials, start=1):
+        candidate = replace(request, config_source=None, config_yaml=trial.config_yaml, overrides=())
+        approved = approve_request(candidate)
+        if approved.config_yaml != dump_yaml(parse_yaml_text(trial.config_yaml)):
+            raise RunServiceError(f"Public analysis changed trial {index}; inspect the configuration again.")
+        trials.append({"index": index, "status": "pending", "run_id": "", "error": "",
+                       "config_yaml": approved.config_yaml, "fit_count": fits[index - 1]})
+    with _LOCK:
+        _require_available(root)
+        batch_id = _new_run_id()
+        directory = _batch_root(root) / batch_id
+        directory.mkdir(parents=True, exist_ok=False)
+        payload = {"status": "running", "created_at": _utc_now(), "ended_at": "",
+                   "total_fits": plan.total_fits, "trials": trials, "error": ""}
+        _save_batch(directory, payload)
+        managed = _ManagedBatch(replace(approved, metadata=copy.deepcopy(approved.metadata)),
+                                batch_id, directory)
+        _BATCHES[root] = managed
+        _start_batch_worker(managed)
+        return _batch_record(directory, payload)
+
+
+def _start_batch_worker(managed: _ManagedBatch) -> None:
+    threading.Thread(target=_run_batch, args=(managed,),
+                     name=f"phm-batch-{managed.batch_id}", daemon=True).start()
+
+
+def _finish_batch(managed: _ManagedBatch, payload: Dict[str, Any], status: str) -> None:
+    """Called under _LOCK, only after the current child has reached a terminal state."""
+
+    payload.update(status=status, ended_at=_utc_now())
+    if status == "cancelled":
+        for trial in payload["trials"]:
+            if trial["status"] == "pending":
+                trial["status"] = "cancelled"
+    _save_batch(managed.batch_dir, payload)
+    _BATCHES.pop(managed.request.repo_root, None)
+
+
+def _run_batch(managed: _ManagedBatch) -> None:
+    root, directory = managed.request.repo_root, managed.batch_dir
+    while True:
+        with _LOCK:
+            payload = _batch_payload(directory)
+            if managed.cancel.is_set():
+                _finish_batch(managed, payload, "cancelled")
+                return
+            pending = next((t for t in payload["trials"] if t["status"] == "pending"), None)
+            if pending is None:
+                status = "succeeded" if all(t["status"] == "succeeded" for t in payload["trials"]) else "failed"
+                _finish_batch(managed, payload, status)
+                return
+            index = pending["index"] - 1
+            pending["status"] = "starting"
+            payload["error"] = ""
+            _save_batch(directory, payload)
+        record = None
+        error = ""
+        try:
+            request = replace(managed.request, config_yaml=pending["config_yaml"],
+                              metadata={**managed.request.metadata, "batch_id": managed.batch_id,
+                                        "trial_index": index + 1})
+            record = start_run(request, _batch_id=managed.batch_id)
+            with _LOCK:
+                payload = _batch_payload(directory)
+                payload["trials"][index].update(run_id=record.run_id, status=record.status)
+                _save_batch(directory, payload)
+            while not record.is_terminal:
+                if managed.cancel.wait(0.1):
+                    record = cancel_run(root, record.run_id)
+                else:
+                    record = get_run(root, record.run_id)
+            error = record.error or (f"Run {record.run_id} ended as {record.status} (exit {record.exit_code})."
+                                     if record.status != "succeeded" else "")
+        except Exception as exc:
+            # A worker cannot raise into the UI thread. Keep the original type and
+            # message visible and pause; never repair the configuration or skip it.
+            error = f"{type(exc).__name__}: {exc}"
+            if record is not None and not record.is_terminal:
+                cancel_run(root, record.run_id)
+        with _LOCK:
+            payload = _batch_payload(directory)
+            status = (record.status if record is not None and record.is_terminal
+                      else "cancelled" if managed.cancel.is_set() else "failed")
+            payload["trials"][index].update(status=status, error=error)
+            payload["error"] = error
+            if managed.cancel.is_set():
+                _finish_batch(managed, payload, "cancelled")
+                return
+            if status != "succeeded":
+                if any(t["status"] == "pending" for t in payload["trials"]):
+                    payload["status"] = "paused"
+                    _save_batch(directory, payload)
+                else:
+                    _finish_batch(managed, payload, "failed")
+                return
+            _save_batch(directory, payload)
+
+
+def get_batch(repo_root: Path, batch_id: str) -> BatchRecord:
+    root = _ensure_repo_root(repo_root)
+    if not batch_id or Path(batch_id).name != batch_id or batch_id in {".", ".."}:
+        raise RunServiceError("Invalid batch identifier.")
+    directory = _batch_root(root) / batch_id
+    with _LOCK:
+        payload = _batch_payload(directory)
+        managed = _BATCHES.get(root)
+        if payload["status"] in {"running", "paused", "cancelling"} and (
+            managed is None or managed.batch_id != batch_id
+        ):
+            payload.update(status="interrupted", ended_at=_utc_now(),
+                           error="The service lost batch ownership. No pending trial was resubmitted; inspect child runs before creating a new plan.")
+            _save_batch(directory, payload)
+        return _batch_record(directory, payload)
+
+
+def list_batches(repo_root: Path, *, limit: int = 20) -> Tuple[BatchRecord, ...]:
+    root = _ensure_repo_root(repo_root)
+    directory = _batch_root(root)
+    if not directory.exists():
+        return ()
+    paths = sorted((p for p in directory.iterdir() if (p / "batch.json").is_file()), reverse=True)
+    return tuple(get_batch(root, path.name) for path in paths[:limit])
+
+
+def continue_batch(repo_root: Path, batch_id: str) -> BatchRecord:
+    """Explicitly continue pending trials; a failed trial is never retried or erased."""
+
+    root = _ensure_repo_root(repo_root)
+    with _LOCK:
+        record = get_batch(root, batch_id)
+        managed = _BATCHES.get(root)
+        if record.status != "paused" or managed is None or managed.batch_id != batch_id:
+            raise RunServiceError("Only a paused batch owned by this service can continue.")
+        payload = _batch_payload(managed.batch_dir)
+        payload["status"] = "running"
+        _save_batch(managed.batch_dir, payload)
+        _start_batch_worker(managed)
+        return _batch_record(managed.batch_dir, payload)
+
+
+def cancel_batch(repo_root: Path, batch_id: str) -> BatchRecord:
+    """Cancel the current child via the existing service and cancel unstarted trials."""
+
+    root = _ensure_repo_root(repo_root)
+    # Signal before acquiring the execution lock, including while preflight is
+    # running. start_run checks this event again before it may create a child.
+    managed = _BATCHES.get(root)
+    if managed is None or managed.batch_id != batch_id:
+        return get_batch(root, batch_id)
+    managed.cancel.set()
+    with _LOCK:
+        payload = _batch_payload(managed.batch_dir)
+        if payload["status"] == "paused":
+            _finish_batch(managed, payload, "cancelled")
+        elif payload["status"] == "running":
+            payload["status"] = "cancelling"
+            _save_batch(managed.batch_dir, payload)
+        return _batch_record(managed.batch_dir, payload)

--- a/apps/streamlit/run_service.py
+++ b/apps/streamlit/run_service.py
@@ -809,7 +809,28 @@ def _batch_root(root: Path) -> Path:
 
 
 def _batch_payload(directory: Path) -> Dict[str, Any]:
-    return json.loads((directory / "batch.json").read_text(encoding="utf-8"))
+    """Read operational fields before callers index them; never repair old records."""
+
+    path = directory / "batch.json"
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise RunServiceError(f"Batch record must contain a JSON object: {path}")
+    for name, expected in (("status", str), ("trials", list), ("total_fits", int)):
+        if name not in payload or type(payload[name]) is not expected:
+            raise RunServiceError(
+                f"Invalid batch record {path}: {name} must be {expected.__name__}."
+            )
+    for index, trial in enumerate(payload["trials"], start=1):
+        if not isinstance(trial, dict):
+            raise RunServiceError(f"Invalid batch record {path}: trial {index} must be an object.")
+        for name, expected in (("index", int), ("status", str), ("fit_count", int),
+                               ("run_id", str), ("error", str), ("config_yaml", str)):
+            if name not in trial or type(trial[name]) is not expected:
+                raise RunServiceError(
+                    f"Invalid batch record {path}: trial {index}.{name} "
+                    f"must be {expected.__name__}."
+                )
+    return payload
 
 
 def _save_batch(directory: Path, payload: Mapping[str, Any]) -> None:

--- a/apps/streamlit/run_service.py
+++ b/apps/streamlit/run_service.py
@@ -550,17 +550,23 @@ def _monitor_process(repo_root: Path, run_id: str, managed: _ManagedProcess) -> 
             _PROCESSES.pop(_key(repo_root, run_id), None)
 
 
-def _pid_exists(pid: int) -> bool:
-    if pid <= 0:
-        return False
-    if os.name == "nt":
-        return False
+def _pid_exists(pid: Optional[int]) -> Optional[bool]:
+    """False proves absence; None means this worker cannot check safely.
+
+    Do not use os.kill(pid, 0) on Windows: it is not a harmless liveness probe.
+    A present PID never proves process identity and is never adopted or killed.
+    """
+
+    if isinstance(pid, bool) or not isinstance(pid, int) or pid <= 0:
+        return None
+    if sys.platform == "win32":
+        return None
     try:
         os.kill(pid, 0)
     except ProcessLookupError:
         return False
-    except PermissionError:
-        return True
+    except OSError:
+        return None
     return True
 
 
@@ -575,7 +581,7 @@ def get_run(repo_root: Path, run_id: str) -> RunRecord:
     with _LOCK:
         payload = _read_payload(run_dir)
         status = str(payload.get("status") or "unknown")
-        if status in {"starting", "running", "cancelling"}:
+        if status in {"starting", "running", "cancelling", "detached"}:
             managed = _PROCESSES.get(key)
             if managed is not None:
                 return_code = managed.process.poll()
@@ -596,27 +602,58 @@ def get_run(repo_root: Path, run_id: str) -> RunRecord:
                     # process-registry removal. get_run only reconciles durable state.
                     _atomic_write_json(_manifest_path(run_dir), payload)
             else:
-                pid = payload.get("pid")
-                cancel_requested = bool(payload.get("cancel_requested"))
-                new_status = (
-                    "cancelled"
-                    if cancel_requested
-                    else "detached" if isinstance(pid, int) and _pid_exists(pid) else "orphaned"
-                )
-                payload.update(
-                    status=new_status,
-                    ended_at="" if new_status == "detached" else _utc_now(),
-                    error=(
-                        "The Streamlit worker restarted while the process is still alive; "
-                        "automatic cancellation is disabled for safety."
-                        if new_status == "detached"
-                        else ""
-                        if new_status == "cancelled"
-                        else "The managed process is no longer available."
+                present = _pid_exists(payload.get("pid"))
+                # A persisted cancellation request is not proof that an unmanaged
+                # process stopped. Only observed absence releases its reservation.
+                changes = {
+                    "status": "orphaned" if present is False else "detached",
+                    "ended_at": _utc_now() if present is False else "",
+                    "exit_code": None,
+                    "error": (
+                        "The unmanaged process is no longer present. Its final exit "
+                        "status is unknown; logs and outputs are preserved."
+                        if present is False else
+                        "This worker does not own the recorded process. A present or "
+                        "unverifiable PID remains reserved; recheck it or confirm in "
+                        "the operating system that the original run has stopped. "
+                        "No process will be adopted, signalled or automatically retried."
                     ),
-                )
-                _atomic_write_json(_manifest_path(run_dir), payload)
+                }
+                if any(payload.get(key) != value for key, value in changes.items()):
+                    payload.update(changes)
+                    _atomic_write_json(_manifest_path(run_dir), payload)
         return _record(payload, run_dir)
+
+
+def release_detached_run(
+    repo_root: Path, run_id: str, *, confirmed_stopped: bool = False
+) -> RunRecord:
+    """Release an unverifiable reservation after explicit OS-level confirmation.
+
+    This acknowledges an unknown outcome, not success. It never signals a PID
+    or removes the run's configuration, logs or scientific outputs.
+    """
+
+    if confirmed_stopped is not True:
+        raise RunServiceError("Confirm that the original run has stopped before releasing it.")
+    root = _ensure_repo_root(repo_root)
+    with _LOCK:
+        record = get_run(root, run_id)
+        if record.is_terminal:
+            return record
+        if record.status != "detached" or _key(root, run_id) in _PROCESSES:
+            raise RunServiceError("Only a detached run can be released this way.")
+        if _pid_exists(record.pid) is True:
+            raise RunServiceError(
+                "The recorded PID still exists. This worker cannot prove it is the "
+                "original process and will not release or terminate it automatically."
+            )
+        payload = _update_payload(
+            record.run_dir, status="orphaned", ended_at=_utc_now(), exit_code=None,
+            error="User confirmed the original run stopped. Its final exit status "
+                  "is unknown; logs and outputs are preserved.",
+        )
+        return _record(payload, record.run_dir)
 
 
 def list_runs(repo_root: Path, *, limit: int = 30) -> Tuple[RunRecord, ...]:

--- a/apps/streamlit/ui_batch.py
+++ b/apps/streamlit/ui_batch.py
@@ -1,0 +1,133 @@
+"""Finite batch controls; rendering never schedules the next experiment."""
+from pathlib import Path
+
+import streamlit as st
+import yaml
+
+from .batch_service import BatchPlanError, plan_grid
+from .config_service import ConfigServiceError, parse_yaml_text
+from .run_service import (
+    RunRequest, RunServiceError, cancel_batch, continue_batch, get_batch,
+    list_batches, start_batch,
+)
+
+# Only these existing user-selected fields can vary in the first batch UI.
+# In particular, planning does not change data selection, split or model identity.
+GRID_PATHS = (
+    "task.lr", "data.batch_size", "trainer.num_epochs",
+    "environment.seed", "environment.iterations",
+)
+
+
+def _batch_status(repo_root: Path, record) -> None:
+    st.write(f"Batch {record.batch_id}: **{record.status}**")
+    st.caption(f"{len(record.trials)} planned CLI calls; {record.total_fits} planned fits. "
+               "Trial status is process status, not benchmark validation.")
+    st.dataframe([
+        {key: trial[key] for key in ("index", "status", "fit_count", "run_id", "error")}
+        for trial in record.trials
+    ], hide_index=True, use_container_width=True)
+    if record.error:
+        st.warning(record.error)
+    left, right = st.columns(2)
+    if left.button("Continue remaining trials", key=f"continue-batch::{record.batch_id}",
+                   disabled=record.status != "paused"):
+        try:
+            continue_batch(repo_root, record.batch_id)
+            st.rerun()
+        except RunServiceError as error:
+            st.error(str(error))
+    if right.button("Cancel batch", key=f"cancel-batch::{record.batch_id}",
+                    disabled=record.is_terminal):
+        cancel_batch(repo_root, record.batch_id)
+        st.rerun()
+    st.caption("Continuing runs only pending trials. Failed trials remain failed and are not retried.")
+    for trial in record.trials:
+        if trial["run_id"] and st.button(f"View trial {trial['index']}",
+                                        key=f"batch-run::{record.batch_id}::{trial['index']}"):
+            st.session_state.selected_run_id = trial["run_id"]
+            st.session_state.active_run_id = trial["run_id"]
+            st.rerun()
+
+
+@st.fragment(run_every="2s")
+def _active_batch(repo_root_text: str, batch_id: str) -> None:
+    record = get_batch(Path(repo_root_text), batch_id)
+    if record.status not in {"running", "cancelling"}:
+        st.rerun()
+    _batch_status(Path(repo_root_text), record)
+
+
+def render_batch_controls(repo_root: Path, approved_yaml: str, *, template_id: str, mode: str) -> None:
+    st.subheader("有限批次 | Finite batch")
+    st.caption("Preview a fixed grid, then explicitly run it. One trial at a time; "
+               "the first failed or cancelled trial pauses pending work.")
+    with st.expander("Plan parameter combinations"):
+        st.caption("Allowed existing paths: " + ", ".join(GRID_PATHS))
+        grid_text = st.text_area("Parameter grid (YAML lists)",
+                                value="task.lr: [0.001, 0.0005]", key="batch_grid_text")
+        left, right = st.columns(2)
+        max_trials = left.number_input("Maximum CLI calls", min_value=1, max_value=16,
+                                      value=16, step=1, key="batch_max_trials")
+        max_fits = right.number_input("Maximum fits", min_value=1, max_value=64,
+                                       value=64, step=1, key="batch_max_fits")
+        inputs = (approved_yaml, grid_text, max_trials, max_fits, template_id, mode)
+        if st.button("Preview batch", disabled=not approved_yaml):
+            try:
+                plan = plan_grid(parse_yaml_text(approved_yaml), yaml.safe_load(grid_text),
+                                 allowed_paths=GRID_PATHS, max_trials=max_trials, max_fits=max_fits)
+                st.session_state.batch_plan = plan
+                st.session_state.batch_plan_inputs = inputs
+                st.session_state.batch_plan_submitted = False
+            except (BatchPlanError, ConfigServiceError, yaml.YAMLError) as error:
+                st.session_state.batch_plan = None
+                st.session_state.batch_plan_inputs = None
+                st.error(str(error))
+        plan = st.session_state.get("batch_plan")
+        current = plan is not None and st.session_state.get("batch_plan_inputs") == inputs
+        if plan is not None and not current:
+            st.warning("Batch inputs changed. Preview the new plan before running.")
+        if current:
+            st.write(f"**{len(plan.trials)} CLI calls / {plan.total_fits} fits**")
+            st.dataframe([
+                {"trial": trial.trial_id, "fits": trial.fit_count,
+                 **{path: repr(value) for path, value in trial.overrides}}
+                for trial in plan.trials
+            ], hide_index=True, use_container_width=True)
+            st.caption("Seed and iterations are preserved. A seed grid does not reset iterations to one.")
+            selected_trial = st.selectbox("Inspect planned YAML",
+                                             range(len(plan.trials)),
+                                             format_func=lambda i: plan.trials[i].trial_id)
+            st.code(plan.trials[selected_trial].config_yaml, language="yaml")
+        batches = list_batches(repo_root)
+        reserved = any(not batch.is_terminal for batch in batches)
+        submitted = st.session_state.get("batch_plan_submitted", False)
+        if st.button("Run batch", disabled=not current or reserved or submitted, type="primary"):
+            try:
+                with st.spinner("Checking all trial snapshots before submitting the batch..."):
+                    batch = start_batch(
+                        RunRequest(repo_root=repo_root, template_id=template_id, mode=mode,
+                                   config_yaml=approved_yaml), plan)
+                st.session_state.selected_batch_id = batch.batch_id
+                # Keep the inspected YAML visible; require a fresh Preview before resubmission.
+                st.session_state.batch_plan_submitted = True
+                st.rerun()
+            except (RunServiceError, BatchPlanError, ConfigServiceError) as error:
+                st.error(str(error))
+        if submitted:
+            st.caption("This preview has been submitted. Preview a new plan to submit again.")
+        if reserved:
+            st.info("A batch owns this worker. Continue or cancel paused work before another submission.")
+    batches = list_batches(repo_root)
+    if not batches:
+        return
+    ids = tuple(batch.batch_id for batch in batches)
+    preferred = st.session_state.get("selected_batch_id", ids[0])
+    selected = st.selectbox("Recent batches", ids,
+                            index=ids.index(preferred) if preferred in ids else 0)
+    st.session_state.selected_batch_id = selected
+    record = get_batch(repo_root, selected)
+    if record.status in {"running", "cancelling"}:
+        _active_batch(str(repo_root), selected)
+    else:
+        _batch_status(repo_root, record)

--- a/apps/streamlit/ui_batch.py
+++ b/apps/streamlit/ui_batch.py
@@ -99,7 +99,11 @@ def render_batch_controls(repo_root: Path, approved_yaml: str, *, template_id: s
                                              range(len(plan.trials)),
                                              format_func=lambda i: plan.trials[i].trial_id)
             st.code(plan.trials[selected_trial].config_yaml, language="yaml")
-        batches = list_batches(repo_root)
+        try:
+            batches = list_batches(repo_root)
+        except (RunServiceError, OSError, ValueError) as error:
+            st.error(f"Batch submission is unavailable until its history is readable: {error}")
+            return
         reserved = any(not batch.is_terminal for batch in batches)
         submitted = st.session_state.get("batch_plan_submitted", False)
         if st.button("Run batch", disabled=not current or reserved or submitted, type="primary"):
@@ -118,6 +122,11 @@ def render_batch_controls(repo_root: Path, approved_yaml: str, *, template_id: s
             st.caption("This preview has been submitted. Preview a new plan to submit again.")
         if reserved:
             st.info("A batch owns this worker. Continue or cancel paused work before another submission.")
+
+
+def render_batch_history(repo_root: Path) -> None:
+    """Existing batches remain controllable without a valid editor draft."""
+
     batches = list_batches(repo_root)
     if not batches:
         return

--- a/apps/streamlit/ui_runtime.py
+++ b/apps/streamlit/ui_runtime.py
@@ -24,6 +24,7 @@ try:
         get_run,
         list_runs,
         read_log_tail,
+        release_detached_run,
         restart_run,
     )
     from .ui_theme import _render_error
@@ -43,6 +44,7 @@ except ImportError:  # pragma: no cover
         get_run,
         list_runs,
         read_log_tail,
+        release_detached_run,
         restart_run,
     )
     from ui_theme import _render_error  # type: ignore
@@ -306,6 +308,26 @@ def _render_run_actions(repo_root: Path, record: RunRecord) -> None:
         )
 
 
+def _render_detached_controls(repo_root: Path, record: RunRecord) -> None:
+    st.warning(record.error)
+    if st.button("Recheck process", key=f"recheck::{record.run_id}"):
+        # get_run rechecks without taking ownership or sending a termination signal.
+        get_run(repo_root, record.run_id)
+        st.rerun()
+    confirmed = st.checkbox(
+        "I confirmed in the operating system that the original run has stopped",
+        key=f"stopped-confirmed::{record.run_id}",
+    )
+    if st.button("Release finished run", disabled=not confirmed,
+                 key=f"release-detached::{record.run_id}"):
+        try:
+            release_detached_run(repo_root, record.run_id, confirmed_stopped=confirmed)
+            st.rerun()
+        except RunServiceError as error:
+            st.error(str(error))
+    st.caption("Release preserves files and records an unknown outcome, not a successful experiment.")
+
+
 def _render_status(repo_root: Path, record: RunRecord) -> None:
     st.markdown(
         f'<span class="phm-status">{html.escape(_status_label(record))}</span> '
@@ -321,6 +343,8 @@ def _render_status(repo_root: Path, record: RunRecord) -> None:
         record.exit_code if record.exit_code is not None else "—",
     )
     _render_run_actions(repo_root, record)
+    if record.status == "detached":
+        _render_detached_controls(repo_root, record)
 
 
 @st.fragment(run_every="2s")

--- a/apps/streamlit/ui_runtime.py
+++ b/apps/streamlit/ui_runtime.py
@@ -75,12 +75,20 @@ def _render_run_selector(repo_root: Path) -> Optional[str]:
         runs = list_runs(repo_root, limit=20)
     except RunServiceError:
         return None
+    preferred = st.session_state.selected_run_id or st.session_state.active_run_id
+    if preferred and all(item.run_id != preferred for item in runs):
+        try:
+            # Batch history can outlive the recent-run window. Load the exact
+            # requested trial rather than showing an unrelated newer result.
+            runs = (get_run(repo_root, preferred), *runs)
+        except RunServiceError as error:
+            st.sidebar.error(str(error))
+            return preferred
     if not runs:
         st.sidebar.caption("No experiment runs yet.")
         return None
     ids = tuple(item.run_id for item in runs)
-    preferred = st.session_state.selected_run_id or st.session_state.active_run_id
-    if preferred not in ids:
+    if not preferred:
         preferred = ids[0]
     lookup = {item.run_id: item for item in runs}
     selected = st.sidebar.selectbox(

--- a/apps/streamlit/workspace.py
+++ b/apps/streamlit/workspace.py
@@ -12,7 +12,7 @@ from typing import Any, Mapping, Sequence, Tuple
 
 import streamlit as st
 
-from .ui_batch import render_batch_controls
+from .ui_batch import render_batch_controls, render_batch_history
 
 try:
     from .config_service import (
@@ -190,6 +190,26 @@ def _safe_smoke_reset(default_template_id: str) -> None:
     st.rerun()
 
 
+def _render_existing_runs(repo_root: Path) -> None:
+    """Do not let a new template or draft failure hide existing process controls."""
+
+    st.header("运行与批次 | Runs and batches")
+    try:
+        selected = _render_run_selector(repo_root)
+        run_id = selected or st.session_state.selected_run_id or st.session_state.active_run_id
+        if run_id:
+            _render_live_run(str(repo_root), run_id)
+        else:
+            st.caption("No run selected. Configure a new experiment below or select a past run.")
+    except (RunServiceError, OSError, ValueError) as error:
+        # A damaged historical file must not disable batches or new configuration.
+        _render_error("The selected run view could not be loaded; batches and the editor remain available.", error)
+    try:
+        render_batch_history(repo_root)
+    except (RunServiceError, OSError, ValueError) as error:
+        _render_error("Batch history could not be loaded; single-run controls remain available.", error)
+
+
 def main() -> None:
     st.set_page_config(
         page_title="PHMFactory Experiment Workspace",
@@ -203,6 +223,14 @@ def main() -> None:
 
     try:
         repo_root = find_repo_root(APP_DIR)
+    except ConfigServiceError as error:
+        _render_error("The repository root could not be found.", error)
+        st.stop()
+
+    # Render first: st.stop in the editor must not remove logs/cancel/history.
+    _render_existing_runs(repo_root)
+
+    try:
         catalog = _cached_catalog(str(APP_DIR / "field_catalog.yaml"))
         profiles = _cached_profiles(str(APP_DIR / "template_profiles.yaml"))
         registry = _cached_registry(str(repo_root))
@@ -235,7 +263,6 @@ def main() -> None:
             "standalone YAML editor and explicit raw overrides."
         ),
     )
-    selected_run = _render_run_selector(repo_root)
 
     st.header("1. 选择实验模板 | Select a validated template")
     group_keys = tuple(catalog.template_groups.keys())
@@ -488,7 +515,7 @@ def main() -> None:
             )
             st.session_state.active_run_id = launched.run_id
             st.session_state.selected_run_id = launched.run_id
-            st.toast("Experiment started. Live logs are available below.")
+            st.toast("Experiment started. Logs and controls are in Runs and batches above.")
             st.rerun()
         except (RunServiceError, RunConflictError) as error:
             _render_error("The experiment could not start.", error)
@@ -497,18 +524,3 @@ def main() -> None:
         repo_root, approved_yaml_text if can_run else "",
         template_id=selected_id, mode=mode,
     )
-
-    st.header("4. 运行与结果 | Live run and evidence")
-    run_id = (
-        selected_run
-        or st.session_state.selected_run_id
-        or st.session_state.active_run_id
-    )
-    if run_id:
-        _render_live_run(str(repo_root), run_id)
-    else:
-        st.info(
-            "Validate the CPU smoke template and start an experiment. This area will "
-            "show live logs, headline metrics, images, artifacts, and the immutable "
-            "reproduction command."
-        )

--- a/apps/streamlit/workspace.py
+++ b/apps/streamlit/workspace.py
@@ -12,6 +12,8 @@ from typing import Any, Mapping, Sequence, Tuple
 
 import streamlit as st
 
+from .ui_batch import render_batch_controls
+
 try:
     from .config_service import (
         Catalog,
@@ -490,6 +492,11 @@ def main() -> None:
             st.rerun()
         except (RunServiceError, RunConflictError) as error:
             _render_error("The experiment could not start.", error)
+
+    render_batch_controls(
+        repo_root, approved_yaml_text if can_run else "",
+        template_id=selected_id, mode=mode,
+    )
 
     st.header("4. 运行与结果 | Live run and evidence")
     run_id = (

--- a/doc/changelog/2026-09-09-streamlit-detached-recovery.md
+++ b/doc/changelog/2026-09-09-streamlit-detached-recovery.md
@@ -1,0 +1,15 @@
+# Recheck detached Streamlit runs
+
+A run whose service restarted no longer reserves the worker forever after its process
+exits. Viewing the run or submitting another experiment rechecks the recorded PID. When
+absence can be established safely, the record becomes `orphaned`, with an unknown final
+exit status. It is not marked successful and no files are removed.
+
+A present or unverifiable PID remains reserved. Windows does not use `os.kill(pid, 0)` as
+a probe. The page provides **Recheck process** and a separately confirmed **Release
+finished run** for cases that require OS-level verification. Neither action adopts,
+terminates or retries an unmanaged process. A saved cancellation request alone is not
+proof that a process exited.
+
+Changes are limited to the optional frontend, its existing tests and this documentation.
+Training, configuration, split, objective, metrics and checkpoint selection are unchanged.

--- a/doc/changelog/2026-09-09-streamlit-independent-monitor.md
+++ b/doc/changelog/2026-09-09-streamlit-independent-monitor.md
@@ -1,0 +1,18 @@
+# Keep run controls independent of experiment editing
+
+The workspace renders existing runs and batch history before loading the editor's
+catalogue or resolving a new template. An empty category, missing template or invalid
+configuration can block a new experiment without hiding existing logs and cancellation.
+A damaged historical run or unreadable log likewise cannot hide batch controls or the
+editor; its original error is displayed separately. Malformed batch records report the
+record path and field at the existing read boundary. They are not repaired or skipped;
+new batch submission is disabled while ordinary configuration editing remains available.
+
+Batch history is rendered separately from batch planning and no longer requires a valid
+base YAML. Both views reuse the existing run and batch services. No second scheduler,
+backend configuration parser or result authority is introduced.
+
+Regression tests cover editor-catalogue failure, empty groups and rejected templates with
+an existing run; cancellation remains addressed to the original run. A paused batch can
+still be continued or cancelled while the editor is unusable. Rendering and page reruns
+do not submit experiments. No training backend or experiment protocol is changed.

--- a/doc/changelog/2026-09-09-streamlit-serial-batches.md
+++ b/doc/changelog/2026-09-09-streamlit-serial-batches.md
@@ -1,0 +1,27 @@
+# Finite Streamlit batches execute through the existing CLI
+
+After validating one experiment, users can preview a finite parameter grid, inspect its
+YAMLs and fit count, then submit it explicitly. The current UI varies learning rate,
+batch size, epochs, seed or iterations and caps the plan at 16 calls and 64 fits.
+
+The existing run service owns all processes. A batch reserves its single-run slot across
+trials, resolves all configurations before launch, and uses the same per-trial public
+preflight, CLI and cancellation path as an individual experiment. A failed trial pauses
+pending work; explicit continuation never retries or erases that failure. Cancellation
+stops the current managed child and cancels unstarted items. No scientific result is
+recomputed or inferred from shared directories.
+
+Scheduling state survives page refresh through a small batch record. Server-process
+restart does not resume execution: the batch becomes interrupted and pending work remains
+unsubmitted. This is a single-control-process feature, not a distributed scheduler or a
+promise of crash recovery. Agent proposals and adaptive search remain separate work.
+
+Validation covers real child-process ordering, mutual exclusion, budgets, failure pause,
+explicit continuation, cancellation during preflight/running/paused states, and lost
+ownership. Existing public integration tests add two real CPU Dummy trials with independent
+CLI result paths. AppTest checks preview/edit invalidation without running experiments.
+
+Changes are limited to the optional frontend, its tests, existing UI workflow selection
+and documentation. Data, model, Task, Trainer, split, estimator and checkpoint selection
+implementations remain unchanged. No external-data download or benchmark promotion is
+part of this change.

--- a/test/test_streamlit_app.py
+++ b/test/test_streamlit_app.py
@@ -5,6 +5,7 @@ Run this separately from the optional-import stub tests.
 from pathlib import Path
 
 import yaml
+import pytest
 from streamlit.testing.v1 import AppTest
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -172,3 +173,137 @@ _render_detached_controls(root, record)
     _button(app, 'Release finished run').click().run()
     assert not app.exception
     assert released == [(Path('.'), 'lost-run', True)]
+
+
+@pytest.mark.parametrize('failure', ['catalogue', 'empty_group', 'template'])
+def test_editor_failure_keeps_existing_run_logs_and_cancel(monkeypatch, tmp_path, failure):
+    from dataclasses import replace
+    from apps.streamlit import workspace, ui_runtime, ui_batch
+    from apps.streamlit.config_service import ConfigServiceError, ValidationReport
+    from apps.streamlit.run_service import RunRecord
+
+    (tmp_path / 'run.log').write_text('existing-run-log', encoding='utf-8')
+    state = {'record': RunRecord('existing-run', 'running', tmp_path, ('python', 'main.py'))}
+    cancelled = []
+    monkeypatch.setattr(ui_runtime, 'list_runs', lambda root, limit: (state['record'],))
+    monkeypatch.setattr(ui_runtime, 'get_run', lambda root, run_id: state['record'])
+    monkeypatch.setattr(ui_batch, 'list_batches', lambda root: ())
+    def cancel(root, run_id):
+        cancelled.append(run_id)
+        state['record'] = replace(state['record'], status='cancelled', cancel_requested=True)
+        return state['record']
+    monkeypatch.setattr(ui_runtime, 'cancel_run', cancel)
+    def forbidden(*args, **kwargs):
+        raise AssertionError('An editor error or page rerun must never submit a run.')
+    monkeypatch.setattr(workspace, 'start_run', forbidden)
+    monkeypatch.setattr(ui_batch, 'start_batch', forbidden)
+    if failure == 'catalogue':
+        def broken(path):
+            raise ConfigServiceError('Broken catalogue fixture')
+        monkeypatch.setattr(workspace, '_cached_catalog', broken)
+    elif failure == 'template':
+        monkeypatch.setattr(workspace, '_cached_inspection', lambda *args: ValidationReport(
+            False, (), error='Rejected template fixture'))
+    app = AppTest.from_file(str(ROOT / 'apps/streamlit/app.py'), default_timeout=90)
+    if failure == 'empty_group':
+        app.session_state['template_group'] = 'generative_models'
+    app.run()
+    assert not app.exception
+    assert any('existing-run-log' in item.value for item in app.code)
+    assert not _button(app, 'Cancel run').disabled
+    assert not any(button.label == 'Run experiment' for button in app.button)
+    _button(app, 'Cancel run').click().run()
+    assert not app.exception
+    assert cancelled == ['existing-run']
+    assert state['record'].status == 'cancelled'
+    app.run()
+    assert cancelled == ['existing-run']
+
+
+def test_broken_editor_keeps_paused_batch_controls(monkeypatch):
+    from types import SimpleNamespace
+    from apps.streamlit import workspace, ui_batch, ui_runtime
+    from apps.streamlit.config_service import ConfigServiceError
+
+    record = SimpleNamespace(batch_id='paused-batch', status='paused', is_terminal=False,
+                             total_fits=1, error='Trial failed', trials=(dict(
+                                 index=1, status='pending', fit_count=1, run_id='', error=''),))
+    cancelled = []
+    monkeypatch.setattr(ui_runtime, 'list_runs', lambda root, limit: ())
+    monkeypatch.setattr(ui_batch, 'list_batches', lambda root: (record,))
+    monkeypatch.setattr(ui_batch, 'get_batch', lambda root, batch_id: record)
+    def broken(path):
+        raise ConfigServiceError('Broken catalogue fixture')
+    monkeypatch.setattr(workspace, '_cached_catalog', broken)
+    def cancel(root, batch_id):
+        cancelled.append(batch_id)
+        record.status = 'cancelled'
+        record.is_terminal = True
+    monkeypatch.setattr(ui_batch, 'cancel_batch', cancel)
+    app = AppTest.from_file(str(ROOT / 'apps/streamlit/app.py'), default_timeout=90).run()
+    assert not app.exception
+    assert not _button(app, 'Continue remaining trials').disabled
+    assert not _button(app, 'Cancel batch').disabled
+    _button(app, 'Cancel batch').click().run()
+    assert not app.exception
+    assert cancelled == ['paused-batch']
+    assert _button(app, 'Cancel batch').disabled
+
+
+def test_unreadable_historical_log_keeps_batch_controls_and_editor(monkeypatch, tmp_path):
+    from types import SimpleNamespace
+    from apps.streamlit import workspace, ui_batch, ui_runtime
+    from apps.streamlit.run_service import RunRecord
+
+    record = RunRecord('old-run', 'succeeded', tmp_path, ('python', 'main.py'))
+    batch = SimpleNamespace(batch_id='paused-batch', status='paused', is_terminal=False,
+                            total_fits=1, error='Trial failed', trials=(dict(
+                                index=1, status='pending', fit_count=1, run_id='', error=''),))
+    monkeypatch.setattr(ui_runtime, 'list_runs', lambda root, limit: (record,))
+    monkeypatch.setattr(ui_runtime, 'get_run', lambda root, run_id: record)
+    monkeypatch.setattr(ui_batch, 'list_batches', lambda root: (batch,))
+    monkeypatch.setattr(ui_batch, 'get_batch', lambda root, batch_id: batch)
+    def unreadable(*args, **kwargs):
+        raise PermissionError('Cannot read old-run/run.log')
+    monkeypatch.setattr(ui_runtime, 'read_log_tail', unreadable)
+    def forbidden(*args, **kwargs):
+        raise AssertionError('Displaying a damaged historical run must not submit work.')
+    monkeypatch.setattr(workspace, 'start_run', forbidden)
+    monkeypatch.setattr(ui_batch, 'start_batch', forbidden)
+    app = AppTest.from_file(str(ROOT / 'apps/streamlit/app.py'), default_timeout=90).run()
+    assert not app.exception
+    assert not _button(app, 'Continue remaining trials').disabled
+    assert not _button(app, 'Cancel batch').disabled
+    assert not _button(app, 'Validate configuration').disabled
+    assert _button(app, 'Run experiment').disabled
+    assert app.session_state['selected_run_id'] == 'old-run'
+    assert any('Cannot read old-run/run.log' in item.value for item in app.error)
+    _button(app, 'Validate configuration').click().run()
+    assert not app.exception
+    assert app.session_state['validation_report'].ok
+    assert app.session_state['selected_run_id'] == 'old-run'
+
+
+def test_damaged_batch_record_keeps_editor_and_single_run_view(monkeypatch, tmp_path):
+    from apps.streamlit import workspace, ui_runtime, ui_batch, run_service
+
+    directory = tmp_path / 'batches' / 'damaged'
+    directory.mkdir(parents=True)
+    path = directory / 'batch.json'
+    path.write_text('{}', encoding='utf-8')
+    monkeypatch.setattr(run_service, '_batch_root', lambda root: directory.parent)
+    monkeypatch.setattr(ui_runtime, 'list_runs', lambda root, limit: ())
+    def forbidden(*args, **kwargs):
+        raise AssertionError('A malformed history must not trigger any submission.')
+    monkeypatch.setattr(workspace, 'start_run', forbidden)
+    monkeypatch.setattr(ui_batch, 'start_batch', forbidden)
+    app = AppTest.from_file(str(ROOT / 'apps/streamlit/app.py'), default_timeout=90).run()
+    assert not app.exception
+    assert not _button(app, 'Validate configuration').disabled
+    assert any(str(path) in error.value for error in app.error)
+    _button(app, 'Validate configuration').click().run()
+    assert not app.exception
+    assert app.session_state['validation_report'].ok
+    assert not _button(app, 'Run experiment').disabled
+    assert not any(button.label == 'Run batch' for button in app.button)
+    assert path.read_text() == '{}'

--- a/test/test_streamlit_app.py
+++ b/test/test_streamlit_app.py
@@ -146,3 +146,29 @@ def test_batch_launch_requires_click_and_locks_the_submitted_preview(monkeypatch
     app.run()
     assert not app.exception
     assert len(submitted) == 1
+
+
+def test_detached_release_requires_confirmation_in_the_page(monkeypatch, tmp_path):
+    from apps.streamlit import ui_runtime
+
+    released = []
+    monkeypatch.setattr(ui_runtime, 'release_detached_run',
+                        lambda root, run_id, *, confirmed_stopped:
+                        released.append((root, run_id, confirmed_stopped)))
+    app = AppTest.from_string('''
+from pathlib import Path
+from apps.streamlit.run_service import RunRecord
+from apps.streamlit.ui_runtime import _render_detached_controls
+root = Path(".")
+record = RunRecord("lost-run", "detached", root, (), error="Process outcome unknown.")
+_render_detached_controls(root, record)
+''').run()
+    assert not app.exception
+    assert _button(app, 'Release finished run').disabled
+    assert released == []
+    app.checkbox(key='stopped-confirmed::lost-run').set_value(True).run()
+    assert not _button(app, 'Release finished run').disabled
+    assert released == []
+    _button(app, 'Release finished run').click().run()
+    assert not app.exception
+    assert released == [(Path('.'), 'lost-run', True)]

--- a/test/test_streamlit_app.py
+++ b/test/test_streamlit_app.py
@@ -87,3 +87,62 @@ def test_advanced_yaml_invalid_integer_is_not_repaired_by_a_widget():
     assert not report.resolved
     assert 'num_epochs' in report.stderr
     assert _button(app, 'Run experiment').disabled
+
+
+def test_batch_preview_counts_and_invalidates_edits_without_launching(monkeypatch):
+    from apps.streamlit import ui_batch
+
+    def forbidden(*args, **kwargs):
+        raise AssertionError('Preview or rerun must not start a process')
+    monkeypatch.setattr(ui_batch, 'start_batch', forbidden)
+    app = AppTest.from_file(str(ROOT / 'apps/streamlit/app.py'), default_timeout=90).run()
+    assert not app.exception
+    assert _button(app, 'Preview batch').disabled
+    assert _button(app, 'Run batch').disabled
+    _button(app, 'Validate configuration').click().run()
+    assert not app.exception
+    _button(app, 'Preview batch').click().run()
+    assert not app.exception
+    assert len(app.session_state['batch_plan'].trials) == 2
+    assert app.session_state['batch_plan'].total_fits == 2
+    assert not _button(app, 'Run batch').disabled
+    app.run()
+    assert not app.exception
+    assert not _button(app, 'Run batch').disabled
+    app.text_area(key='batch_grid_text').set_value('task.lr: [0.001, 0.0005, 0.0001]').run()
+    assert _button(app, 'Run batch').disabled
+    _button(app, 'Preview batch').click().run()
+    assert not app.exception
+    assert len(app.session_state['batch_plan'].trials) == 3
+    app.number_input(key='batch_max_fits').set_value(2).run()
+    _button(app, 'Preview batch').click().run()
+    assert not app.exception
+    assert app.session_state['batch_plan'] is None
+    assert _button(app, 'Run batch').disabled
+    assert any('max_fits' in error.value for error in app.error)
+
+
+def test_batch_launch_requires_click_and_locks_the_submitted_preview(monkeypatch):
+    from types import SimpleNamespace
+    from apps.streamlit import ui_batch
+
+    submitted = []
+    def submit(request, plan):
+        submitted.append((request, plan))
+        return SimpleNamespace(batch_id='submitted-batch')
+    monkeypatch.setattr(ui_batch, 'start_batch', submit)
+    monkeypatch.setattr(ui_batch, 'list_batches', lambda root: ())
+    app = AppTest.from_file(str(ROOT / 'apps/streamlit/app.py'), default_timeout=90).run()
+    _button(app, 'Validate configuration').click().run()
+    _button(app, 'Preview batch').click().run()
+    assert not submitted
+    _button(app, 'Run batch').click().run()
+    assert not app.exception
+    assert len(submitted) == 1
+    assert submitted[0][1].total_fits == 2
+    assert app.session_state['batch_plan'].total_fits == 2
+    assert app.session_state['batch_plan_submitted'] is True
+    assert _button(app, 'Run batch').disabled
+    app.run()
+    assert not app.exception
+    assert len(submitted) == 1

--- a/test/test_streamlit_batch_execution.py
+++ b/test/test_streamlit_batch_execution.py
@@ -212,3 +212,24 @@ def test_snapshot_change_before_execution_is_not_silently_accepted(repo, monkeyp
     assert final.status == 'paused'
     assert 'changed the approved' in final.error
     assert not (repo / 'starts.txt').exists()
+
+
+@pytest.mark.parametrize('payload', [
+    [], {},
+    {'status': 'succeeded', 'trials': None, 'total_fits': 1},
+    {'status': 'succeeded', 'trials': [None], 'total_fits': 1},
+    {'status': 'succeeded', 'trials': [{}], 'total_fits': 1},
+    {'status': 'succeeded', 'trials': [], 'total_fits': True},
+])
+def test_malformed_batch_record_reports_its_path_without_repair(repo, payload):
+    directory = rs._batch_root(repo) / 'damaged'
+    directory.mkdir(parents=True)
+    path = directory / 'batch.json'
+    original = json.dumps(payload)
+    path.write_text(original, encoding='utf-8')
+    with pytest.raises(rs.RunServiceError, match='batch.json'):
+        rs.get_batch(repo, directory.name)
+    with pytest.raises(rs.RunServiceError, match='batch.json'):
+        rs.list_batches(repo)
+    assert path.read_text() == original
+    assert not (repo / 'starts.txt').exists()

--- a/test/test_streamlit_batch_execution.py
+++ b/test/test_streamlit_batch_execution.py
@@ -1,0 +1,214 @@
+"""Real child-process scheduling; public analysis/preflight are isolated in unit tests."""
+import json
+import time
+from dataclasses import replace
+from pathlib import Path
+
+import pytest
+
+from apps.streamlit import run_service as rs
+from apps.streamlit.batch_service import plan_grid
+from apps.streamlit.config_service import dump_yaml, parse_yaml_text
+
+
+BASE = {"environment": {"iterations": 2, "output_dir": "results"},
+        "data": {}, "model": {}, "trainer": {"num_epochs": 1}, "task": {"lr": 0.001}}
+
+
+@pytest.fixture
+def repo(tmp_path, monkeypatch):
+    root = tmp_path / 'repo'
+    root.mkdir()
+    (root / 'main.py').write_text('''import argparse, pathlib, time
+p = argparse.ArgumentParser(); p.add_argument('--config'); args = p.parse_args()
+text = pathlib.Path(args.config).read_text()
+with open('starts.txt', 'a') as f: f.write(args.config + '\\n')
+if '0.002' in text: raise SystemExit(7)
+if '0.003' in text: time.sleep(30)
+time.sleep(0.1)
+''')
+    def approve(request):
+        value = rs.prepare_request(request)
+        return replace(value, config_yaml=dump_yaml(parse_yaml_text(value.config_yaml)), overrides=())
+    monkeypatch.setattr(rs, 'approve_request', approve)
+    monkeypatch.setattr(rs, '_run_public_preflight', lambda *args: None)
+    yield root
+    managed = rs._BATCHES.get(root)
+    if managed:
+        rs.cancel_batch(root, managed.batch_id)
+        wait(root, managed.batch_id, terminal=True)
+
+
+def request(repo):
+    return rs.RunRequest(repo_root=repo, template_id='test', mode='Advanced', config_yaml=dump_yaml(BASE))
+
+
+def plan(values):
+    return plan_grid(BASE, {'task.lr': values}, allowed_paths={'task.lr'})
+
+
+def wait(repo, batch_id, *, terminal=False):
+    deadline = time.monotonic() + 10
+    while time.monotonic() < deadline:
+        record = rs.get_batch(repo, batch_id)
+        if record.is_terminal or (not terminal and record.status == 'paused'):
+            return record
+        time.sleep(0.02)
+    raise AssertionError(record)
+
+
+def test_batch_is_serial_and_preserves_config_and_fit_count(repo):
+    batch = rs.start_batch(request(repo), plan([0.001, 0.0005]))
+    final = wait(repo, batch.batch_id, terminal=True)
+    assert final.status == 'succeeded'
+    assert final.total_fits == 4
+    assert [trial['status'] for trial in final.trials] == ['succeeded', 'succeeded']
+    runs = [rs.get_run(repo, trial['run_id']) for trial in final.trials]
+    assert runs[0].run_id != runs[1].run_id
+    assert len((repo / 'starts.txt').read_text().splitlines()) == 2
+    for trial, run in zip(final.trials, runs):
+        assert (run.run_dir / 'execution.yaml').read_text() == trial['config_yaml']
+        assert parse_yaml_text(trial['config_yaml'])['environment']['iterations'] == 2
+        assert run.metadata['batch_id'] == batch.batch_id
+        assert '--override' not in run.command
+    assert repo not in rs._BATCHES
+
+
+def test_failure_pauses_and_continuing_never_retries_failed_trial(repo):
+    batch = rs.start_batch(request(repo), plan([0.001, 0.002, 0.0005]))
+    paused = wait(repo, batch.batch_id)
+    assert paused.status == 'paused'
+    assert [t['status'] for t in paused.trials] == ['succeeded', 'failed', 'pending']
+    assert 'exit 7' in paused.error
+    assert len((repo / 'starts.txt').read_text().splitlines()) == 2
+    with pytest.raises(rs.RunConflictError, match='owns this worker'):
+        rs.start_run(request(repo))
+    with pytest.raises(rs.RunConflictError):
+        rs.start_batch(request(repo), plan([0.001]))
+    rs.continue_batch(repo, batch.batch_id)
+    final = wait(repo, batch.batch_id, terminal=True)
+    assert final.status == 'failed'
+    assert [t['status'] for t in final.trials] == ['succeeded', 'failed', 'succeeded']
+    assert len((repo / 'starts.txt').read_text().splitlines()) == 3
+
+
+def test_cancel_stops_current_child_and_never_starts_pending(repo):
+    batch = rs.start_batch(request(repo), plan([0.003, 0.001]))
+    deadline = time.monotonic() + 5
+    while not (repo / 'starts.txt').exists() and time.monotonic() < deadline:
+        time.sleep(0.02)
+    rs.cancel_batch(repo, batch.batch_id)
+    final = wait(repo, batch.batch_id, terminal=True)
+    assert final.status == 'cancelled'
+    assert [t['status'] for t in final.trials] == ['cancelled', 'cancelled']
+    assert len((repo / 'starts.txt').read_text().splitlines()) == 1
+    child = rs.get_run(repo, final.trials[0]['run_id'])
+    assert child.is_terminal
+    assert repo not in rs._BATCHES
+
+
+def test_cancel_paused_batch_retains_failure_and_discards_pending(repo):
+    batch = rs.start_batch(request(repo), plan([0.002, 0.001]))
+    assert wait(repo, batch.batch_id).status == 'paused'
+    final = rs.cancel_batch(repo, batch.batch_id)
+    assert final.status == 'cancelled'
+    assert [t['status'] for t in final.trials] == ['failed', 'cancelled']
+
+
+def test_all_snapshots_checked_before_any_child(repo, monkeypatch):
+    original = rs.approve_request
+    def approve(value):
+        if '0.002' in value.config_yaml:
+            raise rs.RunServiceError('Rejected second trial')
+        return original(value)
+    monkeypatch.setattr(rs, 'approve_request', approve)
+    with pytest.raises(rs.RunServiceError, match='second trial'):
+        rs.start_batch(request(repo), plan([0.001, 0.002]))
+    assert not (repo / 'starts.txt').exists()
+    assert not (repo / 'outputs').exists()
+
+
+def test_preflight_failure_pauses_without_substitute_config(repo, monkeypatch):
+    def preflight(root, path):
+        raise rs.RunServiceError('CUDA unavailable')
+    monkeypatch.setattr(rs, '_run_public_preflight', preflight)
+    batch = rs.start_batch(request(repo), plan([0.001, 0.0005]))
+    final = wait(repo, batch.batch_id)
+    assert final.status == 'paused'
+    assert 'CUDA unavailable' in final.error
+    assert not (repo / 'starts.txt').exists()
+
+
+def test_budget_rechecked_at_submission(repo):
+    bad = replace(plan([0.001]), total_fits=1)
+    with pytest.raises(rs.RunServiceError, match='fit count'):
+        rs.start_batch(request(repo), bad)
+    assert not (repo / 'outputs').exists()
+
+
+def test_batch_cannot_interleave_with_an_active_single_run(repo):
+    one = rs.start_run(replace(request(repo), config_yaml=dump_yaml({**BASE, 'task': {'lr': 0.003}})))
+    try:
+        with pytest.raises(rs.RunConflictError, match='active'):
+            rs.start_batch(request(repo), plan([0.001]))
+    finally:
+        rs.cancel_run(repo, one.run_id, grace_seconds=0.1)
+
+
+def test_lost_owner_never_restarts_pending_trials(repo):
+    directory = rs._batch_root(repo) / 'previous-session'
+    directory.mkdir(parents=True)
+    (directory / 'batch.json').write_text(json.dumps({
+        'status': 'running', 'total_fits': 2,
+        'trials': [{'index': 1, 'status': 'pending', 'run_id': '', 'error': '',
+                    'config_yaml': dump_yaml(BASE), 'fit_count': 2}],
+    }))
+    record = rs.get_batch(repo, directory.name)
+    assert record.status == 'interrupted'
+    assert record.trials[0]['status'] == 'pending'
+    assert not (repo / 'starts.txt').exists()
+    with pytest.raises(rs.RunServiceError):
+        rs.continue_batch(repo, directory.name)
+
+
+def test_cancel_during_preflight_never_starts_a_child(repo, monkeypatch):
+    import threading
+
+    entered, release = threading.Event(), threading.Event()
+    def preflight(root, path):
+        entered.set()
+        assert release.wait(5)
+    monkeypatch.setattr(rs, '_run_public_preflight', preflight)
+    batch = rs.start_batch(request(repo), plan([0.001, 0.0005]))
+    assert entered.wait(5)
+    cancelling = threading.Thread(target=rs.cancel_batch, args=(repo, batch.batch_id))
+    cancelling.start()
+    try:
+        assert rs._BATCHES[repo].cancel.wait(5)
+    finally:
+        release.set()
+        cancelling.join(5)
+    final = wait(repo, batch.batch_id, terminal=True)
+    assert final.status == 'cancelled'
+    assert not (repo / 'starts.txt').exists()
+    assert all(trial['status'] == 'cancelled' for trial in final.trials)
+
+
+def test_snapshot_change_before_execution_is_not_silently_accepted(repo, monkeypatch):
+    original = rs.approve_request
+    count = 0
+    def approve(value):
+        nonlocal count
+        count += 1
+        approved = original(value)
+        if count > 2:
+            config = parse_yaml_text(approved.config_yaml)
+            config['trainer']['num_epochs'] = 9
+            return replace(approved, config_yaml=dump_yaml(config))
+        return approved
+    monkeypatch.setattr(rs, 'approve_request', approve)
+    batch = rs.start_batch(request(repo), plan([0.001, 0.0005]))
+    final = wait(repo, batch.batch_id)
+    assert final.status == 'paused'
+    assert 'changed the approved' in final.error
+    assert not (repo / 'starts.txt').exists()

--- a/test/test_streamlit_public_contract.py
+++ b/test/test_streamlit_public_contract.py
@@ -112,3 +112,52 @@ def test_ui_run_service_executes_real_dummy(monkeypatch):
         finally:
             if not rs.get_run(ROOT, record.run_id).is_terminal:
                 rs.cancel_run(ROOT, record.run_id, grace_seconds=1)
+
+
+def test_real_two_trial_batch_keeps_separate_public_results(monkeypatch):
+    from apps.streamlit.batch_service import plan_grid
+
+    report = cs.inspect_config(ROOT, SMOKE)
+    assert report.ok, (report.error, report.stderr)
+    output_parent = ROOT / 'outputs'
+    output_parent.mkdir(exist_ok=True)
+    with tempfile.TemporaryDirectory(prefix='batch-contract-', dir=output_parent) as directory:
+        directory = Path(directory)
+        monkeypatch.setattr(rs, '_run_root', lambda root: directory / 'runs')
+        config = dict(report.resolved)
+        config['environment'] = dict(config['environment'], output_dir=str(directory / 'results'))
+        config['data'] = dict(config['data'], cache_dir=str(directory / 'cache'))
+        plan = plan_grid(config, {'task.lr': [0.001, 0.0005]}, allowed_paths={'task.lr'},
+                         max_trials=2, max_fits=2)
+        batch = rs.start_batch(rs.RunRequest(repo_root=ROOT, template_id='dummy-batch',
+                                            mode='Quick Start', config_yaml=cs.dump_yaml(config)), plan)
+        try:
+            deadline = time.monotonic() + 180
+            while not batch.is_terminal and batch.status != 'paused' and time.monotonic() < deadline:
+                time.sleep(0.1)
+                batch = rs.get_batch(ROOT, batch.batch_id)
+            logs = [rs.read_log_tail(rs.get_run(ROOT, t['run_id'])) for t in batch.trials if t['run_id']]
+            assert batch.status == 'succeeded', (batch.error, logs)
+            assert batch.total_fits == 2
+            roots = []
+            for planned, trial in zip(plan.trials, batch.trials):
+                record = rs.get_run(ROOT, trial['run_id'])
+                assert record.status == 'succeeded'
+                assert (record.run_dir / 'execution.yaml').read_text() == planned.config_yaml
+                assert '--override' not in record.command
+                bundle = results.discover_results(ROOT, record)
+                assert bundle.direct.completed
+                assert bundle.direct.result_dir.is_relative_to(directory)
+                assert bundle.direct.best_checkpoint.is_file()
+                assert bundle.direct.test_metrics.is_file()
+                assert bundle.direct.run_summary.is_file()
+                assert bundle.direct.primary_metrics
+                roots.append(bundle.direct.result_dir)
+            assert len(set(roots)) == 2
+            assert len(rs.list_runs(ROOT)) == 2
+        finally:
+            rs.cancel_batch(ROOT, batch.batch_id)
+            deadline = time.monotonic() + 15
+            while ROOT.resolve() in rs._BATCHES and time.monotonic() < deadline:
+                time.sleep(0.1)
+            assert ROOT.resolve() not in rs._BATCHES

--- a/test/test_streamlit_refresh_policy.py
+++ b/test/test_streamlit_refresh_policy.py
@@ -109,3 +109,36 @@ def test_terminal_renderer_discovers_results_once(monkeypatch) -> None:
 
     assert len(discovered) == 1
     assert discovered[0][1] is record
+
+
+def test_explicit_batch_trial_outside_recent_window_is_loaded(monkeypatch):
+    runtime = _load_runtime(monkeypatch)
+    old = types.SimpleNamespace(run_id='old-trial', status='succeeded', template_id='old')
+    recent = tuple(types.SimpleNamespace(run_id=f'new-{i}', status='succeeded', template_id='new') for i in range(20))
+    runtime.st.session_state.selected_run_id = old.run_id
+    loaded, options = [], []
+    def selectbox(label, ids, *, index, **kwargs):
+        options.extend(ids)
+        return ids[index]
+    runtime.st.sidebar = types.SimpleNamespace(selectbox=selectbox, caption=lambda value: None)
+    monkeypatch.setattr(runtime, 'list_runs', lambda root, limit: recent)
+    monkeypatch.setattr(runtime, 'get_run', lambda root, run_id: loaded.append(run_id) or old)
+    assert runtime._render_run_selector('repo') == 'old-trial'
+    assert loaded == ['old-trial']
+    assert options == ['old-trial', *(run.run_id for run in recent)]
+
+
+def test_missing_explicit_trial_does_not_select_another_run(monkeypatch):
+    runtime = _load_runtime(monkeypatch)
+    runtime.st.session_state.selected_run_id = 'removed-trial'
+    recent = (types.SimpleNamespace(run_id='other', status='succeeded', template_id='new'),)
+    errors = []
+    runtime.st.sidebar = types.SimpleNamespace(
+        error=errors.append, selectbox=lambda label, ids, **kwargs: ids[kwargs["index"]])
+    monkeypatch.setattr(runtime, 'list_runs', lambda root, limit: recent)
+    def missing(root, run_id):
+        raise runtime.RunServiceError('Run record not found: removed-trial')
+    monkeypatch.setattr(runtime, 'get_run', missing)
+    assert runtime._render_run_selector('repo') == 'removed-trial'
+    assert runtime.st.session_state.selected_run_id == 'removed-trial'
+    assert errors == ['Run record not found: removed-trial']

--- a/test/test_streamlit_run_service.py
+++ b/test/test_streamlit_run_service.py
@@ -310,3 +310,89 @@ def test_public_preflight_failure_does_not_launch_training(monkeypatch, tmp_path
         )
     run_root = repo / 'outputs' / 'streamlit'
     assert not run_root.exists() or not any(run_root.iterdir())
+
+
+def _unmanaged_record(repo, *, status='detached', pid=None, cancel_requested=False):
+    directory = repo / 'outputs' / 'streamlit' / 'unmanaged'
+    directory.mkdir(parents=True)
+    (directory / 'run.json').write_text(json.dumps({
+        'run_id': directory.name, 'status': status, 'pid': pid,
+        'command': [], 'overrides': [], 'exit_code': None,
+        'cancel_requested': cancel_requested,
+    }), encoding='utf-8')
+    return directory
+
+
+def test_exited_detached_process_releases_slot_without_claiming_success(tmp_path):
+    import os
+    import subprocess
+    import sys
+
+    if os.name == 'nt':
+        pytest.skip('Automatic non-signalling PID checks are POSIX-only.')
+    repo = make_repo(tmp_path)
+    child = subprocess.Popen([sys.executable, '-c', 'pass'])
+    assert child.wait(timeout=5) == 0
+    directory = _unmanaged_record(repo, pid=child.pid)
+    record = get_run(repo, directory.name)
+    assert record.status == 'orphaned'
+    assert record.exit_code is None
+    assert 'unknown' in record.error.lower()
+    assert not record.is_active
+    launched = start_run(RunRequest(repo, 'demo', 'Advanced', config_yaml=CONFIG))
+    assert wait_terminal(repo, launched.run_id).status == 'succeeded'
+
+
+def test_live_unmanaged_process_stays_reserved_even_after_cancel_request(monkeypatch, tmp_path):
+    import os
+
+    repo = make_repo(tmp_path)
+    _unmanaged_record(repo, status='cancelling', pid=os.getpid(), cancel_requested=True)
+    monkeypatch.setattr(run_service_module, '_pid_exists', lambda pid: True)
+    record = get_run(repo, 'unmanaged')
+    assert record.status == 'detached'
+    assert record.is_active
+    assert record.exit_code is None
+    with pytest.raises(RunConflictError):
+        start_run(RunRequest(repo, 'demo', 'Advanced', config_yaml=CONFIG))
+    with pytest.raises(RunServiceError, match='still exists'):
+        run_service_module.release_detached_run(repo, 'unmanaged', confirmed_stopped=True)
+
+
+def test_unknown_process_requires_explicit_confirmation_and_preserves_outputs(monkeypatch, tmp_path):
+    repo = make_repo(tmp_path)
+    directory = _unmanaged_record(repo, pid=12345)
+    (directory / 'run.log').write_text('original log', encoding='utf-8')
+    monkeypatch.setattr(run_service_module, '_pid_exists', lambda pid: None)
+    def forbidden(*args, **kwargs):
+        raise AssertionError('Unmanaged processes must not be signalled.')
+    monkeypatch.setattr(run_service_module, '_terminate_process', forbidden)
+    assert get_run(repo, 'unmanaged').status == 'detached'
+    with pytest.raises(RunServiceError, match='Confirm'):
+        run_service_module.release_detached_run(repo, 'unmanaged')
+    with pytest.raises(RunServiceError, match='Confirm'):
+        run_service_module.release_detached_run(repo, 'unmanaged', confirmed_stopped='true')
+    released = run_service_module.release_detached_run(repo, 'unmanaged', confirmed_stopped=True)
+    assert released.status == 'orphaned'
+    assert released.exit_code is None
+    assert 'confirmed' in released.error.lower()
+    assert (directory / 'run.log').read_text() == 'original log'
+
+
+def test_windows_unknown_probe_never_uses_os_kill(monkeypatch):
+    monkeypatch.setattr(run_service_module.sys, 'platform', 'win32')
+    def forbidden(*args):
+        raise AssertionError('os.kill(pid, 0) is not a safe Windows liveness probe.')
+    monkeypatch.setattr(run_service_module.os, 'kill', forbidden)
+    assert run_service_module._pid_exists(12345) is None
+
+
+def test_unverifiable_pid_is_not_assumed_exited(monkeypatch, tmp_path):
+    repo = make_repo(tmp_path)
+    _unmanaged_record(repo, status='running')
+    assert get_run(repo, 'unmanaged').status == 'detached'
+    def denied(*args):
+        raise PermissionError('permission denied')
+    monkeypatch.setattr(run_service_module.sys, 'platform', 'linux')
+    monkeypatch.setattr(run_service_module.os, 'kill', denied)
+    assert run_service_module._pid_exists(12345) is None

--- a/test/test_streamlit_ui_imports.py
+++ b/test/test_streamlit_ui_imports.py
@@ -171,3 +171,70 @@ def test_common_fields_do_not_repair_invalid_yaml_types(monkeypatch, spec, value
 
     with pytest.raises(ui_theme.ConfigServiceError):
         ui_theme._validated_widget_value(field, value)
+
+
+def test_existing_runs_render_before_editor_catalog_failure(monkeypatch):
+    _install_streamlit_stub(monkeypatch)
+    sys.modules.pop('apps.streamlit.workspace', None)
+    workspace = importlib.import_module('apps.streamlit.workspace')
+    calls = []
+    monkeypatch.setattr(workspace, '_initialize_state', lambda: None)
+    workspace.st.session_state = types.SimpleNamespace(selected_run_id='running-a', active_run_id='running-a')
+    for name in ('set_page_config', 'header', 'info', 'caption'):
+        monkeypatch.setattr(workspace.st, name, lambda *args, **kwargs: None, raising=False)
+    monkeypatch.setattr(workspace, '_inject_style', lambda: None)
+    monkeypatch.setattr(workspace, '_render_hero', lambda: None)
+    monkeypatch.setattr(workspace, 'find_repo_root', lambda path: path)
+    monkeypatch.setattr(workspace, '_render_run_selector', lambda root: 'running-a')
+    monkeypatch.setattr(workspace, '_render_live_run', lambda root, run_id: calls.append(('run', run_id)))
+    monkeypatch.setattr(workspace, 'render_batch_history', lambda root: calls.append(('batches',)), raising=False)
+    monkeypatch.setattr(workspace, '_render_error', lambda *args, **kwargs: calls.append(('editor-error',)))
+    def invalid(path):
+        raise workspace.ConfigServiceError('Broken field catalogue')
+    monkeypatch.setattr(workspace, '_cached_catalog', invalid)
+    class StopPage(Exception):
+        pass
+    def stop():
+        raise StopPage
+    monkeypatch.setattr(workspace.st, 'stop', stop, raising=False)
+    with pytest.raises(StopPage):
+        workspace.main()
+    assert ('run', 'running-a') in calls
+    assert ('batches',) in calls
+    assert calls.index(('run', 'running-a')) < calls.index(('editor-error',))
+    assert calls.index(('batches',)) < calls.index(('editor-error',))
+
+
+@pytest.mark.parametrize('failure_owner', ['selector', 'run_view'])
+def test_damaged_run_view_does_not_block_batches_or_editor(monkeypatch, failure_owner):
+    _install_streamlit_stub(monkeypatch)
+    sys.modules.pop('apps.streamlit.workspace', None)
+    workspace = importlib.import_module('apps.streamlit.workspace')
+    calls = []
+    workspace.st.session_state = types.SimpleNamespace(selected_run_id='old-run', active_run_id='')
+    for name in ('set_page_config', 'header', 'caption'):
+        monkeypatch.setattr(workspace.st, name, lambda *args, **kwargs: None, raising=False)
+    monkeypatch.setattr(workspace, '_initialize_state', lambda: None)
+    monkeypatch.setattr(workspace, '_inject_style', lambda: None)
+    monkeypatch.setattr(workspace, '_render_hero', lambda: None)
+    monkeypatch.setattr(workspace, 'find_repo_root', lambda path: path)
+    monkeypatch.setattr(workspace, '_render_run_selector', lambda root: 'old-run')
+    monkeypatch.setattr(workspace, '_render_live_run', lambda *args: None)
+    def unreadable(*args):
+        raise PermissionError('Cannot read old-run/run.log')
+    owner = '_render_run_selector' if failure_owner == 'selector' else '_render_live_run'
+    monkeypatch.setattr(workspace, owner, unreadable)
+    monkeypatch.setattr(workspace, '_render_error', lambda title, error, **kwargs: calls.append(('error', str(error))))
+    monkeypatch.setattr(workspace, 'render_batch_history', lambda root: calls.append(('batches',)))
+    class EditorReached(Exception):
+        pass
+    def editor(path):
+        calls.append(('editor',))
+        raise EditorReached
+    monkeypatch.setattr(workspace, '_cached_catalog', editor)
+    with pytest.raises(EditorReached):
+        workspace.main()
+    assert ('error', 'Cannot read old-run/run.log') in calls
+    assert ('batches',) in calls
+    assert ('editor',) in calls
+    assert workspace.st.session_state.selected_run_id == 'old-run'


### PR DESCRIPTION
## Authorized scope
Promote only the three reviewed frontend changes requested by the maintainer. Candidate dev: 65786dff3f21bf84c286f897b4e0ceac953a1db1. Base main: 8f02b02c1ce6576e56612bbf7450b4f7382fc903. Compare confirms exactly three commits ahead, zero behind, and fifteen frontend/test/documentation/workflow paths.

- #252 / 81b20d7a592544f3666200a1d22c1e5923596633: explicitly approved finite serial batches; pause, continue pending trials, cancellation and exact historical-trial selection.
- #253 / 9ef529d3f548ffea0e47f41bc5b087246a4603db: recheck detached runs, release confirmed absent processes without inventing exit outcomes, and explicitly confirmed manual release for unknown cases.
- #254 / 65786dff3f21bf84c286f897b4e0ceac953a1db1: editor-independent run/batch controls, and isolation of unreadable run logs or malformed batch records without replacing runs or repairing data.

## Verification
#254 final head 0df539d125aac6f6cdc1afd02dd77a08c83283c3 passed all four PR workflows: Streamlit 34347755954, Layout 34347755968, Submodule 34347756080, Core 34347756100. Reviewed exact code and regression tests; both inline review issues are resolved. Job details confirm Linux/Windows focused tests, real public-inspector/Dummy and Streamlit AppTest execution. These are CI results inspected during closure, not claimed new local browser or external-data tests.
This promotion requires its own current-candidate checks before merge. Prior-head green checks are not substituted for the promotion's status.

## Documentation
User changes are already recorded in doc/changelog/2026-09-09-streamlit-serial-batches.md, doc/changelog/2026-09-09-streamlit-detached-recovery.md and doc/changelog/2026-09-09-streamlit-independent-monitor.md, and in apps/streamlit/README.md.

## Boundaries
No Factory, backend config, training runtime, model, split, objective, estimator, checkpoint-selection or experiment-YAML changes. Research PRs #230 and #231 are excluded. No new Agent implementation, data download, THU rerun, benchmark-status change, release tag or package publication. No temporary transfer files are included.

## Merge and rollback
Use a merge commit to preserve main/dev ancestry; do not squash the long-lived branch. Merge only the expected candidate head. After merge, fast-forward dev without force only if no unrelated commit intervened. Rollback of this promotion is a maintainer-reviewed revert of the merge commit.