### PR TITLE
fix(config): reject malformed overrides and unused default Trainer fields

### DIFF
--- a/doc/changelog/2026-09-11-explicit-override-paths.md
+++ b/doc/changelog/2026-09-11-explicit-override-paths.md
@@ -1,0 +1,11 @@
+# 2026-09-11：错误 override 不再被当作有效设置
+
+公共配置解析器拒绝空路径段和段首尾空格，例如 `trainer..num_epochs=2`、`.trainer.num_epochs=2`。错误保留原路径，不自动折叠点号或修改字段名。
+
+现有 Trainer Schema 明确列出 Default_trainer 实际消费的可选参数。选择 Default_trainer 时，未知字段（如 `num_epoch`）在公共配置分析阶段失败，并给出支持字段；不再添加一个被训练器忽略的新键后继续运行。正确字段仍是 `trainer.num_epochs`。
+
+合法可选字段无需预先出现在 base YAML 中。Schema 仍只做验证，不把其默认值写入运行配置；自定义 Trainer 和现有 Model/Task 研究扩展字段保持原来的显式配置能力。本次不采用“只能覆盖已存在叶子”的全局禁令。
+
+回归测试进入已有 `test/test_trainer_lifecycle_schema.py`，覆盖两个本地复现输入、路径边界、公开 analyze/inspect/preflight/run 一致拒绝、错误 YAML、合法可选字段、研究扩展、最后覆盖优先及严格类型。被拒绝请求不会进入 Pipeline import 或创建最终结果目录。
+
+本次不修改运行期默认值、训练器、checkpoint/early-stopping 数学行为、数据或实验配置，不处理 L03 成功状态合同，也不下载或训练 THU。验证结果以本次 PR 的最终检查为准。

--- a/phmfactory/config.py
+++ b/phmfactory/config.py
@@ -88,8 +88,8 @@ class ConfigDiagnostic:
         return {
             "code": self.code,
             "severity": self.severity,
-            "message": self.message,
             "field": self.field,
+            "message": self.message,
             "suggestion": self.suggestion,
         }
 
@@ -155,8 +155,8 @@ def parse_overrides(values: Sequence[str] | None) -> dict[str, Any]:
     Raises
     ------
     ValueError
