### PR TITLE
fix(results): require declared metrics before each seed is published

### DIFF
--- a/doc/changelog/2026-09-11-declared-metric-closure.md
+++ b/doc/changelog/2026-09-11-declared-metric-closure.md
@@ -10,6 +10,8 @@
 - 测试总体不从完整训练 metadata 或测试后结果反推，也不提前读取样本。
 - training-only 不请求测试 loader，不要求测试指标。
 
-新增回归位于现有 `test/test_run_summary.py`，覆盖同漏 f1、后 seed 缺项、遗漏整个测试 Name、完整正例、别名、额外 loss、Name pooling、acc-only、training-only 及非法测试身份。低层 summary 保持纯数值汇总；原缺项反例提升至真实分类生命周期，并检查失败产物，而不是把配置解析塞入汇总函数。
+HSE 对比预训练保留自己的全局 `test_acc`，不套用普通分类 Task 的 Name 后缀。该任务仅在分类目标启用时计算 acc；要求 evaluated 但未启用分类、或声明它没有计算的 f1 等指标，现在在 Task 构造时失败，不再训练后才发现缺项。纯对比学习仍可显式使用 `test_after_fit=false`。现有预训练模板中“分类权重为零但要求测试 acc”的组合需要用户明确选择训练还是评价；本次不自动改模板、目标权重或声明指标。
 
-本次不修改数据划分、模型、训练目标、checkpoint 选择、实验 YAML、依赖或 benchmark 状态。THU 不下载、不重训。相关 CI 结果以对应 PR 的实际最终检查为准。
+新增回归位于现有 `test/test_run_summary.py` 和 `test/test_hse_objective_contract.py`。覆盖同漏 f1、后 seed 缺项、遗漏整个测试 Name、完整正例、既有大小写规范化、额外 loss、Name pooling、acc-only、training-only、非法测试身份，以及 HSE 的实际日志键和矛盾请求前置失败。`accuracy` 不是现有合法 metric ID，测试不新增该别名；结果断言区分输入 metadata CSV 与成功结果 CSV。
+
+低层 summary 保持纯数值汇总；原缺项反例提升至真实分类生命周期，并检查失败产物，而不是把配置解析塞入汇总函数。本次不修改数据划分、模型、训练目标、checkpoint 选择、实验 YAML、依赖或 benchmark 状态。THU 不下载、不重训。相关 CI 结果以对应 PR 的实际最终检查为准。

--- a/doc/changelog/2026-09-11-declared-metric-closure.md
+++ b/doc/changelog/2026-09-11-declared-metric-closure.md
@@ -1,0 +1,15 @@
+# 2026-09-11：声明指标与逐 seed 结果发布闭合
+
+分类执行链在每次 test 前，从实际测试 dataset 已选定的 file IDs 取得 Name 集合，并由 Task 使用既有规范化指标名生成 expected keys。实际 metric logging 与 expected keys 共享同一个普通命名函数。
+
+每次 test 后先检查有限标量，再检查配置声明的指标是否完整。缺少指标时，错误列出 seed、声明指标、测试 Name、缺项及实际返回键；当前 seed CSV、汇总 CSV 和 summary 不发布成功。此前完成的 seed 诊断可以保留，不做事务式产物回滚。
+
+- 只声明 acc 的实验仍只要求 acc；不强制增加 f1。
+- 允许额外 test loss，不改变 F1/AUROC 等数学定义。
+- 同 Name 的不同 Dataset_id 继续按现有协议汇总；不新增身份管理层。
+- 测试总体不从完整训练 metadata 或测试后结果反推，也不提前读取样本。
+- training-only 不请求测试 loader，不要求测试指标。
+
+新增回归位于现有 `test/test_run_summary.py`，覆盖同漏 f1、后 seed 缺项、遗漏整个测试 Name、完整正例、别名、额外 loss、Name pooling、acc-only、training-only 及非法测试身份。低层 summary 保持纯数值汇总；原缺项反例提升至真实分类生命周期，并检查失败产物，而不是把配置解析塞入汇总函数。
+
+本次不修改数据划分、模型、训练目标、checkpoint 选择、实验 YAML、依赖或 benchmark 状态。THU 不下载、不重训。相关 CI 结果以对应 PR 的实际最终检查为准。

--- a/src/data_factory/dataset_task/Dataset_cluster.py
+++ b/src/data_factory/dataset_task/Dataset_cluster.py
@@ -43,6 +43,30 @@ class IdIncludedDataset(Dataset):
     def __len__(self):
         return self._total_samples
 
+    def expected_dataset_names(self) -> tuple[str, ...]:
+        """Declare this dataset's Name-level populations without reading samples.
+
+        Only selected file IDs participate. Multiple Dataset_id values may intentionally
+        share one Name and retain the existing pooled metric namespace.
+        """
+        if not self.dataset_dict:
+            raise ValueError("Evaluation requires a non-empty selected test population.")
+        names: set[str] = set()
+        for file_id in self.dataset_dict:
+            try:
+                name = self.metadata[file_id]["Name"]
+            except (KeyError, IndexError, TypeError) as exc:
+                raise KeyError(
+                    f"Cannot resolve evaluation Name for selected file_id={file_id!r}."
+                ) from exc
+            if not isinstance(name, str) or not name or name != name.strip():
+                raise ValueError(
+                    f"Evaluation Name for file_id={file_id!r} must be a non-empty "
+                    f"string without surrounding whitespace, got {name!r}."
+                )
+            names.add(name)
+        return tuple(sorted(names))
+
     def get_file_windows_list(self):
         return self.file_windows_list
 

--- a/src/runtime/classification.py
+++ b/src/runtime/classification.py
@@ -222,7 +222,7 @@ def _write_aggregate_outputs(
     run_seeds: list[int],
     configs: Any,
 ) -> dict[str, Any]:
-    """Write repeated-run metrics only after the complete estimator validates."""
+    """Write metrics already checked against each seed's declared test population."""
 
     if last_iteration_path is None or not all_results:
         raise ValueError("aggregate outputs require at least one completed iteration")
@@ -411,12 +411,22 @@ def run_classification_pipeline(
             best_checkpoints.append(_best_checkpoint_path(context.trainer))
             if not test_after_fit:
                 continue
+
+            test_loader = context.data_factory.get_dataloader("test")
+            dataset_names = test_loader.dataset.expected_dataset_names()
+            expected_keys = context.task.expected_evaluation_metric_keys(dataset_names)
             context.result = _result_row(
-                context.trainer.test(
-                    context.task,
-                    context.data_factory.get_dataloader("test"),
-                )
+                context.trainer.test(context.task, test_loader)
             )
+            missing_keys = sorted(expected_keys - context.result.keys())
+            if missing_keys:
+                raise RuntimeError(
+                    "Declared evaluation metrics were not reported: "
+                    f"seed={current_seed}, configured_metrics={args_task.metrics!r}, "
+                    f"expected_test_datasets={list(dataset_names)!r}, "
+                    f"missing_metric_keys={missing_keys!r}, "
+                    f"reported_metric_keys={sorted(context.result)!r}"
+                )
             all_results.append(context.result)
 
             print("[INFO] 保存测试结果...")

--- a/src/task_factory/Default_task.py
+++ b/src/task_factory/Default_task.py
@@ -20,6 +20,11 @@ from .Components.metrics import get_metrics, prepare_metric_inputs
 from .Components.regularization import calculate_regularization
 
 
+def _metric_log_key(metric_key: str, data_name: str) -> str:
+    """Use the same Name-level key for metric logging and publication checks."""
+    return f"{metric_key}_{data_name}"
+
+
 @register_task("Default_task", "Default_task")
 class Default_task(pl.LightningModule):
     """General Lightning task with explicit objective and metric semantics."""
@@ -95,6 +100,19 @@ class Default_task(pl.LightningModule):
             **vars(self.args_environment),
         }
         self.save_hyperparameters(hparams_dict, ignore=["network", "metadata"])