-        If a token is missing ``=``, has an empty key/value, contains malformed YAML,
-        or attempts to traverse a non-mapping field.
+        If a token is missing ``=``, has an empty key/value or invalid dotted segment,
+        contains malformed YAML, or attempts to traverse a non-mapping field.
     """
 
     parsed: dict[str, Any] = {}
@@ -441,6 +441,12 @@ def _read_yaml_mapping(path: Path) -> dict[str, Any]:
 def _set_dotted(target: dict[str, Any], key: str, value: Any) -> None:
     current = target
     parts = key.split(".")
+    if any(not part or part != part.strip() for part in parts):
+        raise ValueError(
+            f"Invalid override path {key!r}: path segments must be non-empty "
+            "and have no surrounding whitespace. Use a dotted field such as "
+            "trainer.num_epochs; PHMFactory does not repair field paths."
+        )
     for part in parts[:-1]:
         existing = current.get(part)
         if existing is None:

--- a/phmfactory/config.py
+++ b/phmfactory/config.py
@@ -88,8 +88,8 @@ class ConfigDiagnostic:
         return {
             "code": self.code,
             "severity": self.severity,
-            "field": self.field,
             "message": self.message,
+            "field": self.field,
             "suggestion": self.suggestion,
         }
 
@@ -140,7 +140,9 @@ class ConfigAnalysis:
             "pipeline": self.pipeline,
             "overrides": deepcopy(self.overrides),
             "local_config_path": (
-                str(self.local_config_path) if self.local_config_path is not None else None
+                str(self.local_config_path)
+                if self.local_config_path is not None
+                else None
             ),
             "source_files": [str(path) for path in self.source_files],
             "sources": dict(self.sources),

--- a/src/config_schema/models.py
+++ b/src/config_schema/models.py
@@ -291,6 +291,16 @@ class TrainerConfig(BaseModel):
     test_after_fit: Optional[bool] = None
     monitor: Optional[str] = None
     monitor_mode: Optional[Literal["min", "max"]] = None
+    # Declare actual Default_trainer inputs; validation never materializes defaults
+    # into the visible runtime mapping. Custom trainers may still own extra fields.
+    save_top_k: Optional[int] = None
+    early_stopping: Optional[bool] = None
+    patience: Optional[int] = None
+    min_delta: Optional[float] = None
+    deterministic: Optional[bool | Literal["warn"]] = None
+    pruning: Optional[float | List[float]] = None
+    log_every_n_steps: Optional[int] = None
+    logger_name: Optional[str] = None
     extensions: Optional[Dict[str, Any]] = Field(
         default=None,
         description=(
@@ -311,6 +321,12 @@ class TrainerConfig(BaseModel):
             raise ValueError(
                 "trainer.gpus is unsupported; use the single public field "
                 "trainer.devices"
+            )
+        if self.name == "Default_trainer" and extras:
+            raise ValueError(
+                "Default_trainer does not consume these trainer fields: "
+                f"{sorted(extras)}. Supported fields: {sorted(type(self).model_fields)}. "
+                "Use an exact supported field name; unknown fields are not applied."
             )
         return self
 

--- a/test/test_trainer_lifecycle_schema.py
+++ b/test/test_trainer_lifecycle_schema.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from copy import deepcopy
 from pathlib import Path
 from typing import Callable
 
@@ -9,7 +10,7 @@ import yaml
 
 from phmfactory import cli as public_cli
 from phmfactory.commands import preflight
-from phmfactory.config import analyze_config
+from phmfactory.config import analyze_config, parse_overrides, validate_complete_experiment
 from scripts.config_inspect import inspect_config
 from scripts.validate_configs import validate_one
 
@@ -104,3 +105,102 @@ def test_pipeline06_does_not_receive_unused_classification_policy() -> None:
 
     assert analysis.pipeline == "Pipeline_06_Generative_Modeling"
     assert "test_after_fit" not in analysis.effective_config["trainer"]
+
+
+@pytest.mark.parametrize("token", [
+    "trainer..num_epochs=2",
+    ".trainer.num_epochs=2",
+    "trainer.num_epochs.=2",
+    "trainer. .num_epochs=2",
+    "trainer. num_epochs=2",
+])
+def test_empty_or_padded_override_segments_are_rejected(token):
+    with pytest.raises(ValueError, match="Invalid override path"):
+        parse_overrides([token])
+
+
+@pytest.mark.parametrize("token,exception,detail", [
+    ("trainer.num_epoch=2", ValidationError, "num_epoch"),
+    ("trainer..num_epochs=2", ValueError, "Invalid override path"),
+])
+def test_invalid_overrides_fail_at_each_public_entry_before_execution(
+    tmp_path, monkeypatch, token, exception, detail,
+):
+    config_path, output_dir = _write_variant(tmp_path, "valid-input", lambda config: None)
+
+    def fail_pipeline_import(*args, **kwargs):
+        pytest.fail("invalid override must fail before Pipeline import")
+
+    monkeypatch.setattr(public_cli.importlib, "import_module", fail_pipeline_import)
+    argv = ["--config", str(config_path), "--override", token]
+    calls = [
+        lambda: analyze_config(config_path, override_values=[token]),
+        lambda: inspect_config(str(config_path), overrides=[token]),
+        lambda: preflight.run(argv),
+        lambda: public_cli.run(public_cli.build_parser().parse_args(argv)),
+    ]
+    for call in calls:
+        with pytest.raises(exception, match=detail):
+            call()
+    assert not output_dir.exists()
+
+
+def test_unknown_default_trainer_yaml_field_is_not_an_ignored_setting(tmp_path):
+    config_path, output_dir = _write_variant(
+        tmp_path, "misspelled-epoch",
+        lambda config: config["trainer"].__setitem__("num_epoch", 2),
+    )
+    errors = validate_one(config_path)
+    assert errors and "num_epoch" in "\n".join(errors)
+    with pytest.raises(ValidationError, match="Supported fields:.*num_epochs"):
+        analyze_config(config_path)
+    assert not output_dir.exists()
+
+
+def test_valid_optional_trainer_fields_need_not_exist_in_base_yaml(tmp_path):
+    config_path, _ = _write_variant(
+        tmp_path, "without-optional-selection",
+        lambda config: [config["trainer"].pop(key, None) for key in ("min_delta", "save_top_k")],
+    )
+    config = analyze_config(config_path).runtime_config()
+    before = deepcopy(config)
+    validate_complete_experiment(config)
+    assert config == before
+    assert "min_delta" not in config["trainer"]
+    assert "save_top_k" not in config["trainer"]
+
+    changed = analyze_config(config_path, override_values=[
+        "trainer.min_delta=0.0", "trainer.save_top_k=2",
+        "trainer.early_stopping=false", "trainer.deterministic=warn",
+    ]).runtime_config()
+    assert changed["trainer"]["min_delta"] == 0.0
+    assert changed["trainer"]["save_top_k"] == 2
+    assert changed["trainer"]["early_stopping"] is False
+    assert changed["trainer"]["deterministic"] == "warn"
+    assert changed["trainer"]["num_epochs"] == before["trainer"]["num_epochs"]
+
+
+def test_custom_trainer_and_research_component_extras_remain_explicit():
+    config = analyze_config("smoke", override_values=[
+        "trainer.name=ResearchTrainer",
+        "trainer.research_control.alpha=0.5",
+        "model.research_parameter=7",
+        "task.research_parameter=false",
+    ]).runtime_config()
+    assert config["trainer"]["research_control"] == {"alpha": 0.5}
+    assert config["model"]["research_parameter"] == 7
+    assert config["task"]["research_parameter"] is False
+    # Configuration acceptance is not a claim that this example Trainer is installed.
+
+
+def test_supported_repeated_override_keeps_last_value_and_strict_types():
+    config = analyze_config("smoke", override_values=[
+        "trainer.num_epochs=1", "trainer.num_epochs=2",
+        "trainer.test_after_fit=false",
+    ]).runtime_config()
+    assert config["trainer"]["num_epochs"] == 2
+    assert "num_epoch" not in config["trainer"]
+    assert config["trainer"]["test_after_fit"] is False
+    for token in ("trainer.num_epochs='2'", "trainer.early_stopping='false'"):
+        with pytest.raises(ValidationError):
+            analyze_config("smoke", override_values=[token])


### PR DESCRIPTION
## Requested optimization — L02

Second bounded fix from the maintainer's local validation results, after merged L01 #258. Base is dev@9bb8c7a297ad1dc7e9db1b44837967d02aebc757. No unrelated research changes.

## Verified problem

`trainer.num_epoch=2` previously created an ignored field, leaving num_epochs unchanged. `trainer..num_epochs=2` created an empty nested key instead of changing the real epoch field. Both were accepted by public analysis.

## Change

- Existing dotted-key parser rejects empty or whitespace-padded segments rather than repairing them.
- Existing TrainerConfig declares the actual Default_trainer optional inputs. For Default_trainer only, remaining unknown fields fail at public analysis with supported field names.
- Existing strict acceptance does not materialize schema defaults into runtime configuration. Valid optional fields may be absent from base YAML, and custom Trainer/Model/Task extras remain allowed under their existing interface.
- Preserve legacy max_epochs/gpus error messages and final override precedence.

This is not a global existing-leaf-only override policy or a blanket extra=forbid change. No new resolver or registry.

## Tests

Extend already-executed test/test_trainer_lifecycle_schema.py: both original failures through analyze, inspector, preflight and public run before Pipeline import/output creation; malformed dotted segments; invalid YAML field; valid optional fields not present in base; custom component extras; precedence; strict integer/boolean inputs; no schema-default materialization. Existing lifecycle and Pipeline06 policy tests remain.

Run current-head config validation and existing user-path CI; do not substitute earlier green checks. Local full checkout execution is not claimed in this environment.

## Non-goals

No Trainer runtime, selection defaults, objective, data, split, model, metric, experimental YAML, dependency or benchmark-status changes; no THU download/retraining. L03 remains a separate PR. Changelog: doc/changelog/2026-09-11-explicit-override-paths.md.

Merge via bounded squash after relevant checks and review closure; then refresh dev for L03 under the maintainer's existing authorization.