+
+    def expected_evaluation_metric_keys(
+        self,
+        dataset_names: tuple[str, ...],
+    ) -> set[str]:
+        """Require configured estimators for every population declared before test."""
+        if not dataset_names:
+            raise ValueError("Evaluation requires a non-empty selected test population.")
+        return {
+            _metric_log_key(f"test_{metric_name}", data_name)
+            for data_name in dataset_names
+            for metric_name in self.metric_names
+        }
 
     def _resolve_model_task_id(self, batch: Mapping[str, Any]) -> str:
         """Return the configured task head and reject batch-level overrides."""
@@ -198,7 +216,7 @@ class Default_task(pl.LightningModule):
                 loss_name=self.loss_name,
             )
             metric_fn.update(metric_predictions, metric_target)
-            metric_values[f"{metric_key}_{data_name}"] = metric_fn
+            metric_values[_metric_log_key(metric_key, data_name)] = metric_fn
         return metric_values
 
     def _compute_regularization(self) -> Dict[str, torch.Tensor]:

--- a/src/task_factory/task/pretrain/hse_contrastive.py
+++ b/src/task_factory/task/pretrain/hse_contrastive.py
@@ -64,6 +64,9 @@ class task(Default_task):
                 "hse_contrastive requires at least one positive objective weight: "
                 "set task.contrast_weight or task.classification_weight above zero."
             )
+        if getattr(args_trainer, "test_after_fit", None) is True:
+            # Reject an impossible evaluation request before spending time training.
+            self._require_evaluation_metrics()
 
         self.ce_loss_fn = get_loss_fn("CE")
         self.strategy_manager = None
@@ -84,6 +87,25 @@ class task(Default_task):
                     f"{loss_type!r}. Check task.contrast_loss and its parameters."
                 ) from exc
             logger.info("[hse_contrastive] Enabled contrastive strategy: %s", loss_type)
+
+    def _require_evaluation_metrics(self) -> None:
+        if self.classification_weight <= 0 or self.metric_names != ("acc",):
+            raise ValueError(
+                "hse_contrastive reports only pooled task.metrics=['acc'] when "
+                "task.classification_weight > 0; "
+                f"configured metrics={list(self.metric_names)!r}, "
+                f"classification_weight={self.classification_weight!r}. "
+                "For contrastive-only training explicitly set trainer.test_after_fit=false. "
+                "Otherwise choose a task/objective that computes the requested metrics; "
+                "PHMFactory does not change objective weights or drop metrics."
+            )
+
+    def expected_evaluation_metric_keys(self, dataset_names: tuple[str, ...]) -> set[str]:
+        """Keep this task's existing pooled accuracy, not Default_task's per-Name keys."""
+        if not dataset_names:
+            raise ValueError("Evaluation requires a non-empty selected test population.")
+        self._require_evaluation_metrics()
+        return {"test_acc"}
 
     @staticmethod
     def _validated_weight(value: Any, name: str) -> float:

--- a/test/test_hse_objective_contract.py
+++ b/test/test_hse_objective_contract.py
@@ -289,3 +289,50 @@ def test_hse_training_augmentation_remains_stochastic():
     )
 
     assert not torch.equal(first, second)
+
+
+def _real_hse_task(*, evaluated=True, classification_weight=1.0, metrics=("acc",)):
+    class Network(torch.nn.Module):
+        def forward(self, x, *, file_id, task_id, return_feature):
+            assert task_id == "classification" and return_feature
+            return torch.cat([x, -x], dim=1), x
+
+    return HSETask(
+        Network(), SimpleNamespace(), SimpleNamespace(),
+        _task_args(name="hse_contrastive", loss="CE", metrics=list(metrics),
+                   contrast_weight=1.0 if classification_weight == 0 else 0.0,
+                   classification_weight=classification_weight),
+        SimpleNamespace(test_after_fit=evaluated), SimpleNamespace(seed=17),
+        {0: {"Name": "A", "Dataset_id": 7, "Label": 0},
+         1: {"Name": "A", "Dataset_id": 7, "Label": 1}},
+    )
+
+
+def test_hse_declared_accuracy_matches_its_existing_logged_namespace(monkeypatch):
+    instance = _real_hse_task(metrics=("ACC",))
+    logged = {}
+    monkeypatch.setattr(instance, "log", lambda key, value, **kwargs: logged.update({key: value}))
+    instance.test_step(
+        {"x": torch.tensor([[1.0], [-1.0]]), "y": torch.tensor([0, 1]),
+         "file_id": torch.tensor([0, 1])},
+        0,
+    )
+    expected = instance.expected_evaluation_metric_keys(("A",))
+    assert expected == {"test_acc"}
+    assert expected <= logged.keys()
+    assert logged["test_acc"].item() == 1.0
+    assert "test_acc_A" not in logged
+
+
+@pytest.mark.parametrize("weight,metrics", [(0.0, ("acc",)), (1.0, ("acc", "f1"))])
+def test_hse_impossible_evaluation_is_rejected_during_construction(weight, metrics):
+    with pytest.raises(ValueError, match="hse_contrastive reports only pooled"):
+        _real_hse_task(classification_weight=weight, metrics=metrics)
+
+
+def test_hse_contrastive_only_remains_available_as_explicit_training_only():
+    instance = _real_hse_task(evaluated=False, classification_weight=0.0)
+    assert instance.classification_weight == 0.0
+    assert instance.contrast_weight == 1.0
+    with pytest.raises(ValueError, match="test_after_fit=false"):
+        instance.expected_evaluation_metric_keys(("A",))

--- a/test/test_run_summary.py
+++ b/test/test_run_summary.py
@@ -255,7 +255,6 @@ class _UnreadSamples:
 
 
 @pytest.fixture
-ndef_placeholder
 def publication_case(tmp_path, monkeypatch):
     """Real config, dataset identities, Task and writer; only training is isolated."""
     metadata = {

--- a/test/test_run_summary.py
+++ b/test/test_run_summary.py
@@ -367,11 +367,12 @@ def test_missing_test_name_cannot_disappear_from_expectations(publication_case, 
     with pytest.raises(RuntimeError, match="test_acc_B.*test_f1_B"):
         run([{"test_acc_A": 0.5, "test_f1_A": 0.4}], names=("A", "B"))
     assert state.tests == 1
-    assert not list(tmp_path.rglob("*.csv"))
+    assert not list(tmp_path.rglob("test_result_*.csv"))
+    assert not list(tmp_path.rglob("all_results.csv"))
     assert not list(tmp_path.rglob("run_summary.json"))
 
 
-@pytest.mark.parametrize("metrics", [("acc", "f1"), ("accuracy", "F1")])
+@pytest.mark.parametrize("metrics", [("acc", "f1"), ("ACC", "F1")])
 def test_complete_publication_preserves_aliases_extra_loss_and_name_pooling(publication_case, metrics):
     run, state = publication_case
     payload = {"test_acc_A": 0.5, "test_f1_A": 0.4, "test_loss": 1.0}
@@ -412,7 +413,9 @@ def test_training_only_skips_declared_test_closure(publication_case, tmp_path):
     assert state.tests == 0
     assert result["status"] == "succeeded"
     assert result["test_metrics"] is result["run_summary"] is None
-    assert not list(tmp_path.rglob("*.csv"))
+    assert not list(tmp_path.rglob("test_result_*.csv"))
+    assert not list(tmp_path.rglob("all_results.csv"))
+    assert not list(tmp_path.rglob("run_summary.json"))
 
 
 @pytest.mark.parametrize("row", [{}, {"Name": ""}, {"Name": " A"}, {"Name": None}])

--- a/test/test_run_summary.py
+++ b/test/test_run_summary.py
@@ -125,9 +125,9 @@ def test_metric_result_rejects_empty_nonnumeric_boolean_and_nonscalar_values():
 
 
 def test_summary_rejects_noninteger_seed_values():
-    with pytest.raises(ValueError, match="seed 0 must be an integer"):
+    with pytest.raises(TypeError, match="seed 0 must be an integer"):
         build_run_summary([{"test_acc": 0.5}], [42.5], _config())
-    with pytest.raises(ValueError, match="seed 0 must be an integer"):
+    with pytest.raises(TypeError, match="seed 0 must be an integer"):
         build_run_summary([{"test_acc": 0.5}], [True], _config())
 
 
@@ -255,6 +255,7 @@ class _UnreadSamples:
 
 
 @pytest.fixture
+ndef_placeholder
 def publication_case(tmp_path, monkeypatch):
     """Real config, dataset identities, Task and writer; only training is isolated."""
     metadata = {

--- a/test/test_run_summary.py
+++ b/test/test_run_summary.py
@@ -5,9 +5,15 @@ from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
+import torch
+from torch.utils.data import DataLoader
 
+from phmfactory.config import ResolvedConfig, analyze_config
+from phmfactory.runtime import CompiledRunSpec
+from src.data_factory.dataset_task.Dataset_cluster import IdIncludedDataset
 from src.runtime import classification
 from src.runtime.classification import _result_row
+from src.task_factory.Default_task import Default_task
 from src.utils.run_summary import (
     build_run_summary,
     normalize_metric_result,
@@ -34,7 +40,7 @@ def _runtime_config(tmp_path: Path, *, iterations: int = 3) -> SimpleNamespace:
         ),
         data=SimpleNamespace(data_dir=str(tmp_path), metadata_file="dummy.csv"),
         model=SimpleNamespace(type="dummy", name="dummy"),
-        task=SimpleNamespace(type="DG", name="classification"),
+        task=SimpleNamespace(type="DG", name="classification", loss="CE", metrics=["acc"]),
         trainer=SimpleNamespace(test_after_fit=True),
     )
 
@@ -119,9 +125,9 @@ def test_metric_result_rejects_empty_nonnumeric_boolean_and_nonscalar_values():
 
 
 def test_summary_rejects_noninteger_seed_values():
-    with pytest.raises(TypeError, match="seed 0 must be an integer"):
+    with pytest.raises(ValueError, match="seed 0 must be an integer"):
         build_run_summary([{"test_acc": 0.5}], [42.5], _config())
-    with pytest.raises(TypeError, match="seed 0 must be an integer"):
+    with pytest.raises(ValueError, match="seed 0 must be an integer"):
         build_run_summary([{"test_acc": 0.5}], [True], _config())
 
 
@@ -162,15 +168,19 @@ def test_pipeline_creates_one_root_for_all_iterations(
     run_root = tmp_path / "one-run"
     root_calls = 0
     trainer_calls = 0
+    metadata = {
+        0: {"Name": "A", "Dataset_id": 0, "Label": 0, "Domain_id": 0},
+        1: {"Name": "A", "Dataset_id": 0, "Label": 1, "Domain_id": 0},
+    }
 
     class DataFactory:
         data = SimpleNamespace(close=lambda: None)
 
         def get_metadata(self):
-            return {0: {"Label": 0, "Domain_id": 0}}
+            return metadata
 
         def get_dataloader(self, split: str):
-            return split
+            return DataLoader(IdIncludedDataset({0: [0], 1: [0]}, metadata))
 
     class Trainer:
         def __init__(self, path: str, value: float):
@@ -182,7 +192,7 @@ def test_pipeline_creates_one_root_for_all_iterations(
             return None
 
         def test(self, *args):
-            return [{"test_acc": self.value}]
+            return [{"test_acc_A": self.value}]
 
     def create_root(configs):
         nonlocal root_calls
@@ -205,9 +215,9 @@ def test_pipeline_creates_one_root_for_all_iterations(
     monkeypatch.setattr(
         classification,
         "build_model",
-        lambda *args, **kwargs: object(),
+        lambda *args, **kwargs: torch.nn.Linear(1, 2),
     )
-    monkeypatch.setattr(classification, "build_task", lambda **kwargs: object())
+    monkeypatch.setattr(classification, "build_task", lambda **kwargs: Default_task(**kwargs))
     monkeypatch.setattr(classification, "build_trainer", build_trainer)
     monkeypatch.setattr(
         classification,
@@ -234,3 +244,188 @@ def test_pipeline_creates_one_root_for_all_iterations(
     assert (run_root / "run_summary.json").is_file()
     for checkpoint in result["best_checkpoints"]:
         Path(checkpoint).resolve().relative_to(run_root.resolve())
+
+
+class _UnreadSamples:
+    def __len__(self):
+        return 1
+
+    def __getitem__(self, index):
+        raise AssertionError("Population declaration must not consume a sample.")
+
+
+@pytest.fixture
+def publication_case(tmp_path, monkeypatch):
+    """Real config, dataset identities, Task and writer; only training is isolated."""
+    metadata = {
+        0: {"Name": "A", "Dataset_id": 7, "Label": 0},
+        1: {"Name": "A", "Dataset_id": 8, "Label": 1},
+        2: {"Name": "B", "Dataset_id": 9, "Label": 0},
+        3: {"Name": "B", "Dataset_id": 9, "Label": 1},
+        4: {"Name": "Train_only", "Dataset_id": 10, "Label": 0},
+        5: {"Name": "Train_only", "Dataset_id": 10, "Label": 1},
+    }
+    state = SimpleNamespace(tests=0, closed=0, fits=0, tasks=[])
+
+    def run(payloads, *, names=("A",), metrics=("acc", "f1"), evaluated=True):
+        analysis = analyze_config("smoke", override_values=[
+            f"environment.output_dir={tmp_path.as_posix()}",
+            f"environment.iterations={len(payloads)}",
+            "environment.seed=17",
+            f"task.metrics={list(metrics)!r}",
+            f"trainer.test_after_fit={str(evaluated).lower()}",
+        ])
+        resolved = ResolvedConfig(
+            requested="smoke", path=tmp_path / "smoke.yaml",
+            data=analysis.runtime_config(), pipeline="Pipeline_01_Fault_Diagnosis",
+            overrides={},
+        )
+        args = SimpleNamespace(
+            compiled_run_spec=CompiledRunSpec.compile(resolved),
+            resolved_pipeline=resolved.pipeline, config_path=str(resolved.path), notes="",
+        )
+        selected = {
+            file_id: _UnreadSamples() for file_id, row in metadata.items()
+            if row["Name"] in names
+        }
+        dataset = IdIncludedDataset(selected, metadata)
+        state.dataset = dataset
+
+        class DataFactory:
+            def __init__(self):
+                self.data = SimpleNamespace(close=self.close)
+
+            def close(self):
+                state.closed += 1
+
+            def get_metadata(self):
+                return metadata
+
+            def get_dataloader(self, split):
+                if split == "test" and not evaluated:
+                    pytest.fail("training-only must not request a test loader")
+                return DataLoader(dataset)
+
+        class Trainer:
+            def __init__(self, path):
+                self.checkpoint = Path(path) / "best.ckpt"
+
+            def fit(self, *args):
+                state.fits += 1
+                self.checkpoint.write_text("isolated-training checkpoint\n")
+
+            def test(self, task, loader):
+                state.tests += 1
+                return [dict(payloads[state.tests - 1])]
+
+        def build_task(**kwargs):
+            task = Default_task(**kwargs)
+            state.tasks.append(task)
+            return task
+
+        monkeypatch.setattr(classification, "init_lab", lambda *args: None)
+        monkeypatch.setattr(classification, "close_lab", lambda: None)
+        monkeypatch.setattr(classification, "seed_everything", lambda seed: None)
+        monkeypatch.setattr(classification, "build_data", lambda *args: DataFactory())
+        monkeypatch.setattr(classification, "build_model", lambda *a, **k: torch.nn.Linear(1, 2))
+        monkeypatch.setattr(classification, "build_task", build_task)
+        monkeypatch.setattr(classification, "build_trainer", lambda *args: Trainer(args[-1]))
+        monkeypatch.setattr(classification, "load_best_model_checkpoint", lambda task, trainer: task)
+        monkeypatch.setattr(classification, "_best_checkpoint_path", lambda trainer: trainer.checkpoint.resolve())
+        return classification.run_classification_pipeline(args)
+
+    return run, state
+
+
+def test_declared_metrics_missing_from_all_seeds_block_first_publication(publication_case, tmp_path, capsys):
+    run, state = publication_case
+    with pytest.raises(RuntimeError, match="missing_metric_keys=.*test_f1_A") as error:
+        run([{"test_acc_A": 0.5}, {"test_acc_A": 0.5}])
+    assert "seed=17" in str(error.value)
+    assert "configured_metrics" in str(error.value)
+    assert "expected_test_datasets=['A']" in str(error.value)
+    assert state.tests == state.closed == 1
+    assert not list(tmp_path.rglob("test_result_*.csv"))
+    assert not list(tmp_path.rglob("all_results.csv"))
+    assert not list(tmp_path.rglob("run_summary.json"))
+    assert "所有实验已完成" not in capsys.readouterr().out
+
+
+def test_later_missing_metric_preserves_prior_diagnostics_only(publication_case, tmp_path):
+    run, state = publication_case
+    with pytest.raises(RuntimeError, match="seed=18.*test_f1_A"):
+        run([{"test_acc_A": 0.5, "test_f1_A": 0.4}, {"test_acc_A": 0.5}])
+    assert state.tests == state.closed == 2
+    assert len(list(tmp_path.rglob("test_result_0.csv"))) == 1
+    assert not list(tmp_path.rglob("test_result_1.csv"))
+    assert not list(tmp_path.rglob("all_results.csv"))
+    assert not list(tmp_path.rglob("run_summary.json"))
+
+
+def test_missing_test_name_cannot_disappear_from_expectations(publication_case, tmp_path):
+    run, state = publication_case
+    with pytest.raises(RuntimeError, match="test_acc_B.*test_f1_B"):
+        run([{"test_acc_A": 0.5, "test_f1_A": 0.4}], names=("A", "B"))
+    assert state.tests == 1
+    assert not list(tmp_path.rglob("*.csv"))
+    assert not list(tmp_path.rglob("run_summary.json"))
+
+
+@pytest.mark.parametrize("metrics", [("acc", "f1"), ("accuracy", "F1")])
+def test_complete_publication_preserves_aliases_extra_loss_and_name_pooling(publication_case, metrics):
+    run, state = publication_case
+    payload = {"test_acc_A": 0.5, "test_f1_A": 0.4, "test_loss": 1.0}
+    result = run([payload], metrics=metrics)
+    assert result["status"] == "succeeded"
+    assert Path(result["test_metrics"]).is_file()
+    assert Path(result["run_summary"]).is_file()
+    assert set(result["primary_metrics"]) == set(payload)
+    assert result["primary_metrics"]["test_f1_A"]["sample_std"] is None
+    # Distinct Dataset_id values share Name A by existing protocol; train-only Names
+    # must not be added to expected test keys merely because they occur in metadata.
+    assert state.dataset.expected_dataset_names() == ("A",)
+    task = state.tasks[0]
+    expected = task.expected_evaluation_metric_keys(("A",))
+    logged = task._compute_metrics(torch.tensor([[1., 0.], [0., 1.]]), torch.tensor([0, 1]), "A", "test")
+    assert expected == set(logged) == {"test_acc_A", "test_f1_A"}
+
+
+def test_complete_multiple_names_and_seeds_publish(publication_case):
+    run, state = publication_case
+    payload = {"test_acc_A": 0.5, "test_f1_A": 0.4, "test_acc_B": 0.6, "test_f1_B": 0.5}
+    result = run([payload, payload], names=("A", "B"))
+    assert state.tests == state.closed == 2
+    summary = json.loads(Path(result["run_summary"]).read_text())
+    assert summary["seeds"] == [17, 18]
+    assert all(item["count"] == 2 for item in summary["metrics"].values())
+
+
+def test_acc_only_request_does_not_acquire_an_f1_requirement(publication_case):
+    run, _ = publication_case
+    result = run([{"test_acc_A": 0.5}], metrics=("acc",))
+    assert set(result["primary_metrics"]) == {"test_acc_A"}
+
+
+def test_training_only_skips_declared_test_closure(publication_case, tmp_path):
+    run, state = publication_case
+    result = run([{}], evaluated=False)
+    assert state.tests == 0
+    assert result["status"] == "succeeded"
+    assert result["test_metrics"] is result["run_summary"] is None
+    assert not list(tmp_path.rglob("*.csv"))
+
+
+@pytest.mark.parametrize("row", [{}, {"Name": ""}, {"Name": " A"}, {"Name": None}])
+def test_expected_populations_reject_missing_or_invalid_names(row):
+    dataset = IdIncludedDataset({7: _UnreadSamples()}, {7: row})
+    with pytest.raises((KeyError, ValueError), match="Name"):
+        dataset.expected_dataset_names()
+
+
+def test_expected_populations_reject_missing_id_and_empty_selection():
+    dataset = IdIncludedDataset({7: _UnreadSamples()}, {})
+    with pytest.raises(KeyError, match="file_id=7"):
+        dataset.expected_dataset_names()
+    dataset.dataset_dict.clear()
+    with pytest.raises(ValueError, match="non-empty selected test population"):
+        dataset.expected_dataset_names()


### PR DESCRIPTION
## Requested optimization — L01

Implement the first bounded fix from the maintainer-supplied 2026-09-11 local validation results. Base dev remains 9b595f72498621ddb05741ead29d8e7e2b0b7896; unrelated research PRs are excluded.

## Invariant

Before publishing each evaluated seed, all configured metrics for the test populations declared before evaluation must be reported. Consistent omissions across seeds are not success.

## Minimal change

- IdIncludedDataset declares Names from its actual selected file IDs without reading samples or using the complete training metadata as the test population.
- Default_task builds expected keys from its existing normalized metric names. Logging and expected keys share one ordinary formatting helper.
- Classification checks finite results and then missing keys before writing the current seed CSV. Earlier successful diagnostics may remain; failing invocations cannot publish aggregate success.
- Keep Name-level pooling, aliases, extra losses, acc-only configurations and training-only behavior. No Dataset_id uniqueness policy is introduced.

The dataset already owns the selected membership, so no additional DataFactory state or manager is needed.

## Regression placement

The original local counterexample directly called the internal aggregate helper. The permanent regression instead runs the actual public config analysis and classification lifecycle, using real IdIncludedDataset and Default_task while isolating only expensive training/checkpoint I/O. Expected construction and the missing-key check are NOT mocked. It asserts exact missing keys and absence of failing-seed/aggregate publication. Existing pure summary tests remain.

New cases live in the already-executed test/test_run_summary.py, including complete and missing metrics, missing population, later-seed failure, aliases, pooled Names, acc-only, training-only and invalid population identities. Existing real Dummy and Streamlit public-integration gates supply end-to-end execution evidence.

## Non-goals

No metric mathematics, split, model, optimizer/checkpoint policy, experiment YAML, dependency, L02/L03, THU download/retraining, or benchmark/release-status changes. No hash/manifest/ledger, second evaluator or transaction framework.

## Validation honesty

The current container cannot resolve github.com, so a full local clone/test is not claimed. GitHub connector reads/writes work; execute and inspect the existing final-head workflows before merging. Do not substitute the uploaded old green logs for the candidate's results. No test standards are lowered.

Changelog: doc/changelog/2026-09-11-declared-metric-closure.md. Rollback: revert this bounded squash commit. After closure, refresh dev and implement L02 separately under the same task authorization.